### PR TITLE
Add real TUN device and tunnel manager for data-plane tunneling

### DIFF
--- a/mcp-servers/protocol-mcp/bgp/tun.py
+++ b/mcp-servers/protocol-mcp/bgp/tun.py
@@ -1,0 +1,185 @@
+"""
+TUN Device Manager — Cross-platform TUN interface for NetClaw data-plane tunnels.
+
+Linux:  /dev/net/tun with IFF_TUN | IFF_NO_PI
+macOS:  utun via PF_SYSTEM socket (SYSPROTO_CONTROL + com.apple.net.utun_control)
+
+Requires root/sudo or CAP_NET_ADMIN.
+"""
+
+import fcntl
+import logging
+import os
+import platform
+import re
+import socket
+import struct
+import subprocess
+from typing import Optional
+
+logger = logging.getLogger("TUN")
+
+# Linux TUN constants
+TUNSETIFF = 0x400454ca
+IFF_TUN = 0x0001
+IFF_NO_PI = 0x1000
+
+# macOS utun constants
+PF_SYSTEM = 32
+SYSPROTO_CONTROL = 2
+AF_SYS_CONTROL = 2
+UTUN_CONTROL_NAME = b"com.apple.net.utun_control"
+CTLIOCGINFO = 0xC0644E03  # _IOWR('N', 3, struct ctl_info)
+
+
+class TUNDevice:
+    """
+    Cross-platform TUN device for reading/writing raw IP packets.
+
+    Attributes:
+        name: Actual interface name (e.g. "nclaw0" on Linux, "utun5" on macOS)
+        fd:   File descriptor for reading/writing raw IP packets
+    """
+
+    def __init__(self, name: str):
+        self.requested_name = name
+        self.name: str = ""
+        self.fd: int = -1
+        self._sock: Optional[socket.socket] = None  # macOS utun socket
+        self._system = platform.system()
+
+    def open(self) -> str:
+        """Open TUN device. Returns actual interface name. Raises OSError on failure."""
+        if self._system == "Linux":
+            return self._open_linux()
+        elif self._system == "Darwin":
+            return self._open_darwin()
+        else:
+            raise OSError(f"Unsupported platform: {self._system}")
+
+    def _open_linux(self) -> str:
+        self.fd = os.open("/dev/net/tun", os.O_RDWR)
+        # struct ifreq: 16-byte name + 2-byte flags, padded to 40 bytes
+        ifr = struct.pack("16sH", self.requested_name.encode(), IFF_TUN | IFF_NO_PI)
+        ifr = ifr.ljust(40, b'\x00')
+        result = fcntl.ioctl(self.fd, TUNSETIFF, ifr)
+        self.name = result[:16].decode().strip('\x00')
+        logger.info("Opened Linux TUN: %s (fd=%d)", self.name, self.fd)
+        return self.name
+
+    def _open_darwin(self) -> str:
+        # Parse unit number from requested name (e.g., "nclaw0" -> unit 0)
+        match = re.search(r'(\d+)$', self.requested_name)
+        unit = int(match.group(1)) if match else 0
+
+        self._sock = socket.socket(PF_SYSTEM, socket.SOCK_DGRAM, SYSPROTO_CONTROL)
+
+        # Get control ID for utun
+        ctl_info = struct.pack("I", 0) + UTUN_CONTROL_NAME.ljust(96, b'\x00')
+        ctl_info = fcntl.ioctl(self._sock.fileno(), CTLIOCGINFO, ctl_info)
+        ctl_id = struct.unpack("I", ctl_info[:4])[0]
+
+        # Connect with unit number (unit+1 because 0 means auto-assign)
+        sc_addr = struct.pack("=BBHIi", 32, AF_SYS_CONTROL, 0, ctl_id, unit + 1)
+        self._sock.connect(sc_addr)
+
+        self.fd = self._sock.fileno()
+        self.name = f"utun{unit}"
+        logger.info("Opened macOS TUN: %s (fd=%d)", self.name, self.fd)
+        return self.name
+
+    def close(self) -> None:
+        """Close TUN device."""
+        if self._sock:
+            self._sock.close()
+            self._sock = None
+            self.fd = -1
+        elif self.fd >= 0:
+            os.close(self.fd)
+            self.fd = -1
+        if self.name:
+            logger.info("Closed TUN: %s", self.name)
+
+    def read_packet(self) -> bytes:
+        """Read one raw IP packet (blocking). Returns bytes or empty on error."""
+        if self.fd < 0:
+            return b''
+        try:
+            data = os.read(self.fd, 65535)
+            if self._system == "Darwin" and len(data) > 4:
+                data = data[4:]  # Strip 4-byte AF header on macOS utun
+            return data
+        except OSError:
+            return b''
+
+    def write_packet(self, packet: bytes) -> int:
+        """Write raw IP packet to TUN. Returns bytes written."""
+        if self.fd < 0 or not packet:
+            return 0
+        try:
+            if self._system == "Darwin":
+                # Prepend 4-byte AF header (AF_INET6=30 for IPv6, AF_INET=2 for IPv4)
+                ip_version = (packet[0] >> 4) if packet else 0
+                af = 30 if ip_version == 6 else 2
+                af_header = struct.pack(">I", af)
+                return os.write(self.fd, af_header + packet) - 4
+            return os.write(self.fd, packet)
+        except OSError:
+            return 0
+
+    def configure_address(self, address: str, prefix_len: int) -> bool:
+        """Assign IPv6 address to TUN interface."""
+        try:
+            if self._system == "Linux":
+                subprocess.run(
+                    ["ip", "-6", "addr", "add", f"{address}/{prefix_len}", "dev", self.name],
+                    check=True, capture_output=True, timeout=5
+                )
+            elif self._system == "Darwin":
+                subprocess.run(
+                    ["ifconfig", self.name, "inet6", f"{address}/{prefix_len}"],
+                    check=True, capture_output=True, timeout=5
+                )
+            logger.info("Configured %s/%d on %s", address, prefix_len, self.name)
+            return True
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr.decode() if e.stderr else ""
+            if "exists" in stderr or "already" in stderr:
+                return True
+            logger.error("Failed to configure address on %s: %s", self.name, stderr)
+            return False
+
+    def bring_up(self) -> bool:
+        """Bring TUN interface up."""
+        try:
+            if self._system == "Linux":
+                subprocess.run(
+                    ["ip", "link", "set", self.name, "up"],
+                    check=True, capture_output=True, timeout=5
+                )
+            elif self._system == "Darwin":
+                subprocess.run(
+                    ["ifconfig", self.name, "up"],
+                    check=True, capture_output=True, timeout=5
+                )
+            return True
+        except subprocess.CalledProcessError as e:
+            logger.error("Failed to bring up %s: %s", self.name, e)
+            return False
+
+    def set_mtu(self, mtu: int) -> bool:
+        """Set MTU on TUN interface."""
+        try:
+            if self._system == "Linux":
+                subprocess.run(
+                    ["ip", "link", "set", self.name, "mtu", str(mtu)],
+                    check=True, capture_output=True, timeout=5
+                )
+            elif self._system == "Darwin":
+                subprocess.run(
+                    ["ifconfig", self.name, "mtu", str(mtu)],
+                    check=True, capture_output=True, timeout=5
+                )
+            return True
+        except subprocess.CalledProcessError:
+            return False

