### PR TITLE
feat: add EVE-NG MCP server, skills, and smoke test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ mcp-servers/*
 !mcp-servers/snmptrap-mcp/
 !mcp-servers/ipfix-mcp/
 !mcp-servers/gns3-mcp-server/
+!mcp-servers/eve-ng-mcp-server/
 !mcp-servers/prisma-sdwan-mcp/
 
 # Traces

--- a/mcp-servers/eve-ng-mcp-server/.env.example
+++ b/mcp-servers/eve-ng-mcp-server/.env.example
@@ -1,0 +1,28 @@
+# EVE-NG MCP Server — environment configuration
+# Copy to .env and fill in your values
+
+# EVE-NG server base URL (no trailing slash)
+EVE_URL=http://127.0.0.1
+
+# EVE-NG API credentials
+EVE_USER=your_eve_username
+EVE_PASSWORD=your_eve_password
+
+# Set to 'false' to disable TLS certificate verification (self-signed certs)
+EVE_VERIFY_SSL=true
+
+# Session cookie TTL in seconds (default 1800 = 30 minutes)
+# Re-login is triggered automatically when the session expires
+EVE_SESSION_TTL=1800
+
+# html5 login flag (-1 = auto, 0 = Java, 1 = HTML5)
+EVE_HTML5=-1
+
+# Host used for telnet console connections
+# Use 127.0.0.1 when MCP server runs on the EVE host itself
+# Use the EVE host IP when running MCP server remotely
+EVE_CONSOLE_HOST=127.0.0.1
+
+# Optional guest console credentials for platforms that prompt on login
+EVE_CONSOLE_USER=
+EVE_CONSOLE_PASSWORD=

--- a/mcp-servers/eve-ng-mcp-server/README.md
+++ b/mcp-servers/eve-ng-mcp-server/README.md
@@ -1,0 +1,262 @@
+# EVE-NG MCP Server
+
+MCP server for managing EVE-NG network lab environments. Provides natural language control over lab files, nodes, virtual networks, topology wiring, telnet console execution, and startup configuration management.
+
+## Features
+
+- **Lab Lifecycle**: List, inspect, create, delete, and export `.unl` lab files
+- **Node Operations**: Add/remove nodes from templates, start/stop individual nodes or whole labs, wipe to factory defaults
+- **Network & Topology**: Create virtual bridges, wire node interfaces to networks, inspect full topology
+- **Console Execution**: Full telnet console access for IOS/IOL, Junos, VPCS, Arista EOS, and NX-OS — mode-aware with automatic bootstrap
+- **Config Management**: Read, push, and clear node startup configs; bulk-export all configs before changes
+- **System**: EVE-NG status, available images, authentication check
+
+## Prerequisites
+
+- EVE-NG Community or Professional (tested on Community 6.x)
+- Python 3.10+
+- Network access to the EVE-NG host API (`/api/`) and console ports (`32768+`)
+- Valid EVE-NG credentials
+
+## Installation
+
+```bash
+cd mcp-servers/eve-ng-mcp-server
+
+pip install -r requirements.txt
+
+cp .env.example .env
+# Edit .env with your EVE-NG host details
+```
+
+## Configuration
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `EVE_URL` | Yes | `http://127.0.0.1` | EVE-NG base URL (no trailing slash) |
+| `EVE_USER` | Yes | - | EVE-NG username |
+| `EVE_PASSWORD` | Yes | - | EVE-NG password |
+| `EVE_VERIFY_SSL` | No | `true` | Verify TLS certificate (set `false` for self-signed) |
+| `EVE_SESSION_TTL` | No | `1800` | Session cookie TTL in seconds (30 min default) |
+| `EVE_HTML5` | No | `-1` | Login html5 flag (`-1` = auto, `0` = Java, `1` = HTML5) |
+| `EVE_CONSOLE_HOST` | No | `127.0.0.1` | Host for telnet console connections — set to EVE host IP when running MCP server off-host |
+| `EVE_CONSOLE_USER` | No | - | Optional guest console username for platforms that prompt on login |
+| `EVE_CONSOLE_PASSWORD` | No | - | Optional guest console password |
+
+### Auth Notes
+
+EVE-NG uses **cookie-based sessions**, not Bearer tokens. The client logs in once, caches the session cookie, and re-authenticates automatically when the session expires or returns 401/412.
+
+## Usage
+
+### As MCP Server (stdio transport)
+
+```bash
+python3 -u eve_ng_mcp_server.py
+```
+
+### Register in OpenClaw
+
+Add to `config/openclaw.json`:
+
+```json
+{
+  "mcpServers": {
+    "eve-ng": {
+      "command": "python3",
+      "args": ["-u", "mcp-servers/eve-ng-mcp-server/eve_ng_mcp_server.py"],
+      "env": {
+        "EVE_URL": "${EVE_URL}",
+        "EVE_USER": "${EVE_USER}",
+        "EVE_PASSWORD": "${EVE_PASSWORD}",
+        "EVE_CONSOLE_HOST": "${EVE_CONSOLE_HOST}"
+      }
+    }
+  }
+}
+```
+
+## Available Tools (34)
+
+### System (3 tools)
+
+| Tool | Parameters | Description |
+|------|------------|-------------|
+| `eve_status` | — | EVE-NG system status: version, CPU, memory, disk |
+| `eve_auth` | — | Verify authentication and get current user info |
+| `eve_list_images` | `node_type?` | List available images, optionally filtered by type (`iol`, `qemu`, `dynamips`) |
+
+### Lab Lifecycle (5 tools)
+
+| Tool | Parameters | Description |
+|------|------------|-------------|
+| `eve_list_labs` | `folder?` | List all labs recursively (default `/`) |
+| `eve_get_lab` | `lab_path` | Lab metadata: description, version, author |
+| `eve_create_lab` | `name, folder?, description?, version?, author?` | Create a new empty lab |
+| `eve_delete_lab` | `lab_path` | Delete lab and runtime objects |
+| `eve_export_lab` | `lab_path` | Export raw `.unl` XML content |
+
+### Node Operations (9 tools)
+
+| Tool | Parameters | Description |
+|------|------------|-------------|
+| `eve_list_nodes` | `lab_path` | All nodes with status, type, image, console port |
+| `eve_get_node` | `lab_path, node` | Full node details |
+| `eve_create_node` | `lab_path, name, node_type, template, image?, left?, top?, ram?, ethernet?, serial?, console?, cpu?, icon?` | Add node from template |
+| `eve_delete_node` | `lab_path, node` | Remove a node (stop first) |
+| `eve_start_node` | `lab_path, node` | Start node + poll until running |
+| `eve_stop_node` | `lab_path, node` | Stop node + poll until stopped |
+| `eve_start_lab` | `lab_path` | Start all nodes, return per-node results |
+| `eve_stop_lab` | `lab_path` | Stop all nodes, return per-node results |
+| `eve_wipe_node` | `lab_path, node` | Factory reset — clear NVRAM (stop first) |
+
+Nodes can be referenced by **name** (`R1`) or **numeric ID** — resolution is case-insensitive.
+
+### Network & Topology (7 tools)
+
+| Tool | Parameters | Description |
+|------|------------|-------------|
+| `eve_get_topology` | `lab_path` | Full topology: nodes, networks, link connections |
+| `eve_list_networks` | `lab_path` | All virtual networks with type and ID |
+| `eve_create_network` | `lab_path, name, network_type?, visibility?, left?, top?` | Create a virtual network |
+| `eve_delete_network` | `lab_path, network` | Delete a network |
+| `eve_list_node_interfaces` | `lab_path, node` | Node interfaces and their current network connections |
+| `eve_connect_interface` | `lab_path, node, interface_id, network` | Wire node interface to a network |
+| `eve_list_node_types` | — | All node templates installed on EVE-NG |
+
+#### Network Types
+
+| `network_type` | Description |
+|---|---|
+| `bridge` | Internal L2 bridge — isolated between nodes |
+| `ovs` | Open vSwitch bridge |
+| `pnet0`–`pnet9` | Physical uplink to EVE host interfaces |
+| `cloud0`–`cloud9` | Cloud/internet bridge mapped to host interfaces |
+
+### Console Execution (6 tools)
+
+| Tool | Parameters | Description |
+|------|------------|-------------|
+| `eve_discover_node` | `lab_path, node` | Resolve node → console host:port + running status |
+| `eve_exec_ios` | `lab_path, node, commands, config_mode?, save?, command_timeout?, wait?` | IOS / IOL / IOS-XE console |
+| `eve_exec_junos` | `lab_path, node, commands, command_timeout?, wait?` | Junos operational mode |
+| `eve_exec_vpcs` | `lab_path, node, commands, command_timeout?, dhcp_timeout?, prompt_timeout?` | VPCS console |
+| `eve_exec_eos` | `lab_path, node, commands, config_mode?, save?, command_timeout?, wait?` | Arista EOS console |
+| `eve_exec_nxos` | `lab_path, node, commands, config_mode?, save?, command_timeout?, wait?` | Cisco NX-OS console |
+
+#### OS Console Behavior
+
+| OS | Prompt detection | Auto-bootstrap | Pagination |
+|---|---|---|---|
+| IOS/IOL | `#`, `>`, `(config)#`, `(config-if)#`, `(config-router)#` | Bypasses setup dialog + autoinstall | `terminal length 0` |
+| Junos | `>` (op), `[edit]` (config), `%`/`$` (unix) | Login if needed, unix→cli, exit config mode | `set cli screen-length 0` |
+| VPCS | `VPCS>` | Waits for prompt | N/A |
+| Arista EOS | `#`, `>`, `(config)#`, `(config-XX)#` | Login if needed | `terminal length 0` + `terminal width 512` |
+| NX-OS | `#`, `>`, `(config)#`, `(config-XX)#` | Login + setup wizard dismiss | `terminal length 0` + `terminal width 511` |
+
+Console connections go via **raw telnet** to `EVE_CONSOLE_HOST:port`. Default port formula: `32768 + node_id` (overridden by the API `console` field when present).
+
+If a guest prompts for credentials, set `EVE_CONSOLE_USER` and `EVE_CONSOLE_PASSWORD` explicitly instead of relying on baked-in defaults.
+
+### Config Management (4 tools)
+
+| Tool | Parameters | Description |
+|------|------------|-------------|
+| `eve_get_node_config` | `lab_path, node` | Get stored startup config for one node |
+| `eve_set_node_config` | `lab_path, node, config` | Push startup config text (node must be stopped) |
+| `eve_get_all_configs` | `lab_path` | Bulk export all node configs in one call |
+| `eve_wipe_node_config` | `lab_path, node` | Clear startup config only (lighter than `eve_wipe_node`) |
+
+## Response Format
+
+All tools return JSON with a consistent envelope:
+
+```json
+// Success
+{
+  "success": true,
+  "data": { ... },
+  "message": "Human-readable summary",
+  "count": 5
+}
+
+// Error
+{
+  "success": false,
+  "error": "Node 'R99' not found. Available: ['R1', 'R2', 'R3']",
+  "error_code": "EVE_NOT_FOUND",
+  "status_code": 404
+}
+```
+
+## Error Codes
+
+| Code | HTTP | Description |
+|------|------|-------------|
+| `EVE_AUTH_FAILED` | 401 | Wrong credentials |
+| `EVE_SESSION_EXPIRED` | 412 | Session cookie expired (auto-retry) |
+| `EVE_NOT_FOUND` | 404 | Lab, node, or network doesn't exist |
+| `EVE_CONFLICT` | 409 | Name already in use |
+| `EVE_VALIDATION` | 400 | Invalid parameters |
+| `EVE_SERVER_ERROR` | 500 | EVE-NG internal error |
+| `EVE_UNREACHABLE` | — | Cannot connect to EVE-NG host |
+| `EVE_CONSOLE_TIMEOUT` | — | Cannot connect to telnet console port |
+
+## Example Commands
+
+```
+"Is EVE-NG healthy?"
+"What labs do I have?"
+"Start the BGP lab"
+"Show me the nodes in /Labs/demo.unl"
+"Add a vIOS router called R3 to the BGP lab"
+"Connect R1 interface 0 to Net12"
+"Run 'show ip route' on R1"
+"Configure R2 with OSPF and save"
+"Export all startup configs from the BGP lab before I change anything"
+"Wipe R1 back to factory and reload it"
+```
+
+## Workflow: Build a Lab from Scratch
+
+```
+1. eve_create_lab        name=Triangle-OSPF
+2. eve_create_node       (x3: R1, R2, R3 — node_type=iol, template=iol)
+3. eve_create_network    (x3: Net12, Net23, Net13 — network_type=bridge)
+4. eve_connect_interface (wire each router pair through its network)
+5. eve_set_node_config   (push pre-built startup configs while nodes are stopped)
+6. eve_start_lab         (boot all three nodes)
+7. eve_exec_ios          (verify OSPF adjacencies)
+```
+
+## Important Constraints
+
+- **Single-user**: This EVE-NG instance is single-user. Do not start a new lab while another is running.
+- **Wiring rule**: Stop affected nodes before changing interface connections to avoid stale host bridges.
+- **Boot lag**: API may report a node as "running" while it is still booting — use `eve_discover_node` to confirm console readiness.
+- **Config write**: `eve_set_node_config` requires the node to be stopped; configs are stored inside the `.unl` file.
+
+## Related Skills
+
+| Skill | Focus |
+|---|---|
+| `eve-ng-lab-management` | Lab CRUD, system status, images |
+| `eve-ng-node-operations` | Node lifecycle, start/stop/wipe |
+| `eve-lab-topology-build` | Networks, interface wiring, topology inspection |
+| `eve-ng-console-ops` | Telnet console execution across all supported OSes |
+| `eve-ng-config-ops` | Startup config read/push/clear/bulk-export |
+| `eve-lab-topology-design` | Design planning and `.unl` validation |
+
+## Smoke Test
+
+From the repo root:
+
+```bash
+python3 mcp-servers/eve-ng-mcp-server/tests/test_eve_skills_smoke.py
+```
+
+This validates the EVE skill docs against the MCP server tool set and checks that the UNL validator script launches correctly.
+
+## License
+
+Part of the NetClaw project.

--- a/mcp-servers/eve-ng-mcp-server/eve_ng_mcp_server.py
+++ b/mcp-servers/eve-ng-mcp-server/eve_ng_mcp_server.py
@@ -1,0 +1,1820 @@
+#!/usr/bin/env python3
+"""
+EVE-NG MCP Server - Network lab management via Model Context Protocol.
+
+34 tools across 6 domains:
+  System        (3)  — status, auth, list images
+  Lab Lifecycle (5)  — list, get, create, delete, export
+  Node Ops      (9)  — list, get, create, delete, start, stop, start-lab, stop-lab, wipe
+  Network/Topo  (7)  — topology, list-nets, create-net, delete-net, interfaces, connect, node-types
+  Console Exec  (6)  — discover, exec-ios, exec-junos, exec-vpcs, exec-eos, exec-nxos
+  Config Mgmt   (4)  — get-config, set-config, get-all-configs, wipe-config
+
+Auth: cookie-based session (EVE-NG does not use Bearer tokens).
+      Session TTL tracked; re-login triggered on expiry or 401/412.
+"""
+
+import json
+import logging
+import os
+import re
+import socket
+import sys
+import time
+from functools import wraps
+from typing import Any, Optional
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(name)s | %(levelname)s | %(message)s",
+    stream=sys.stderr,
+)
+log = logging.getLogger("eve-ng-mcp")
+
+try:
+    import httpx
+    from fastmcp import FastMCP
+except ImportError as e:
+    log.error("Missing required dependency: %s", e)
+    log.error("Install with: pip install fastmcp httpx python-dotenv")
+    sys.exit(1)
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+EVE_URL               = os.getenv("EVE_URL", "http://127.0.0.1")
+EVE_USER              = os.getenv("EVE_USER", "")
+EVE_PASSWORD          = os.getenv("EVE_PASSWORD", "")
+EVE_VERIFY_SSL        = os.getenv("EVE_VERIFY_SSL", "true").lower() == "true"
+EVE_SESSION_TTL       = int(os.getenv("EVE_SESSION_TTL", "1800"))   # 30 minutes
+EVE_HTML5             = int(os.getenv("EVE_HTML5", "-1"))
+EVE_CONSOLE_HOST      = os.getenv("EVE_CONSOLE_HOST", "127.0.0.1")
+EVE_CONSOLE_USER      = os.getenv("EVE_CONSOLE_USER", "")
+EVE_CONSOLE_PASSWORD  = os.getenv("EVE_CONSOLE_PASSWORD", "")
+
+# =============================================================================
+# EVE-NG HTTP Client
+# =============================================================================
+
+class EVEClient:
+    """HTTP client for EVE-NG REST API with cookie-based session caching."""
+
+    RETRYABLE_CODES = {401, 412}
+
+    def __init__(self, base_url: str, username: str, password: str,
+                 verify_ssl: bool = True, session_ttl: int = 1800, html5: int = -1):
+        self.base_url = base_url.rstrip("/")
+        self.username = username
+        self.password = password
+        self.html5 = html5
+        self.session_ttl = session_ttl
+        self._session_expires: float = 0
+        self._client = httpx.Client(
+            verify=verify_ssl,
+            timeout=30.0,
+            headers={"Accept": "application/json", "User-Agent": "eve-ng-mcp/1.0"},
+        )
+
+    def _login(self):
+        """Authenticate and cache session cookie."""
+        log.info("Authenticating with EVE-NG...")
+        resp = self._client.post(
+            f"{self.base_url}/api/auth/login",
+            json={"username": self.username, "password": self.password, "html5": self.html5},
+        )
+        if resp.status_code not in (200, 204):
+            raise EVEError("EVE_AUTH_FAILED", f"Login failed: HTTP {resp.status_code}", resp.status_code)
+        self._session_expires = time.time() + self.session_ttl
+        log.info("EVE-NG authentication successful")
+
+    def _ensure_auth(self):
+        if time.time() >= self._session_expires:
+            self._login()
+
+    def request(self, method: str, path: str, **kwargs) -> httpx.Response:
+        """Authenticated request with one auto-retry on session errors."""
+        self._ensure_auth()
+        url = f"{self.base_url}{path}"
+        try:
+            resp = self._client.request(method, url, **kwargs)
+            if resp.status_code in self.RETRYABLE_CODES:
+                log.info("Session error %s — re-authenticating", resp.status_code)
+                self._session_expires = 0
+                self._login()
+                resp = self._client.request(method, url, **kwargs)
+            return resp
+        except httpx.ConnectError:
+            raise EVEError("EVE_UNREACHABLE", f"Cannot connect to EVE-NG at {self.base_url}", -1)
+        except httpx.TimeoutException:
+            raise EVEError("EVE_UNREACHABLE", "Request to EVE-NG timed out", -1)
+
+    def get(self, path: str, **kw) -> httpx.Response:
+        return self.request("GET", path, **kw)
+
+    def post(self, path: str, **kw) -> httpx.Response:
+        return self.request("POST", path, **kw)
+
+    def put(self, path: str, **kw) -> httpx.Response:
+        return self.request("PUT", path, **kw)
+
+    def delete(self, path: str, **kw) -> httpx.Response:
+        return self.request("DELETE", path, **kw)
+
+
+# =============================================================================
+# Error Handling
+# =============================================================================
+
+class EVEError(Exception):
+    """Structured EVE-NG error with code and HTTP status."""
+
+    def __init__(self, error_code: str, message: str, status_code: int = 500):
+        self.error_code = error_code
+        self.message = message
+        self.status_code = status_code
+        super().__init__(message)
+
+    def to_dict(self) -> dict:
+        return {
+            "success": False,
+            "error": self.message,
+            "error_code": self.error_code,
+            "status_code": self.status_code,
+        }
+
+
+_HTTP_ERROR_MAP = {
+    400: "EVE_VALIDATION",
+    401: "EVE_AUTH_FAILED",
+    404: "EVE_NOT_FOUND",
+    409: "EVE_CONFLICT",
+    412: "EVE_SESSION_EXPIRED",
+    500: "EVE_SERVER_ERROR",
+}
+
+
+def handle_eve_response(response: httpx.Response, success_codes: list | None = None) -> Any:
+    """Parse EVE-NG API response. Unwraps the {'status':'success','data':{}} envelope."""
+    success_codes = success_codes or [200, 201, 204]
+    if response.status_code in success_codes:
+        if response.status_code == 204 or not response.content:
+            return None
+        body = response.json()
+        # EVE-NG sometimes returns HTTP 200 with a failure body — check application status.
+        if isinstance(body, dict) and body.get("status") == "fail":
+            eve_code = body.get("code", "")
+            msg = body.get("message") or str(body)
+            raise EVEError("EVE_SERVER_ERROR", f"EVE error {eve_code}: {msg}", response.status_code)
+        if isinstance(body, dict) and "data" in body:
+            return body["data"]
+        return body
+
+    code = _HTTP_ERROR_MAP.get(response.status_code, "EVE_SERVER_ERROR")
+    try:
+        body = response.json()
+        msg = body.get("message") or body.get("data") or str(body)
+        if isinstance(msg, dict):
+            msg = json.dumps(msg)
+    except Exception:
+        msg = response.text or f"HTTP {response.status_code}"
+    raise EVEError(code, str(msg), response.status_code)
+
+
+def success_response(data: Any = None, message: str | None = None, count: int | None = None) -> str:
+    result: dict = {"success": True}
+    if data is not None:
+        result["data"] = data
+    if message:
+        result["message"] = message
+    if count is not None:
+        result["count"] = count
+    return json.dumps(result, indent=2)
+
+
+def error_response(error: Exception) -> str:
+    if isinstance(error, EVEError):
+        return json.dumps(error.to_dict(), indent=2)
+    return json.dumps({
+        "success": False,
+        "error": str(error),
+        "error_code": "EVE_SERVER_ERROR",
+        "status_code": 500,
+    }, indent=2)
+
+
+# =============================================================================
+# GAIT Audit Logging
+# =============================================================================
+
+def with_gait_logging(operation: str):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            log.info("GAIT: Starting %s", operation)
+            try:
+                result = func(*args, **kwargs)
+                log.info("GAIT: Completed %s", operation)
+                return result
+            except Exception as exc:
+                log.error("GAIT: Failed %s — %s", operation, exc)
+                raise
+        return wrapper
+    return decorator
+
+
+# =============================================================================
+# Path and ID Helpers
+# =============================================================================
+
+def normalize_lab_path(path: str) -> str:
+    """Ensure lab path has leading slash and .unl extension."""
+    path = path.strip()
+    if not path.startswith("/"):
+        path = "/" + path
+    if not path.endswith(".unl"):
+        path += ".unl"
+    return path
+
+
+def normalize_folder_path(path: str) -> str:
+    path = path.strip()
+    if not path.startswith("/"):
+        path = "/" + path
+    return path
+
+
+def collect_labs(client: EVEClient, folder: str = "/") -> list:
+    """Recursively collect all .unl lab paths from folder tree."""
+    folder = normalize_folder_path(folder)
+    try:
+        raw = client.get(f"/api/folders{folder}").json()
+    except Exception:
+        return []
+    payload = raw.get("data") if isinstance(raw, dict) else raw
+    if not isinstance(payload, dict):
+        return []
+    labs: list = []
+    prefix = "" if folder == "/" else folder.rstrip("/")
+    for lab in payload.get("labs") or []:
+        name = lab.get("file") or lab.get("name", "")
+        if name:
+            labs.append(f"{prefix}/{name}")
+    for sub in payload.get("folders") or []:
+        fname = sub.get("name", "")
+        if fname and fname not in (".", ".."):
+            sub_path = f"/{fname}" if folder == "/" else f"{folder.rstrip('/')}/{fname}"
+            labs.extend(collect_labs(client, sub_path))
+    return labs
+
+
+def resolve_node_id(client: EVEClient, lab_path: str, node_ref: str) -> str:
+    """Resolve node name or numeric string to numeric ID string."""
+    if str(node_ref).isdigit():
+        return str(node_ref)
+    response = client.get(f"/api/labs{normalize_lab_path(lab_path)}/nodes")
+    data = handle_eve_response(response)
+    if isinstance(data, dict):
+        for nid, node in data.items():
+            if isinstance(node, dict) and node.get("name", "").lower() == str(node_ref).lower():
+                return str(nid)
+        available = [n.get("name", nid) for nid, n in data.items() if isinstance(n, dict)]
+    else:
+        available = []
+    raise EVEError("EVE_NOT_FOUND", f"Node '{node_ref}' not found. Available: {available}", 404)
+
+
+def resolve_network_id(client: EVEClient, lab_path: str, net_ref: str) -> str:
+    """Resolve network name or numeric string to numeric ID string."""
+    if str(net_ref).isdigit():
+        return str(net_ref)
+    response = client.get(f"/api/labs{normalize_lab_path(lab_path)}/networks")
+    data = handle_eve_response(response)
+    if isinstance(data, dict):
+        for nid, net in data.items():
+            if isinstance(net, dict) and net.get("name", "").lower() == str(net_ref).lower():
+                return str(nid)
+        available = [n.get("name", nid) for nid, n in data.items() if isinstance(n, dict)]
+    else:
+        available = []
+    raise EVEError("EVE_NOT_FOUND", f"Network '{net_ref}' not found. Available: {available}", 404)
+
+
+def node_is_running(node: dict) -> bool:
+    try:
+        return int(node.get("status", 0)) != 0
+    except Exception:
+        return False
+
+
+def ensure_nodes_stopped_for_link_edit(client: EVEClient, lab_path: str, node_refs: list[str], polls: int = 8, interval: float = 2.0) -> dict:
+    """Refuse link edits when any referenced node is still running after polling."""
+    last = {}
+    for _ in range(polls):
+        response = client.get(f"/api/labs{normalize_lab_path(lab_path)}/nodes")
+        data = handle_eve_response(response)
+        if not isinstance(data, dict):
+            return {}
+        last = data
+        by_id = {str(nid): node for nid, node in data.items() if isinstance(node, dict)}
+        by_name = {str(node.get("name", "")).lower(): (str(nid), node) for nid, node in data.items() if isinstance(node, dict)}
+        running = []
+        for ref in node_refs:
+            ref_s = str(ref)
+            if ref_s.isdigit():
+                node = by_id.get(ref_s)
+                node_id = ref_s
+            else:
+                resolved = by_name.get(ref_s.lower())
+                if not resolved:
+                    continue
+                node_id, node = resolved
+            if node and node_is_running(node):
+                running.append({"node": node.get("name", node_id), "node_id": node_id, "status": node.get("status")})
+        if not running:
+            return data
+        time.sleep(interval)
+    names = ", ".join(item["node"] for item in running)
+    raise EVEError(
+        "EVE_CONFLICT",
+        f"Link edits require affected endpoint nodes to be stopped first. Still running: {names}",
+        409,
+    )
+
+
+def poll_node_status(client: EVEClient, lab_path: str, node_id: str,
+                     expect_running: bool, polls: int = 5, interval: float = 2.0) -> dict:
+    """Poll until node reaches expected state. Returns final nodes dict."""
+    last: dict = {}
+    for _ in range(polls):
+        try:
+            data = handle_eve_response(client.get(f"/api/labs{normalize_lab_path(lab_path)}/nodes"))
+            if isinstance(data, dict):
+                last = data
+                node = data.get(str(node_id), {})
+                if isinstance(node, dict) and node_is_running(node) == expect_running:
+                    break
+        except Exception:
+            pass
+        time.sleep(interval)
+    return last
+
+
+def build_verification(action: str, node_id: str, before: dict, after: dict) -> dict:
+    bn = before.get(str(node_id), {})
+    an = after.get(str(node_id), {})
+    before_run = node_is_running(bn) if isinstance(bn, dict) else None
+    after_run  = node_is_running(an) if isinstance(an, dict) else None
+    verified = bool(after_run) if action == "start" else (after_run is False)
+    return {
+        "verified": verified,
+        "before_running": before_run,
+        "after_running": after_run,
+        "note": "EVE-NG node status can lag; polling applied after action.",
+    }
+
+
+def get_console_port(client: EVEClient, lab_path: str, node_id: str) -> int:
+    """Get console port from node data; fall back to 32768+id formula."""
+    try:
+        data = handle_eve_response(client.get(f"/api/labs{normalize_lab_path(lab_path)}/nodes/{node_id}"))
+        if isinstance(data, dict):
+            port = data.get("console")
+            if port and int(port) > 0:
+                return int(port)
+    except Exception:
+        pass
+    return 32768 + int(node_id)
+
+
+# =============================================================================
+# Console Engine — Telnet Sessions
+# =============================================================================
+
+READ_CHUNK = 65535
+
+IOS_PROMPT_RE  = re.compile(r'(?P<prompt>[A-Za-z0-9_.-]+(?:\([^\r\n)]*\))?[>#])\s*$')
+VPCS_PROMPT_RE = re.compile(r'VPCS>\s*$')
+JUNOS_OP_RE    = re.compile(r'(?m)^[^\r\n\s>]+>\s*$')
+JUNOS_CFG_RE   = re.compile(r'(?m)^\[[^\r\n]+\]\s*\n[^\r\n\s#]+#\s*$')
+EOS_PROMPT_RE  = re.compile(r'(?P<prompt>[A-Za-z0-9_.-]+(?:\([^\r\n)]*\))?[>#])\s*$')
+NXOS_PROMPT_RE = re.compile(r'(?P<prompt>[A-Za-z0-9_.-]+(?:\([^\r\n)]*\))?[>#])\s*$')
+
+
+class TelnetSession:
+    """Raw telnet session for EVE-NG console access."""
+
+    def __init__(self, host: str, port: int, timeout: float = 1.5):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.sock: socket.socket | None = None
+
+    def __enter__(self):
+        self.sock = socket.socket()
+        self.sock.settimeout(self.timeout)
+        try:
+            self.sock.connect((self.host, self.port))
+        except (ConnectionRefusedError, OSError) as exc:
+            raise EVEError("EVE_CONSOLE_TIMEOUT",
+                           f"Cannot connect to console {self.host}:{self.port}: {exc}", -2)
+        return self
+
+    def __exit__(self, *_):
+        if self.sock:
+            try:
+                self.sock.close()
+            except Exception:
+                pass
+            self.sock = None
+
+    def recv_all(self, wait: float = 0.7, loops: int = 4) -> str:
+        time.sleep(wait)
+        out = ""
+        for _ in range(loops):
+            try:
+                data = self.sock.recv(READ_CHUNK)
+                if not data:
+                    break
+                out += data.decode("utf-8", "ignore")
+                if len(data) < READ_CHUNK:
+                    break
+            except Exception:
+                break
+        return out
+
+    def recv_until(self, pattern, timeout: float = 10.0, poll: float = 0.2) -> str:
+        end = time.time() + timeout
+        out = ""
+        while time.time() < end:
+            try:
+                data = self.sock.recv(READ_CHUNK)
+                if data:
+                    out += data.decode("utf-8", "ignore")
+                    if pattern.search(out):
+                        return out
+                    continue
+            except socket.timeout:
+                pass
+            except Exception:
+                break
+            time.sleep(poll)
+        return out
+
+    def send(self, command: str, wait: float = 0.7) -> str:
+        self.sock.sendall((command + "\r").encode())
+        return self.recv_all(wait=wait)
+
+    def send_until(self, command: str, pattern, timeout: float = 10.0) -> str:
+        self.sock.sendall((command + "\r").encode())
+        return self.recv_until(pattern, timeout=timeout)
+
+
+# --- IOS / IOL / IOS-XE ---
+
+def detect_ios_mode(text: str) -> dict:
+    for line in reversed([l.strip() for l in text.splitlines() if l.strip()]):
+        m = IOS_PROMPT_RE.search(line)
+        if not m:
+            continue
+        p = m.group("prompt")
+        if "(config-router)" in p: return {"prompt": p, "mode": "config-router"}
+        if "(config-subif)" in p:  return {"prompt": p, "mode": "config-subif"}
+        if "(config-if)" in p:     return {"prompt": p, "mode": "config-if"}
+        if "(config)" in p:        return {"prompt": p, "mode": "config"}
+        if p.endswith("#"):        return {"prompt": p, "mode": "privileged"}
+        if p.endswith(">"):        return {"prompt": p, "mode": "exec"}
+    return {"prompt": None, "mode": "unknown"}
+
+
+def bootstrap_ios(session: TelnetSession) -> list:
+    transcript = []
+    text = session.recv_all(wait=1.0, loops=6)
+    transcript.append({"command": None, "output": text, "mode_after": detect_ios_mode(text)})
+    if "initial configuration dialog" in text:
+        text = session.send("no", wait=0.8)
+        transcript.append({"command": "no", "output": text, "mode_after": detect_ios_mode(text)})
+    if "terminate autoinstall" in text:
+        text = session.send("yes", wait=0.8)
+        transcript.append({"command": "yes", "output": text, "mode_after": detect_ios_mode(text)})
+    if "Press RETURN to get started" in text:
+        text = session.send("", wait=0.8)
+        transcript.append({"command": "", "output": text, "mode_after": detect_ios_mode(text)})
+    return transcript
+
+
+def ensure_ios_privileged(session: TelnetSession) -> list:
+    transcript = []
+    wake = session.send("", wait=0.5)
+    mode = detect_ios_mode(wake)
+    transcript.append({"command": "", "output": wake, "mode_after": mode})
+    if mode["mode"] in ("config-router", "config-subif", "config-if", "config"):
+        out = session.send("end", wait=0.7)
+        mode = detect_ios_mode(out)
+        transcript.append({"command": "end", "output": out, "mode_after": mode})
+    if mode["mode"] == "exec":
+        out = session.send("enable", wait=0.7)
+        mode = detect_ios_mode(out)
+        transcript.append({"command": "enable", "output": out, "mode_after": mode})
+    out = session.send("terminal length 0", wait=0.7)
+    transcript.append({"command": "terminal length 0", "output": out, "mode_after": detect_ios_mode(out)})
+    return transcript
+
+
+def ensure_ios_config(session: TelnetSession) -> list:
+    transcript = ensure_ios_privileged(session)
+    out = session.send("configure terminal", wait=0.7)
+    transcript.append({"command": "configure terminal", "output": out, "mode_after": detect_ios_mode(out)})
+    return transcript
+
+
+def run_ios_command(session: TelnetSession, cmd: str, wait: float = 0.8, timeout: float = 15.0) -> str:
+    lower = cmd.strip().lower()
+    if lower.startswith("ping ") or lower.startswith("traceroute "):
+        return session.send_until(cmd, IOS_PROMPT_RE, timeout=timeout)
+    return session.send(cmd, wait=wait)
+
+
+# --- Junos ---
+
+def detect_junos_mode(text: str) -> dict:
+    if JUNOS_CFG_RE.search(text):
+        lines = [l.rstrip() for l in text.splitlines() if l.strip()]
+        return {"prompt": lines[-1] if lines else None, "mode": "config"}
+    m = JUNOS_OP_RE.search(text)
+    if m:
+        return {"prompt": m.group(0).strip(), "mode": "operational"}
+    return {"prompt": None, "mode": "unknown"}
+
+
+def ensure_junos_operational(session: TelnetSession) -> list:
+    transcript = []
+    wake = session.send("", wait=0.7)
+    mode = detect_junos_mode(wake)
+    transcript.append({"command": "", "output": wake, "mode_after": mode})
+    if "login:" in wake:
+        out = session.send("root", wait=0.8)
+        transcript.append({"command": "root", "output": out, "mode_after": detect_junos_mode(out)})
+        if "Password:" in out:
+            out = session.send("eve-ng", wait=1.0)
+            mode = detect_junos_mode(out)
+            transcript.append({"command": "<password>", "output": out, "mode_after": mode})
+            wake = out
+    if wake.strip().endswith("%") or wake.strip().endswith("$"):
+        out = session.send("cli", wait=1.0)
+        mode = detect_junos_mode(out)
+        transcript.append({"command": "cli", "output": out, "mode_after": mode})
+    elif mode["mode"] == "config":
+        out = session.send("exit configuration-mode", wait=0.8)
+        transcript.append({"command": "exit configuration-mode", "output": out,
+                            "mode_after": detect_junos_mode(out)})
+    out = session.send("set cli screen-length 0", wait=0.8)
+    transcript.append({"command": "set cli screen-length 0", "output": out,
+                        "mode_after": detect_junos_mode(out)})
+    out = session.send("set cli screen-width 0", wait=0.8)
+    transcript.append({"command": "set cli screen-width 0", "output": out,
+                        "mode_after": detect_junos_mode(out)})
+    return transcript
+
+
+def run_junos_command(session: TelnetSession, cmd: str, timeout: float = 15.0) -> str:
+    normalized = cmd.strip()
+    lower = normalized.lower()
+    if lower.startswith("show ") and "| no-more" not in lower:
+        normalized += " | no-more"
+    return session.send_until(normalized, JUNOS_OP_RE, timeout=timeout)
+
+
+# --- Arista EOS ---
+
+def detect_eos_mode(text: str) -> dict:
+    for line in reversed([l.strip() for l in text.splitlines() if l.strip()]):
+        m = EOS_PROMPT_RE.search(line)
+        if not m:
+            continue
+        p = m.group("prompt")
+        if "(config-" in p: return {"prompt": p, "mode": "config-sub"}
+        if "(config)" in p:  return {"prompt": p, "mode": "config"}
+        if p.endswith("#"):  return {"prompt": p, "mode": "privileged"}
+        if p.endswith(">"):  return {"prompt": p, "mode": "exec"}
+    return {"prompt": None, "mode": "unknown"}
+
+
+def ensure_eos_privileged(session: TelnetSession) -> list:
+    transcript = []
+    wake = session.send("", wait=0.7)
+    mode = detect_eos_mode(wake)
+    transcript.append({"command": "", "output": wake, "mode_after": mode})
+    if ("login:" in wake or "Username:" in wake) and EVE_CONSOLE_USER:
+        out = session.send(EVE_CONSOLE_USER, wait=0.8)
+        transcript.append({"command": "<username>", "output": out, "mode_after": detect_eos_mode(out)})
+    if mode["mode"] in ("config", "config-sub"):
+        out = session.send("end", wait=0.7)
+        mode = detect_eos_mode(out)
+        transcript.append({"command": "end", "output": out, "mode_after": mode})
+    if mode["mode"] == "exec":
+        out = session.send("enable", wait=0.7)
+        mode = detect_eos_mode(out)
+        transcript.append({"command": "enable", "output": out, "mode_after": mode})
+    out = session.send("terminal length 0", wait=0.7)
+    transcript.append({"command": "terminal length 0", "output": out, "mode_after": detect_eos_mode(out)})
+    out = session.send("terminal width 512", wait=0.7)
+    transcript.append({"command": "terminal width 512", "output": out, "mode_after": detect_eos_mode(out)})
+    return transcript
+
+
+def ensure_eos_config(session: TelnetSession) -> list:
+    transcript = ensure_eos_privileged(session)
+    out = session.send("configure terminal", wait=0.7)
+    transcript.append({"command": "configure terminal", "output": out, "mode_after": detect_eos_mode(out)})
+    return transcript
+
+
+def run_eos_command(session: TelnetSession, cmd: str, wait: float = 0.8, timeout: float = 15.0) -> str:
+    lower = cmd.strip().lower()
+    if lower.startswith("ping ") or lower.startswith("traceroute "):
+        return session.send_until(cmd, EOS_PROMPT_RE, timeout=timeout)
+    return session.send(cmd, wait=wait)
+
+
+# --- Cisco NX-OS ---
+
+def detect_nxos_mode(text: str) -> dict:
+    for line in reversed([l.strip() for l in text.splitlines() if l.strip()]):
+        m = NXOS_PROMPT_RE.search(line)
+        if not m:
+            continue
+        p = m.group("prompt")
+        if "(config-" in p: return {"prompt": p, "mode": "config-sub"}
+        if "(config)" in p:  return {"prompt": p, "mode": "config"}
+        if p.endswith("#"):  return {"prompt": p, "mode": "privileged"}
+        if p.endswith(">"):  return {"prompt": p, "mode": "exec"}
+    return {"prompt": None, "mode": "unknown"}
+
+
+def ensure_nxos_privileged(session: TelnetSession) -> list:
+    transcript = []
+    wake = session.send("", wait=1.0)
+    mode = detect_nxos_mode(wake)
+    transcript.append({"command": "", "output": wake, "mode_after": mode})
+    if ("login:" in wake or "Login:" in wake) and EVE_CONSOLE_USER:
+        out = session.send(EVE_CONSOLE_USER, wait=1.0)
+        transcript.append({"command": "<username>", "output": out, "mode_after": detect_nxos_mode(out)})
+        if "Password:" in out and EVE_CONSOLE_PASSWORD:
+            out = session.send(EVE_CONSOLE_PASSWORD, wait=1.0)
+            transcript.append({"command": "<password>", "output": out, "mode_after": detect_nxos_mode(out)})
+    # Dismiss first-boot setup wizard
+    if ("Do you want to enforce secure password" in wake
+            or "Would you like to enter the basic configuration" in wake):
+        out = session.send("no", wait=1.0)
+        transcript.append({"command": "no", "output": out, "mode_after": detect_nxos_mode(out)})
+    if mode["mode"] in ("config", "config-sub"):
+        out = session.send("end", wait=0.7)
+        mode = detect_nxos_mode(out)
+        transcript.append({"command": "end", "output": out, "mode_after": mode})
+    out = session.send("terminal length 0", wait=0.7)
+    transcript.append({"command": "terminal length 0", "output": out, "mode_after": detect_nxos_mode(out)})
+    out = session.send("terminal width 511", wait=0.7)
+    transcript.append({"command": "terminal width 511", "output": out, "mode_after": detect_nxos_mode(out)})
+    return transcript
+
+
+def ensure_nxos_config(session: TelnetSession) -> list:
+    transcript = ensure_nxos_privileged(session)
+    out = session.send("configure terminal", wait=0.7)
+    transcript.append({"command": "configure terminal", "output": out, "mode_after": detect_nxos_mode(out)})
+    return transcript
+
+
+def run_nxos_command(session: TelnetSession, cmd: str, wait: float = 0.8, timeout: float = 15.0) -> str:
+    lower = cmd.strip().lower()
+    if lower.startswith("ping ") or lower.startswith("traceroute "):
+        return session.send_until(cmd, NXOS_PROMPT_RE, timeout=timeout)
+    return session.send(cmd, wait=wait)
+
+
+# =============================================================================
+# MCP Server + Client Singleton
+# =============================================================================
+
+mcp = FastMCP("EVE-NG MCP Server")
+_client: Optional[EVEClient] = None
+
+
+def get_client() -> EVEClient:
+    global _client
+    if _client is None:
+        if not EVE_USER or not EVE_PASSWORD:
+            raise EVEError("EVE_AUTH_FAILED",
+                           "EVE_USER and EVE_PASSWORD environment variables are required", 401)
+        _client = EVEClient(EVE_URL, EVE_USER, EVE_PASSWORD, EVE_VERIFY_SSL, EVE_SESSION_TTL, EVE_HTML5)
+    return _client
+
+
+# =============================================================================
+# System Tools
+# =============================================================================
+
+@mcp.tool()
+@with_gait_logging("eve_status")
+def eve_status() -> str:
+    """Get EVE-NG system status including version, CPU, memory, and disk."""
+    try:
+        data = handle_eve_response(get_client().get("/api/status"))
+        return success_response(data, "EVE-NG system status retrieved")
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_auth")
+def eve_auth() -> str:
+    """Verify EVE-NG authentication and return current user details."""
+    try:
+        data = handle_eve_response(get_client().get("/api/auth"))
+        return success_response(data, "Authentication verified")
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_list_images")
+def eve_list_images(node_type: Optional[str] = None) -> str:
+    """
+    List available node images on the EVE-NG server.
+
+    Args:
+        node_type: Optional filter — 'iol', 'qemu', 'dynamips', 'docker', etc.
+                   Omit to list all template types.
+    """
+    try:
+        c = get_client()
+        path = f"/api/list/{node_type}s/templates/" if node_type else "/api/list/templates/"
+        data = handle_eve_response(c.get(path))
+        if isinstance(data, dict):
+            items = [{"type": k, **(v if isinstance(v, dict) else {"name": v})} for k, v in data.items()]
+        elif isinstance(data, list):
+            items = data
+        else:
+            items = [data] if data else []
+        return success_response(items, f"Found {len(items)} images", len(items))
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+# =============================================================================
+# Lab Lifecycle Tools
+# =============================================================================
+
+@mcp.tool()
+@with_gait_logging("eve_list_labs")
+def eve_list_labs(folder: str = "/") -> str:
+    """
+    List all labs recursively from a folder.
+
+    Args:
+        folder: Root folder to search (default '/')
+    """
+    try:
+        labs = collect_labs(get_client(), folder)
+        return success_response(sorted(labs), f"Found {len(labs)} labs", len(labs))
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_get_lab")
+def eve_get_lab(lab_path: str) -> str:
+    """
+    Get lab metadata: description, version, author, and body.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl' — folder prefix required when outside root
+    """
+    try:
+        data = handle_eve_response(get_client().get(f"/api/labs{normalize_lab_path(lab_path)}"))
+        return success_response(data)
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_create_lab")
+def eve_create_lab(
+    name: str,
+    folder: str = "/",
+    description: str = "",
+    version: str = "1",
+    author: str = "",
+) -> str:
+    """
+    Create a new empty lab file.
+
+    Args:
+        name: Lab name without .unl extension (e.g. 'BGP-Test')
+        folder: Target folder (default '/')
+        description: Lab description
+        version: Version string
+        author: Author name
+    """
+    try:
+        payload: dict = {
+            "name": name,
+            "path": normalize_folder_path(folder),
+            "version": version,
+        }
+        if description:
+            payload["description"] = description
+        if author:
+            payload["author"] = author
+        data = handle_eve_response(get_client().post("/api/labs", json=payload),
+                                   success_codes=[200, 201])
+        return success_response(data, f"Lab '{name}' created in {folder}")
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_delete_lab")
+def eve_delete_lab(lab_path: str) -> str:
+    """
+    Delete a lab and all its runtime objects. Stop all nodes first.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+    """
+    try:
+        handle_eve_response(get_client().delete(f"/api/labs{normalize_lab_path(lab_path)}"),
+                            success_codes=[200, 204])
+        return success_response(message=f"Lab '{lab_path}' deleted")
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_export_lab")
+def eve_export_lab(lab_path: str) -> str:
+    """
+    Export a lab as raw .unl XML content (topology backup / sharing).
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+    """
+    try:
+        c = get_client()
+        resp = c.get(f"/api/labs{normalize_lab_path(lab_path)}/export")
+        if resp.status_code not in (200, 201):
+            handle_eve_response(resp)
+        content = resp.text
+        return success_response(
+            {"content": content, "size_bytes": len(content)},
+            f"Lab exported ({len(content)} bytes)",
+        )
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+# =============================================================================
+# Node Operation Tools
+# =============================================================================
+
+@mcp.tool()
+@with_gait_logging("eve_list_nodes")
+def eve_list_nodes(lab_path: str) -> str:
+    """
+    List all nodes in a lab with runtime status, type, image, and console port.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+    """
+    try:
+        data = handle_eve_response(get_client().get(f"/api/labs{normalize_lab_path(lab_path)}/nodes"))
+        if not isinstance(data, dict):
+            return success_response([], "No nodes found", 0)
+        nodes = [
+            {
+                "id": nid,
+                "name": n.get("name"),
+                "type": n.get("type"),
+                "template": n.get("template"),
+                "image": n.get("image"),
+                "status": n.get("status"),
+                "running": node_is_running(n),
+                "console_port": n.get("console"),
+                "cpu": n.get("cpu"),
+                "ram": n.get("ram"),
+            }
+            for nid, n in data.items() if isinstance(n, dict)
+        ]
+        return success_response(nodes, f"Found {len(nodes)} nodes", len(nodes))
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_get_node")
+def eve_get_node(lab_path: str, node: str) -> str:
+    """
+    Get full details for a single node (config, status, interfaces, console).
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+        node: Node name (e.g. 'R1') or numeric ID
+    """
+    try:
+        c = get_client()
+        node_id = resolve_node_id(c, lab_path, node)
+        data = handle_eve_response(c.get(f"/api/labs{normalize_lab_path(lab_path)}/nodes/{node_id}"))
+        return success_response(data)
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_create_node")
+def eve_create_node(
+    lab_path: str,
+    name: str,
+    node_type: str,
+    template: str,
+    image: str = "",
+    left: int = 100,
+    top: int = 100,
+    ram: int = 256,
+    ethernet: int = 4,
+    serial: int = 0,
+    console: str = "telnet",
+    cpu: int = 1,
+    icon: str = "Router.png",
+    node_id: int | None = None,
+) -> str:
+    """
+    Add a new node to a lab from a template.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+        name: Node name (e.g. 'R1')
+        node_type: Node type — 'iol', 'qemu', 'dynamips', 'docker', 'vpcs'
+        template: Template name (e.g. 'vios', 'csr1000v', 'iol')
+        image: Image filename — uses template default when blank
+        left: Canvas X position (pixels)
+        top: Canvas Y position (pixels)
+        ram: RAM in MB
+        ethernet: Number of Ethernet interfaces
+        serial: Number of serial interfaces
+        console: Console type — 'telnet' or 'vnc'
+        cpu: Number of vCPUs
+        icon: Canvas icon filename (e.g. 'Router.png', 'Switch.png', 'Server.png')
+        node_id: Optional explicit node ID. Use lab-number block IDs on this host, e.g. 801, 802.
+    """
+    try:
+        c = get_client()
+        payload: dict = {
+            "name": name, "type": node_type, "template": template,
+            "left": left, "top": top, "ram": ram,
+            "ethernet": ethernet, "serial": serial,
+            "console": console, "cpu": cpu, "icon": icon,
+        }
+        if image:
+            payload["image"] = image
+        if node_id is not None:
+            existing = handle_eve_response(c.get(f"/api/labs{normalize_lab_path(lab_path)}/nodes"))
+            if isinstance(existing, dict) and str(node_id) in existing:
+                raise EVEError(
+                    "EVE_CONFLICT",
+                    f"Node ID '{node_id}' already exists in lab '{lab_path}'",
+                    409,
+                )
+            payload["id"] = int(node_id)
+        data = handle_eve_response(
+            c.post(f"/api/labs{normalize_lab_path(lab_path)}/nodes", json=payload),
+            success_codes=[200, 201],
+        )
+        verify = handle_eve_response(c.get(f"/api/labs{normalize_lab_path(lab_path)}/nodes"))
+        resolved_id = None
+        if node_id is not None and isinstance(verify, dict) and str(node_id) in verify:
+            resolved_id = str(node_id)
+        elif isinstance(verify, dict):
+            for nid, node in verify.items():
+                if isinstance(node, dict) and node.get("name", "").lower() == name.lower():
+                    resolved_id = str(nid)
+                    break
+        if node_id is not None and resolved_id != str(node_id):
+            raise EVEError(
+                "EVE_SERVER_ERROR",
+                f"Node '{name}' was created but did not persist with requested ID '{node_id}'",
+                500,
+            )
+        return success_response({
+            "requested_id": node_id,
+            "resolved_id": resolved_id,
+            "api_result": data,
+        }, f"Node '{name}' created")
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_delete_node")
+def eve_delete_node(lab_path: str, node: str) -> str:
+    """
+    Remove a node from a lab. Node must be stopped first.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+        node: Node name or numeric ID
+    """
+    try:
+        c = get_client()
+        node_id = resolve_node_id(c, lab_path, node)
+        handle_eve_response(c.delete(f"/api/labs{normalize_lab_path(lab_path)}/nodes/{node_id}"),
+                            success_codes=[200, 204])
+        return success_response({"node_id": node_id}, f"Node '{node}' deleted")
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_start_node")
+def eve_start_node(lab_path: str, node: str) -> str:
+    """
+    Start a node and poll to verify it reaches running state.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+        node: Node name (e.g. 'R1') or numeric ID
+    """
+    try:
+        c = get_client()
+        node_id = resolve_node_id(c, lab_path, node)
+        path = normalize_lab_path(lab_path)
+        before = handle_eve_response(c.get(f"/api/labs{path}/nodes")) or {}
+        handle_eve_response(c.get(f"/api/labs{path}/nodes/{node_id}/start"))
+        after = poll_node_status(c, lab_path, node_id, expect_running=True)
+        node_info = before.get(str(node_id), {})
+        return success_response({
+            "node_id": node_id,
+            "node_name": node_info.get("name", node) if isinstance(node_info, dict) else node,
+            "verification": build_verification("start", node_id, before, after),
+        }, "Node started")
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_stop_node")
+def eve_stop_node(lab_path: str, node: str) -> str:
+    """
+    Stop a node and poll to verify it reaches stopped state.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+        node: Node name (e.g. 'R1') or numeric ID
+    """
+    try:
+        c = get_client()
+        node_id = resolve_node_id(c, lab_path, node)
+        path = normalize_lab_path(lab_path)
+        before = handle_eve_response(c.get(f"/api/labs{path}/nodes")) or {}
+        handle_eve_response(c.get(f"/api/labs{path}/nodes/{node_id}/stop"))
+        after = poll_node_status(c, lab_path, node_id, expect_running=False)
+        node_info = before.get(str(node_id), {})
+        return success_response({
+            "node_id": node_id,
+            "node_name": node_info.get("name", node) if isinstance(node_info, dict) else node,
+            "verification": build_verification("stop", node_id, before, after),
+        }, "Node stopped")
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_start_lab")
+def eve_start_lab(lab_path: str) -> str:
+    """
+    Start all nodes in a lab. Returns per-node results and running/stopped summary.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+    """
+    try:
+        c = get_client()
+        path = normalize_lab_path(lab_path)
+        before = handle_eve_response(c.get(f"/api/labs{path}/nodes")) or {}
+        steps = []
+        for nid, node in (before.items() if isinstance(before, dict) else {}.items()):
+            name = node.get("name", nid) if isinstance(node, dict) else nid
+            try:
+                handle_eve_response(c.get(f"/api/labs{path}/nodes/{nid}/start"))
+                steps.append({"node_id": nid, "node_name": name, "ok": True})
+            except Exception as exc:
+                steps.append({"node_id": nid, "node_name": name, "ok": False, "error": str(exc)})
+        time.sleep(3)
+        after = handle_eve_response(c.get(f"/api/labs{path}/nodes")) or {}
+        running = [n.get("name", nid) for nid, n in after.items()
+                   if isinstance(n, dict) and node_is_running(n)]
+        stopped  = [n.get("name", nid) for nid, n in after.items()
+                   if isinstance(n, dict) and not node_is_running(n)]
+        failures = [s["node_name"] for s in steps if not s["ok"]]
+        return success_response(
+            {"steps": steps, "summary": {"running": running, "stopped": stopped, "failures": failures}},
+            f"Start complete: {len(running)} running, {len(stopped)} stopped",
+        )
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_stop_lab")
+def eve_stop_lab(lab_path: str) -> str:
+    """
+    Stop all nodes in a lab. Returns per-node results and final summary.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+    """
+    try:
+        c = get_client()
+        path = normalize_lab_path(lab_path)
+        before = handle_eve_response(c.get(f"/api/labs{path}/nodes")) or {}
+        steps = []
+        for nid, node in (before.items() if isinstance(before, dict) else {}.items()):
+            name = node.get("name", nid) if isinstance(node, dict) else nid
+            try:
+                handle_eve_response(c.get(f"/api/labs{path}/nodes/{nid}/stop"))
+                steps.append({"node_id": nid, "node_name": name, "ok": True})
+            except Exception as exc:
+                steps.append({"node_id": nid, "node_name": name, "ok": False, "error": str(exc)})
+        time.sleep(2)
+        after = handle_eve_response(c.get(f"/api/labs{path}/nodes")) or {}
+        running = [n.get("name", nid) for nid, n in after.items()
+                   if isinstance(n, dict) and node_is_running(n)]
+        stopped  = [n.get("name", nid) for nid, n in after.items()
+                   if isinstance(n, dict) and not node_is_running(n)]
+        failures = [s["node_name"] for s in steps if not s["ok"]]
+        return success_response(
+            {"steps": steps, "summary": {"running": running, "stopped": stopped, "failures": failures}},
+            f"Stop complete: {len(stopped)} stopped, {len(running)} still running",
+        )
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_wipe_node")
+def eve_wipe_node(lab_path: str, node: str) -> str:
+    """
+    Wipe a node to factory defaults — clears NVRAM and startup config.
+    Node must be stopped before wiping.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+        node: Node name or numeric ID
+    """
+    try:
+        c = get_client()
+        node_id = resolve_node_id(c, lab_path, node)
+        handle_eve_response(c.get(f"/api/labs{normalize_lab_path(lab_path)}/nodes/{node_id}/wipe"))
+        return success_response({"node_id": node_id}, f"Node '{node}' wiped to factory defaults")
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+# =============================================================================
+# Network / Topology Tools
+# =============================================================================
+
+@mcp.tool()
+@with_gait_logging("eve_get_topology")
+def eve_get_topology(lab_path: str) -> str:
+    """
+    Get full lab topology: nodes, networks, and all interconnection links.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+    """
+    try:
+        data = handle_eve_response(get_client().get(f"/api/labs{normalize_lab_path(lab_path)}/topology"))
+        return success_response(data)
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_list_networks")
+def eve_list_networks(lab_path: str) -> str:
+    """
+    List all virtual networks (bridges, clouds, physical interfaces) in a lab.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+    """
+    try:
+        data = handle_eve_response(get_client().get(f"/api/labs{normalize_lab_path(lab_path)}/networks"))
+        if not isinstance(data, dict):
+            return success_response([], "No networks found", 0)
+        networks = [{"id": nid, **net} for nid, net in data.items() if isinstance(net, dict)]
+        return success_response(networks, f"Found {len(networks)} networks", len(networks))
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_create_network")
+def eve_create_network(
+    lab_path: str,
+    name: str,
+    network_type: str = "bridge",
+    visibility: int = 1,
+    left: int = 200,
+    top: int = 200,
+) -> str:
+    """
+    Create a virtual network in a lab.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+        name: Network name (e.g. 'Net1', 'Management', 'WAN')
+        network_type: 'bridge' (internal L2), 'ovs', 'pnet0'-'pnet9' (physical uplink),
+                      'cloud0'-'cloud9' (cloud/internet bridge)
+        visibility: 1 = visible on canvas, 0 = hidden
+        left: Canvas X position
+        top: Canvas Y position
+    """
+    try:
+        c = get_client()
+        payload = {"name": name, "type": network_type, "visibility": visibility,
+                   "left": left, "top": top}
+        data = handle_eve_response(
+            c.post(f"/api/labs{normalize_lab_path(lab_path)}/networks", json=payload),
+            success_codes=[200, 201],
+        )
+        networks = handle_eve_response(c.get(f"/api/labs{normalize_lab_path(lab_path)}/networks"))
+        created_id = None
+        if isinstance(networks, dict):
+            for nid, net in networks.items():
+                if isinstance(net, dict) and net.get("name", "").lower() == name.lower():
+                    created_id = str(nid)
+                    break
+        if not created_id:
+            raise EVEError(
+                "EVE_SERVER_ERROR",
+                f"Network '{name}' creation was acknowledged but did not persist in lab topology",
+                500,
+            )
+        return success_response({
+            "network_id": created_id,
+            "name": name,
+            "network_type": network_type,
+            "visibility": visibility,
+            "left": left,
+            "top": top,
+            "api_result": data,
+        }, f"Network '{name}' created")
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_delete_network")
+def eve_delete_network(lab_path: str, network: str) -> str:
+    """
+    Delete a network from a lab. Disconnect all nodes before deleting.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+        network: Network name or numeric ID
+    """
+    try:
+        c = get_client()
+        net_id = resolve_network_id(c, lab_path, network)
+        handle_eve_response(c.delete(f"/api/labs{normalize_lab_path(lab_path)}/networks/{net_id}"),
+                            success_codes=[200, 204])
+        return success_response(message=f"Network '{network}' deleted")
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_list_node_interfaces")
+def eve_list_node_interfaces(lab_path: str, node: str) -> str:
+    """
+    List all interfaces of a node and their current network connections.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+        node: Node name or numeric ID
+    """
+    try:
+        c = get_client()
+        node_id = resolve_node_id(c, lab_path, node)
+        data = handle_eve_response(
+            c.get(f"/api/labs{normalize_lab_path(lab_path)}/nodes/{node_id}/interfaces"))
+        return success_response(data)
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_connect_interface")
+def eve_connect_interface(
+    lab_path: str,
+    node: str,
+    interface_id: int,
+    network: str,
+) -> str:
+    """
+    Connect a node interface to a network.
+    Stop the node before rewiring to avoid runtime bridge conflicts.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+        node: Node name or numeric ID
+        interface_id: Interface index — 0 = first (Ethernet0/0), 1 = second, etc.
+        network: Target network name or numeric ID
+    """
+    try:
+        c = get_client()
+        ensure_nodes_stopped_for_link_edit(c, lab_path, [node])
+        node_id = resolve_node_id(c, lab_path, node)
+        net_id = resolve_network_id(c, lab_path, network)
+        handle_eve_response(
+            c.put(f"/api/labs{normalize_lab_path(lab_path)}/nodes/{node_id}/interfaces",
+                  json={str(interface_id): int(net_id)}))
+        interfaces = handle_eve_response(
+            c.get(f"/api/labs{normalize_lab_path(lab_path)}/nodes/{node_id}/interfaces"))
+        attached = None
+        if isinstance(interfaces, dict):
+            iface = interfaces.get(str(interface_id)) or interfaces.get(interface_id)
+            if isinstance(iface, dict):
+                attached = str(iface.get("network_id") or iface.get("network") or "")
+            elif isinstance(interfaces.get("ethernet"), list) and 0 <= int(interface_id) < len(interfaces.get("ethernet")):
+                eth = interfaces.get("ethernet")[int(interface_id)]
+                if isinstance(eth, dict):
+                    attached = str(eth.get("network_id") or eth.get("network") or "")
+        if attached != str(net_id):
+            raise EVEError(
+                "EVE_SERVER_ERROR",
+                f"Interface {interface_id} of '{node}' did not persist on network '{network}' after API success",
+                500,
+            )
+        return success_response({
+            "node": node, "node_id": node_id,
+            "interface_id": interface_id,
+            "network": network, "network_id": net_id,
+        }, f"Interface {interface_id} of '{node}' connected to '{network}'")
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_list_node_types")
+def eve_list_node_types() -> str:
+    """List available node types (templates) installed on the EVE-NG server."""
+    try:
+        data = handle_eve_response(get_client().get("/api/list/templates/"))
+        if isinstance(data, dict):
+            types = [{"type": k, **(v if isinstance(v, dict) else {"name": str(v)})}
+                     for k, v in data.items()]
+        else:
+            types = data if isinstance(data, list) else []
+        return success_response(types, f"Found {len(types)} node types", len(types))
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+# =============================================================================
+# Console Execution Tools
+# =============================================================================
+
+@mcp.tool()
+@with_gait_logging("eve_discover_node")
+def eve_discover_node(lab_path: str, node: str) -> str:
+    """
+    Resolve a node by name or ID and return its console connection details.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+        node: Node name (e.g. 'R1') or numeric ID
+    """
+    try:
+        c = get_client()
+        node_id = resolve_node_id(c, lab_path, node)
+        data = handle_eve_response(c.get(f"/api/labs{normalize_lab_path(lab_path)}/nodes/{node_id}"))
+        port = get_console_port(c, lab_path, node_id)
+        return success_response({
+            "node_id": node_id,
+            "name": data.get("name") if isinstance(data, dict) else node,
+            "type": data.get("type") if isinstance(data, dict) else None,
+            "status": data.get("status") if isinstance(data, dict) else None,
+            "running": node_is_running(data) if isinstance(data, dict) else None,
+            "console_host": EVE_CONSOLE_HOST,
+            "console_port": port,
+            "telnet": f"telnet://{EVE_CONSOLE_HOST}:{port}",
+        })
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_exec_ios")
+def eve_exec_ios(
+    lab_path: str,
+    node: str,
+    commands: list[str],
+    config_mode: bool = False,
+    save: bool = False,
+    command_timeout: float = 15.0,
+    wait: float = 0.8,
+) -> str:
+    """
+    Execute commands on an IOS / IOL / IOS-XE node via telnet console.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+        node: Node name or numeric ID
+        commands: Commands to run (e.g. ['show ip route', 'show interfaces'])
+        config_mode: Enter global config mode before running (for config commands)
+        save: Run 'write memory' after all commands
+        command_timeout: Seconds to wait for each command's output (default 15)
+        wait: Inter-command pause in seconds (default 0.8)
+    """
+    try:
+        c = get_client()
+        node_id = resolve_node_id(c, lab_path, node)
+        port = get_console_port(c, lab_path, node_id)
+        transcript: list = []
+        with TelnetSession(EVE_CONSOLE_HOST, port) as sess:
+            transcript.extend(bootstrap_ios(sess))
+            if config_mode:
+                transcript.extend(ensure_ios_config(sess))
+            else:
+                transcript.extend(ensure_ios_privileged(sess))
+            for cmd in commands:
+                out = run_ios_command(sess, cmd, wait=wait, timeout=command_timeout)
+                transcript.append({"command": cmd, "output": out, "mode_after": detect_ios_mode(out)})
+            transcript.extend(ensure_ios_privileged(sess))
+            if save:
+                out = sess.send("write memory", wait=2.0)
+                transcript.append({"command": "write memory", "output": out,
+                                   "mode_after": detect_ios_mode(out)})
+        return success_response({"node_id": node_id, "node": node,
+                                  "config_mode": config_mode, "saved": save,
+                                  "transcript": transcript})
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_exec_junos")
+def eve_exec_junos(
+    lab_path: str,
+    node: str,
+    commands: list[str],
+    command_timeout: float = 15.0,
+    wait: float = 0.8,
+) -> str:
+    """
+    Execute operational mode commands on a Junos node via telnet console.
+    'show' commands get '| no-more' appended automatically.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+        node: Node name or numeric ID
+        commands: Junos operational commands (e.g. ['show route', 'show interfaces terse'])
+        command_timeout: Seconds to wait for each command's output (default 15)
+        wait: Not used for Junos (prompt-based timing), kept for API consistency
+    """
+    try:
+        c = get_client()
+        node_id = resolve_node_id(c, lab_path, node)
+        port = get_console_port(c, lab_path, node_id)
+        transcript: list = []
+        with TelnetSession(EVE_CONSOLE_HOST, port) as sess:
+            transcript.extend(ensure_junos_operational(sess))
+            for cmd in commands:
+                out = run_junos_command(sess, cmd, timeout=command_timeout)
+                transcript.append({"command": cmd, "output": out, "mode_after": detect_junos_mode(out)})
+        return success_response({"node_id": node_id, "node": node, "transcript": transcript})
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_exec_vpcs")
+def eve_exec_vpcs(
+    lab_path: str,
+    node: str,
+    commands: list[str],
+    command_timeout: float = 8.0,
+    dhcp_timeout: float = 10.0,
+    prompt_timeout: float = 5.0,
+) -> str:
+    """
+    Execute commands on a VPCS node via telnet console.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+        node: Node name or numeric ID
+        commands: VPCS commands (e.g. ['ip dhcp', 'show ip', 'ping 10.0.0.1'])
+        command_timeout: Seconds to wait for command output
+        dhcp_timeout: Extra wait seconds for 'ip dhcp' command
+        prompt_timeout: Seconds to wait for initial VPCS> prompt
+    """
+    try:
+        c = get_client()
+        node_id = resolve_node_id(c, lab_path, node)
+        port = get_console_port(c, lab_path, node_id)
+        transcript: list = []
+        with TelnetSession(EVE_CONSOLE_HOST, port) as sess:
+            banner = sess.recv_until(VPCS_PROMPT_RE, timeout=prompt_timeout)
+            if not VPCS_PROMPT_RE.search(banner):
+                banner += sess.send("", wait=0.8)
+            transcript.append({"command": None, "output": banner})
+            for cmd in commands:
+                timeout = dhcp_timeout if cmd.strip() == "ip dhcp" else command_timeout
+                out = sess.send_until(cmd, VPCS_PROMPT_RE, timeout=timeout)
+                transcript.append({"command": cmd, "output": out})
+        return success_response({"node_id": node_id, "node": node, "transcript": transcript})
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_exec_eos")
+def eve_exec_eos(
+    lab_path: str,
+    node: str,
+    commands: list[str],
+    config_mode: bool = False,
+    save: bool = False,
+    command_timeout: float = 15.0,
+    wait: float = 0.8,
+) -> str:
+    """
+    Execute commands on an Arista EOS node via telnet console.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+        node: Node name or numeric ID
+        commands: EOS commands (e.g. ['show ip bgp summary', 'show interfaces status'])
+        config_mode: Enter global config mode before running
+        save: Run 'copy running-config startup-config' after commands
+        command_timeout: Seconds to wait for each command's output
+        wait: Inter-command pause in seconds
+    """
+    try:
+        c = get_client()
+        node_id = resolve_node_id(c, lab_path, node)
+        port = get_console_port(c, lab_path, node_id)
+        transcript: list = []
+        with TelnetSession(EVE_CONSOLE_HOST, port) as sess:
+            if config_mode:
+                transcript.extend(ensure_eos_config(sess))
+            else:
+                transcript.extend(ensure_eos_privileged(sess))
+            for cmd in commands:
+                out = run_eos_command(sess, cmd, wait=wait, timeout=command_timeout)
+                transcript.append({"command": cmd, "output": out, "mode_after": detect_eos_mode(out)})
+            transcript.extend(ensure_eos_privileged(sess))
+            if save:
+                out = sess.send("copy running-config startup-config", wait=3.0)
+                transcript.append({"command": "copy running-config startup-config", "output": out,
+                                   "mode_after": detect_eos_mode(out)})
+        return success_response({"node_id": node_id, "node": node,
+                                  "config_mode": config_mode, "saved": save,
+                                  "transcript": transcript})
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_exec_nxos")
+def eve_exec_nxos(
+    lab_path: str,
+    node: str,
+    commands: list[str],
+    config_mode: bool = False,
+    save: bool = False,
+    command_timeout: float = 15.0,
+    wait: float = 0.8,
+) -> str:
+    """
+    Execute commands on a Cisco NX-OS node via telnet console.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+        node: Node name or numeric ID
+        commands: NX-OS commands (e.g. ['show ip route', 'show vlan brief'])
+        config_mode: Enter global config mode before running
+        save: Run 'copy running-config startup-config' after commands
+        command_timeout: Seconds to wait for each command's output
+        wait: Inter-command pause in seconds
+    """
+    try:
+        c = get_client()
+        node_id = resolve_node_id(c, lab_path, node)
+        port = get_console_port(c, lab_path, node_id)
+        transcript: list = []
+        with TelnetSession(EVE_CONSOLE_HOST, port) as sess:
+            if config_mode:
+                transcript.extend(ensure_nxos_config(sess))
+            else:
+                transcript.extend(ensure_nxos_privileged(sess))
+            for cmd in commands:
+                out = run_nxos_command(sess, cmd, wait=wait, timeout=command_timeout)
+                transcript.append({"command": cmd, "output": out, "mode_after": detect_nxos_mode(out)})
+            transcript.extend(ensure_nxos_privileged(sess))
+            if save:
+                out = sess.send("copy running-config startup-config", wait=3.0)
+                transcript.append({"command": "copy running-config startup-config", "output": out,
+                                   "mode_after": detect_nxos_mode(out)})
+        return success_response({"node_id": node_id, "node": node,
+                                  "config_mode": config_mode, "saved": save,
+                                  "transcript": transcript})
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+# =============================================================================
+# Config Management Tools
+# =============================================================================
+
+@mcp.tool()
+@with_gait_logging("eve_get_node_config")
+def eve_get_node_config(lab_path: str, node: str) -> str:
+    """
+    Get the stored startup configuration for a node.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+        node: Node name or numeric ID
+    """
+    try:
+        c = get_client()
+        node_id = resolve_node_id(c, lab_path, node)
+        data = handle_eve_response(
+            c.get(f"/api/labs{normalize_lab_path(lab_path)}/nodes/{node_id}/configs"))
+        return success_response({"node_id": node_id, "node": node, "config": data})
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_set_node_config")
+def eve_set_node_config(lab_path: str, node: str, config: str) -> str:
+    """
+    Push a startup configuration to a node. Node should be stopped.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+        node: Node name or numeric ID
+        config: Full configuration text to store as startup config
+    """
+    try:
+        c = get_client()
+        node_id = resolve_node_id(c, lab_path, node)
+        handle_eve_response(
+            c.put(f"/api/labs{normalize_lab_path(lab_path)}/nodes/{node_id}/configs",
+                  json={"id": int(node_id), "data": config}))
+        return success_response({"node_id": node_id, "node": node},
+                                f"Config applied to node '{node}'")
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_get_all_configs")
+def eve_get_all_configs(lab_path: str) -> str:
+    """
+    Retrieve startup configurations for all nodes in a lab at once.
+    Useful for lab-wide config backup before changes.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+    """
+    try:
+        c = get_client()
+        path = normalize_lab_path(lab_path)
+        nodes = handle_eve_response(c.get(f"/api/labs{path}/nodes")) or {}
+        configs = handle_eve_response(c.get(f"/api/labs{path}/configs")) or {}
+        result = [
+            {
+                "node_id": nid,
+                "name": node.get("name") if isinstance(node, dict) else nid,
+                "config": configs.get(str(nid), "") if isinstance(configs, dict) else "",
+            }
+            for nid, node in nodes.items() if isinstance(node, dict)
+        ]
+        return success_response(result, f"Configs retrieved for {len(result)} nodes", len(result))
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+@mcp.tool()
+@with_gait_logging("eve_wipe_node_config")
+def eve_wipe_node_config(lab_path: str, node: str) -> str:
+    """
+    Clear the startup configuration of a node (writes empty string).
+    Lighter than eve_wipe_node — config only, no NVRAM wipe. Node must be stopped.
+
+    Args:
+        lab_path: Lab path like '/Labs/demo.unl'
+        node: Node name or numeric ID
+    """
+    try:
+        c = get_client()
+        node_id = resolve_node_id(c, lab_path, node)
+        handle_eve_response(
+            c.put(f"/api/labs{normalize_lab_path(lab_path)}/nodes/{node_id}/configs",
+                  json={"id": int(node_id), "data": ""}))
+        return success_response({"node_id": node_id, "node": node},
+                                f"Startup config cleared for node '{node}'")
+    except EVEError as e:
+        return error_response(e)
+    except Exception as e:
+        return error_response(e)
+
+
+# =============================================================================
+# Entry Point
+# =============================================================================
+
+if __name__ == "__main__":
+    log.info("EVE-NG MCP Server starting")
+    log.info("EVE URL:          %s", EVE_URL)
+    log.info("EVE User:         %s", EVE_USER)
+    log.info("Console host:     %s", EVE_CONSOLE_HOST)
+    log.info("Session TTL:      %ss", EVE_SESSION_TTL)
+    log.info("SSL verification: %s", EVE_VERIFY_SSL)
+    mcp.run(transport="stdio")

--- a/mcp-servers/eve-ng-mcp-server/requirements.txt
+++ b/mcp-servers/eve-ng-mcp-server/requirements.txt
@@ -1,0 +1,3 @@
+fastmcp>=0.1.0
+httpx>=0.27.0
+python-dotenv>=1.0.0

--- a/mcp-servers/eve-ng-mcp-server/tests/test_eve_skills_smoke.py
+++ b/mcp-servers/eve-ng-mcp-server/tests/test_eve_skills_smoke.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Smoke test for NetClaw EVE-NG skill docs.
+
+Checks:
+- core EVE skill files exist
+- documented tool names are implemented by the MCP server
+- stale local/private references are absent
+- the UNL validator script responds to --help
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKSPACE = REPO_ROOT / "workspace" / "skills"
+SERVER = REPO_ROOT / "mcp-servers" / "eve-ng-mcp-server" / "eve_ng_mcp_server.py"
+VALIDATOR = WORKSPACE / "eve-lab-topology-design" / "scripts" / "validate_unl_topology.py"
+
+SKILL_FILES = [
+    WORKSPACE / "eve-ng-lab-management" / "SKILL.md",
+    WORKSPACE / "eve-ng-lab-management" / "README.md",
+    WORKSPACE / "eve-ng-lab-management" / "references" / "commands.md",
+    WORKSPACE / "eve-ng-lab-management" / "references" / "troubleshooting.md",
+    WORKSPACE / "eve-ng-node-operations" / "SKILL.md",
+    WORKSPACE / "eve-ng-config-ops" / "SKILL.md",
+    WORKSPACE / "eve-ng-console-ops" / "SKILL.md",
+    WORKSPACE / "eve-lab-topology-build" / "SKILL.md",
+    WORKSPACE / "eve-lab-topology-design" / "SKILL.md",
+    VALIDATOR,
+]
+
+BANNED_STRINGS = [
+    "/root/.openclaw/workspace",
+    "ishare2",
+    "ENSLD/",
+    "eve_api_helper.py",
+    "eve_console_helper.py",
+    "eve_lab_helper.py",
+    "eve-ng-topology-builder",
+]
+
+BANNED_SERVER_SNIPPETS = [
+    'os.getenv("EVE_USER", "admin")',
+    'os.getenv("EVE_PASSWORD", "eve")',
+    'session.send("admin"',
+]
+
+TOOL_RE = re.compile(r"`(eve_[a-z0-9_]+)`")
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}")
+    raise SystemExit(1)
+
+
+def parse_server_tools() -> set[str]:
+    module = ast.parse(SERVER.read_text())
+    tools = set()
+    for node in module.body:
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        for decorator in node.decorator_list:
+            if isinstance(decorator, ast.Call) and getattr(decorator.func, "attr", None) == "tool":
+                tools.add(node.name)
+    return tools
+
+
+def documented_tools(paths: list[Path]) -> set[str]:
+    tools: set[str] = set()
+    for path in paths:
+        if path.suffix != ".md":
+            continue
+        tools.update(TOOL_RE.findall(path.read_text()))
+    return tools
+
+
+def main() -> int:
+    missing = [str(path.relative_to(REPO_ROOT)) for path in SKILL_FILES if not path.exists()]
+    if missing:
+        fail(f"missing required files: {', '.join(missing)}")
+
+    md_files = [path for path in SKILL_FILES if path.suffix == ".md"]
+    for path in md_files:
+        text = path.read_text()
+        for banned in BANNED_STRINGS:
+            if banned in text:
+                fail(f"stale reference '{banned}' found in {path.relative_to(REPO_ROOT)}")
+
+    server_tools = parse_server_tools()
+    docs_tools = documented_tools(md_files)
+    unknown = sorted(tool for tool in docs_tools if tool not in server_tools)
+    if unknown:
+        fail(f"documented tools missing from server: {', '.join(unknown)}")
+
+    server_text = SERVER.read_text()
+    for snippet in BANNED_SERVER_SNIPPETS:
+        if snippet in server_text:
+            fail(f"hardcoded credential pattern found in server: {snippet}")
+
+    result = subprocess.run(
+        [sys.executable, str(VALIDATOR), "--help"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        fail("validator script did not return success for --help")
+
+    print("PASS: EVE skill smoke test")
+    print(f"Validated {len(md_files)} documentation files and {len(server_tools)} MCP tools.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workspace/skills/eve-lab-topology-build/SKILL.md
+++ b/workspace/skills/eve-lab-topology-build/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: eve-lab-topology-build
+description: Build and wire EVE-NG topologies — inspect links, create networks, and connect node interfaces.
+user-invocable: true
+metadata:
+  openclaw:
+    requires:
+      bins: ["python3"]
+      env: ["EVE_URL", "EVE_USER", "EVE_PASSWORD"]
+---
+
+# EVE Lab Topology Build
+
+Use this skill for network objects and interface wiring inside an existing EVE-NG lab.
+
+## When to Use
+
+- Inspect current topology and network attachments
+- Create or delete virtual networks
+- Connect node interfaces to networks
+- Check which interfaces are available on a node
+- Discover available node templates before building
+
+## Wiring Rules
+
+- Stop affected nodes before rewiring interfaces.
+- Confirm the current topology before changing links.
+- Re-read topology after the change; do not trust the write response alone.
+- Build through networks or bridges, not direct node-to-node links.
+
+## MCP Server
+
+- **Command**: `python3 -u mcp-servers/eve-ng-mcp-server/eve_ng_mcp_server.py`
+- **Requires**: `EVE_URL`, `EVE_USER`, `EVE_PASSWORD`
+
+## Available Tools
+
+| Tool | Parameters | Purpose |
+|---|---|---|
+| `eve_get_topology` | `lab_path` | Full topology view |
+| `eve_list_networks` | `lab_path` | List existing networks |
+| `eve_create_network` | `lab_path, name, network_type?, visibility?, left?, top?` | Create a network |
+| `eve_delete_network` | `lab_path, network` | Delete a network |
+| `eve_list_node_interfaces` | `lab_path, node` | List node interfaces and attachments |
+| `eve_connect_interface` | `lab_path, node, interface_id, network` | Connect one interface to a network |
+| `eve_list_node_types` | — | List installed templates |
+
+Networks and nodes can be referenced by **name** or **numeric ID**.
+
+## Network Types
+
+| Type | Use |
+|---|---|
+| `bridge` | Internal L2 segment |
+| `ovs` | Open vSwitch bridge |
+| `pnet0`–`pnet9` | Physical uplinks |
+| `cloud0`–`cloud9` | Cloud or internet mapping |
+
+## Workflow Examples
+
+```text
+"Show full topology for /Labs/bgp-demo.unl"             → eve_get_topology /Labs/bgp-demo.unl
+"List networks in /Labs/bgp-demo.unl"                   → eve_list_networks /Labs/bgp-demo.unl
+"Show R1 interfaces and attachments"                    → eve_list_node_interfaces /Labs/bgp-demo.unl R1
+"Create bridge Net12"                                   → eve_create_network /Labs/bgp-demo.unl Net12 bridge
+"Connect R1 interface 0 to Net12"                       → eve_connect_interface /Labs/bgp-demo.unl R1 0 Net12
+```
+
+## Build Flow
+
+1. Create the lab with **eve-ng-lab-management**.
+2. Add nodes with **eve-ng-node-operations**.
+3. Create required networks.
+4. Connect interfaces.
+5. Re-read the topology.
+6. Start nodes and verify with **eve-ng-console-ops**.
+
+## Integration with Other Skills
+
+- **eve-ng-lab-management**: create or export the lab
+- **eve-ng-node-operations**: add nodes and manage stop/start windows
+- **eve-ng-console-ops**: verify adjacency after wiring
+- **eve-lab-topology-design**: validate the intended design before or after build
+
+## Error Handling
+
+| Error Code | Meaning | Resolution |
+|---|---|---|
+| `EVE_NOT_FOUND` | Node or network missing | Run `eve_list_networks` or `eve_list_nodes` |
+| `EVE_CONFLICT` | Duplicate network name | Use a unique name |
+| `EVE_VALIDATION` | Invalid type or interface reference | Re-check parameters |
+
+## Notes
+
+- Interface IDs are zero-based.
+- `visibility=0` hides the network icon but does not disable the network.
+- `left` and `top` are cosmetic canvas coordinates.

--- a/workspace/skills/eve-lab-topology-design/SKILL.md
+++ b/workspace/skills/eve-lab-topology-design/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: eve-lab-topology-design
+description: Design and validate EVE-NG topologies before build — requirements, trade-offs, link plan, and UNL validation.
+---
+
+# EVE Lab Topology Design
+
+Use this skill for planning and review work before touching the lab.
+
+## When to Use
+
+- The user wants a topology proposal
+- Requirements are incomplete and need structure
+- You need a build plan before creating nodes or links
+- You need to validate a `.unl` file against design intent
+
+## Design Workflow
+
+1. Classify the lab: campus, branch/WAN, ISP, data center, or hybrid.
+2. Gather the minimum requirements.
+3. State assumptions explicitly.
+4. Present 2-3 viable design options when trade-offs matter.
+5. Recommend one design.
+6. Produce a physical link plan and logical/protocol plan.
+7. Validate the design before build.
+8. If a `.unl` exists, run the validator.
+
+## Minimum Discovery Set
+
+Ask for these if the request is underspecified:
+- topology type
+- number of sites or devices
+- desired hierarchy or fabric style
+- routing or control-plane protocols
+- redundancy target
+- image/platform choices
+- host resource limits
+- design-only vs build/config help
+
+If the user does not answer, offer a clearly labeled default that is resilient and realistic for lab scale.
+
+## Required Output
+
+For every design, provide:
+
+### 1) Requirement summary
+A short bullet list of scope, assumptions, and constraints.
+
+### 2) Connectivity matrix
+```text
+NODE      ROLE          LINKS  NEIGHBORS
+CORE1     core          2      DIST1, DIST2
+DIST1     distribution  3      CORE1, CORE2, ACC1
+ACC1      access        2      DIST1, DIST2
+HOST1     host          1      ACC1
+```
+
+### 3) Required links
+```text
+CORE1 <-> DIST1
+CORE2 <-> DIST1
+DIST1 <-> ACC1
+ACC1  <-> HOST1
+```
+
+### 4) Redundancy statement
+Spell out what single-node or single-link failures the design should tolerate.
+
+### 5) Validator input JSON
+```json
+{
+  "required_links": [
+    {"from": "CORE1", "to": "DIST1"},
+    {"from": "CORE2", "to": "DIST1"}
+  ],
+  "redundancy_groups": [
+    {"nodes": ["CORE1", "CORE2"], "role": "core", "min_uplinks": 1}
+  ],
+  "forbidden_links": [
+    {"from": "HOST1", "to": "CORE1"}
+  ]
+}
+```
+
+## UNL Validator
+
+Validator path:
+
+```bash
+python3 workspace/skills/eve-lab-topology-design/scripts/validate_unl_topology.py --help
+```
+
+Typical usage:
+
+```bash
+python3 workspace/skills/eve-lab-topology-design/scripts/validate_unl_topology.py /path/to/lab.unl --verbose
+python3 workspace/skills/eve-lab-topology-design/scripts/validate_unl_topology.py /path/to/lab.unl --reqs design_reqs.json --roles roles.json
+python3 workspace/skills/eve-lab-topology-design/scripts/validate_unl_topology.py /path/to/lab.unl --json
+```
+
+The validator checks:
+- orphan nodes
+- dangling network references
+- isolated networks
+- disconnected graph components
+- forbidden adjacencies
+- articulation-point node SPOFs
+- bridge-link SPOFs
+- asymmetric peer redundancy
+- required and forbidden links from the JSON spec
+
+## Design Defaults
+
+Prefer simple, supportable defaults:
+- **Campus**: dual distribution or collapsed core
+- **WAN**: dual hub/edge when scale allows
+- **ISP/MPLS**: small redundant P/PE layout
+- **Data center**: compact leaf-spine before larger meshes
+
+## Integration with Other Skills
+
+- **eve-ng-lab-management**: create or export the target lab
+- **eve-ng-node-operations**: map design to nodes and images
+- **eve-lab-topology-build**: implement the network objects and links
+- **eve-ng-config-ops**: preload configs once the design is settled
+- **eve-ng-console-ops**: verify the resulting topology live
+
+## Notes
+
+- Separate physical topology from protocol topology.
+- Avoid over-designing for lab scale.
+- Prefer small outputs with explicit assumptions to long generic design essays.

--- a/workspace/skills/eve-lab-topology-design/scripts/validate_unl_topology.py
+++ b/workspace/skills/eve-lab-topology-design/scripts/validate_unl_topology.py
@@ -1,0 +1,608 @@
+#!/usr/bin/env python3
+"""
+EVE-NG UNL Topology Validator
+
+Parses a .unl lab file and validates:
+  - Connectivity: orphan nodes, dangling interfaces, isolated networks
+  - Role adjacency: hierarchy rules based on node name prefixes
+  - Resilience: SPOF detection, asymmetric redundancy, dual-homing gaps
+  - Design requirements: optional comparison against expected links (JSON)
+
+Usage:
+  python3 validate_unl_topology.py <lab.unl> [--reqs design_reqs.json] [--roles roles.json] [--verbose]
+
+Design requirements JSON format:
+  {
+    "required_links": [
+      {"from": "R1", "to": "R2", "type": "p2p"},
+      {"from": "SW1", "to": "SW2", "type": "p2p"}
+    ],
+    "redundancy_groups": [
+      {"nodes": ["DIST1", "DIST2"], "role": "distribution", "min_uplinks": 2},
+      {"nodes": ["SPINE1", "SPINE2"], "role": "spine", "min_uplinks": 2}
+    ],
+    "forbidden_links": [
+      {"from": "HOST1", "to": "CORE1"}
+    ]
+  }
+
+Roles JSON format (override name-based heuristics):
+  {
+    "R1": "core",
+    "R2": "core",
+    "PE1": "pe",
+    "SW1": "distribution",
+    "SW3": "access",
+    "HOST1": "host"
+  }
+"""
+
+import argparse
+import json
+import sys
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Role inference from node names (heuristic, overrideable via --roles)
+# ---------------------------------------------------------------------------
+
+ROLE_PATTERNS = [
+    (["spine", "sp-"],         "spine"),
+    (["leaf", "lf-"],          "leaf"),
+    (["border", "bl-"],        "border-leaf"),
+    (["core", "cr-", "p-"],    "core"),
+    (["pe-", "pe_"],           "pe"),
+    (["rr-", "rr_"],           "rr"),
+    (["dist", "distribution", "dr-", "agg"], "distribution"),
+    (["access", "acc-", "sw-", "sw_"], "access"),
+    (["fw", "firewall", "asa", "ftd", "palo"], "firewall"),
+    (["wan", "edge", "ce-", "ce_"], "wan-edge"),
+    (["host", "pc", "server", "srv", "endpoint"], "host"),
+    (["mgmt", "oob"],          "mgmt"),
+    (["internet", "cloud", "isp"], "internet"),
+]
+
+ROLE_HIERARCHY = {
+    "internet":    0,
+    "wan-edge":    1,
+    "firewall":    1,
+    "core":        2,
+    "pe":          2,
+    "rr":          2,
+    "spine":       2,
+    "distribution": 3,
+    "leaf":        3,
+    "border-leaf": 3,
+    "access":      4,
+    "host":        5,
+    "mgmt":        5,
+    "unknown":     3,
+}
+
+FORBIDDEN_ADJACENCY = [
+    ("host", "core"),
+    ("host", "spine"),
+    ("host", "pe"),
+    ("host", "wan-edge"),
+    ("access", "core"),
+    ("access", "internet"),
+]
+
+
+def infer_role(name: str, role_map: dict) -> str:
+    if name in role_map:
+        return role_map[name]
+    lname = name.lower()
+    for prefixes, role in ROLE_PATTERNS:
+        for p in prefixes:
+            if lname.startswith(p) or p in lname:
+                return role
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# UNL parser
+# ---------------------------------------------------------------------------
+
+def parse_unl(lab_path: Path):
+    tree = ET.parse(lab_path)
+    root = tree.getroot()
+    lab_name = root.attrib.get("name", lab_path.stem)
+
+    nodes = {}      # node_id -> {name, type, template, image, interfaces: [{id, name, network_id}]}
+    networks = {}   # network_id -> {name, type}
+
+    for node_el in root.findall(".//node"):
+        nid = node_el.attrib.get("id")
+        if not nid:
+            continue
+        ifaces = []
+        for iface_el in node_el.findall("interface"):
+            ifaces.append({
+                "id":         iface_el.attrib.get("id"),
+                "name":       iface_el.attrib.get("name", f"iface{iface_el.attrib.get('id')}"),
+                "network_id": iface_el.attrib.get("network_id"),
+            })
+        nodes[nid] = {
+            "id":        nid,
+            "name":      node_el.attrib.get("name", f"node{nid}"),
+            "type":      node_el.attrib.get("type", ""),
+            "template":  node_el.attrib.get("template", ""),
+            "image":     node_el.attrib.get("image", ""),
+            "interfaces": ifaces,
+        }
+
+    for net_el in root.findall(".//network"):
+        nid = net_el.attrib.get("id")
+        if not nid:
+            continue
+        networks[nid] = {
+            "id":   nid,
+            "name": net_el.attrib.get("name", f"net{nid}"),
+            "type": net_el.attrib.get("type", "bridge"),
+        }
+
+    return lab_name, nodes, networks
+
+
+# ---------------------------------------------------------------------------
+# Connectivity analysis
+# ---------------------------------------------------------------------------
+
+def build_connectivity(nodes: dict, networks: dict):
+    """
+    Returns:
+      net_members: network_id -> list of (node_id, iface_name)
+      node_nets:   node_id -> set of network_ids the node is connected to
+      adjacency:   node_id -> set of neighbor node_ids
+    """
+    net_members = defaultdict(list)
+    node_nets = defaultdict(set)
+    dangling_ifaces = []          # (node_name, iface_name, network_id) where network_id unknown
+    declared_net_ids = set(networks.keys())
+
+    for nid, node in nodes.items():
+        for iface in node["interfaces"]:
+            netid = iface.get("network_id")
+            if netid:
+                node_nets[nid].add(netid)
+                net_members[netid].append((nid, iface["name"]))
+                if netid not in declared_net_ids:
+                    dangling_ifaces.append((node["name"], iface["name"], netid))
+
+    adjacency = defaultdict(set)
+    for netid, members in net_members.items():
+        for i, (nid_a, _) in enumerate(members):
+            for nid_b, _ in members[i+1:]:
+                adjacency[nid_a].add(nid_b)
+                adjacency[nid_b].add(nid_a)
+
+    return net_members, node_nets, adjacency, dangling_ifaces
+
+
+# ---------------------------------------------------------------------------
+# Graph utilities
+# ---------------------------------------------------------------------------
+
+def find_connected_components(node_ids: set, adjacency: dict) -> list:
+    visited = set()
+    components = []
+    for start in node_ids:
+        if start in visited:
+            continue
+        comp = set()
+        stack = [start]
+        while stack:
+            n = stack.pop()
+            if n in visited:
+                continue
+            visited.add(n)
+            comp.add(n)
+            for nb in adjacency.get(n, set()):
+                if nb in node_ids and nb not in visited:
+                    stack.append(nb)
+        components.append(comp)
+    return components
+
+
+def find_articulation_points(node_ids: set, adjacency: dict) -> set:
+    """Tarjan's algorithm for articulation points (SPOF nodes)."""
+    ids = list(node_ids)
+    idx_map = {n: i for i, n in enumerate(ids)}
+    n = len(ids)
+    disc = [-1] * n
+    low  = [-1] * n
+    parent = [-1] * n
+    ap = set()
+    timer = [0]
+
+    def dfs(u):
+        children = 0
+        disc[u] = low[u] = timer[0]
+        timer[0] += 1
+        for nb in adjacency.get(ids[u], set()):
+            if nb not in idx_map:
+                continue
+            v = idx_map[nb]
+            if disc[v] == -1:
+                children += 1
+                parent[v] = u
+                dfs(v)
+                low[u] = min(low[u], low[v])
+                if parent[u] == -1 and children > 1:
+                    ap.add(ids[u])
+                if parent[u] != -1 and low[v] >= disc[u]:
+                    ap.add(ids[u])
+            elif v != parent[u]:
+                low[u] = min(low[u], disc[v])
+
+    for i in range(n):
+        if disc[i] == -1:
+            dfs(i)
+
+    return ap
+
+
+def find_bridge_links(node_ids: set, adjacency: dict) -> list:
+    """Find bridge edges (links whose removal disconnects the graph)."""
+    ids = list(node_ids)
+    idx_map = {n: i for i, n in enumerate(ids)}
+    n = len(ids)
+    disc = [-1] * n
+    low  = [-1] * n
+    parent = [-1] * n
+    bridges = []
+    timer = [0]
+
+    def dfs(u):
+        disc[u] = low[u] = timer[0]
+        timer[0] += 1
+        for nb in adjacency.get(ids[u], set()):
+            if nb not in idx_map:
+                continue
+            v = idx_map[nb]
+            if disc[v] == -1:
+                parent[v] = u
+                dfs(v)
+                low[u] = min(low[u], low[v])
+                if low[v] > disc[u]:
+                    bridges.append((ids[u], ids[v]))
+            elif v != parent[u]:
+                low[u] = min(low[u], disc[v])
+
+    for i in range(n):
+        if disc[i] == -1:
+            dfs(i)
+
+    return bridges
+
+
+# ---------------------------------------------------------------------------
+# Validation checks
+# ---------------------------------------------------------------------------
+
+class ValidationResult:
+    def __init__(self):
+        self.passed = []
+        self.warnings = []
+        self.failures = []
+
+    def ok(self, msg):   self.passed.append(msg)
+    def warn(self, msg): self.warnings.append(msg)
+    def fail(self, msg): self.failures.append(msg)
+
+    @property
+    def score(self):
+        total = len(self.passed) + len(self.warnings) + len(self.failures)
+        if total == 0:
+            return 100
+        return int(100 * len(self.passed) / total)
+
+
+def check_orphan_nodes(nodes, node_nets, result):
+    orphans = [n["name"] for nid, n in nodes.items() if not node_nets.get(nid)]
+    if orphans:
+        result.fail(f"Orphan nodes (no connected interfaces): {', '.join(sorted(orphans))}")
+    else:
+        result.ok("No orphan nodes")
+
+
+def check_dangling_interfaces(dangling_ifaces, result):
+    if dangling_ifaces:
+        for node_name, iface_name, netid in dangling_ifaces:
+            result.fail(f"Dangling interface: {node_name}/{iface_name} references missing network_id={netid}")
+    else:
+        result.ok("No dangling interface references")
+
+
+def check_isolated_networks(net_members, networks, result):
+    for netid, members in net_members.items():
+        net_name = networks.get(netid, {}).get("name", f"net{netid}")
+        if len(members) < 2:
+            result.warn(f"Isolated network '{net_name}' (id={netid}) has only {len(members)} endpoint(s) — possible dangling link")
+        elif len(members) > 2:
+            net_type = networks.get(netid, {}).get("type", "bridge")
+            if net_type not in ("bridge", "ovs"):
+                result.warn(f"Network '{net_name}' (id={netid}) has {len(members)} endpoints — verify this is intentional shared segment")
+
+
+def check_connectivity(node_ids, adjacency, result):
+    components = find_connected_components(node_ids, adjacency)
+    if len(components) > 1:
+        comp_names_list = []
+        for comp in components:
+            comp_names_list.append("{" + ", ".join(sorted(comp)[:5]) + ("..." if len(comp) > 5 else "") + "}")
+        result.fail(f"Topology is partitioned into {len(components)} disconnected components: {', '.join(comp_names_list)}")
+    else:
+        result.ok(f"All {len(node_ids)} nodes are in one connected component")
+
+
+def check_role_adjacency(nodes, adjacency, role_map, result):
+    id_to_name = {nid: n["name"] for nid, n in nodes.items()}
+    name_to_id = {n["name"]: nid for nid, n in nodes.items()}
+    violations = []
+    for nid, node in nodes.items():
+        role_a = infer_role(node["name"], role_map)
+        for nb_id in adjacency.get(nid, set()):
+            nb_name = id_to_name.get(nb_id, nb_id)
+            role_b = infer_role(nb_name, role_map)
+            for fa, fb in FORBIDDEN_ADJACENCY:
+                if (role_a == fa and role_b == fb) or (role_a == fb and role_b == fa):
+                    pair = tuple(sorted([node["name"], nb_name]))
+                    if pair not in violations:
+                        violations.append(pair)
+                        result.fail(f"Forbidden adjacency: {node['name']} ({role_a}) <-> {nb_name} ({role_b})")
+    if not violations:
+        result.ok("Role-based adjacency rules respected")
+
+
+def check_spof(node_ids, adjacency, nodes, result):
+    id_to_name = {nid: n["name"] for nid, n in nodes.items()}
+    aps = find_articulation_points(node_ids, adjacency)
+    bridges = find_bridge_links(node_ids, adjacency)
+
+    if aps:
+        ap_names = sorted(id_to_name.get(n, n) for n in aps)
+        result.warn(f"SPOF nodes (articulation points — removal splits topology): {', '.join(ap_names)}")
+    else:
+        result.ok("No single-node SPOFs detected")
+
+    if bridges:
+        bridge_names = sorted(
+            f"{id_to_name.get(a, a)} <-> {id_to_name.get(b, b)}"
+            for a, b in bridges
+        )
+        result.warn(f"SPOF links (bridge links — loss splits topology): {'; '.join(bridge_names)}")
+    else:
+        result.ok("No single-link SPOFs detected")
+
+
+def check_symmetry(nodes, adjacency, role_map, result):
+    """Check that nodes sharing the same role have the same number of uplinks."""
+    role_to_nodes = defaultdict(list)
+    for nid, node in nodes.items():
+        role = infer_role(node["name"], role_map)
+        role_to_nodes[role].append(nid)
+
+    id_to_name = {nid: n["name"] for nid, n in nodes.items()}
+
+    for role, nids in role_to_nodes.items():
+        if len(nids) < 2:
+            continue
+        degree_map = {nid: len(adjacency.get(nid, set())) for nid in nids}
+        degrees = list(degree_map.values())
+        if len(set(degrees)) > 1:
+            detail = ", ".join(
+                f"{id_to_name.get(nid, nid)}={d}" for nid, d in sorted(degree_map.items(), key=lambda x: id_to_name.get(x[0], x[0]))
+            )
+            result.warn(f"Asymmetric link count in role '{role}': {detail}")
+        else:
+            result.ok(f"Role '{role}' ({len(nids)} nodes) has symmetric link count: {degrees[0]} each")
+
+
+def check_design_requirements(nodes, adjacency, net_members, networks, reqs, role_map, result):
+    if not reqs:
+        return
+
+    name_to_id = {n["name"]: nid for nid, n in nodes.items()}
+    id_to_name = {nid: n["name"] for nid, n in nodes.items()}
+
+    # Required links
+    for req in reqs.get("required_links", []):
+        a, b = req["from"], req["to"]
+        aid = name_to_id.get(a)
+        bid = name_to_id.get(b)
+        if not aid:
+            result.fail(f"Required link: node '{a}' not found in lab")
+            continue
+        if not bid:
+            result.fail(f"Required link: node '{b}' not found in lab")
+            continue
+        if bid in adjacency.get(aid, set()):
+            result.ok(f"Required link present: {a} <-> {b}")
+        else:
+            result.fail(f"Required link MISSING: {a} <-> {b}")
+
+    # Forbidden links
+    for req in reqs.get("forbidden_links", []):
+        a, b = req["from"], req["to"]
+        aid = name_to_id.get(a)
+        bid = name_to_id.get(b)
+        if not aid or not bid:
+            continue
+        if bid in adjacency.get(aid, set()):
+            result.fail(f"Forbidden link EXISTS: {a} <-> {b}")
+        else:
+            result.ok(f"Forbidden link absent: {a} <-> {b}")
+
+    # Redundancy groups
+    for grp in reqs.get("redundancy_groups", []):
+        role = grp.get("role", "group")
+        min_uplinks = grp.get("min_uplinks", 2)
+        for node_name in grp.get("nodes", []):
+            nid = name_to_id.get(node_name)
+            if not nid:
+                result.warn(f"Redundancy group '{role}': node '{node_name}' not found")
+                continue
+            count = len(adjacency.get(nid, set()))
+            if count < min_uplinks:
+                result.fail(f"Redundancy group '{role}': {node_name} has {count} links, requires >= {min_uplinks}")
+            else:
+                result.ok(f"Redundancy group '{role}': {node_name} has {count} links (>= {min_uplinks} required)")
+
+
+# ---------------------------------------------------------------------------
+# Connectivity matrix printer
+# ---------------------------------------------------------------------------
+
+def print_connectivity_matrix(nodes, adjacency, role_map):
+    id_to_name = {nid: n["name"] for nid, n in nodes.items()}
+    sorted_nodes = sorted(nodes.values(), key=lambda n: (ROLE_HIERARCHY.get(infer_role(n["name"], role_map), 99), n["name"]))
+
+    print("\n=== CONNECTIVITY MATRIX ===")
+    print(f"  {'NODE':<20} {'ROLE':<16} {'DEGREE':>6}  NEIGHBORS")
+    print(f"  {'-'*20} {'-'*16} {'-'*6}  {'-'*40}")
+    for node in sorted_nodes:
+        nid = node["id"]
+        role = infer_role(node["name"], role_map)
+        neighbors = sorted(id_to_name.get(nb, nb) for nb in adjacency.get(nid, set()))
+        print(f"  {node['name']:<20} {role:<16} {len(neighbors):>6}  {', '.join(neighbors)}")
+
+
+def print_network_table(nodes, networks, net_members):
+    id_to_name = {nid: n["name"] for nid, n in nodes.items()}
+    print("\n=== NETWORK MEMBERSHIP TABLE ===")
+    print(f"  {'NETWORK':<28} {'TYPE':<10} {'ENDPOINTS'}")
+    print(f"  {'-'*28} {'-'*10} {'-'*40}")
+    for netid in sorted(networks.keys(), key=lambda x: int(x) if x.isdigit() else x):
+        net = networks[netid]
+        members = net_members.get(netid, [])
+        endpoint_strs = [f"{id_to_name.get(nid, nid)}/{iname}" for nid, iname in members]
+        print(f"  {net['name']:<28} {net['type']:<10} {', '.join(endpoint_strs) or '(none)'}")
+
+
+# ---------------------------------------------------------------------------
+# Resilience score
+# ---------------------------------------------------------------------------
+
+def resilience_level(result, bridges, aps):
+    failures = len(result.failures)
+    warnings = len(result.warnings)
+    spof_count = len(bridges) + len(aps)
+
+    if failures > 0:
+        return "CRITICAL", "One or more validation failures"
+    if spof_count > 4 or warnings > 5:
+        return "LOW",      "Multiple SPOFs or warnings present"
+    if spof_count > 1 or warnings > 2:
+        return "MEDIUM",   "Some SPOFs or asymmetries present"
+    if spof_count == 1 or warnings > 0:
+        return "HIGH",     "Minor resilience gaps"
+    return "FULL",         "No SPOFs or validation issues detected"
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser(description="Validate an EVE-NG .unl topology file")
+    ap.add_argument("lab", help="Path to the .unl lab file")
+    ap.add_argument("--reqs",    help="JSON file with design requirements", default=None)
+    ap.add_argument("--roles",   help="JSON file mapping node name to role", default=None)
+    ap.add_argument("--verbose", action="store_true", help="Show full connectivity matrix and network table")
+    ap.add_argument("--json",    action="store_true", help="Output results as JSON")
+    args = ap.parse_args()
+
+    lab_path = Path(args.lab)
+    if not lab_path.exists():
+        print(f"ERROR: file not found: {lab_path}", file=sys.stderr)
+        sys.exit(1)
+
+    role_map = {}
+    if args.roles:
+        with open(args.roles) as f:
+            role_map = json.load(f)
+
+    reqs = None
+    if args.reqs:
+        with open(args.reqs) as f:
+            reqs = json.load(f)
+
+    lab_name, nodes, networks = parse_unl(lab_path)
+    net_members, node_nets, adjacency, dangling_ifaces = build_connectivity(nodes, networks)
+
+    node_ids = set(nodes.keys())
+    aps      = find_articulation_points(node_ids, adjacency)
+    bridges  = find_bridge_links(node_ids, adjacency)
+
+    result = ValidationResult()
+
+    check_orphan_nodes(nodes, node_nets, result)
+    check_dangling_interfaces(dangling_ifaces, result)
+    check_isolated_networks(net_members, networks, result)
+    check_connectivity(node_ids, adjacency, result)
+    check_role_adjacency(nodes, adjacency, role_map, result)
+    check_spof(node_ids, adjacency, nodes, result)
+    check_symmetry(nodes, adjacency, role_map, result)
+    check_design_requirements(nodes, adjacency, net_members, networks, reqs, role_map, result)
+
+    level, reason = resilience_level(result, bridges, aps)
+
+    if args.json:
+        out = {
+            "lab":       lab_name,
+            "nodes":     len(nodes),
+            "networks":  len(networks),
+            "resilience": {"level": level, "reason": reason},
+            "score":     result.score,
+            "passed":    result.passed,
+            "warnings":  result.warnings,
+            "failures":  result.failures,
+        }
+        print(json.dumps(out, indent=2))
+        sys.exit(0 if not result.failures else 1)
+
+    print(f"\n{'='*60}")
+    print(f" EVE-NG UNL Topology Validator")
+    print(f"{'='*60}")
+    print(f" Lab      : {lab_name}")
+    print(f" File     : {lab_path}")
+    print(f" Nodes    : {len(nodes)}")
+    print(f" Networks : {len(networks)}")
+    print(f"{'='*60}")
+
+    if args.verbose:
+        print_connectivity_matrix(nodes, adjacency, role_map)
+        print_network_table(nodes, networks, net_members)
+
+    print(f"\n=== VALIDATION RESULTS ===")
+    for msg in result.passed:
+        print(f"  [PASS] {msg}")
+    for msg in result.warnings:
+        print(f"  [WARN] {msg}")
+    for msg in result.failures:
+        print(f"  [FAIL] {msg}")
+
+    print(f"\n=== RESILIENCE ASSESSMENT ===")
+    print(f"  Level : {level}")
+    print(f"  Reason: {reason}")
+    print(f"  Score : {result.score}/100  ({len(result.passed)} passed, {len(result.warnings)} warnings, {len(result.failures)} failures)")
+
+    print(f"\n{'='*60}")
+    if result.failures:
+        print(f" RESULT: FAILED — {len(result.failures)} critical issue(s) must be resolved")
+        sys.exit(1)
+    elif result.warnings:
+        print(f" RESULT: PASSED WITH WARNINGS — review {len(result.warnings)} item(s)")
+        sys.exit(0)
+    else:
+        print(f" RESULT: PASSED — topology is valid and resilient")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/workspace/skills/eve-ng-config-ops/SKILL.md
+++ b/workspace/skills/eve-ng-config-ops/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: eve-ng-config-ops
+description: Manage EVE-NG startup configs — read, write, wipe, and bulk-export node configurations.
+user-invocable: true
+metadata:
+  openclaw:
+    requires:
+      bins: ["python3"]
+      env: ["EVE_URL", "EVE_USER", "EVE_PASSWORD"]
+---
+
+# EVE-NG Config Operations
+
+Use this skill for startup config handling stored in the lab file.
+
+## When to Use
+
+- Back up startup configs before a change
+- Preload startup configs before first boot
+- Clear startup config without a full node wipe
+- Export all configs from a lab in one call
+
+## Config vs Wipe
+
+| Operation | Effect | Node State |
+|---|---|---|
+| `eve_set_node_config` | Write startup config | Stopped |
+| `eve_wipe_node_config` | Clear startup config only | Stopped |
+| `eve_wipe_node` | Clear NVRAM and startup state | Stopped |
+
+## MCP Server
+
+- **Command**: `python3 -u mcp-servers/eve-ng-mcp-server/eve_ng_mcp_server.py`
+- **Requires**: `EVE_URL`, `EVE_USER`, `EVE_PASSWORD`
+
+## Available Tools
+
+| Tool | Parameters | Purpose |
+|---|---|---|
+| `eve_get_node_config` | `lab_path, node` | Read one startup config |
+| `eve_set_node_config` | `lab_path, node, config` | Write one startup config |
+| `eve_get_all_configs` | `lab_path` | Export all startup configs |
+| `eve_wipe_node_config` | `lab_path, node` | Clear one startup config |
+
+## Workflow Examples
+
+```text
+"Export all configs from /Labs/bgp-demo.unl"           → eve_get_all_configs /Labs/bgp-demo.unl
+"Show the stored config for R1"                        → eve_get_node_config /Labs/bgp-demo.unl R1
+"Load a startup config onto R2"                        → eve_stop_node → eve_set_node_config → eve_start_node
+"Clear only the startup config for R3"                 → eve_stop_node → eve_wipe_node_config → eve_start_node
+```
+
+## Provisioning Flow
+
+1. Create the lab with **eve-ng-lab-management**.
+2. Add nodes with **eve-ng-node-operations**.
+3. Wire links with **eve-lab-topology-build**.
+4. Load startup configs while nodes are stopped.
+5. Start the lab.
+6. Verify with **eve-ng-console-ops**.
+
+## Integration with Other Skills
+
+- **eve-ng-node-operations**: stop before write, start after write
+- **eve-ng-console-ops**: verify applied config on boot
+- **eve-lab-topology-design**: map design intent to startup configs
+
+## Error Handling
+
+| Error Code | Meaning | Resolution |
+|---|---|---|
+| `EVE_NOT_FOUND` | Node not found | Run `eve_list_nodes` |
+| `EVE_VALIDATION` | Config rejected by API | Check formatting and line endings |
+| `EVE_AUTH_FAILED` | Session failed | Retry after auth check |
+
+## Notes
+
+- Startup configs are stored in the `.unl` data model.
+- `eve_set_node_config` does not validate vendor syntax.
+- `eve_get_all_configs` is the most efficient backup path for multi-node labs.

--- a/workspace/skills/eve-ng-console-ops/SKILL.md
+++ b/workspace/skills/eve-ng-console-ops/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: eve-ng-console-ops
+description: Execute commands on running EVE-NG nodes through the console for IOS, Junos, VPCS, EOS, and NX-OS.
+user-invocable: true
+metadata:
+  openclaw:
+    requires:
+      bins: ["python3"]
+      env: ["EVE_URL", "EVE_USER", "EVE_PASSWORD"]
+---
+
+# EVE-NG Console Operations
+
+Use this skill when the lab is already running and you need live CLI access.
+
+## When to Use
+
+- Run show commands on active devices
+- Push configuration interactively
+- Verify routing adjacencies after topology changes
+- Test reachability with `ping` or `traceroute`
+- Confirm console readiness after node boot
+
+## Console Rules
+
+- Run `eve_discover_node` first when readiness is uncertain.
+- Treat API `running` state as separate from console readiness.
+- Keep command batches focused; long transcripts consume tokens fast.
+- Use config mode only when the task truly needs it.
+
+## MCP Server
+
+- **Command**: `python3 -u mcp-servers/eve-ng-mcp-server/eve_ng_mcp_server.py`
+- **Requires**: `EVE_URL`, `EVE_USER`, `EVE_PASSWORD`
+- **Optional**: `EVE_CONSOLE_HOST` when the MCP server runs off-box
+
+## Available Tools
+
+| Tool | Parameters | Purpose |
+|---|---|---|
+| `eve_discover_node` | `lab_path, node` | Resolve console host, port, and runtime status |
+| `eve_exec_ios` | `lab_path, node, commands, config_mode?, save?, command_timeout?, wait?` | IOS / IOL / IOS-XE console |
+| `eve_exec_junos` | `lab_path, node, commands, command_timeout?, wait?` | Junos console |
+| `eve_exec_vpcs` | `lab_path, node, commands, command_timeout?, dhcp_timeout?, prompt_timeout?` | VPCS console |
+| `eve_exec_eos` | `lab_path, node, commands, config_mode?, save?, command_timeout?, wait?` | Arista EOS console |
+| `eve_exec_nxos` | `lab_path, node, commands, config_mode?, save?, command_timeout?, wait?` | Cisco NX-OS console |
+
+## Workflow Examples
+
+```text
+"Is R1 ready for CLI access?"                            → eve_discover_node /Labs/bgp-demo.unl R1
+"Run show ip route on R1"                                → eve_exec_ios /Labs/bgp-demo.unl R1 ["show ip route"]
+"Show bgp summary on vMX1"                               → eve_exec_junos /Labs/wan-demo.unl vMX1 ["show bgp summary"]
+"Run DHCP then ping from PC1"                            → eve_exec_vpcs /Labs/access-demo.unl PC1 ["ip dhcp", "ping 10.0.0.1"]
+"Create VLAN 10 on SW1 and save"                         → eve_exec_nxos config_mode=true save=true
+```
+
+## Output Model
+
+Exec tools return a `transcript` array with one entry per command. Prefer targeted command sets instead of large diagnostic dumps.
+
+## Timeout Tuning
+
+- Raise `command_timeout` for slow boots or large outputs.
+- Raise `wait` if the guest CLI is sluggish.
+- Use the smallest values that still produce clean prompts.
+
+## Integration with Other Skills
+
+- **eve-ng-node-operations**: boot or stop nodes
+- **eve-lab-topology-build**: verify links after rewiring
+- **eve-ng-config-ops**: compare startup vs running state
+
+## Error Handling
+
+| Error Code | Meaning | Resolution |
+|---|---|---|
+| `EVE_CONSOLE_TIMEOUT` | Console not reachable | Check node state and wait for boot |
+| `EVE_NOT_FOUND` | Node name unresolved | Run `eve_list_nodes` |
+| `EVE_CONSOLE_AUTH` | Login failed | Verify node credentials |
+
+## Notes
+
+- Junos output automatically suppresses pagination.
+- `save=true` writes config using the platform-appropriate save command.
+- Console transcripts can get large quickly; ask for only what you need.

--- a/workspace/skills/eve-ng-lab-management/README.md
+++ b/workspace/skills/eve-ng-lab-management/README.md
@@ -1,0 +1,34 @@
+# EVE-NG Skills Overview
+
+This skill set covers the full EVE-NG workflow in small, focused pieces:
+
+- `eve-ng-lab-management` — platform health, lab inventory, create/delete/export
+- `eve-ng-node-operations` — node lifecycle and lab start/stop
+- `eve-lab-topology-build` — networks, links, and topology inspection
+- `eve-ng-config-ops` — startup config backup, load, and clear
+- `eve-ng-console-ops` — live CLI execution on running nodes
+- `eve-lab-topology-design` — design planning and `.unl` validation
+
+## Recommended Flow
+
+1. Design or validate the topology.
+2. Create the lab.
+3. Add nodes.
+4. Build the links.
+5. Load startup configs if needed.
+6. Start nodes.
+7. Verify through the console.
+
+## Smoke Test
+
+Run the EVE skill smoke test from the repo root:
+
+```bash
+python3 mcp-servers/eve-ng-mcp-server/tests/test_eve_skills_smoke.py
+```
+
+The smoke test checks that:
+- the EVE skill files exist
+- documented MCP tools match the server implementation
+- stale local-only references are not present
+- the UNL validator script starts successfully

--- a/workspace/skills/eve-ng-lab-management/SKILL.md
+++ b/workspace/skills/eve-ng-lab-management/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: eve-ng-lab-management
+description: Manage EVE-NG labs — list, inspect, create, delete, export, and check platform status.
+user-invocable: true
+metadata:
+  openclaw:
+    requires:
+      bins: ["python3"]
+      env: ["EVE_URL", "EVE_USER", "EVE_PASSWORD"]
+---
+
+# EVE-NG Lab Management
+
+Use this skill for lab lifecycle work: platform health, lab inventory, lab metadata, create/delete, and `.unl` export.
+
+## When to Use
+
+- List labs on the EVE-NG server
+- Check lab metadata before making changes
+- Create a new empty lab
+- Delete an unused lab
+- Export a `.unl` file for backup or review
+- Verify EVE-NG API health and installed images
+
+## MCP Server
+
+- **Command**: `python3 -u mcp-servers/eve-ng-mcp-server/eve_ng_mcp_server.py`
+- **Requires**: `EVE_URL`, `EVE_USER`, `EVE_PASSWORD`
+- **Optional**: `EVE_VERIFY_SSL`, `EVE_SESSION_TTL`, `EVE_HTML5`, `EVE_CONSOLE_HOST`
+
+## Available Tools
+
+| Tool | Parameters | Purpose |
+|---|---|---|
+| `eve_status` | — | Check EVE-NG version, CPU, memory, and disk |
+| `eve_auth` | — | Verify API login and current user |
+| `eve_list_images` | `node_type?` | List installed images |
+| `eve_list_labs` | `folder?` | List labs recursively |
+| `eve_get_lab` | `lab_path` | Read lab metadata |
+| `eve_create_lab` | `name, folder?, description?, version?, author?` | Create an empty lab |
+| `eve_delete_lab` | `lab_path` | Delete a lab |
+| `eve_export_lab` | `lab_path` | Export raw `.unl` XML |
+
+## Core Workflow
+
+1. Check platform health with `eve_status` when behavior looks odd.
+2. Locate the target lab with `eve_list_labs`.
+3. Read metadata with `eve_get_lab` before changing anything.
+4. Hand off to the relevant skill:
+   - **eve-ng-node-operations** for node lifecycle
+   - **eve-lab-topology-build** for networks and links
+   - **eve-ng-console-ops** for live CLI work
+   - **eve-ng-config-ops** for startup config handling
+
+## Workflow Examples
+
+```text
+"Is EVE-NG healthy?"                    → eve_status
+"List all EVE labs"                     → eve_list_labs
+"Show details for /Labs/ospf-demo.unl"  → eve_get_lab /Labs/ospf-demo.unl
+"Create a new lab called bgp-demo"      → eve_create_lab name=bgp-demo
+"Export /Labs/bgp-demo.unl"             → eve_export_lab /Labs/bgp-demo.unl
+"Delete /Labs/old-test.unl"             → eve_delete_lab /Labs/old-test.unl
+```
+
+## Integration with Other Skills
+
+- **eve-ng-node-operations**: start, stop, create, delete, wipe nodes
+- **eve-lab-topology-build**: create networks and wire interfaces
+- **eve-ng-console-ops**: run CLI commands on active nodes
+- **eve-ng-config-ops**: read or write startup configs
+- **eve-lab-topology-design**: design or validate the topology before building
+
+## Error Handling
+
+| Error Code | Meaning | Resolution |
+|---|---|---|
+| `EVE_AUTH_FAILED` | Login failed | Check credentials |
+| `EVE_NOT_FOUND` | Lab path not found | Run `eve_list_labs` |
+| `EVE_CONFLICT` | Lab already exists | Choose a different name |
+| `EVE_UNREACHABLE` | API is unreachable | Check `EVE_URL` and connectivity |
+
+## Notes
+
+- Prefer `eve_export_lab` before major topology edits.
+- Use full lab paths such as `/Labs/demo.unl`.
+- Deleting a lab does not replace change control or backups.
+- Lab operations are environment changes; verify state before and after.

--- a/workspace/skills/eve-ng-lab-management/references/commands.md
+++ b/workspace/skills/eve-ng-lab-management/references/commands.md
@@ -1,0 +1,63 @@
+# EVE-NG Command Patterns
+
+These are host-side checks that complement the MCP tools when the API, runtime bridges, or web UI behave unexpectedly.
+
+## Platform checks
+
+```bash
+systemctl is-active apache2 mysql mariadb guacd docker tomcat9
+systemctl --no-pager --type=service --state=running | grep -Ei 'apache|mysql|mariadb|guacd|docker|tomcat|eve|unetlab'
+ss -ltnp | grep -E ':(80|443) '
+```
+
+## Lab file checks
+
+```bash
+find /opt/unetlab/labs -type f -name '*.unl' | sort
+sed -n '1,220p' /opt/unetlab/labs/<path>/<lab>.unl
+```
+
+## Runtime ownership checks
+
+```bash
+ps -ef | grep -E 'qemu-system|dynamips|vpcs' | grep -v grep
+ss -ltnp | grep -E '3276[0-9]|3277[0-9]|3278[0-9]'
+ip link show | grep -E 'vnet|vunl|pnet'
+brctl show
+```
+
+## Wrapper and platform logs
+
+```bash
+sed -n '1,200p' /opt/unetlab/data/Logs/unl_wrapper.txt
+sed -n '1,200p' /opt/unetlab/data/Logs/error.txt
+sed -n '1,200p' /opt/unetlab/data/Logs/php_errors.txt
+```
+
+## Image inventory checks
+
+```bash
+find /opt/unetlab/addons/qemu -maxdepth 2 -type d | sort
+find /opt/unetlab/addons/iol/bin -maxdepth 1 -type f | sort
+```
+
+## Template inspection
+
+```bash
+sed -n '1,220p' /opt/unetlab/html/templates/intel/<template>.yml
+```
+
+## Validator check
+
+```bash
+python3 workspace/skills/eve-lab-topology-design/scripts/validate_unl_topology.py /path/to/lab.unl --verbose
+```
+
+## MCP-first preference
+
+For normal lab operations, prefer the EVE MCP tools over ad-hoc shell parsing:
+- lab inventory and metadata → `eve_list_labs`, `eve_get_lab`
+- node state → `eve_list_nodes`, `eve_get_node`
+- topology view → `eve_get_topology`, `eve_list_node_interfaces`
+- config export → `eve_get_all_configs`
+- live CLI → `eve_discover_node`, `eve_exec_*`

--- a/workspace/skills/eve-ng-lab-management/references/troubleshooting.md
+++ b/workspace/skills/eve-ng-lab-management/references/troubleshooting.md
@@ -1,0 +1,84 @@
+# EVE-NG Troubleshooting Notes
+
+## Lab start fails with `network_name already in use`
+
+Meaning:
+- stale runtime bridges or tap interfaces still exist on the host
+- the saved `.unl` file may be fine
+
+Check:
+
+```bash
+ip link show | grep -E 'vnet|vunl|pnet'
+ps -ef | grep -E 'qemu-system|dynamips|vpcs' | grep -v grep
+sed -n '1,200p' /opt/unetlab/data/Logs/unl_wrapper.txt
+```
+
+Recommended response:
+1. confirm the affected nodes are actually stopped
+2. inspect stale `vnet*` and `vunl*` interfaces
+3. clean up only what belongs to the failed lab, or restart the relevant EVE services if change policy allows
+4. retry the start and re-check node processes
+
+## Lab looks stopped but restart still fails
+
+Possible cause:
+- UI state and host runtime state disagree
+
+Check:
+
+```bash
+ps -ef | grep -E 'qemu-system|dynamips|vpcs' | grep -v grep
+ip link show | grep -E 'vnet|vunl|pnet'
+ss -ltnp | grep -E '3276[0-9]|3277[0-9]|3278[0-9]'
+```
+
+## Web UI appears down
+
+Check:
+
+```bash
+systemctl is-active apache2 mysql mariadb guacd docker tomcat9
+ss -ltnp | grep -E ':(80|443) '
+```
+
+Interpretation:
+- Apache on `80` usually means basic UI is up
+- missing `443` means HTTPS is not listening
+- inactive MySQL or MariaDB can break login and inventory behavior
+
+## Direct neighbors do not form adjacency even though interfaces are up
+
+Work from evidence in this order:
+1. `.unl` interface-to-network bindings
+2. host bridge membership (`vnet*`, `vunl*`)
+3. guest interface names from CLI
+4. protocol discovery such as CDP or LLDP
+
+Check:
+
+```bash
+sed -n '1,220p' /opt/unetlab/labs/<lab>.unl
+brctl show
+ip -o link show | grep -E 'vnet|vunl'
+```
+
+Do not call a port mapping confirmed unless saved topology, host runtime state, and guest evidence agree.
+
+## Image mismatch or missing image
+
+Symptoms:
+- node start exits quickly
+- wrapper log mentions image or template failure
+
+Check:
+
+```bash
+find /opt/unetlab/addons/qemu -maxdepth 2 -type d | sort
+find /opt/unetlab/addons/iol/bin -maxdepth 1 -type f | sort
+sed -n '1,220p' /opt/unetlab/html/templates/intel/<template>.yml
+```
+
+## Token-efficiency reminder
+
+When troubleshooting through the console, prefer short targeted commands over long blanket outputs. Large routing tables and full running configs add tokens fast.

--- a/workspace/skills/eve-ng-node-operations/SKILL.md
+++ b/workspace/skills/eve-ng-node-operations/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: eve-ng-node-operations
+description: Manage EVE-NG nodes — list, inspect, create, delete, start, stop, and wipe nodes or full labs.
+user-invocable: true
+metadata:
+  openclaw:
+    requires:
+      bins: ["python3"]
+      env: ["EVE_URL", "EVE_USER", "EVE_PASSWORD"]
+---
+
+# EVE-NG Node Operations
+
+Use this skill for node lifecycle work inside an existing lab.
+
+## When to Use
+
+- List nodes and runtime state
+- Read node details such as image, CPU, RAM, and console port
+- Add or remove nodes
+- Start or stop one node or a full lab
+- Wipe a node back to factory state
+
+## Operational Rules
+
+- Confirm the target lab first with **eve-ng-lab-management**.
+- After `eve_start_node`, verify console readiness with **eve-ng-console-ops** before sending config.
+- Stop nodes before deleting or wiping them.
+- For bulk changes, prefer a full lab stop/start window over piecemeal churn.
+
+## MCP Server
+
+- **Command**: `python3 -u mcp-servers/eve-ng-mcp-server/eve_ng_mcp_server.py`
+- **Requires**: `EVE_URL`, `EVE_USER`, `EVE_PASSWORD`
+
+## Available Tools
+
+| Tool | Parameters | Purpose |
+|---|---|---|
+| `eve_list_nodes` | `lab_path` | List nodes with status, image, and console |
+| `eve_get_node` | `lab_path, node` | Get full details for one node |
+| `eve_create_node` | `lab_path, name, node_type, template, image?, left?, top?, ram?, ethernet?, serial?, console?, cpu?, icon?` | Add a node |
+| `eve_delete_node` | `lab_path, node` | Delete a node |
+| `eve_start_node` | `lab_path, node` | Start one node |
+| `eve_stop_node` | `lab_path, node` | Stop one node |
+| `eve_start_lab` | `lab_path` | Start all nodes in a lab |
+| `eve_stop_lab` | `lab_path` | Stop all nodes in a lab |
+| `eve_wipe_node` | `lab_path, node` | Clear NVRAM and startup state |
+
+Nodes can be referenced by **name** or **numeric ID**.
+
+## Workflow Examples
+
+```text
+"List nodes in /Labs/bgp-demo.unl"          → eve_list_nodes /Labs/bgp-demo.unl
+"Start R1 in /Labs/bgp-demo.unl"            → eve_start_node /Labs/bgp-demo.unl R1
+"Stop all nodes in /Labs/wan-demo.unl"      → eve_stop_lab /Labs/wan-demo.unl
+"Add a vIOS router named R3"                → eve_create_node /Labs/bgp-demo.unl R3 qemu vios
+"Delete PC2 from /Labs/access-demo.unl"     → eve_delete_node /Labs/access-demo.unl PC2
+"Wipe R2 back to defaults"                  → eve_stop_node → eve_wipe_node
+```
+
+## Verification Behavior
+
+Start and stop tools poll EVE-NG after the action. Treat API state as necessary but not sufficient for device readiness.
+
+Use **eve-ng-console-ops** for final confirmation when the next step depends on CLI availability.
+
+## Integration with Other Skills
+
+- **eve-ng-lab-management**: lab inventory and metadata
+- **eve-lab-topology-build**: connect interfaces after node creation
+- **eve-ng-console-ops**: verify boot readiness and run commands
+- **eve-ng-config-ops**: preload or clear startup configs
+
+## Error Handling
+
+| Error Code | Meaning | Resolution |
+|---|---|---|
+| `EVE_NOT_FOUND` | Node not found | Run `eve_list_nodes` |
+| `EVE_CONFLICT` | Duplicate node name | Use a unique name |
+| `EVE_VALIDATION` | Invalid node type or template | Check `eve_list_node_types` and installed images |
+| `EVE_IMAGE_MISSING` | Image not installed | Run `eve_list_images` |
+| `EVE_AUTH_FAILED` | Session failed | Retry after auth check |
+
+## Notes
+
+- Use image names exactly as installed on the EVE host.
+- Canvas coordinates are cosmetic.
+- Wipe is destructive for node state; use **eve-ng-config-ops** for config-only resets.


### PR DESCRIPTION
## Summary

Adds a complete EVE-NG contribution to NetClaw:

- new `eve-ng-mcp-server` MCP server with 34 tools
- 5 focused EVE execution skills plus 1 topology-design skill
- UNL topology validator for pre-build and post-build checks
- short EVE skill overview README
- smoke test that validates skill docs against the MCP server tool set

### Skills
- `workspace/skills/eve-ng-lab-management/SKILL.md`
- `workspace/skills/eve-ng-node-operations/SKILL.md`
- `workspace/skills/eve-ng-config-ops/SKILL.md`
- `workspace/skills/eve-ng-console-ops/SKILL.md`
- `workspace/skills/eve-lab-topology-build/SKILL.md`
- `workspace/skills/eve-lab-topology-design/SKILL.md`
- `workspace/skills/eve-ng-lab-management/README.md`
- lab-management references for commands and troubleshooting

### Validation
- `workspace/skills/eve-lab-topology-design/scripts/validate_unl_topology.py`
- `mcp-servers/eve-ng-mcp-server/tests/test_eve_skills_smoke.py`


## Smoke test

Run from repo root:

```bash
python3 mcp-servers/eve-ng-mcp-server/tests/test_eve_skills_smoke.py
```

## Local validation performed

```bash
python3 -m py_compile \
  mcp-servers/eve-ng-mcp-server/eve_ng_mcp_server.py \
  mcp-servers/eve-ng-mcp-server/tests/test_eve_skills_smoke.py \
  workspace/skills/eve-lab-topology-design/scripts/validate_unl_topology.py

python3 mcp-servers/eve-ng-mcp-server/tests/test_eve_skills_smoke.py
```

Result:
- smoke test passed
- validator script launches successfully
- documented EVE tools match the MCP server implementation

