### PR TITLE
Improve MCP call robustness when servers emit stdout logs

### DIFF
--- a/scripts/mcp-call.py
+++ b/scripts/mcp-call.py
@@ -24,12 +24,39 @@ def send(proc, msg):
     proc.stdin.flush()
 
 
-def recv(proc, timeout=30):
-    """Read a JSON-RPC response from the MCP server via stdout."""
-    if select.select([proc.stdout], [], [], timeout)[0]:
-        line = proc.stdout.readline().decode().strip()
-        if line:
-            return json.loads(line)
+def recv(proc, timeout=30, expected_id=None):
+    """Read JSON-RPC messages from stdout and return the matching response.
+
+    Some MCP servers emit startup logs or notifications before the response we
+    care about. This function tolerates non-JSON lines and can optionally wait
+    for a specific JSON-RPC id.
+    """
+    deadline = time.monotonic() + timeout
+
+    while time.monotonic() < deadline:
+        remaining = max(0, deadline - time.monotonic())
+        if not select.select([proc.stdout], [], [], remaining)[0]:
+            break
+
+        raw = proc.stdout.readline()
+        if not raw:
+            continue
+
+        line = raw.decode(errors="replace").strip()
+        if not line:
+            continue
+
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            # Ignore non-JSON log lines on stdout.
+            continue
+
+        if expected_id is not None and msg.get("id") != expected_id:
+            continue
+
+        return msg
+
     return None
 
 
@@ -40,7 +67,15 @@ def main():
 
     server_cmd = sys.argv[1]
     tool_name = sys.argv[2]
-    args_json = json.loads(sys.argv[3]) if len(sys.argv) > 3 else {}
+
+    if len(sys.argv) > 3:
+        try:
+            args_json = json.loads(sys.argv[3])
+        except json.JSONDecodeError as exc:
+            print(f"Error: arguments-json must be valid JSON ({exc})", file=sys.stderr)
+            sys.exit(1)
+    else:
+        args_json = {}
 
     cmd_parts = shlex.split(server_cmd)
     proc = subprocess.Popen(
@@ -62,7 +97,7 @@ def main():
                 "clientInfo": {"name": "netclaw", "version": "1.0"},
             },
         })
-        init_resp = recv(proc, timeout=10)
+        init_resp = recv(proc, timeout=10, expected_id=0)
         if not init_resp:
             print("Error: No response to initialize", file=sys.stderr)
             sys.exit(1)
@@ -78,7 +113,7 @@ def main():
             "method": "tools/call",
             "params": {"name": tool_name, "arguments": args_json},
         })
-        resp = recv(proc, timeout=30)
+        resp = recv(proc, timeout=30, expected_id=1)
         if resp:
             print(json.dumps(resp.get("result", resp), indent=2))
         else:


### PR DESCRIPTION
## What changed
- Hardened `scripts/mcp-call.py` response handling so it no longer crashes when an MCP server emits non-JSON stdout lines.
- Updated `recv()` to keep reading until timeout, ignore non-JSON/log lines, and optionally wait for a specific JSON-RPC response id.
- Added explicit JSON parsing validation for `arguments-json` with a clear error message.

## Why
- Some MCP servers print startup logs or notifications before returning the JSON-RPC response. The previous implementation attempted to parse the first stdout line as JSON and could fail early.
- Matching by response id avoids accidentally treating unrelated notifications as tool-call results.
- Better input validation makes CLI failures easier to diagnose.

## Testing
- `python3 -m py_compile scripts/mcp-call.py`
- `scripts/clone_and_test.sh automateyournetwork/netclaw`
- Tests: not run (no tests found)