--- a/mcp-servers/protocol-mcp/bgp/tunnel.py
+++ b/mcp-servers/protocol-mcp/bgp/tunnel.py
@@ -1,0 +1,357 @@
+"""
+NetClaw IP-over-TCP Tunnel Manager
+
+Establishes a data-plane tunnel alongside each BGP session:
+- Protocol discrimination via 5-byte magic "NCTUN" + 4-byte AS on port 1179
+- Length-prefixed framing: [2-byte big-endian length][raw IP packet]
+- Asyncio forwarding: TUN <-> TCP
+- Deterministic IPv6 /127 address assignment per peer pair
+
+Lower-AS side initiates the tunnel TCP connection (avoids collision).
+"""
+
+import asyncio
+import logging
+import struct
+import subprocess
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Tuple
+
+from .constants import (
+    NCTUN_MAGIC, NCTUN_FRAME_HEADER_SIZE, NCTUN_MAX_PACKET_SIZE,
+)
+from .tun import TUNDevice
+
+logger = logging.getLogger("TunnelManager")
+
+# Global tunnel index counter
+_tun_index = 0
+
+
+def compute_tunnel_addresses(local_as: int, peer_as: int) -> Tuple[str, str]:
+    """
+    Deterministic overlay address assignment for a peer pair.
+
+    Overlay prefix: fd00:cc::/48
+    For pair (AS_low, AS_high): subnet fd00:cc:{low_hex}:{high_hex}::/127
+    Lower AS gets ::0, higher AS gets ::1
+
+    Args:
+        local_as: Our AS number
+        peer_as: Peer AS number
+
+    Returns:
+        (local_address, remote_address) as full IPv6 address strings
+    """
+    as_low = min(local_as, peer_as)
+    as_high = max(local_as, peer_as)
+
+    subnet = f"fd00:cc:{as_low:x}:{as_high:x}::"
+
+    if local_as <= peer_as:
+        return f"{subnet}0", f"{subnet}1"
+    else:
+        return f"{subnet}1", f"{subnet}0"
+
+
+@dataclass
+class PeerTunnel:
+    """State for a single peer's data-plane tunnel."""
+    peer_as: int
+    local_as: int
+    tun_device: Optional[TUNDevice] = None
+    reader: Optional[asyncio.StreamReader] = None
+    writer: Optional[asyncio.StreamWriter] = None
+    local_address: str = ""
+    remote_address: str = ""
+    tun_to_tcp_task: Optional[asyncio.Task] = None
+    tcp_to_tun_task: Optional[asyncio.Task] = None
+    running: bool = False
+    stats: Dict = field(default_factory=lambda: {
+        "packets_tx": 0, "packets_rx": 0,
+        "bytes_tx": 0, "bytes_rx": 0,
+        "errors": 0,
+    })
+
+
+class TunnelManager:
+    """
+    Manages data-plane tunnels for all BGP peers.
+
+    Lifecycle:
+    1. BGP session established, both peers advertise CAP_NETCLAW_TUNNEL=201
+    2. Lower-AS side initiates TCP connection with NCTUN magic + 4-byte AS
+    3. Higher-AS side accepts via protocol discrimination in agent._handle_incoming_connection
+    4. Both sides create TUN device, assign overlay addresses, start forwarding
+    """
+
+    def __init__(self, local_as: int, kernel_route_manager=None):
+        self.local_as = local_as
+        self.kernel_route_manager = kernel_route_manager
+        self.tunnels: Dict[int, PeerTunnel] = {}  # peer_as -> PeerTunnel
+        self.logger = logging.getLogger(f"TunnelManager[AS{local_as}]")
+        self._forwarding_enabled = False
+
+    def enable_ip_forwarding(self) -> None:
+        """Enable kernel IP forwarding (requires sudo)."""
+        if self._forwarding_enabled:
+            return
+        for cmd in [
+            ["sysctl", "-w", "net.ipv4.ip_forward=1"],
+            ["sysctl", "-w", "net.ipv6.conf.all.forwarding=1"],
+        ]:
+            try:
+                subprocess.run(cmd, capture_output=True, timeout=5)
+            except Exception as e:
+                self.logger.warning("Could not run %s: %s", " ".join(cmd), e)
+        self._forwarding_enabled = True
+        self.logger.info("IP forwarding enabled (v4+v6)")
+
+    async def initiate_tunnel(self, peer_as: int, endpoint: str) -> bool:
+        """
+        Initiate outbound tunnel connection (called by lower-AS side).
+
+        Args:
+            peer_as: Peer AS number
+            endpoint: Peer's tunnel endpoint "host:port"
+
+        Returns:
+            True if tunnel established successfully
+        """
+        if peer_as in self.tunnels and self.tunnels[peer_as].running:
+            self.logger.debug("Tunnel to AS%d already active", peer_as)
+            return True
+
+        # Parse host:port (handle hostname:port format)
+        host, _, port_str = endpoint.rpartition(":")
+        port = int(port_str)
+
+        self.logger.info("Initiating tunnel to AS%d at %s:%d", peer_as, host, port)
+
+        try:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(host, port),
+                timeout=30.0,
+            )
+            # Send magic + our AS number for identification
+            writer.write(NCTUN_MAGIC + struct.pack("!I", self.local_as))
+            await writer.drain()
+
+            tunnel = await self._setup_tunnel(peer_as, reader, writer)
+            if tunnel:
+                self.logger.info("Tunnel to AS%d established (initiator)", peer_as)
+                return True
+            return False
+
+        except Exception as e:
+            self.logger.error("Failed to initiate tunnel to AS%d: %s", peer_as, e)
+            return False
+
+    async def accept_tunnel(self, peer_as: int,
+                            reader: asyncio.StreamReader,
+                            writer: asyncio.StreamWriter) -> bool:
+        """
+        Accept inbound tunnel connection (called by higher-AS side).
+
+        The NCTUN magic + 4-byte AS have already been consumed by the agent's
+        protocol discrimination logic.
+
+        Args:
+            peer_as: Peer AS number (read from tunnel handshake)
+            reader: TCP stream reader
+            writer: TCP stream writer
+
+        Returns:
+            True if tunnel set up successfully
+        """
+        self.logger.info("Accepting tunnel from AS%d", peer_as)
+
+        tunnel = await self._setup_tunnel(peer_as, reader, writer)
+        if tunnel:
+            self.logger.info("Tunnel from AS%d established (acceptor)", peer_as)
+            return True
+        return False
+
+    async def _setup_tunnel(self, peer_as: int,
+                            reader: asyncio.StreamReader,
+                            writer: asyncio.StreamWriter) -> Optional[PeerTunnel]:
+        """Common tunnel setup: create TUN, assign addresses, start forwarding."""
+        global _tun_index
+
+        # Tear down existing tunnel for this peer if any
+        if peer_as in self.tunnels:
+            await self.teardown_tunnel(peer_as)
+
+        # Compute overlay addresses
+        local_addr, remote_addr = compute_tunnel_addresses(self.local_as, peer_as)
+
+        # Create TUN device
+        tun_name = f"nclaw{_tun_index}"
+        _tun_index += 1
+
+        tun = TUNDevice(tun_name)
+        try:
+            actual_name = tun.open()
+        except OSError as e:
+            self.logger.error("Cannot create TUN %s: %s (need sudo?)", tun_name, e)
+            return None
+
+        # Bring up and configure
+        tun.bring_up()
+        tun.set_mtu(NCTUN_MAX_PACKET_SIZE)
+        tun.configure_address(local_addr, 127)
+
+        # Enable IP forwarding
+        self.enable_ip_forwarding()
+
+        # Create tunnel state
+        tunnel = PeerTunnel(
+            peer_as=peer_as,
+            local_as=self.local_as,
+            tun_device=tun,
+            reader=reader,
+            writer=writer,
+            local_address=local_addr,
+            remote_address=remote_addr,
+            running=True,
+        )
+        self.tunnels[peer_as] = tunnel
+
+        # Start forwarding tasks
+        tunnel.tun_to_tcp_task = asyncio.create_task(
+            self._forward_tun_to_tcp(tunnel)
+        )
+        tunnel.tcp_to_tun_task = asyncio.create_task(
+            self._forward_tcp_to_tun(tunnel)
+        )
+
+        self.logger.info(
+            "Tunnel AS%d ready: %s <-> %s on %s",
+            peer_as, local_addr, remote_addr, actual_name
+        )
+        return tunnel
+
+    async def _forward_tun_to_tcp(self, tunnel: PeerTunnel) -> None:
+        """Read IP packets from TUN, length-frame them, send over TCP."""
+        loop = asyncio.get_event_loop()
+        tun = tunnel.tun_device
+
+        while tunnel.running and tunnel.writer and not tunnel.writer.is_closing():
+            try:
+                # Read from TUN fd in executor (blocking read)
+                packet = await loop.run_in_executor(None, tun.read_packet)
+                if not packet:
+                    await asyncio.sleep(0.01)
+                    continue
+
+                if len(packet) > NCTUN_MAX_PACKET_SIZE:
+                    tunnel.stats["errors"] += 1
+                    continue
+
+                # Frame: [2-byte big-endian length][raw IP packet]
+                frame = struct.pack("!H", len(packet)) + packet
+                tunnel.writer.write(frame)
+                await tunnel.writer.drain()
+
+                tunnel.stats["packets_tx"] += 1
+                tunnel.stats["bytes_tx"] += len(packet)
+
+            except asyncio.CancelledError:
+                break
+            except (ConnectionError, BrokenPipeError):
+                self.logger.warning("Tunnel TCP lost (tun->tcp) AS%d", tunnel.peer_as)
+                break
+            except Exception as e:
+                self.logger.error("tun->tcp error AS%d: %s", tunnel.peer_as, e)
+                tunnel.stats["errors"] += 1
+                await asyncio.sleep(0.1)
+
+    async def _forward_tcp_to_tun(self, tunnel: PeerTunnel) -> None:
+        """Read length-framed IP packets from TCP, write to TUN."""
+        tun = tunnel.tun_device
+        loop = asyncio.get_event_loop()
+
+        while tunnel.running and tunnel.reader:
+            try:
+                # Read 2-byte length header
+                len_bytes = await tunnel.reader.readexactly(NCTUN_FRAME_HEADER_SIZE)
+                pkt_len = struct.unpack("!H", len_bytes)[0]
+
+                if pkt_len == 0 or pkt_len > NCTUN_MAX_PACKET_SIZE:
+                    tunnel.stats["errors"] += 1
+                    continue
+
+                # Read packet payload
+                packet = await tunnel.reader.readexactly(pkt_len)
+
+                # Write to TUN in executor (blocking write)
+                await loop.run_in_executor(None, tun.write_packet, packet)
+
+                tunnel.stats["packets_rx"] += 1
+                tunnel.stats["bytes_rx"] += pkt_len
+
+            except asyncio.IncompleteReadError:
+                self.logger.warning("Tunnel TCP closed (tcp->tun) AS%d", tunnel.peer_as)
+                break
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                self.logger.error("tcp->tun error AS%d: %s", tunnel.peer_as, e)
+                tunnel.stats["errors"] += 1
+                await asyncio.sleep(0.1)
+
+    async def teardown_tunnel(self, peer_as: int) -> None:
+        """Tear down tunnel for a specific peer."""
+        tunnel = self.tunnels.pop(peer_as, None)
+        if not tunnel:
+            return
+
+        tunnel.running = False
+
+        # Cancel forwarding tasks
+        for task in [tunnel.tun_to_tcp_task, tunnel.tcp_to_tun_task]:
+            if task and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+        # Close TCP
+        if tunnel.writer:
+            try:
+                tunnel.writer.close()
+                await tunnel.writer.wait_closed()
+            except Exception:
+                pass
+
+        # Close TUN device
+        if tunnel.tun_device:
+            tunnel.tun_device.close()
+
+        self.logger.info("Tunnel to AS%d torn down", peer_as)
+
+    async def teardown_all(self) -> None:
+        """Tear down all tunnels (called on shutdown)."""
+        for peer_as in list(self.tunnels.keys()):
+            await self.teardown_tunnel(peer_as)
+
+    def get_tunnel_address(self, peer_as: int) -> Optional[str]:
+        """Get our local overlay address for a specific peer tunnel."""
+        tunnel = self.tunnels.get(peer_as)
+        if tunnel and tunnel.running:
+            return tunnel.local_address
+        return None
+
+    def get_tunnel_stats(self) -> Dict:
+        """Get statistics for all tunnels."""
+        return {
+            f"AS{peer_as}": {
+                "local_address": t.local_address,
+                "remote_address": t.remote_address,
+                "tun_device": t.tun_device.name if t.tun_device else None,
+                "running": t.running,
+                **t.stats,
+            }
+            for peer_as, t in self.tunnels.items()
+        }


### PR DESCRIPTION
The tun.py (cross-platform TUN device) and tunnel.py (IP-over-TCP tunnel manager) were created but never committed. The Mac was running stubs instead of the real implementations.