### PR TITLE
Add nmap-mcp server and 3 network scanning skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ NetClaw ships with the full set of OpenClaw workspace markdown files. These are 
 
 ---
 
-## MCP Servers (37)
+## MCP Servers (38)
 
 | # | MCP Server | Repository | Transport | Function |
 |---|------------|------------|-----------|----------|
@@ -252,12 +252,13 @@ NetClaw ships with the full set of OpenClaw workspace markdown files. These are 
 | 44 | Grafana | [grafana/mcp-grafana](https://github.com/grafana/mcp-grafana) | uvx (Go) | Observability platform — dashboards, Prometheus PromQL, Loki LogQL, alerting, incidents, OnCall, annotations, panel rendering (75+ tools) |
 | 45 | Prometheus | [pab1it0/prometheus-mcp-server](https://github.com/pab1it0/prometheus-mcp-server) | stdio (Python) | Direct PromQL monitoring — instant/range queries, metric discovery with pagination, metric metadata, scrape target health, system health check (6 tools) |
 | 46 | Kubeshark | [kubeshark/kubeshark](https://github.com/kubeshark/kubeshark) | remote HTTP (Go) | Kubernetes L4/L7 traffic analysis — capture, pcap export, snapshots, KFL filtering, TCP/UDP flow stats, TLS decryption via eBPF (6 tools) |
+| 47 | nmap | [sbmilburn/nmap-mcp](https://github.com/sbmilburn/nmap-mcp) | stdio (Python) | Network scanning — host discovery, SYN/TCP/UDP port scanning, service/OS detection, NSE scripts, vuln scanning with CIDR allowlist + audit logging (14 tools) |
 
-All MCP servers communicate via stdio (JSON-RPC 2.0) through `scripts/mcp-call.py`. GitHub MCP runs via Docker. CML MCP is pip-installed (`cml-mcp`). NSO MCP is pip-installed (`cisco-nso-mcp-server`). FMC MCP runs as an HTTP server on port 8000. Meraki Magic MCP runs via FastMCP stdio (~804 Dashboard API endpoints). ThousandEyes community MCP runs via stdio (9 read-only tools); ThousandEyes official MCP is a remote HTTP endpoint hosted by Cisco at `https://api.thousandeyes.com/mcp` (~20 tools via `npx mcp-remote`). RADKit MCP runs via FastMCP stdio with certificate-based cloud relay auth (5 tools for remote device access). Nautobot MCP runs via MCP SDK stdio (5 IPAM tools, alternative to NetBox). Infrahub MCP runs via stdio (10 tools for schema-driven SoT, GraphQL queries, and versioned branches). Itential MCP is pip-installed (`itential-mcp`) and runs via stdio (65+ tools for network automation orchestration). JunOS MCP runs via stdio (10 tools for PyEZ/NETCONF device automation). Arista CVP MCP runs via uv/stdio (4 tools for CloudVision Portal device inventory, events, connectivity monitoring, and tag management). UML MCP runs via stdio (2 tools for 27+ diagram types via Kroki multi-engine rendering). Protocol MCP runs via stdio (10 tools for live BGP/OSPF/GRE control-plane participation using scapy-based protocol speakers). ContainerLab MCP runs via stdio (6 tools for containerized network lab lifecycle management via ContainerLab API). SD-WAN MCP runs via stdio (12 read-only tools for Cisco SD-WAN vManage fabric monitoring). Grafana MCP runs via `uvx mcp-grafana` (75+ tools for dashboards, Prometheus, Loki, alerting, incidents, OnCall). Prometheus MCP is pip-installed (`prometheus-mcp-server`) and runs via stdio (6 tools for direct PromQL queries, metric discovery, and scrape target health). Kubeshark MCP is a remote HTTP endpoint running inside a Kubernetes cluster (6 tools for L4/L7 traffic capture, pcap export, flow analysis, and TLS decryption via eBPF; access via `kubectl port-forward svc/kubeshark-hub 8898:8898`). AWS MCPs run via `uvx` (uv tool runner). GCP MCPs are remote HTTP endpoints hosted by Google (OAuth 2.0 auth). No persistent connections, no port management.
+All MCP servers communicate via stdio (JSON-RPC 2.0) through `scripts/mcp-call.py`. GitHub MCP runs via Docker. CML MCP is pip-installed (`cml-mcp`). NSO MCP is pip-installed (`cisco-nso-mcp-server`). FMC MCP runs as an HTTP server on port 8000. Meraki Magic MCP runs via FastMCP stdio (~804 Dashboard API endpoints). ThousandEyes community MCP runs via stdio (9 read-only tools); ThousandEyes official MCP is a remote HTTP endpoint hosted by Cisco at `https://api.thousandeyes.com/mcp` (~20 tools via `npx mcp-remote`). RADKit MCP runs via FastMCP stdio with certificate-based cloud relay auth (5 tools for remote device access). Nautobot MCP runs via MCP SDK stdio (5 IPAM tools, alternative to NetBox). Infrahub MCP runs via stdio (10 tools for schema-driven SoT, GraphQL queries, and versioned branches). Itential MCP is pip-installed (`itential-mcp`) and runs via stdio (65+ tools for network automation orchestration). JunOS MCP runs via stdio (10 tools for PyEZ/NETCONF device automation). Arista CVP MCP runs via uv/stdio (4 tools for CloudVision Portal device inventory, events, connectivity monitoring, and tag management). UML MCP runs via stdio (2 tools for 27+ diagram types via Kroki multi-engine rendering). Protocol MCP runs via stdio (10 tools for live BGP/OSPF/GRE control-plane participation using scapy-based protocol speakers). ContainerLab MCP runs via stdio (6 tools for containerized network lab lifecycle management via ContainerLab API). SD-WAN MCP runs via stdio (12 read-only tools for Cisco SD-WAN vManage fabric monitoring). Grafana MCP runs via `uvx mcp-grafana` (75+ tools for dashboards, Prometheus, Loki, alerting, incidents, OnCall). Prometheus MCP is pip-installed (`prometheus-mcp-server`) and runs via stdio (6 tools for direct PromQL queries, metric discovery, and scrape target health). Kubeshark MCP is a remote HTTP endpoint running inside a Kubernetes cluster (6 tools for L4/L7 traffic capture, pcap export, flow analysis, and TLS decryption via eBPF; access via `kubectl port-forward svc/kubeshark-hub 8898:8898`). nmap MCP runs via FastMCP stdio (14 tools for host discovery, port scanning, service/OS detection, NSE scripts, and vulnerability scanning with CIDR scope enforcement and audit logging). AWS MCPs run via `uvx` (uv tool runner). GCP MCPs are remote HTTP endpoints hosted by Google (OAuth 2.0 auth). No persistent connections, no port management.
 
 ---
 
-## Skills (82)
+## Skills (85)
 
 ### pyATS Device Skills (9)
 
@@ -351,6 +352,14 @@ All MCP servers communicate via stdio (JSON-RPC 2.0) through `scripts/mcp-call.p
 | Skill | What It Does |
 |-------|-------------|
 | **packet-analysis** | Deep pcap analysis via tshark. Upload a `.pcap` or `.pcapng` file to Slack and NetClaw analyzes it: protocol hierarchy, IP/TCP/UDP conversations, top endpoints, DNS queries, HTTP requests, expert info (retransmissions, errors), filtered packet inspection, and full JSON decode. 12 MCP tools for comprehensive L2-L7 packet investigation. |
+
+### nmap Network Scanning Skills (3)
+
+| Skill | What It Does |
+|-------|-------------|
+| **nmap-network-scan** | Host discovery and port scanning — ICMP/ARP host discovery, SYN/TCP/UDP port scanning on authorized networks. CIDR scope enforcement and audit logging. 6 tools for subnet discovery and targeted port scanning. |
+| **nmap-service-detection** | Service fingerprinting, OS detection, NSE scripts, and vulnerability scanning. Full recon sweeps combining SYN scan + service detection + OS fingerprinting + default NSE scripts. 5 tools for security assessment. |
+| **nmap-scan-management** | Custom nmap scans with arbitrary flags (scope-enforced), scan history listing, and result retrieval by ID. Before/after comparison workflows for change validation. 3 tools. |
 
 ### Cisco CML Skills (5)
 

--- a/workspace/skills/nmap-network-scan/SKILL.md
+++ b/workspace/skills/nmap-network-scan/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: nmap-network-scan
+description: "Host discovery and port scanning using nmap — ICMP/ARP host discovery, SYN/TCP/UDP port scanning with scope enforcement and audit logging"
+user-invocable: true
+metadata:
+  { "openclaw": { "requires": { "bins": ["python3", "nmap"], "env": ["NMAP_MCP_SCRIPT"] } } }
+---
+
+# Network Scanning with nmap
+
+Discover live hosts and scan ports on authorized networks using nmap MCP. All scans are scope-enforced (CIDR allowlist) and audit-logged.
+
+## How to Call the nmap MCP Tools
+
+```bash
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" TOOL_NAME '{"param":"value"}'
+```
+
+## When to Use
+
+- Discover what hosts are alive on a subnet before deeper analysis
+- Find open ports on network devices, servers, or lab infrastructure
+- Verify firewall rules by checking which ports are reachable
+- Pre-change/post-change port scans to confirm expected service exposure
+- Asset discovery on RFC1918 or lab networks
+
+## Available Tools
+
+| Tool | Purpose | Privileges |
+|------|---------|-----------|
+| `nmap_ping_scan` | ICMP+TCP host discovery (no port scan) | none |
+| `nmap_arp_discovery` | ARP host discovery (LAN only) | cap_net_raw |
+| `nmap_top_ports` | Fast scan of N most common ports | none |
+| `nmap_syn_scan` | SYN half-open port scan (fast, stealthy) | cap_net_raw |
+| `nmap_tcp_scan` | Full TCP connect scan (no root needed) | none |
+| `nmap_udp_scan` | UDP port scan (DNS, SNMP, NTP, etc.) | cap_net_raw |
+
+## Workflow: Subnet Discovery
+
+When asked "what's on this network?" or "scan this subnet":
+
+### Step 1: Host Discovery
+
+Find live hosts first — avoids wasting time port-scanning dead IPs.
+
+```bash
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_ping_scan '{"target":"192.168.1.0/24"}'
+```
+
+On directly-connected LANs, ARP discovery is more reliable:
+
+```bash
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_arp_discovery '{"target":"192.168.1.0/24"}'
+```
+
+### Step 2: Quick Port Scan
+
+Scan the top 100 common ports on discovered hosts:
+
+```bash
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_top_ports '{"target":"192.168.1.1","count":100}'
+```
+
+### Step 3: Targeted Port Scan
+
+For deeper scanning, use SYN scan (faster) or TCP connect scan:
+
+```bash
+# SYN scan — faster, requires cap_net_raw
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_syn_scan '{"target":"192.168.1.1","ports":"1-65535"}'
+
+# TCP connect — works without special privileges
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_tcp_scan '{"target":"192.168.1.1","ports":"22,80,443,8080"}'
+```
+
+### Step 4: UDP Services
+
+Check for UDP services (DNS, SNMP, TFTP, NTP, syslog):
+
+```bash
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_udp_scan '{"target":"192.168.1.1","ports":"53,67,68,69,123,161,162,500,514,1900"}'
+```
+
+## Tool Parameters
+
+### nmap_ping_scan
+- `target` (required): IP, hostname, or CIDR range
+
+### nmap_arp_discovery
+- `target` (required): CIDR range or IP (LAN segment only)
+
+### nmap_top_ports
+- `target` (required): IP, hostname, or CIDR range
+- `count` (optional): Number of top ports to scan (default 100, max 65535)
+
+### nmap_syn_scan
+- `target` (required): IP, hostname, or CIDR range
+- `ports` (optional): Port range (default "1-1024", use "common" for top 1000)
+
+### nmap_tcp_scan
+- `target` (required): IP, hostname, or CIDR range
+- `ports` (optional): Port range (default "1-1024")
+
+### nmap_udp_scan
+- `target` (required): IP, hostname, or CIDR range
+- `ports` (optional): Port list or range (default: common UDP service ports)
+
+## Scope Enforcement
+
+All targets are validated against the CIDR allowlist in `config.yaml`. Targets outside the allowed ranges are hard-rejected before nmap runs. Default allowed ranges:
+
+- `127.0.0.0/8` (loopback)
+- `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` (RFC1918)
+- `fd00::/8` (IPv6 ULA)
+
+## Output Format
+
+All tools return structured JSON with:
+- `scan_id` — unique identifier for retrieving results later
+- `target` — what was scanned
+- `hosts_up` / `per_host` — discovered hosts with open ports
+- `count` / `total_open` — summary counts
+
+## Important Rules
+
+- Always start with host discovery before port scanning large ranges
+- SYN scan is faster but requires cap_net_raw on the nmap binary
+- UDP scans are inherently slow — keep port lists targeted
+- Every scan is logged in the audit log for compliance
+- Scan results are persisted and retrievable via `nmap_list_scans` / `nmap_get_scan`

--- a/workspace/skills/nmap-scan-management/SKILL.md
+++ b/workspace/skills/nmap-scan-management/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: nmap-scan-management
+description: "Custom nmap scans with arbitrary flags, plus scan history retrieval and management"
+user-invocable: true
+metadata:
+  { "openclaw": { "requires": { "bins": ["python3", "nmap"], "env": ["NMAP_MCP_SCRIPT"] } } }
+---
+
+# nmap Scan Management
+
+Run custom nmap scans with arbitrary flags and manage scan history. All scans remain scope-enforced and audit-logged regardless of flags used.
+
+## How to Call the nmap MCP Tools
+
+```bash
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" TOOL_NAME '{"param":"value"}'
+```
+
+## When to Use
+
+- Run nmap with flags not covered by the purpose-built tools
+- Review past scan results without re-scanning
+- Compare before/after scans (pre-change vs post-change)
+- Retrieve a specific scan result by ID
+
+## Available Tools
+
+| Tool | Purpose |
+|------|---------|
+| `nmap_custom_scan` | Run nmap with arbitrary flags (scope-enforced + audit-logged) |
+| `nmap_list_scans` | List recent saved scans with IDs, timestamps, targets |
+| `nmap_get_scan` | Retrieve full results of a previous scan by ID |
+
+## Custom Scans
+
+For power users who need flags not covered by the dedicated tools:
+
+```bash
+# Aggressive scan with version detection
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_custom_scan '{"target":"192.168.1.1","flags":"-A -T4"}'
+
+# Scan specific ports with timing template
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_custom_scan '{"target":"10.0.0.0/24","flags":"-sS -p 22,80,443 -T3 --open"}'
+
+# Idle scan using a zombie host
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_custom_scan '{"target":"192.168.1.1","flags":"-sI 192.168.1.254"}'
+
+# IPv6 scan
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_custom_scan '{"target":"fd00:cc:1:2::1","flags":"-6 -sT -p 179,22,80"}'
+```
+
+**Safety:** The following are blocked in custom scans:
+- Shell metacharacters (`;`, `&`, `|`, `` ` ``, `$`, etc.)
+- Output-writing flags (`-oN`, `-oX`, `-oG`, `-oA`)
+- Path-based flags (`--datadir`, `--servicedb`, `--script` with path)
+
+Use the dedicated `nmap_script_scan` or `nmap_vuln_scan` tools for NSE scripts.
+
+## Scan History
+
+### List Recent Scans
+
+```bash
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_list_scans '{"limit":20}'
+```
+
+Returns newest-first list with scan_id, timestamp, tool used, and target.
+
+### Retrieve a Specific Scan
+
+```bash
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_get_scan '{"scan_id":"20250307_143022_a1b2c3"}'
+```
+
+Returns the full scan result as originally captured.
+
+## Workflow: Before/After Comparison
+
+When validating a change:
+
+1. **Before change:** Run a baseline scan and note the scan_id
+2. **Make the change** (firewall rule, service deploy, etc.)
+3. **After change:** Run the same scan again
+4. **Compare:** Retrieve both scans and diff the open ports / services
+
+```bash
+# Baseline
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_top_ports '{"target":"192.168.1.1","count":1000}'
+# Note: scan_id from output, e.g. "20250307_140000_abc123"
+
+# ... make changes ...
+
+# Post-change
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_top_ports '{"target":"192.168.1.1","count":1000}'
+
+# Retrieve both for comparison
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_get_scan '{"scan_id":"20250307_140000_abc123"}'
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_get_scan '{"scan_id":"20250307_141500_def456"}'
+```
+
+## Tool Parameters
+
+### nmap_custom_scan
+- `target` (required): IP, hostname, or CIDR range
+- `flags` (required): Raw nmap flags (do NOT include the target in flags)
+
+### nmap_list_scans
+- `limit` (optional): Max number of scans to return (default: 20, newest first)
+
+### nmap_get_scan
+- `scan_id` (required): The scan_id returned by any scan tool or nmap_list_scans
+
+## Important Rules
+
+- Custom scans still enforce the CIDR allowlist — out-of-scope targets are rejected
+- Every scan (including custom) is recorded in the audit log
+- All scan results are saved to disk and retrievable by scan_id
+- Do NOT put the target in the `flags` parameter — it's added automatically
+- Shell injection is blocked — forbidden characters are rejected

--- a/workspace/skills/nmap-service-detection/SKILL.md
+++ b/workspace/skills/nmap-service-detection/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: nmap-service-detection
+description: "Service fingerprinting, OS detection, NSE script execution, and vulnerability scanning using nmap MCP"
+user-invocable: true
+metadata:
+  { "openclaw": { "requires": { "bins": ["python3", "nmap"], "env": ["NMAP_MCP_SCRIPT"] } } }
+---
+
+# Service Detection & Vulnerability Scanning with nmap
+
+Identify running services, fingerprint operating systems, run NSE scripts, and check for known vulnerabilities on authorized targets.
+
+## How to Call the nmap MCP Tools
+
+```bash
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" TOOL_NAME '{"param":"value"}'
+```
+
+## When to Use
+
+- Identify what software/version is running on an open port
+- Fingerprint the OS of a network device or server
+- Run targeted NSE scripts (SSL cert check, banner grab, protocol probe)
+- Scan for known CVEs and common misconfigurations
+- Full reconnaissance sweep of a single host or small range
+
+## Available Tools
+
+| Tool | Purpose | Privileges |
+|------|---------|-----------|
+| `nmap_service_detection` | Service name + version on open ports (-sV) | none |
+| `nmap_os_detection` | OS fingerprinting (-O) | cap_net_raw |
+| `nmap_script_scan` | Run specific NSE scripts | none |
+| `nmap_vuln_scan` | Run the "vuln" NSE script category | none |
+| `nmap_full_recon` | SYN + service + OS + default scripts all-in-one | cap_net_raw |
+
+## Workflow: Service Identification
+
+When asked "what's running on this host?" or "identify the services":
+
+### Step 1: Service Version Detection
+
+```bash
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_service_detection '{"target":"192.168.1.1","ports":"common","intensity":7}'
+```
+
+Returns per-port: service name, product, version, CPE identifier.
+
+### Step 2: OS Fingerprinting
+
+```bash
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_os_detection '{"target":"192.168.1.1"}'
+```
+
+Works best when the target has at least one open and one closed port.
+
+## Workflow: Security Assessment
+
+When asked "check this host for vulnerabilities" or "security scan":
+
+### Step 1: Full Recon
+
+Run the all-in-one audit sweep:
+
+```bash
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_full_recon '{"target":"192.168.1.1","ports":"common"}'
+```
+
+This combines SYN scan + service detection + OS fingerprinting + default NSE scripts.
+
+### Step 2: Vulnerability Scan
+
+Run the vuln NSE category for known CVEs:
+
+```bash
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_vuln_scan '{"target":"192.168.1.1","ports":"common"}'
+```
+
+This is slow — use on specific targets, not wide ranges.
+
+### Step 3: Targeted Script Scans
+
+Run specific NSE scripts for focused checks:
+
+```bash
+# SSL certificate inspection
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_script_scan '{"target":"192.168.1.1","scripts":"ssl-cert,ssl-enum-ciphers","ports":"443"}'
+
+# HTTP title + headers
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_script_scan '{"target":"192.168.1.1","scripts":"http-title,http-headers","ports":"80,443,8080"}'
+
+# Banner grabbing
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_script_scan '{"target":"192.168.1.1","scripts":"banner","ports":"1-1024"}'
+
+# SMB enumeration
+python3 $MCP_CALL "python3 -u $NMAP_MCP_SCRIPT" nmap_script_scan '{"target":"192.168.1.1","scripts":"smb-enum-shares,smb-os-discovery","ports":"445"}'
+```
+
+## Tool Parameters
+
+### nmap_service_detection
+- `target` (required): IP, hostname, or CIDR range
+- `ports` (optional): Port range or "common" for top 1000 (default: "common")
+- `intensity` (optional): Version detection aggressiveness 0-9 (default: 7)
+
+### nmap_os_detection
+- `target` (required): Single IP or hostname (ranges don't work well)
+
+### nmap_script_scan
+- `target` (required): IP, hostname, or CIDR range
+- `scripts` (required): NSE script name(s), e.g. "ssl-cert", "http-title,http-headers", "banner"
+- `ports` (optional): Port range or "common" (default: "common")
+
+### nmap_vuln_scan
+- `target` (required): IP or hostname (keep scope tight)
+- `ports` (optional): Port range or "common" (default: "common")
+
+### nmap_full_recon
+- `target` (required): IP, hostname, or small CIDR range (/28 or smaller)
+- `ports` (optional): Port range or "common" (default: "common")
+
+## Common NSE Script Names
+
+| Script | Purpose |
+|--------|---------|
+| `ssl-cert` | Display SSL certificate details |
+| `ssl-enum-ciphers` | List supported SSL/TLS ciphers |
+| `http-title` | Grab HTML page title |
+| `http-headers` | Dump HTTP response headers |
+| `http-methods` | Check supported HTTP methods |
+| `banner` | Grab service banners |
+| `smb-enum-shares` | Enumerate SMB shares |
+| `smb-os-discovery` | Discover OS via SMB |
+| `ssh-hostkey` | Show SSH host keys |
+| `dns-brute` | DNS subdomain brute force |
+| `ftp-anon` | Check for anonymous FTP |
+
+## Output Format
+
+All tools return structured JSON:
+- `scan_id` — for retrieving results later
+- `per_host` — per-host breakdown with open ports, services, versions
+- `os_detection` — OS match name, accuracy, device type
+- `results` / `vulnerability_findings` — script output organized by port
+
+## Important Rules
+
+- OS detection requires at least one open and one closed port to fingerprint accurately
+- Vuln scans are slow — target specific hosts, not wide ranges
+- Full recon combines multiple scan types — takes longer but gives comprehensive results
+- All scans respect the CIDR allowlist and are audit-logged
+- Scan results persist and can be retrieved with `nmap_list_scans` / `nmap_get_scan`


### PR DESCRIPTION
Integrate sbmilburn/nmap-mcp — FastMCP server wrapping nmap with 14 tools for host discovery, port scanning, service/OS detection, NSE scripts, and vulnerability scanning. Includes CIDR allowlist scope enforcement and audit logging.

New skills:
- nmap-network-scan: host discovery + SYN/TCP/UDP port scanning (6 tools)
- nmap-service-detection: service/OS fingerprint + vuln assessment (5 tools)
- nmap-scan-management: custom scans + scan history retrieval (3 tools)