### PR TITLE
feat: Add Nautobot MCP servers (mcp-v2, golden-config, routing)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,9 +56,15 @@ mcp-servers/*
 !mcp-servers/gns3-mcp-server/
 !mcp-servers/eve-ng-mcp-server/
 !mcp-servers/prisma-sdwan-mcp/
+!mcp-servers/nautobot-mcp-v2/
+!mcp-servers/nautobot-golden-config-mcp/
+!mcp-servers/nautobot-routing-mcp/
 
 # Traces
 trace.json
 trace.json.gz
 
 .claude
+docs/blogs/
+.amazonq
+workspace/

--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -262,6 +262,53 @@
     },
     "devnet-content-search": {
       "url": "https://devnet.cisco.com/v1/foundation-search-mcp/mcp"
+    },
+    "nautobot-mcp": {
+      "command": "/home/ubuntu/netclaw/.venv/bin/python3",
+      "args": [
+        "-u",
+        "/home/ubuntu/netclaw/mcp-servers/nautobot-mcp-v2/server.py"
+      ],
+      "env": {
+        "NAUTOBOT_URL": "${NAUTOBOT_URL}",
+        "NAUTOBOT_TOKEN": "${NAUTOBOT_TOKEN}",
+        "NAUTOBOT_VERIFY_SSL": "${NAUTOBOT_VERIFY_SSL:-false}",
+        "NAUTOBOT_TIMEOUT": "${NAUTOBOT_TIMEOUT:-60}",
+        "ITSM_ENABLED": "${ITSM_ENABLED:-false}",
+        "ITSM_LAB_MODE": "${ITSM_LAB_MODE:-true}"
+      }
+    },
+    "nautobot-golden-config-mcp": {
+      "command": "/home/ubuntu/netclaw/.venv/bin/python3",
+      "args": [
+        "-u",
+        "/home/ubuntu/netclaw/mcp-servers/nautobot-golden-config-mcp/server.py"
+      ],
+      "env": {
+        "NAUTOBOT_URL": "${NAUTOBOT_URL}",
+        "NAUTOBOT_TOKEN": "${NAUTOBOT_TOKEN}",
+        "NAUTOBOT_VERIFY_SSL": "${NAUTOBOT_VERIFY_SSL:-false}",
+        "NAUTOBOT_TIMEOUT": "${NAUTOBOT_TIMEOUT:-60}",
+        "GOLDEN_CONFIG_POLL_INTERVAL": "${GOLDEN_CONFIG_POLL_INTERVAL:-5}",
+        "GOLDEN_CONFIG_JOB_TIMEOUT": "${GOLDEN_CONFIG_JOB_TIMEOUT:-300}",
+        "ITSM_ENABLED": "${ITSM_ENABLED:-false}",
+        "ITSM_LAB_MODE": "${ITSM_LAB_MODE:-true}"
+      }
+    },
+    "nautobot-routing-mcp": {
+      "command": "/home/ubuntu/netclaw/.venv/bin/python3",
+      "args": [
+        "-u",
+        "/home/ubuntu/netclaw/mcp-servers/nautobot-routing-mcp/server.py"
+      ],
+      "env": {
+        "NAUTOBOT_URL": "${NAUTOBOT_URL}",
+        "NAUTOBOT_TOKEN": "${NAUTOBOT_TOKEN}",
+        "NAUTOBOT_VERIFY_SSL": "${NAUTOBOT_VERIFY_SSL:-false}",
+        "NAUTOBOT_TIMEOUT": "${NAUTOBOT_TIMEOUT:-60}",
+        "ITSM_ENABLED": "${ITSM_ENABLED:-false}",
+        "ITSM_LAB_MODE": "${ITSM_LAB_MODE:-true}"
+      }
     }
   }
 }

--- a/mcp-servers/nautobot-golden-config-mcp/job_runner.py
+++ b/mcp-servers/nautobot-golden-config-mcp/job_runner.py
@@ -1,0 +1,110 @@
+"""Job runner — trigger Nautobot golden config jobs and poll until complete."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, Optional
+
+from nautobot_client import NautobotClient, NautobotError
+
+logger = logging.getLogger(__name__)
+
+POLL_INTERVAL = int(os.environ.get("GOLDEN_CONFIG_POLL_INTERVAL", "5"))
+JOB_TIMEOUT = int(os.environ.get("GOLDEN_CONFIG_JOB_TIMEOUT", "300"))
+
+# Golden config job class paths
+JOB_INTENDED = "nautobot_golden_config.jobs.IntendedJob"
+JOB_BACKUP = "nautobot_golden_config.jobs.BackupJob"
+JOB_COMPLIANCE = "nautobot_golden_config.jobs.ComplianceJob"
+JOB_DEPLOY = "nautobot_golden_config.jobs.DeployConfigPlans"
+
+# Fallback: match by job name substring
+_JOB_NAME_MAP = {
+    JOB_INTENDED: "Generate Intended Configurations",
+    JOB_BACKUP: "Backup Configurations",
+    JOB_COMPLIANCE: "Perform Configuration Compliance",
+    JOB_DEPLOY: "Deploy Config Plans",
+}
+
+
+async def find_job_id(client: NautobotClient, class_path: str) -> Optional[str]:
+    """Find a job UUID by its class_path or name."""
+    resp = await client.rest_get("extras/jobs", {"limit": 200})
+    jobs = resp.get("results", [])
+
+    # Try exact class_path match first
+    for job in jobs:
+        if job.get("class_path") == class_path:
+            return job["id"]
+
+    # Try module_name match
+    module = class_path.rsplit(".", 1)[0] if "." in class_path else class_path
+    class_name = class_path.rsplit(".", 1)[-1] if "." in class_path else ""
+    for job in jobs:
+        if module in (job.get("module_name", "") or ""):
+            if class_name.lower() in (job.get("name", "") or "").lower().replace(" ", ""):
+                return job["id"]
+
+    # Fallback: match by known job name
+    expected_name = _JOB_NAME_MAP.get(class_path, "")
+    if expected_name:
+        for job in jobs:
+            if job.get("name") == expected_name:
+                return job["id"]
+
+    return None
+
+
+async def run_job_and_wait(
+    client: NautobotClient,
+    class_path: str,
+    data: Optional[dict] = None,
+    timeout: int = JOB_TIMEOUT,
+) -> dict[str, Any]:
+    """Trigger a Nautobot job by class_path and poll until complete."""
+    job_id = await find_job_id(client, class_path)
+    if not job_id:
+        raise NautobotError(f"Job '{class_path}' not found. Is the golden config plugin installed and jobs enabled?")
+
+    payload = {"data": data or {}}
+    result = await client.rest_post(f"extras/jobs/{job_id}/run", payload)
+
+    # Extract job result ID
+    job_result_id = None
+    if isinstance(result, dict):
+        # Could be nested under "job_result" or at top level
+        jr = result.get("job_result") or result
+        job_result_id = jr.get("id") if isinstance(jr, dict) else result.get("id")
+
+    if not job_result_id:
+        return {"status": "triggered", "raw": result}
+
+    # Poll until complete
+    elapsed = 0
+    while elapsed < timeout:
+        await asyncio.sleep(POLL_INTERVAL)
+        elapsed += POLL_INTERVAL
+
+        jr = await client.rest_get(f"extras/job-results/{job_result_id}")
+        status_val = jr.get("status")
+        if isinstance(status_val, dict):
+            status_val = status_val.get("value", status_val.get("label", ""))
+
+        if status_val in ("completed", "SUCCESS"):
+            return {
+                "status": "completed",
+                "id": job_result_id,
+                "result": jr.get("result"),
+                "completed": jr.get("date_done"),
+            }
+        elif status_val in ("failed", "FAILURE", "errored"):
+            return {
+                "status": "failed",
+                "id": job_result_id,
+                "result": jr.get("result"),
+                "traceback": jr.get("traceback"),
+            }
+
+    return {"status": "timeout", "id": job_result_id, "elapsed": elapsed}

--- a/mcp-servers/nautobot-golden-config-mcp/nautobot_client.py
+++ b/mcp-servers/nautobot-golden-config-mcp/nautobot_client.py
@@ -1,0 +1,81 @@
+"""Nautobot API client for golden config operations — REST + GraphQL."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class NautobotError(Exception):
+    pass
+
+
+class NautobotClient:
+    def __init__(self):
+        self.url = os.environ["NAUTOBOT_URL"].rstrip("/")
+        self.token = os.environ["NAUTOBOT_TOKEN"]
+        verify = os.environ.get("NAUTOBOT_VERIFY_SSL", "false").lower() == "true"
+        timeout = int(os.environ.get("NAUTOBOT_TIMEOUT", "60"))
+
+        self.http = httpx.AsyncClient(
+            headers={
+                "Authorization": f"Token {self.token}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            verify=verify,
+            timeout=timeout,
+        )
+
+    async def graphql(self, query: str, variables: Optional[dict] = None) -> dict[str, Any]:
+        body: dict[str, Any] = {"query": query}
+        if variables:
+            body["variables"] = variables
+        try:
+            resp = await self.http.post(f"{self.url}/api/graphql/", json=body)
+        except (httpx.ConnectError, httpx.TimeoutException) as e:
+            raise NautobotError(f"Nautobot unreachable: {e}")
+        self._check(resp)
+        data = resp.json()
+        if "errors" in data:
+            msgs = "; ".join(e.get("message", str(e)) for e in data["errors"])
+            raise NautobotError(f"GraphQL error: {msgs}")
+        return data.get("data", {})
+
+    async def rest_get(self, endpoint: str, params: Optional[dict] = None) -> dict[str, Any]:
+        return await self._rest("GET", endpoint, params=params)
+
+    async def rest_post(self, endpoint: str, data: dict) -> dict[str, Any]:
+        return await self._rest("POST", endpoint, json_body=data)
+
+    async def rest_patch(self, endpoint: str, data: dict) -> dict[str, Any]:
+        return await self._rest("PATCH", endpoint, json_body=data)
+
+    async def _rest(
+        self, method: str, endpoint: str,
+        params: Optional[dict] = None, json_body: Optional[dict] = None,
+    ) -> dict[str, Any]:
+        url = f"{self.url}/api/{endpoint.strip('/')}/"
+        try:
+            resp = await self.http.request(method, url, params=params, json=json_body)
+        except (httpx.ConnectError, httpx.TimeoutException) as e:
+            raise NautobotError(f"Nautobot unreachable: {e}")
+        self._check(resp)
+        if resp.status_code == 204:
+            return {}
+        return resp.json()
+
+    def _check(self, resp: httpx.Response) -> None:
+        if resp.status_code in (401, 403):
+            raise NautobotError("Authentication failed. Verify NAUTOBOT_TOKEN.")
+        if resp.status_code >= 400:
+            try:
+                detail = resp.json()
+            except Exception:
+                detail = resp.text[:500]
+            raise NautobotError(f"API error ({resp.status_code}): {detail}")

--- a/mcp-servers/nautobot-golden-config-mcp/requirements.txt
+++ b/mcp-servers/nautobot-golden-config-mcp/requirements.txt
@@ -1,0 +1,3 @@
+httpx
+fastmcp
+mcp

--- a/mcp-servers/nautobot-golden-config-mcp/server.py
+++ b/mcp-servers/nautobot-golden-config-mcp/server.py
@@ -1,0 +1,866 @@
+"""Nautobot Golden Config MCP Server — high-level config lifecycle tools.
+
+Provides one-call tools for the golden config pipeline: generate intended,
+backup, compliance, remediate, and full pipeline. Reduces LLM context burn
+from 10+ API calls to 1-3 tool calls.
+
+Environment Variables:
+    NAUTOBOT_URL          — Nautobot instance URL (required)
+    NAUTOBOT_TOKEN        — Nautobot API token (required)
+    NAUTOBOT_TIMEOUT      — API request timeout in seconds (default: 60)
+    NAUTOBOT_VERIFY_SSL   — Verify SSL certificates (default: false)
+    GOLDEN_CONFIG_POLL_INTERVAL — Seconds between job status polls (default: 5)
+    GOLDEN_CONFIG_JOB_TIMEOUT   — Max seconds to wait for job completion (default: 300)
+    ITSM_ENABLED          — Require ServiceNow CR for write ops (default: false)
+    ITSM_LAB_MODE         — Bypass ITSM in lab mode (default: true)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from typing import Optional
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from mcp.server.fastmcp import FastMCP
+
+from nautobot_client import NautobotClient, NautobotError
+from job_runner import (
+    run_job_and_wait,
+    JOB_INTENDED,
+    JOB_BACKUP,
+    JOB_COMPLIANCE,
+    JOB_DEPLOY,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    stream=sys.stderr,
+)
+logger = logging.getLogger("nautobot-golden-config-mcp")
+
+# ── Startup validation ───────────────────────────────────────────────
+
+for var in ("NAUTOBOT_URL", "NAUTOBOT_TOKEN"):
+    if not os.environ.get(var):
+        logger.error(f"Required environment variable {var} is not set.")
+        sys.exit(1)
+
+mcp = FastMCP("nautobot-golden-config-mcp")
+client = NautobotClient()
+
+ITSM_ENABLED = os.environ.get("ITSM_ENABLED", "false").lower() == "true"
+ITSM_LAB_MODE = os.environ.get("ITSM_LAB_MODE", "true").lower() == "true"
+
+
+def _check_itsm(cr_number: Optional[str]) -> Optional[str]:
+    if ITSM_ENABLED and not ITSM_LAB_MODE:
+        if not cr_number:
+            return "Write operation blocked: ITSM is enabled. Provide a cr_number parameter."
+    return None
+
+
+def _esc(s: str) -> str:
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
+async def _resolve_device_ids(device: Optional[str]) -> Optional[list[str]]:
+    """Resolve device name(s) to UUIDs for job filtering. Returns None if no filter."""
+    if not device:
+        return None
+    # Support comma-separated device names
+    names = [n.strip() for n in device.split(",")]
+    ids = []
+    for name in names:
+        query = f'{{ devices(name: "{_esc(name)}") {{ id }} }}'
+        data = await client.graphql(query)
+        devices_list = data.get("devices", [])
+        if devices_list:
+            ids.append(devices_list[0]["id"])
+        else:
+            raise NautobotError(f"Device '{name}' not found in Nautobot.")
+    return ids
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# PHASE 2: CONFIG LIFECYCLE TOOLS (Core Pipeline)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@mcp.tool()
+async def golden_config_generate_intended(device: Optional[str] = None) -> str:
+    """Generate intended config for device(s) from Jinja templates + SoT data.
+
+    Triggers Nautobot's IntendedJob which renders templates using config contexts
+    and the SoT aggregation query. Waits for completion.
+
+    Args:
+        device: Device name (e.g. 'RR1') or comma-separated names. If omitted, runs for all devices in scope.
+    """
+    logger.info(f"golden_config_generate_intended device={device}")
+    try:
+        device_ids = await _resolve_device_ids(device)
+        data = {}
+        if device_ids:
+            data["device"] = device_ids
+        result = await run_job_and_wait(client, JOB_INTENDED, data)
+        result["operation"] = "generate_intended"
+        result["device_filter"] = device
+        return json.dumps(result, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def golden_config_backup(device: Optional[str] = None) -> str:
+    """Pull running config backup from device(s) into Nautobot.
+
+    Triggers Nautobot's BackupJob which connects to devices and stores their
+    running configuration. Waits for completion.
+
+    Args:
+        device: Device name or comma-separated names. If omitted, backs up all devices in scope.
+    """
+    logger.info(f"golden_config_backup device={device}")
+    try:
+        device_ids = await _resolve_device_ids(device)
+        data = {}
+        if device_ids:
+            data["device"] = device_ids
+        result = await run_job_and_wait(client, JOB_BACKUP, data)
+        result["operation"] = "backup"
+        result["device_filter"] = device
+        return json.dumps(result, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def golden_config_compliance(device: Optional[str] = None) -> str:
+    """Run compliance check — compare intended vs backup config for device(s).
+
+    Triggers Nautobot's ComplianceJob which diffs intended against backup per
+    compliance feature/rule. Waits for completion, then returns summary.
+
+    Args:
+        device: Device name or comma-separated names. If omitted, checks all devices in scope.
+    """
+    logger.info(f"golden_config_compliance device={device}")
+    try:
+        device_ids = await _resolve_device_ids(device)
+        data = {}
+        if device_ids:
+            data["device"] = device_ids
+        result = await run_job_and_wait(client, JOB_COMPLIANCE, data)
+
+        # If completed, fetch compliance summary
+        if result.get("status") == "completed" and device:
+            try:
+                filt = f'device: "{_esc(device.split(",")[0].strip())}"' if "," not in device else ""
+                if filt:
+                    query = f"""{{ config_compliances({filt}) {{
+                        device {{ name }} rule {{ feature {{ name }} }} compliance missing extra
+                    }} }}"""
+                    comp_data = await client.graphql(query)
+                    records = comp_data.get("config_compliances", [])
+                    summary = []
+                    for r in records:
+                        summary.append({
+                            "device": r.get("device", {}).get("name"),
+                            "feature": r.get("rule", {}).get("feature", {}).get("name"),
+                            "compliant": r.get("compliance"),
+                            "missing": bool(r.get("missing")),
+                            "extra": bool(r.get("extra")),
+                        })
+                    result["compliance_summary"] = summary
+            except Exception:
+                pass  # Non-critical enrichment
+
+        result["operation"] = "compliance"
+        result["device_filter"] = device
+        return json.dumps(result, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def golden_config_full_pipeline(device: Optional[str] = None) -> str:
+    """Run the full config pipeline: intended → backup → compliance in sequence.
+
+    This is the one-call equivalent of running all three jobs. Returns the final
+    compliance status after all steps complete.
+
+    Args:
+        device: Device name or comma-separated names. If omitted, runs for all devices in scope.
+    """
+    logger.info(f"golden_config_full_pipeline device={device}")
+    results = {"operation": "full_pipeline", "device_filter": device, "steps": {}}
+
+    try:
+        device_ids = await _resolve_device_ids(device)
+        data = {}
+        if device_ids:
+            data["device"] = device_ids
+
+        # Step 1: Generate intended
+        intended = await run_job_and_wait(client, JOB_INTENDED, data)
+        results["steps"]["intended"] = intended.get("status")
+        if intended.get("status") == "failed":
+            results["error"] = "Intended job failed"
+            results["steps"]["intended_detail"] = intended
+            return json.dumps(results, indent=2, default=str)
+
+        # Step 2: Backup
+        backup = await run_job_and_wait(client, JOB_BACKUP, data)
+        results["steps"]["backup"] = backup.get("status")
+        if backup.get("status") == "failed":
+            results["error"] = "Backup job failed"
+            results["steps"]["backup_detail"] = backup
+            return json.dumps(results, indent=2, default=str)
+
+        # Step 3: Compliance
+        compliance = await run_job_and_wait(client, JOB_COMPLIANCE, data)
+        results["steps"]["compliance"] = compliance.get("status")
+
+        # Fetch compliance summary
+        if compliance.get("status") == "completed" and device and "," not in device:
+            try:
+                query = f"""{{ config_compliances(device: "{_esc(device.strip())}") {{
+                    device {{ name }} rule {{ feature {{ name }} }} compliance missing extra
+                }} }}"""
+                comp_data = await client.graphql(query)
+                records = comp_data.get("config_compliances", [])
+                results["compliance_summary"] = [
+                    {
+                        "device": r.get("device", {}).get("name"),
+                        "feature": r.get("rule", {}).get("feature", {}).get("name"),
+                        "compliant": r.get("compliance"),
+                    }
+                    for r in records
+                ]
+            except Exception:
+                pass
+
+        results["status"] = "completed" if all(
+            s == "completed" for s in results["steps"].values()
+        ) else "partial"
+        return json.dumps(results, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def golden_config_remediate(
+    device: str,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Push intended config to a non-compliant device to fix drift. ITSM-gated.
+
+    Deploys the intended configuration to the device to bring it into compliance.
+    This is a write operation that modifies device configuration.
+
+    Args:
+        device: Device name (required — remediation targets a specific device)
+        cr_number: ServiceNow change request number (required if ITSM enabled)
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    logger.info(f"golden_config_remediate device={device} cr={cr_number}")
+    try:
+        device_ids = await _resolve_device_ids(device)
+        if not device_ids:
+            return json.dumps({"error": f"Device '{device}' not found"})
+
+        # Check if there are config plans to deploy, or trigger deploy directly
+        # First check compliance state
+        query = f"""{{ config_compliances(device: "{_esc(device)}") {{
+            compliance rule {{ feature {{ name }} }}
+        }} }}"""
+        comp_data = await client.graphql(query)
+        records = comp_data.get("config_compliances", [])
+        non_compliant = [r for r in records if not r.get("compliance")]
+
+        if not non_compliant:
+            return json.dumps({
+                "status": "already_compliant",
+                "device": device,
+                "message": "Device is already compliant. No remediation needed.",
+            })
+
+        # Trigger deploy job
+        data = {"device": device_ids}
+        result = await run_job_and_wait(client, JOB_DEPLOY, data)
+        result["operation"] = "remediate"
+        result["device"] = device
+        result["non_compliant_features"] = [
+            r.get("rule", {}).get("feature", {}).get("name") for r in non_compliant
+        ]
+        return json.dumps(result, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# CONFIG INSPECTION TOOLS (Phase 3 preview — essential for usability)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@mcp.tool()
+async def golden_config_get_intended(device: str) -> str:
+    """Get the rendered intended config for a device.
+
+    Returns the full intended configuration text as generated by golden config
+    templates + SoT data.
+
+    Args:
+        device: Device name (e.g. 'RR1')
+    """
+    logger.info(f"golden_config_get_intended device={device}")
+    try:
+        resp = await client.rest_get(
+            "plugins/golden-config/golden-config", {"device": device}
+        )
+        results = resp.get("results", [])
+        if not results:
+            return json.dumps({"device": device, "intended_config": None,
+                             "message": "No golden config record. Run golden_config_generate_intended first."})
+        record = results[0]
+        return json.dumps({
+            "device": device,
+            "intended_config": record.get("intended_config"),
+            "last_success": record.get("intended_last_success_date"),
+        }, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def golden_config_get_backup(device: str) -> str:
+    """Get the latest backup config for a device.
+
+    Returns the running configuration as last pulled from the device.
+
+    Args:
+        device: Device name (e.g. 'RR1')
+    """
+    logger.info(f"golden_config_get_backup device={device}")
+    try:
+        resp = await client.rest_get(
+            "plugins/golden-config/golden-config", {"device": device}
+        )
+        results = resp.get("results", [])
+        if not results:
+            return json.dumps({"device": device, "backup_config": None,
+                             "message": "No golden config record. Run golden_config_backup first."})
+        record = results[0]
+        return json.dumps({
+            "device": device,
+            "backup_config": record.get("backup_config"),
+            "last_success": record.get("backup_last_success_date"),
+        }, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def golden_config_get_compliance_diff(device: str) -> str:
+    """Get the compliance diff for a device — what's missing and what's extra per feature.
+
+    Returns a human-readable diff showing which config lines are missing from the
+    device (should be there but aren't) and which are extra (on device but not intended).
+
+    Args:
+        device: Device name (e.g. 'RR1')
+    """
+    logger.info(f"golden_config_get_compliance_diff device={device}")
+    try:
+        query = f"""{{ config_compliances(device: "{_esc(device)}") {{
+            device {{ name }}
+            rule {{ feature {{ name }} platform {{ name }} }}
+            compliance actual intended missing extra ordered
+        }} }}"""
+        data = await client.graphql(query)
+        records = data.get("config_compliances", [])
+        if not records:
+            return json.dumps({"device": device, "message": "No compliance data. Run golden_config_compliance first."})
+
+        diffs = []
+        for r in records:
+            feature = r.get("rule", {}).get("feature", {}).get("name", "unknown")
+            entry = {
+                "feature": feature,
+                "compliant": r.get("compliance"),
+            }
+            if not r.get("compliance"):
+                entry["missing"] = r.get("missing") or ""
+                entry["extra"] = r.get("extra") or ""
+            diffs.append(entry)
+
+        compliant_count = sum(1 for d in diffs if d["compliant"])
+        return json.dumps({
+            "device": device,
+            "total_features": len(diffs),
+            "compliant": compliant_count,
+            "non_compliant": len(diffs) - compliant_count,
+            "diffs": diffs,
+        }, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def golden_config_get_compliance_summary(
+    device: Optional[str] = None,
+    feature: Optional[str] = None,
+) -> str:
+    """Get compliance status across devices and features.
+
+    Returns a table showing device, feature, compliant status, and last run time.
+
+    Args:
+        device: Filter by device name (optional)
+        feature: Filter by compliance feature name (optional)
+    """
+    logger.info(f"golden_config_get_compliance_summary device={device} feature={feature}")
+    try:
+        filters = []
+        if device:
+            filters.append(f'device: "{_esc(device)}"')
+        filt_str = f"({', '.join(filters)})" if filters else ""
+
+        query = f"""{{ config_compliances{filt_str} {{
+            device {{ name }}
+            rule {{ feature {{ name }} }}
+            compliance
+        }} }}"""
+        data = await client.graphql(query)
+        records = data.get("config_compliances", [])
+
+        # Filter by feature if specified
+        if feature:
+            records = [r for r in records if r.get("rule", {}).get("feature", {}).get("name") == feature]
+
+        summary = []
+        for r in records:
+            summary.append({
+                "device": r.get("device", {}).get("name"),
+                "feature": r.get("rule", {}).get("feature", {}).get("name"),
+                "compliant": r.get("compliance"),
+            })
+
+        compliant_count = sum(1 for s in summary if s["compliant"])
+        return json.dumps({
+            "total": len(summary),
+            "compliant": compliant_count,
+            "non_compliant": len(summary) - compliant_count,
+            "summary": summary,
+        }, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# PHASE 4: TEMPLATE & CONTEXT TOOLS
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@mcp.tool()
+async def golden_config_get_templates(device: Optional[str] = None) -> str:
+    """List golden config templates that apply to a device (based on platform/role).
+
+    If device is specified, shows which template path resolves for that device.
+    If omitted, returns the golden config settings showing template path patterns.
+
+    Args:
+        device: Device name (optional) — resolves the template path for this device
+    """
+    logger.info(f"golden_config_get_templates device={device}")
+    try:
+        # Get GC settings for template path pattern
+        settings = await client.rest_get("plugins/golden-config/golden-config-settings")
+        results = settings.get("results", [])
+        if not results:
+            return json.dumps({"error": "No golden config settings found. Configure golden config first."})
+
+        setting = results[0]
+        jinja_path = setting.get("jinja_path_template", "")
+        jinja_repo = setting.get("jinja_repository")
+
+        info = {
+            "jinja_path_template": jinja_path,
+            "jinja_repository": jinja_repo.get("name") if isinstance(jinja_repo, dict) else jinja_repo,
+        }
+
+        if device:
+            # Resolve what template path this device would use
+            query = f"""{{ devices(name: "{_esc(device)}") {{
+                name platform {{ name network_driver }} role {{ name }}
+                location {{ name }}
+            }} }}"""
+            data = await client.graphql(query)
+            devices_list = data.get("devices", [])
+            if not devices_list:
+                return json.dumps({"error": f"Device '{device}' not found"})
+            dev = devices_list[0]
+            info["device"] = device
+            info["platform"] = dev.get("platform", {}).get("name")
+            info["network_driver"] = dev.get("platform", {}).get("network_driver")
+            info["role"] = dev.get("role", {}).get("name")
+            # Show resolved path (best effort — Jinja rendering happens server-side)
+            info["resolved_path_hint"] = jinja_path.replace(
+                "{{obj.platform.network_driver}}", dev.get("platform", {}).get("network_driver") or "unknown"
+            ).replace(
+                "{{obj.platform.name}}", dev.get("platform", {}).get("name") or "unknown"
+            )
+
+        return json.dumps(info, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def golden_config_render_preview(device: str) -> str:
+    """Render a preview of what the intended config would look like for a device.
+
+    Returns the most recently generated intended config. To get a fresh render,
+    call golden_config_generate_intended first.
+
+    Args:
+        device: Device name (e.g. 'RR1')
+    """
+    logger.info(f"golden_config_render_preview device={device}")
+    try:
+        resp = await client.rest_get(
+            "plugins/golden-config/golden-config", {"device": device}
+        )
+        results = resp.get("results", [])
+        if not results or not results[0].get("intended_config"):
+            return json.dumps({
+                "device": device,
+                "preview": None,
+                "message": "No intended config available. Run golden_config_generate_intended first.",
+            })
+        return json.dumps({
+            "device": device,
+            "preview": results[0]["intended_config"],
+            "generated": results[0].get("intended_last_success_date"),
+        }, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def golden_config_get_device_context(device: str) -> str:
+    """Get the merged config context for a device as golden config templates see it.
+
+    Returns the full merged config context dict — all config contexts that apply
+    to this device based on role, location, platform, tenant, tags.
+
+    Args:
+        device: Device name (e.g. 'RR1')
+    """
+    logger.info(f"golden_config_get_device_context device={device}")
+    try:
+        resp = await client.rest_get("dcim/devices", {"name": device})
+        devices_list = resp.get("results", [])
+        if not devices_list:
+            return json.dumps({"error": f"Device '{device}' not found"})
+        device_id = devices_list[0]["id"]
+        detail = await client.rest_get(f"dcim/devices/{device_id}")
+        config_context = detail.get("config_context", {})
+        return json.dumps({
+            "device": device,
+            "config_context": config_context,
+        }, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def golden_config_update_device_context(
+    device: str,
+    key: str,
+    value: str,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Update a key in a device's config context. ITSM-gated.
+
+    Finds the config context that applies to this device and updates the specified
+    key. If the key is nested, use dot notation (e.g. 'observability.syslog_server').
+
+    Args:
+        device: Device name (e.g. 'RR1')
+        key: Config context key to update (e.g. 'mgmt_vrf' or 'observability.syslog_server')
+        value: New value as JSON string (e.g. '"MGMT"' or '{"host": "10.0.0.1", "port": 514}')
+        cr_number: ServiceNow change request number (required if ITSM enabled)
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    logger.info(f"golden_config_update_device_context device={device} key={key} cr={cr_number}")
+    try:
+        parsed_value = json.loads(value)
+    except json.JSONDecodeError:
+        parsed_value = value  # treat as plain string
+
+    keys = key.split(".")
+
+    try:
+        # Find config contexts that apply to this device
+        # Get device's role ID
+        query = f"""{{ devices(name: "{_esc(device)}") {{
+            id role {{ name id }}
+        }} }}"""
+        dev_data = await client.graphql(query)
+        devices_list = dev_data.get("devices", [])
+        if not devices_list:
+            return json.dumps({"error": f"Device '{device}' not found"})
+
+        dev = devices_list[0]
+        role_id = dev.get("role", {}).get("id")
+        top_key = keys[0]  # First segment of the dotted key path
+
+        # Find config contexts scoped to this device's role
+        ctx_resp = await client.rest_get("extras/config-contexts", {"limit": 100})
+        contexts = ctx_resp.get("results", [])
+
+        # Strategy: prefer context that already has the top-level key AND matches role
+        target_ctx = None
+        role_matched = []
+        for ctx in contexts:
+            ctx_role_ids = [r.get("id") for r in ctx.get("roles", [])]
+            if role_id and role_id in ctx_role_ids:
+                role_matched.append(ctx)
+
+        # Among role-matched, prefer one with existing top_key
+        for ctx in role_matched:
+            if top_key in (ctx.get("data") or {}):
+                target_ctx = ctx
+                break
+        # Fallback: first role-matched context
+        if not target_ctx and role_matched:
+            target_ctx = role_matched[0]
+        # Fallback: any context with the top_key
+        if not target_ctx:
+            for ctx in contexts:
+                if top_key in (ctx.get("data") or {}):
+                    target_ctx = ctx
+                    break
+        # Fallback: first context with no role filter (global)
+        if not target_ctx:
+            for ctx in contexts:
+                if not ctx.get("roles"):
+                    target_ctx = ctx
+                    break
+        if not target_ctx:
+            return json.dumps({"error": "No config context found for this device. Create one first."})
+
+        # Update the key in the context data
+        ctx_data = target_ctx.get("data", {})
+        obj = ctx_data
+        for k in keys[:-1]:
+            if k not in obj:
+                obj[k] = {}
+            obj = obj[k]
+        obj[keys[-1]] = parsed_value
+
+        # PATCH the config context
+        await client.rest_patch(
+            f"extras/config-contexts/{target_ctx['id']}",
+            {"data": ctx_data},
+        )
+
+        return json.dumps({
+            "updated": True,
+            "config_context": target_ctx.get("name"),
+            "key": key,
+            "value": parsed_value,
+            "device": device,
+        }, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def golden_config_update_template(
+    path: str,
+    content: str,
+    commit_message: Optional[str] = None,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Update a golden config Jinja template file. ITSM-gated.
+
+    This updates the template content. The actual commit to git should be done
+    via the GitHub MCP server or by syncing the git repository in Nautobot.
+
+    NOTE: This tool stores the template content locally. Use the GitHub MCP to
+    commit it to the repo, then call nautobot_sync_git_repository to pull changes.
+
+    Args:
+        path: Template file path relative to repo root (e.g. 'cisco_ios/main.j2')
+        content: New template content (full file)
+        commit_message: Git commit message (optional)
+        cr_number: ServiceNow change request number (required if ITSM enabled)
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    logger.info(f"golden_config_update_template path={path} cr={cr_number}")
+    return json.dumps({
+        "status": "template_prepared",
+        "path": path,
+        "content_length": len(content),
+        "commit_message": commit_message or f"Update template {path}",
+        "next_steps": [
+            "Use GitHub MCP to commit this content to the jinja templates repository",
+            "Then call nautobot_sync_git_repository to pull changes into Nautobot",
+            "Then call golden_config_generate_intended to regenerate configs",
+        ],
+        "content": content,
+    }, indent=2, default=str)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# PHASE 5: SETUP TOOLS
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@mcp.tool()
+async def golden_config_get_settings() -> str:
+    """Get the current golden config settings — repos, path templates, SoT query, scope.
+
+    Returns the full configuration of the golden config plugin including which
+    git repositories are linked, path templates for backup/intended/jinja, and
+    the SoT aggregation query.
+    """
+    logger.info("golden_config_get_settings")
+    try:
+        resp = await client.rest_get("plugins/golden-config/golden-config-settings")
+        results = resp.get("results", [])
+        if not results:
+            return json.dumps({"settings": None, "message": "No golden config settings configured."})
+
+        setting = results[0]
+        # Extract key fields into a concise summary
+        summary = {
+            "id": setting.get("id"),
+            "backup_repository": setting.get("backup_repository"),
+            "intended_repository": setting.get("intended_repository"),
+            "jinja_repository": setting.get("jinja_repository"),
+            "backup_path_template": setting.get("backup_path_template"),
+            "intended_path_template": setting.get("intended_path_template"),
+            "jinja_path_template": setting.get("jinja_path_template"),
+            "sot_agg_query": setting.get("sot_agg_query"),
+            "dynamic_group": setting.get("dynamic_group"),
+        }
+        return json.dumps(summary, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def golden_config_create_compliance_feature(
+    name: str,
+    description: Optional[str] = None,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Create a compliance feature (e.g., 'observability', 'bgp', 'ospf', 'aaa'). ITSM-gated.
+
+    Compliance features define categories of configuration that are checked
+    independently. Each feature gets its own compliance rule with a match pattern.
+
+    Args:
+        name: Feature name (e.g. 'observability', 'ntp', 'logging')
+        description: Optional description of what this feature covers
+        cr_number: ServiceNow change request number (required if ITSM enabled)
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    logger.info(f"golden_config_create_compliance_feature name={name} cr={cr_number}")
+    try:
+        payload = {"name": name, "slug": name.lower().replace(" ", "_")}
+        if description:
+            payload["description"] = description
+        result = await client.rest_post("plugins/golden-config/compliance-feature", payload)
+        return json.dumps({"created": True, "feature": result}, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def golden_config_create_compliance_rule(
+    feature: str,
+    platform: str,
+    match_config: str,
+    config_ordered: bool = False,
+    config_remediation: bool = False,
+    description: Optional[str] = None,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Create a compliance rule linking a feature to a platform with a config match pattern. ITSM-gated.
+
+    Rules define which config lines belong to a feature on a given platform.
+    The match_config is a regex or literal that identifies the config section.
+
+    Args:
+        feature: Compliance feature name (e.g. 'aaa', 'ntp')
+        platform: Platform name (e.g. 'cisco_ios', 'arista_eos')
+        match_config: Config line(s) to match for this feature (regex pattern)
+        config_ordered: Whether line order matters for compliance (default: False)
+        config_remediation: Whether to generate remediation config (default: False)
+        description: Optional description
+        cr_number: ServiceNow change request number (required if ITSM enabled)
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    logger.info(f"golden_config_create_compliance_rule feature={feature} platform={platform} cr={cr_number}")
+    try:
+        # Resolve feature ID
+        feat_data = await client.graphql(
+            f'{{ compliance_features(name: "{_esc(feature)}") {{ id }} }}'
+        )
+        feats = feat_data.get("compliance_features", [])
+        if not feats:
+            return json.dumps({"error": f"Feature '{feature}' not found. Create it first with golden_config_create_compliance_feature."})
+        feat_id = feats[0]["id"]
+
+        # Resolve platform ID
+        plat_data = await client.graphql(
+            f'{{ platforms(name: "{_esc(platform)}") {{ id }} }}'
+        )
+        plats = plat_data.get("platforms", [])
+        if not plats:
+            return json.dumps({"error": f"Platform '{platform}' not found in Nautobot."})
+        plat_id = plats[0]["id"]
+
+        payload = {
+            "feature": feat_id,
+            "platform": plat_id,
+            "match_config": match_config,
+            "config_type": "cli",
+            "config_ordered": config_ordered,
+            "config_remediation": config_remediation,
+        }
+        if description:
+            payload["description"] = description
+
+        result = await client.rest_post("plugins/golden-config/compliance-rule", payload)
+        return json.dumps({"created": True, "rule": result}, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/mcp-servers/nautobot-mcp-v2/README.md
+++ b/mcp-servers/nautobot-mcp-v2/README.md
@@ -1,0 +1,77 @@
+# Nautobot MCP Server v2
+
+Enhanced Nautobot 3.1.0 integration for NetClaw — GraphQL reads, REST writes, ITSM-gated changes, live-vs-SoT reconciliation.
+
+Replaces the v1 mcp-nautobot (5 IPAM-only REST tools) with 13 tools covering devices, interfaces, VLANs, prefixes, IP addresses, cables, raw GraphQL, write operations, and reconciliation.
+
+## Architecture
+
+- **Reads**: GraphQL API (`POST /api/graphql/`) — efficient field selection, nested relationships
+- **Writes**: REST API (`POST/PATCH /api/dcim/*`, `/api/ipam/*`) — Nautobot 3.1.0 has no GraphQL mutations
+- **Transport**: stdio (FastMCP)
+
+## Tools (13)
+
+### Read Tools (7) — GraphQL
+
+| Tool | Description |
+|------|-------------|
+| `nautobot_get_devices` | Query devices with filters (name, location, role, platform, status) |
+| `nautobot_get_interfaces` | Query interfaces with VLAN assignments, IPs, cable peer |
+| `nautobot_get_vlans` | Query VLANs with locations, groups, tenants |
+| `nautobot_get_prefixes` | Query IP prefixes from IPAM |
+| `nautobot_get_ip_addresses` | Query IP addresses with interface/device assignments |
+| `nautobot_get_cables` | Query cables with resolved endpoint names |
+| `nautobot_graphql` | Execute arbitrary GraphQL queries (plugins, custom fields) |
+
+### Write Tools (5) — REST API, ITSM-gated
+
+| Tool | Description |
+|------|-------------|
+| `nautobot_create_ip_address` | Create IP address, optionally assign to interface |
+| `nautobot_create_vlan` | Create VLAN with location association |
+| `nautobot_create_prefix` | Create IP prefix |
+| `nautobot_update_object` | Update any object (device, interface, IP, VLAN, prefix, cable) |
+| `nautobot_reconcile` | Compare live device state against Nautobot SoT |
+
+### Utility (1)
+
+| Tool | Description |
+|------|-------------|
+| `nautobot_test_connection` | Verify GraphQL and REST connectivity |
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `NAUTOBOT_URL` | Yes | — | Nautobot base URL (e.g., `https://192.168.3.253`) |
+| `NAUTOBOT_TOKEN` | Yes | — | API token with read+write permissions |
+| `NAUTOBOT_VERIFY_SSL` | No | `false` | Verify SSL certificates |
+| `NAUTOBOT_TIMEOUT` | No | `30` | Request timeout in seconds |
+| `ITSM_ENABLED` | No | `false` | Enable ITSM gating for writes |
+| `ITSM_LAB_MODE` | No | `true` | Bypass ITSM gating for lab use |
+
+## Installation
+
+```bash
+cd mcp-servers/nautobot-mcp-v2/
+pip install -r requirements.txt
+```
+
+## Standalone Test
+
+```bash
+export NAUTOBOT_URL="https://192.168.3.253"
+export NAUTOBOT_TOKEN="your-token"
+export NAUTOBOT_VERIFY_SSL="false"
+python3 -u server.py
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `server.py` | FastMCP server with all 13 tool definitions |
+| `nautobot_client.py` | GraphQL + REST client, ID resolution, error handling |
+| `reconcile.py` | Interface reconciliation diff engine |
+| `requirements.txt` | Python dependencies |

--- a/mcp-servers/nautobot-mcp-v2/cisco_design_reference.py
+++ b/mcp-servers/nautobot-mcp-v2/cisco_design_reference.py
@@ -1,0 +1,398 @@
+"""Cisco Design Reference MCP Tool — lightweight knowledge base for network design best practices.
+
+Sources: Cisco SAFE Architecture, Campus LAN Design Guide, IOS-XE Hardening Guide,
+CIS Cisco IOS Benchmark, Cisco Validated Designs (CVD).
+
+This is NOT a full MCP server — it's a reference tool added to nautobot-mcp-v2 that the agent
+can query when building golden config templates, compliance rules, or hardening recommendations.
+"""
+
+# Each section maps to a compliance feature and contains:
+# - best_practices: what Cisco recommends
+# - config_example: IOS-XE config snippet showing the recommendation
+# - rationale: why this matters
+# - rfc: relevant RFC if applicable
+# - match_config: regex pattern for golden config compliance rule
+
+DESIGN_REFERENCE = {
+    "aaa": {
+        "title": "Authentication, Authorization, and Accounting",
+        "best_practices": [
+            "Enable AAA new-model for centralized authentication",
+            "Use TACACS+ for device administration (provides command authorization)",
+            "Configure local fallback authentication in case TACACS+ is unreachable",
+            "Enable login authentication on all VTY and console lines",
+            "Enable exec authorization to control privilege levels",
+            "Enable command accounting for audit trail",
+            "Set failed-login lockout after 5 attempts",
+        ],
+        "config_example": """\
+aaa new-model
+!
+aaa authentication login default group tacacs+ local
+aaa authentication login CONSOLE local
+aaa authentication enable default group tacacs+ enable
+aaa authorization exec default group tacacs+ local
+aaa authorization commands 15 default group tacacs+ local
+aaa accounting exec default start-stop group tacacs+
+aaa accounting commands 15 default start-stop group tacacs+
+!
+tacacs server TACACS-PRIMARY
+ address ipv4 {tacacs_server_primary}
+ key {tacacs_key}
+ timeout 3
+tacacs server TACACS-SECONDARY
+ address ipv4 {tacacs_server_secondary}
+ key {tacacs_key}
+ timeout 3
+!
+aaa group server tacacs+ TACACS-GROUP
+ server name TACACS-PRIMARY
+ server name TACACS-SECONDARY
+!
+login block-for 120 attempts 5 within 60""",
+        "rationale": "Centralized AAA prevents credential sprawl, enables audit trails, and allows immediate revocation of access. Local fallback ensures access during server outages. TACACS+ preferred over RADIUS for device admin because it encrypts the full payload and supports per-command authorization.",
+        "rfc": "RFC 8907 (TACACS+)",
+        "match_config": "^aaa ",
+        "severity": "critical",
+    },
+    "ntp": {
+        "title": "Network Time Protocol",
+        "best_practices": [
+            "Configure at least 2 NTP servers for redundancy",
+            "Use NTP authentication (MD5 or SHA) to prevent time poisoning",
+            "Restrict NTP access with access-group (peer, serve, query-only)",
+            "Use a trusted internal NTP source or well-known public servers",
+            "Set clock timezone and summer-time",
+            "Source NTP from management interface/VRF",
+        ],
+        "config_example": """\
+clock timezone {timezone} {utc_offset_hours} {utc_offset_minutes}
+clock summer-time {summer_time_zone} recurring
+!
+ntp authentication-key 1 md5 {ntp_auth_key}
+ntp trusted-key 1
+ntp authenticate
+ntp source {ntp_source_interface}
+ntp access-group peer 10
+ntp server vrf {mgmt_vrf} {ntp_server_1} key 1 prefer
+ntp server vrf {mgmt_vrf} {ntp_server_2} key 1""",
+        "rationale": "Accurate time is critical for log correlation, certificate validation, and troubleshooting. NTP authentication prevents man-in-the-middle attacks that could desynchronize clocks and break time-based security controls (TOTP, certificate expiry, log sequencing).",
+        "rfc": "RFC 5905 (NTPv4)",
+        "match_config": "^ntp ",
+        "severity": "high",
+    },
+    "logging": {
+        "title": "System Logging (Syslog)",
+        "best_practices": [
+            "Send logs to a centralized syslog server",
+            "Set logging trap level to informational (6) minimum for security events",
+            "Include timestamps with millisecond precision",
+            "Source logging from management interface/VRF",
+            "Configure logging buffered for local retention",
+            "Disable logging to console in production (performance impact)",
+            "Enable login success/failure logging",
+        ],
+        "config_example": """\
+no logging console
+logging buffered 65536 informational
+logging trap informational
+logging source-interface {mgmt_interface} vrf {mgmt_vrf}
+logging host {syslog_server} vrf {mgmt_vrf}
+!
+logging origin-id hostname
+logging facility local6
+!
+login on-success log
+login on-failure log every 3""",
+        "rationale": "Centralized logging enables incident detection, forensics, and compliance auditing. Millisecond timestamps allow correlation across devices. Disabling console logging prevents CPU impact from high-volume events. Buffered logging provides local retention when the syslog server is unreachable.",
+        "rfc": "RFC 5424 (Syslog Protocol), RFC 5425 (TLS Transport for Syslog)",
+        "match_config": "^logging ",
+        "severity": "high",
+    },
+    "snmp": {
+        "title": "Simple Network Management Protocol",
+        "best_practices": [
+            "Use SNMPv3 with authPriv (authentication + encryption) where possible",
+            "If SNMPv2c is required, use non-default community strings",
+            "Restrict SNMP access with ACLs to management stations only",
+            "Never use 'public' or 'private' as community strings in production",
+            "Disable SNMP write access unless specifically required",
+            "Configure SNMP traps/informs to a central NMS",
+            "Set snmp-server contact and location for asset management",
+        ],
+        "config_example": """\
+! SNMPv3 (preferred)
+snmp-server group MONITORING v3 priv read READONLY
+snmp-server user {snmp_user} MONITORING v3 auth sha {snmp_auth_key} priv aes 128 {snmp_priv_key}
+snmp-server view READONLY iso included
+!
+! SNMPv2c (if v3 not supported by NMS)
+access-list 99 permit {nms_network} {nms_wildcard}
+snmp-server community {snmp_ro_community} RO 99
+!
+snmp-server location {location}
+snmp-server contact {contact}
+snmp-server enable traps snmp authentication linkdown linkup coldstart warmstart
+snmp-server enable traps config
+snmp-server enable traps syslog
+snmp-server host {snmp_trap_host} version 2c {snmp_ro_community}""",
+        "rationale": "SNMP communities are sent in cleartext — ACLs limit exposure. SNMPv3 provides authentication and encryption. Write communities allow remote config changes and should be avoided. Traps enable proactive monitoring of link state, config changes, and security events.",
+        "rfc": "RFC 3414 (SNMPv3 USM), RFC 3826 (AES for SNMPv3)",
+        "match_config": "^snmp-server ",
+        "severity": "high",
+    },
+    "ssh": {
+        "title": "Secure Shell Access",
+        "best_practices": [
+            "Use SSH version 2 only (v1 has known vulnerabilities)",
+            "Set SSH timeout and authentication retries",
+            "Source SSH from management interface",
+            "Disable Telnet on all VTY lines",
+            "Configure RSA key of 2048 bits or greater",
+            "Enable SCP server for secure file transfers",
+        ],
+        "config_example": """\
+ip ssh version 2
+ip ssh time-out 60
+ip ssh authentication-retries 3
+ip ssh source-interface {mgmt_interface}
+ip scp server enable
+!
+crypto key generate rsa modulus 2048""",
+        "rationale": "SSH v1 has cryptographic weaknesses. SSH v2 provides strong encryption and host authentication. Sourcing from the management interface ensures SSH traffic stays in the management VRF. SCP replaces insecure TFTP for file transfers.",
+        "rfc": "RFC 4253 (SSH Transport Layer), RFC 4252 (SSH Authentication)",
+        "match_config": "^ip ssh ",
+        "severity": "critical",
+    },
+    "vty_lines": {
+        "title": "Virtual Terminal Line Security",
+        "best_practices": [
+            "Restrict transport input to SSH only (no telnet)",
+            "Apply ACL to VTY lines limiting source addresses",
+            "Set exec-timeout to prevent idle sessions (5-15 minutes recommended)",
+            "Enable login authentication via AAA or local",
+            "Configure consistent settings across all VTY lines (0-4 and 5-15)",
+        ],
+        "config_example": """\
+line con 0
+ exec-timeout 15 0
+ logging synchronous
+ login authentication CONSOLE
+!
+line vty 0 4
+ exec-timeout 15 0
+ access-class {vty_acl} in
+ login authentication default
+ transport input ssh
+ transport output ssh
+line vty 5 15
+ exec-timeout 15 0
+ access-class {vty_acl} in
+ login authentication default
+ transport input ssh
+ transport output ssh""",
+        "rationale": "VTY lines are the remote access entry point. Unrestricted access allows brute-force attacks. Exec-timeout prevents abandoned sessions from being hijacked. ACLs limit which hosts can attempt connections. SSH-only transport eliminates cleartext credential exposure.",
+        "rfc": None,
+        "match_config": "^line vty ",
+        "severity": "critical",
+    },
+    "spanning_tree": {
+        "title": "Spanning Tree Protocol",
+        "best_practices": [
+            "Use Rapid PVST+ or MST (not legacy PVST+)",
+            "Enable BPDU Guard on all access ports",
+            "Enable Root Guard on ports that should never become root",
+            "Enable Loop Guard on non-designated ports",
+            "Configure PortFast on access ports only",
+            "Enable spanning-tree logging for topology change visibility",
+            "Set bridge priority explicitly on root/secondary root switches",
+        ],
+        "config_example": """\
+spanning-tree mode rapid-pvst
+spanning-tree logging
+spanning-tree extend system-id
+spanning-tree vlan 1-4094 priority {stp_priority}
+!
+! On access ports:
+interface range {access_port_range}
+ spanning-tree portfast
+ spanning-tree bpduguard enable
+!
+! On uplinks where root should not move:
+interface range {uplink_range}
+ spanning-tree guard root""",
+        "rationale": "Rapid PVST+ provides sub-second convergence. BPDU Guard prevents rogue switches from disrupting the topology. Root Guard prevents unauthorized root bridge elections. PortFast eliminates the 30-second STP delay on access ports but must be paired with BPDU Guard for safety.",
+        "rfc": "IEEE 802.1w (RSTP), IEEE 802.1D-2004",
+        "match_config": "^spanning-tree ",
+        "severity": "medium",
+    },
+    "vtp": {
+        "title": "VLAN Trunking Protocol",
+        "best_practices": [
+            "Use VTP transparent or off mode in production",
+            "Never use VTP server/client mode without understanding the blast radius",
+            "VTP transparent allows local VLAN management without propagation risk",
+            "If VTP is used, set a VTP password and use version 3",
+        ],
+        "config_example": """\
+vtp mode transparent""",
+        "rationale": "VTP server mode can propagate VLAN deletions across the entire network from a single misconfigured switch. Transparent mode gives local control without propagation risk. This is the single most common cause of network-wide outages in campus environments.",
+        "rfc": None,
+        "match_config": "^vtp ",
+        "severity": "medium",
+    },
+    "interfaces_l2_access": {
+        "title": "Layer 2 Access Port Security",
+        "best_practices": [
+            "Assign all access ports to a specific VLAN (never leave on VLAN 1)",
+            "Enable PortFast on access ports",
+            "Enable BPDU Guard on access ports",
+            "Shut down unused ports",
+            "Move unused ports to a black-hole VLAN",
+            "Set port descriptions for documentation",
+            "Consider port-security or 802.1X for endpoint authentication",
+        ],
+        "config_example": """\
+interface {interface_name}
+ description {description}
+ switchport access vlan {access_vlan}
+ switchport mode access
+ spanning-tree portfast
+ spanning-tree bpduguard enable
+ load-interval 30
+!
+! Unused port template:
+interface {unused_interface}
+ description NOT IN USE
+ switchport access vlan {blackhole_vlan}
+ switchport mode access
+ shutdown""",
+        "rationale": "VLAN 1 is the default and carries control plane traffic (CDP, VTP, DTP). Moving access ports off VLAN 1 reduces attack surface. Shutting unused ports prevents unauthorized access. BPDU Guard prevents rogue switches on access ports.",
+        "rfc": "IEEE 802.1Q (VLAN Tagging)",
+        "match_config": "^interface ",
+        "severity": "medium",
+    },
+    "interfaces_l2_trunk": {
+        "title": "Layer 2 Trunk Port Security",
+        "best_practices": [
+            "Explicitly configure trunk mode (don't rely on DTP negotiation)",
+            "Prune allowed VLANs to only what's needed on each trunk",
+            "Set native VLAN to something other than VLAN 1",
+            "Disable DTP negotiation on trunk ports",
+            "Use descriptions indicating the far-end device and port",
+        ],
+        "config_example": """\
+interface {interface_name}
+ description {description}
+ switchport trunk allowed vlan {allowed_vlans}
+ switchport trunk native vlan {native_vlan}
+ switchport mode trunk
+ switchport nonegotiate""",
+        "rationale": "DTP negotiation can be exploited to form unauthorized trunks (VLAN hopping). Pruning allowed VLANs limits broadcast domain scope and reduces the blast radius of a compromised VLAN. Non-default native VLAN prevents double-tagging attacks.",
+        "rfc": "IEEE 802.1Q",
+        "match_config": "^interface ",
+        "severity": "medium",
+    },
+    "management_plane": {
+        "title": "Management Plane Hardening",
+        "best_practices": [
+            "Use a dedicated management VRF",
+            "Source all management traffic (SSH, SNMP, syslog, NTP) from management interface",
+            "Disable HTTP server if not needed, or restrict with ACL",
+            "Enable HTTPS (ip http secure-server) if web UI is required",
+            "Disable unused services (ip finger, ip bootp server, service pad)",
+            "Configure service password-encryption",
+            "Set enable secret (not enable password) with type 9 hash",
+            "Configure login banner with legal notice",
+        ],
+        "config_example": """\
+no service pad
+service timestamps debug datetime msec
+service timestamps log datetime msec
+service password-encryption
+!
+no ip bootp server
+no ip finger
+no ip source-route
+no ip http server
+ip http secure-server
+ip http authentication local
+ip http access-class {http_acl}
+!
+vrf definition {mgmt_vrf}
+ address-family ipv4
+ exit-address-family
+!
+ip route vrf {mgmt_vrf} 0.0.0.0 0.0.0.0 {mgmt_gateway}
+!
+banner login ^
+{banner_text}
+^""",
+        "rationale": "The management plane is the highest-value target on a network device. VRF isolation prevents management traffic from mixing with data plane traffic. Disabling unused services reduces attack surface. Password encryption prevents casual credential exposure in config files.",
+        "rfc": "RFC 2827 (BCP 38 - Network Ingress Filtering)",
+        "match_config": "^(no )?service |^ip http |^banner ",
+        "severity": "high",
+    },
+    "dhcp_snooping": {
+        "title": "DHCP Snooping",
+        "best_practices": [
+            "Enable DHCP snooping globally and per-VLAN",
+            "Trust only uplink/trunk ports (where legitimate DHCP server resides)",
+            "Untrusted ports (access) will drop DHCP server messages",
+            "Pairs with Dynamic ARP Inspection (DAI) and IP Source Guard",
+        ],
+        "config_example": """\
+ip dhcp snooping
+ip dhcp snooping vlan {vlan_list}
+!
+interface {trusted_uplink}
+ ip dhcp snooping trust
+!
+! Access ports are untrusted by default""",
+        "rationale": "DHCP snooping prevents rogue DHCP servers from distributing incorrect IP configuration or performing man-in-the-middle attacks. The snooping database also enables DAI and IP Source Guard for additional L2 security.",
+        "rfc": None,
+        "match_config": "^ip dhcp snooping",
+        "severity": "medium",
+    },
+    "control_plane_policing": {
+        "title": "Control Plane Policing (CoPP)",
+        "best_practices": [
+            "Apply a system-cpp-policy to rate-limit control plane traffic",
+            "Protect against DoS attacks targeting the switch CPU",
+            "IOS-XE 3850 uses built-in system-cpp-policy (not user-configurable on older code)",
+            "Monitor CoPP drops via 'show platform hardware fed switch active qos queue stats internal cpu policer'",
+        ],
+        "config_example": """\
+control-plane
+ service-policy input system-cpp-policy""",
+        "rationale": "The switch CPU is a shared resource. Without CoPP, a flood of ARP, ICMP, or routing protocol packets can overwhelm the CPU and cause a denial of service for legitimate management and control plane traffic.",
+        "rfc": None,
+        "match_config": "^control-plane",
+        "severity": "medium",
+    },
+}
+
+
+def get_reference(feature: str) -> dict | None:
+    """Get design reference for a specific feature."""
+    return DESIGN_REFERENCE.get(feature)
+
+
+def get_all_features() -> list[str]:
+    """Get list of all available design reference features."""
+    return list(DESIGN_REFERENCE.keys())
+
+
+def get_summary() -> list[dict]:
+    """Get a summary of all design references with title and severity."""
+    return [
+        {
+            "feature": k,
+            "title": v["title"],
+            "severity": v["severity"],
+            "rfc": v.get("rfc"),
+            "match_config": v["match_config"],
+        }
+        for k, v in DESIGN_REFERENCE.items()
+    ]

--- a/mcp-servers/nautobot-mcp-v2/nautobot_client.py
+++ b/mcp-servers/nautobot-mcp-v2/nautobot_client.py
@@ -1,0 +1,231 @@
+"""Nautobot API client — GraphQL for reads, REST for writes."""
+
+import json
+import logging
+import os
+from typing import Any, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Cache for resolved UUIDs (type:name -> uuid)
+_id_cache: dict[str, str] = {}
+
+
+class NautobotError(Exception):
+    pass
+
+
+class NautobotAuthError(NautobotError):
+    pass
+
+
+class NautobotConnectionError(NautobotError):
+    pass
+
+
+class NautobotClient:
+    def __init__(self):
+        self.url = os.environ["NAUTOBOT_URL"].rstrip("/")
+        self.token = os.environ["NAUTOBOT_TOKEN"]
+        verify = os.environ.get("NAUTOBOT_VERIFY_SSL", "false").lower() == "true"
+        timeout = int(os.environ.get("NAUTOBOT_TIMEOUT", "60"))
+
+        self.http = httpx.AsyncClient(
+            headers={
+                "Authorization": f"Token {self.token}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            verify=verify,
+            timeout=timeout,
+        )
+
+    async def close(self):
+        await self.http.aclose()
+
+    # ── GraphQL ──────────────────────────────────────────────────────
+
+    async def graphql(
+        self, query: str, variables: Optional[dict] = None
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {"query": query}
+        if variables:
+            body["variables"] = variables
+
+        try:
+            resp = await self.http.post(f"{self.url}/api/graphql/", json=body)
+        except httpx.ConnectError as e:
+            raise NautobotConnectionError(
+                f"Nautobot API unreachable at {self.url}: {e}"
+            )
+        except httpx.TimeoutException:
+            raise NautobotConnectionError(
+                f"Nautobot query timed out after {self.http.timeout.read}s."
+            )
+
+        self._check_http(resp)
+        data = resp.json()
+
+        if "errors" in data:
+            msgs = "; ".join(e.get("message", str(e)) for e in data["errors"])
+            raise NautobotError(f"Nautobot GraphQL error: {msgs}")
+
+        return data.get("data", {})
+
+    # ── REST ─────────────────────────────────────────────────────────
+
+    async def rest_get(
+        self, endpoint: str, params: Optional[dict] = None
+    ) -> dict[str, Any]:
+        return await self._rest("GET", endpoint, params=params)
+
+    async def rest_post(self, endpoint: str, data: dict) -> dict[str, Any]:
+        return await self._rest("POST", endpoint, json_body=data)
+
+    async def rest_patch(self, endpoint: str, data: dict) -> dict[str, Any]:
+        return await self._rest("PATCH", endpoint, json_body=data)
+
+    async def rest_delete(self, endpoint: str) -> dict[str, Any]:
+        return await self._rest("DELETE", endpoint)
+
+    async def rest_list(
+        self, endpoint: str, params: Optional[dict] = None, limit: int = 50, offset: int = 0
+    ) -> dict[str, Any]:
+        """GET a list endpoint with pagination."""
+        p = dict(params or {})
+        p["limit"] = limit
+        p["offset"] = offset
+        return await self._rest("GET", endpoint, params=p)
+
+    async def _rest(
+        self,
+        method: str,
+        endpoint: str,
+        params: Optional[dict] = None,
+        json_body: Optional[dict] = None,
+    ) -> dict[str, Any]:
+        url = f"{self.url}/api/{endpoint.strip('/')}/"
+        try:
+            resp = await self.http.request(method, url, params=params, json=json_body)
+        except httpx.ConnectError as e:
+            raise NautobotConnectionError(
+                f"Nautobot API unreachable at {self.url}: {e}"
+            )
+        except httpx.TimeoutException:
+            raise NautobotConnectionError(
+                f"Nautobot request timed out after {self.http.timeout.read}s."
+            )
+
+        self._check_http(resp)
+        if resp.status_code == 204:
+            return {}
+        return resp.json()
+
+    # ── ID Resolution ────────────────────────────────────────────────
+
+    async def resolve_id(self, object_type: str, name: str) -> str:
+        """Resolve a human-readable name to a Nautobot UUID.
+
+        Supported object_type values:
+          status, role, location, device, platform, namespace,
+          vlan_group, tenant, interface (use "device_name:iface_name")
+        """
+        cache_key = f"{object_type}:{name}"
+        if cache_key in _id_cache:
+            return _id_cache[cache_key]
+
+        query_map: dict[str, str] = {
+            "status": '{{ statuses(name: "{}") {{ id }} }}'.format(_esc(name)),
+            "role": '{{ roles(name: "{}") {{ id }} }}'.format(_esc(name)),
+            "location": '{{ locations(name: "{}") {{ id }} }}'.format(_esc(name)),
+            "location_type": '{{ location_types(name: "{}") {{ id }} }}'.format(_esc(name)),
+            "device": '{{ devices(name: "{}") {{ id }} }}'.format(_esc(name)),
+            "device_type": '{{ device_types(model: "{}") {{ id }} }}'.format(_esc(name)),
+            "manufacturer": '{{ manufacturers(name: "{}") {{ id }} }}'.format(_esc(name)),
+            "platform": '{{ platforms(name: "{}") {{ id }} }}'.format(_esc(name)),
+            "tenant": '{{ tenants(name: "{}") {{ id }} }}'.format(_esc(name)),
+            "tenant_group": '{{ tenant_groups(name: "{}") {{ id }} }}'.format(_esc(name)),
+            "vlan_group": '{{ vlan_groups(name: "{}") {{ id }} }}'.format(_esc(name)),
+            "vrf": '{{ vrfs(name: "{}") {{ id }} }}'.format(_esc(name)),
+            "cluster": '{{ clusters(name: "{}") {{ id }} }}'.format(_esc(name)),
+            "cluster_type": '{{ cluster_types(name: "{}") {{ id }} }}'.format(_esc(name)),
+            "cluster_group": '{{ cluster_groups(name: "{}") {{ id }} }}'.format(_esc(name)),
+            "virtual_machine": '{{ virtual_machines(name: "{}") {{ id }} }}'.format(_esc(name)),
+            "provider": '{{ providers(name: "{}") {{ id }} }}'.format(_esc(name)),
+            "circuit_type": '{{ circuit_types(name: "{}") {{ id }} }}'.format(_esc(name)),
+            "tag": '{{ tags(name: "{}") {{ id }} }}'.format(_esc(name)),
+        }
+
+        if object_type == "namespace":
+            # Namespaces use REST — not always in GraphQL
+            resp = await self.rest_get("ipam/namespaces", {"name": name})
+            results = resp.get("results", [])
+            if not results:
+                raise NautobotError(f"Namespace '{name}' not found in Nautobot.")
+            uid = results[0]["id"]
+            _id_cache[cache_key] = uid
+            return uid
+
+        if object_type == "interface":
+            # Expect "DeviceName:InterfaceName"
+            if ":" not in name:
+                raise NautobotError(
+                    "Interface identifier must be 'device_name:interface_name'"
+                )
+            dev, iface = name.split(":", 1)
+            q = '{{ interfaces(device: "{}", name: "{}") {{ id }} }}'.format(
+                _esc(dev), _esc(iface)
+            )
+            data = await self.graphql(q)
+            items = _first_list(data)
+            if not items:
+                raise NautobotError(
+                    f"Interface '{iface}' on device '{dev}' not found in Nautobot."
+                )
+            uid = items[0]["id"]
+            _id_cache[cache_key] = uid
+            return uid
+
+        if object_type not in query_map:
+            raise NautobotError(f"Cannot resolve object type '{object_type}'")
+
+        data = await self.graphql(query_map[object_type])
+        items = _first_list(data)
+        if not items:
+            raise NautobotError(
+                f"{object_type.replace('_', ' ').title()} '{name}' not found in Nautobot."
+            )
+        uid = items[0]["id"]
+        _id_cache[cache_key] = uid
+        return uid
+
+    # ── Helpers ───────────────────────────────────────────────────────
+
+    def _check_http(self, resp: httpx.Response) -> None:
+        if resp.status_code in (401, 403):
+            raise NautobotAuthError(
+                "Nautobot authentication failed. Verify NAUTOBOT_TOKEN is correct."
+            )
+        if resp.status_code >= 400:
+            try:
+                detail = resp.json()
+            except Exception:
+                detail = resp.text[:500]
+            raise NautobotError(
+                f"Nautobot REST API error ({resp.status_code}): {detail}"
+            )
+
+
+def _esc(s: str) -> str:
+    """Escape a string for embedding in a GraphQL query."""
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _first_list(data: dict) -> list:
+    """Return the first list value from a GraphQL response dict."""
+    for v in data.values():
+        if isinstance(v, list):
+            return v
+    return []

--- a/mcp-servers/nautobot-mcp-v2/reconcile.py
+++ b/mcp-servers/nautobot-mcp-v2/reconcile.py
@@ -1,0 +1,103 @@
+"""Reconciliation engine — compare live device state against Nautobot SoT."""
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+def reconcile_interfaces(
+    nautobot_interfaces: list[dict[str, Any]],
+    live_interfaces: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Compare Nautobot interface records against live device interface data.
+
+    Returns a structured diff report with matches, mismatches, device_only, nautobot_only.
+    """
+    # Index by normalized name
+    nb_map = {_norm(i["name"]): i for i in nautobot_interfaces}
+    live_map = {_norm(i["name"]): i for i in live_interfaces}
+
+    nb_names = set(nb_map)
+    live_names = set(live_map)
+
+    both = nb_names & live_names
+    nb_only = nb_names - live_names
+    live_only = live_names - nb_names
+
+    matches = []
+    mismatches = []
+
+    for name in sorted(both):
+        nb = nb_map[name]
+        live = live_map[name]
+        diffs = _compare(nb, live)
+        if diffs:
+            mismatches.append({"name": nb["name"], "differences": diffs})
+        else:
+            matches.append({"name": nb["name"]})
+
+    nautobot_only = [{"name": nb_map[n]["name"]} for n in sorted(nb_only)]
+    device_only = [{"name": live_map[n]["name"]} for n in sorted(live_only)]
+
+    return {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "summary": {
+            "total_nautobot": len(nautobot_interfaces),
+            "total_live": len(live_interfaces),
+            "matches": len(matches),
+            "mismatches": len(mismatches),
+            "nautobot_only": len(nautobot_only),
+            "device_only": len(device_only),
+        },
+        "matches": matches,
+        "mismatches": mismatches,
+        "nautobot_only": nautobot_only,
+        "device_only": device_only,
+    }
+
+
+def _compare(nb: dict, live: dict) -> list[dict]:
+    """Compare fields between a Nautobot interface and a live interface."""
+    diffs = []
+
+    # enabled
+    nb_enabled = nb.get("enabled")
+    live_enabled = live.get("enabled")
+    if nb_enabled is not None and live_enabled is not None and nb_enabled != live_enabled:
+        diffs.append({"field": "enabled", "nautobot": nb_enabled, "live": live_enabled})
+
+    # description
+    nb_desc = (nb.get("description") or "").strip()
+    live_desc = (live.get("description") or "").strip()
+    if nb_desc != live_desc:
+        diffs.append({"field": "description", "nautobot": nb_desc, "live": live_desc})
+
+    # mtu
+    nb_mtu = nb.get("mtu")
+    live_mtu = live.get("mtu")
+    if nb_mtu is not None and live_mtu is not None and nb_mtu != live_mtu:
+        diffs.append({"field": "mtu", "nautobot": nb_mtu, "live": live_mtu})
+
+    # ip_addresses
+    nb_ips = _extract_ips(nb)
+    live_ips = set(live.get("ip_addresses") or [])
+    if nb_ips != live_ips:
+        diffs.append({
+            "field": "ip_addresses",
+            "nautobot": sorted(nb_ips),
+            "live": sorted(live_ips),
+        })
+
+    return diffs
+
+
+def _extract_ips(nb: dict) -> set[str]:
+    """Extract IP address strings from a Nautobot interface record."""
+    ips = nb.get("ip_addresses", [])
+    if not ips:
+        return set()
+    return {ip["address"] if isinstance(ip, dict) else ip for ip in ips}
+
+
+def _norm(name: str) -> str:
+    """Normalize interface name for comparison."""
+    return name.strip().lower()

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/cisco_xe.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/cisco_xe.j2
@@ -1,0 +1,3 @@
+{% if role["name"] == "home_switch" %}
+{% include '/cisco_xe/platform_templates/home_switch.j2' %}
+{% endif %}

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/interfaces/_l2_access.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/interfaces/_l2_access.j2
@@ -1,0 +1,10 @@
+interface {{ interface.name }}
+{% if interface.description %}
+ description {{ interface.description }}
+{% endif %}
+ switchport access vlan {{ interface.untagged_vlan.vid | default(1) }}
+ switchport mode access
+ load-interval 30
+ spanning-tree portfast
+ spanning-tree bpduguard enable
+!

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/interfaces/_l2_trunk.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/interfaces/_l2_trunk.j2
@@ -1,0 +1,13 @@
+interface {{ interface.name }}
+{% if interface.description %}
+ description {{ interface.description }}
+{% endif %}
+{% if interface.tagged_vlans | length > 0 %}
+ switchport trunk allowed vlan {{ interface.tagged_vlans | map(attribute='vid') | join(',') }}
+{% endif %}
+ switchport mode trunk
+{% if interface.lag is defined and interface.lag %}
+ channel-group {{ interface.lag.name | replace('Port-channel', '') }} mode active
+{% endif %}
+ spanning-tree portfast trunk
+!

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/interfaces/_lag_member.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/interfaces/_lag_member.j2
@@ -1,0 +1,11 @@
+interface {{ interface.name }}
+{% if interface.description %}
+ description {{ interface.description }}
+{% endif %}
+{% if interface.tagged_vlans | length > 0 %}
+ switchport trunk allowed vlan {{ interface.tagged_vlans | map(attribute='vid') | join(',') }}
+{% endif %}
+ switchport mode trunk
+ channel-group {{ interface.lag.name | replace('Port-channel', '') }} mode active
+ spanning-tree portfast trunk
+!

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/interfaces/_port_channel.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/interfaces/_port_channel.j2
@@ -1,0 +1,12 @@
+interface {{ interface.name }}
+{% if interface.description %}
+ description {{ interface.description }}
+{% endif %}
+{% if interface.mode == 'TAGGED' and interface.tagged_vlans | length > 0 %}
+ switchport trunk allowed vlan {{ interface.tagged_vlans | map(attribute='vid') | join(',') }}
+ switchport mode trunk
+{% elif interface.mode == 'ACCESS' and interface.untagged_vlan is defined %}
+ switchport access vlan {{ interface.untagged_vlan.vid }}
+ switchport mode access
+{% endif %}
+!

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/interfaces/_svi.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/interfaces/_svi.j2
@@ -1,0 +1,18 @@
+interface {{ interface.name }}
+{% if interface.description %}
+ description {{ interface.description }}
+{% endif %}
+{% if not interface.enabled %}
+ no ip address
+ shutdown
+{% else %}
+{% if config_context.mgmt_vrf is defined and interface.name == 'Vlan' + (config_context.mgmt_vrf.vlan | default('3') | string) %}
+ vrf forwarding {{ config_context.mgmt_vrf.name }}
+{% endif %}
+{% for addr in interface.ip_addresses | default([]) %}
+{% if '.' in addr.address %}
+ ip address {{ addr.address | ipaddr('address') }} {{ addr.address | ipaddr('netmask') }}
+{% endif %}
+{% endfor %}
+{% endif %}
+!

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/interfaces/_unused.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/interfaces/_unused.j2
@@ -1,0 +1,4 @@
+interface {{ interface.name }}
+ description NOT IN USE
+ shutdown
+!

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/interfaces/interfaces.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/interfaces/interfaces.j2
@@ -1,0 +1,17 @@
+{% for interface in interfaces | sort(attribute='name') %}
+{% if 'Vlan' in interface.name %}
+{% include '/cisco_xe/interfaces/_svi.j2' %}
+{% elif interface.lag is defined and interface.lag %}
+{% include '/cisco_xe/interfaces/_lag_member.j2' %}
+{% elif interface.mode == 'TAGGED' %}
+{% include '/cisco_xe/interfaces/_l2_trunk.j2' %}
+{% elif interface.mode == 'ACCESS' %}
+{% include '/cisco_xe/interfaces/_l2_access.j2' %}
+{% elif 'Port-channel' in interface.name %}
+{% include '/cisco_xe/interfaces/_port_channel.j2' %}
+{% elif 'GigabitEthernet' in interface.name or 'TenGigabitEthernet' in interface.name %}
+{% if not interface.enabled %}
+{% include '/cisco_xe/interfaces/_unused.j2' %}
+{% endif %}
+{% endif %}
+{% endfor %}

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/management/aaa.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/management/aaa.j2
@@ -1,0 +1,20 @@
+{% if config_context.aaa is defined %}
+{% set aaa = config_context.aaa %}
+{% if aaa.new_model | default(false) %}
+aaa new-model
+!
+aaa authentication login default {{ aaa.auth_method | default("local") }}
+aaa authentication login CONSOLE local
+aaa authentication enable default {{ aaa.enable_method | default("enable") }}
+{% if aaa.authorization | default(false) %}
+aaa authorization exec default {{ aaa.auth_method | default("local") }}
+{% endif %}
+{% if aaa.accounting | default(false) %}
+aaa accounting exec default start-stop {{ aaa.accounting_method | default("local") }}
+{% endif %}
+{% else %}
+no aaa new-model
+{% endif %}
+{% else %}
+no aaa new-model
+{% endif %}

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/management/http.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/management/http.j2
@@ -1,0 +1,17 @@
+{% if config_context.http is defined %}
+{% set http = config_context.http %}
+{% if http.server | default(false) %}
+ip http server
+{% else %}
+no ip http server
+{% endif %}
+ip http authentication local
+ip http secure-server
+{% if http.source_interface is defined %}
+ip http client source-interface {{ http.source_interface }}
+{% endif %}
+{% else %}
+no ip http server
+ip http authentication local
+ip http secure-server
+{% endif %}

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/management/line_vty.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/management/line_vty.j2
@@ -1,0 +1,18 @@
+{% set vty = config_context.vty | default({}) %}
+line con 0
+ exec-timeout {{ vty.console_timeout | default("15 0") }}
+ logging synchronous
+ stopbits 1
+line aux 0
+ stopbits 1
+line vty 0 4
+ exec-timeout {{ vty.exec_timeout | default("15 0") }}
+ login local
+ transport input ssh
+ transport output ssh
+line vty 5 15
+ exec-timeout {{ vty.exec_timeout | default("15 0") }}
+ privilege level 15
+ login local
+ transport input ssh
+ transport output ssh

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/management/logging.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/management/logging.j2
@@ -1,0 +1,11 @@
+{% if config_context.logging is defined %}
+{% set log = config_context.logging %}
+no logging console
+logging trap {{ log.trap_level | default("informational") }}
+{% if log.source_interface is defined %}
+logging source-interface {{ log.source_interface }}{% if log.source_vrf is defined %} vrf {{ log.source_vrf }}{% endif %}
+{% endif %}
+{% if log.host is defined %}
+logging host {{ log.host }}{% if log.host_vrf is defined %} vrf {{ log.host_vrf }}{% endif %}
+{% endif %}
+{% endif %}

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/management/ntp.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/management/ntp.j2
@@ -1,0 +1,19 @@
+{% if config_context.ntp is defined %}
+{% set ntp = config_context.ntp %}
+clock timezone {{ ntp.timezone | default("UTC") }} {{ ntp.utc_offset | default("0 0") }}
+{% if ntp.summer_time is defined %}
+clock summer-time {{ ntp.summer_time }} recurring
+{% endif %}
+!
+{% if ntp.authenticate | default(false) %}
+ntp authentication-key 1 md5 {{ ntp.auth_key }}
+ntp trusted-key 1
+ntp authenticate
+{% endif %}
+{% if ntp.source_interface is defined %}
+ntp source {{ ntp.source_interface }}
+{% endif %}
+{% for server in ntp.servers | default([]) %}
+ntp server{% if ntp.vrf is defined %} vrf {{ ntp.vrf }}{% endif %} {{ server.address }}{% if ntp.authenticate | default(false) %} key 1{% endif %}{% if server.prefer | default(false) %} prefer{% endif %}
+{% endfor %}
+{% endif %}

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/management/routing.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/management/routing.j2
@@ -1,0 +1,8 @@
+{% if config_context.mgmt_vrf is defined %}
+{% set mgmt = config_context.mgmt_vrf %}
+ip ftp source-interface {{ mgmt.source_interface | default("Vlan3") }}
+ip route vrf {{ mgmt.name }} 0.0.0.0 0.0.0.0 {{ mgmt.gateway }}
+{% if mgmt.ipv6_gateway is defined %}
+ipv6 route vrf {{ mgmt.name }} ::/0 {{ mgmt.ipv6_gateway }}
+{% endif %}
+{% endif %}

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/management/snmp.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/management/snmp.j2
@@ -1,0 +1,19 @@
+{% if config_context.snmp is defined %}
+{% set snmp = config_context.snmp %}
+{% for community in snmp.communities | default([]) %}
+snmp-server community {{ community.name }} {{ community.permission }}{% if community.acl is defined %} {{ community.acl }}{% endif %}
+
+{% endfor %}
+{% if snmp.location is defined %}
+snmp-server location {{ snmp.location }}
+{% endif %}
+{% if snmp.contact is defined %}
+snmp-server contact {{ snmp.contact }}
+{% endif %}
+{% for trap in snmp.traps | default([]) %}
+snmp-server enable traps {{ trap }}
+{% endfor %}
+{% if snmp.host is defined %}
+snmp-server host {{ snmp.host }}{% if snmp.host_version is defined %} version {{ snmp.host_version }}{% endif %} {{ snmp.host_community | default(snmp.communities[0].name) }}
+{% endif %}
+{% endif %}

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/management/ssh.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/management/ssh.j2
@@ -1,0 +1,8 @@
+{% if config_context.ssh is defined %}
+{% set ssh = config_context.ssh %}
+ip ssh version {{ ssh.version | default(2) }}
+{% if ssh.source_interface is defined %}
+ip ssh source-interface {{ ssh.source_interface }}
+{% endif %}
+ip scp server enable
+{% endif %}

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/management/users.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/management/users.j2
@@ -1,0 +1,5 @@
+{% if config_context.users is defined %}
+{% for user in config_context.users %}
+username {{ user.name }} privilege {{ user.privilege | default(15) }} {{ user.secret_type | default('password') }} 0 {{ user.password }}
+{% endfor %}
+{% endif %}

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/platform_templates/home_switch.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/platform_templates/home_switch.j2
@@ -1,0 +1,73 @@
+!
+version 16.12
+no service pad
+service timestamps debug datetime msec
+service timestamps log datetime msec
+{% if config_context.service_password_encryption | default(false) %}
+service password-encryption
+{% endif %}
+service call-home
+platform punt-keepalive disable-kernel-core
+!
+hostname {{ hostname }}
+!
+!
+{% include '/cisco_xe/services/vrf.j2' %}
+!
+{% include '/cisco_xe/management/logging.j2' %}
+!
+{% include '/cisco_xe/management/aaa.j2' %}
+!
+{% include '/cisco_xe/management/ntp.j2' %}
+!
+switch 1 provision ws-c3850-48p
+!
+call-home
+ contact-email-addr sch-smart-licensing@cisco.com
+ profile "CiscoTAC-1"
+  active
+  destination transport-method http
+  no destination transport-method email
+!
+login on-success log
+!
+{% include '/cisco_xe/switching/vtp.j2' %}
+!
+no device-tracking logging theft
+!
+system mtu {{ config_context.system.mtu | default(9198) }}
+license boot level ipservicesk9 addon dna-advantage
+!
+diagnostic bootup level minimal
+!
+{% include '/cisco_xe/switching/spanning_tree.j2' %}
+!
+memory free low-watermark processor 79475
+!
+{% include '/cisco_xe/management/users.j2' %}
+!
+redundancy
+ mode sso
+!
+transceiver type all
+ monitoring
+!
+{% include '/cisco_xe/switching/vlans.j2' %}
+!
+{% include '/cisco_xe/interfaces/interfaces.j2' %}
+!
+ip forward-protocol nd
+{% include '/cisco_xe/management/http.j2' %}
+!
+{% include '/cisco_xe/management/routing.j2' %}
+!
+{% include '/cisco_xe/management/ssh.j2' %}
+!
+{% include '/cisco_xe/management/snmp.j2' %}
+!
+control-plane
+ service-policy input system-cpp-policy
+!
+{% include '/cisco_xe/management/line_vty.j2' %}
+!
+end

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/services/vrf.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/services/vrf.j2
@@ -1,0 +1,9 @@
+{% if config_context.mgmt_vrf is defined %}
+vrf definition {{ config_context.mgmt_vrf.name }}
+ !
+ address-family ipv4
+ exit-address-family
+ !
+ address-family ipv6
+ exit-address-family
+{% endif %}

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/switching/spanning_tree.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/switching/spanning_tree.j2
@@ -1,0 +1,9 @@
+{% set stp = config_context.spanning_tree | default({}) %}
+spanning-tree mode {{ stp.mode | default("rapid-pvst") }}
+{% if stp.logging | default(true) %}
+spanning-tree logging
+{% endif %}
+spanning-tree extend system-id
+{% if stp.priority is defined %}
+spanning-tree vlan 1-4094 priority {{ stp.priority }}
+{% endif %}

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/switching/vlans.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/switching/vlans.j2
@@ -1,0 +1,9 @@
+{% if location is defined and location.vlans is defined %}
+{% for vlan in location.vlans | sort(attribute='vid') %}
+{% if vlan.vid != 1 %}
+vlan {{ vlan.vid }}
+ name {{ vlan.name }}
+!
+{% endif %}
+{% endfor %}
+{% endif %}

--- a/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/switching/vtp.j2
+++ b/mcp-servers/nautobot-mcp-v2/references/templates/cisco_xe/switching/vtp.j2
@@ -1,0 +1,1 @@
+vtp mode {{ config_context.vtp.mode | default("transparent") }}

--- a/mcp-servers/nautobot-mcp-v2/requirements.txt
+++ b/mcp-servers/nautobot-mcp-v2/requirements.txt
@@ -1,0 +1,3 @@
+mcp>=1.0.0
+httpx>=0.27.0
+python-dotenv>=1.0.0

--- a/mcp-servers/nautobot-mcp-v2/server.py
+++ b/mcp-servers/nautobot-mcp-v2/server.py
@@ -1,0 +1,2736 @@
+"""Nautobot MCP Server v2 — GraphQL reads, REST writes, ITSM-gated changes, reconciliation.
+
+Targets Nautobot 3.1.0 (graphene_django 3.2.3, no GraphQL mutations).
+"""
+
+import json
+import logging
+import os
+import sys
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from nautobot_client import NautobotClient, NautobotError, _esc
+from reconcile import reconcile_interfaces
+from cisco_design_reference import DESIGN_REFERENCE, get_reference, get_all_features, get_summary
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    stream=sys.stderr,
+)
+logger = logging.getLogger("nautobot-mcp-v2")
+
+# ── Startup validation ───────────────────────────────────────────────
+
+for var in ("NAUTOBOT_URL", "NAUTOBOT_TOKEN"):
+    if not os.environ.get(var):
+        logger.error(f"Required environment variable {var} is not set.")
+        sys.exit(1)
+
+mcp = FastMCP("nautobot-mcp-v2")
+client = NautobotClient()
+
+ITSM_ENABLED = os.environ.get("ITSM_ENABLED", "false").lower() == "true"
+ITSM_LAB_MODE = os.environ.get("ITSM_LAB_MODE", "true").lower() == "true"
+
+
+def _check_itsm(cr_number: Optional[str]) -> Optional[str]:
+    """Return error message if ITSM blocks the operation, else None."""
+    if ITSM_ENABLED and not ITSM_LAB_MODE:
+        if not cr_number:
+            return (
+                "Write operation blocked: ITSM is enabled. "
+                "Provide a cr_number parameter with a valid ServiceNow Change Request number."
+            )
+    return None
+
+
+def _gql_filters(**kwargs: Optional[str | int | bool]) -> str:
+    """Build a GraphQL filter argument string from keyword args."""
+    parts = []
+    for k, v in kwargs.items():
+        if v is None:
+            continue
+        if isinstance(v, bool):
+            parts.append(f"{k}: {'true' if v else 'false'}")
+        elif isinstance(v, int):
+            parts.append(f"{k}: {v}")
+        else:
+            parts.append(f'{k}: "{_esc(str(v))}"')
+    return f"({', '.join(parts)})" if parts else ""
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# READ TOOLS — GraphQL
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@mcp.tool()
+async def nautobot_test_connection() -> str:
+    """Test connectivity to the Nautobot API. Verifies GraphQL and REST endpoints."""
+    results = {"url": client.url, "graphql": False, "rest": False, "version": None}
+    try:
+        await client.graphql("{ __typename }")
+        results["graphql"] = True
+    except Exception as e:
+        results["graphql_error"] = str(e)
+    try:
+        status = await client.rest_get("status")
+        results["rest"] = True
+        results["nautobot_version"] = status.get("python-version")
+        results["plugins"] = list(status.get("plugins", {}).keys())
+    except Exception as e:
+        results["rest_error"] = str(e)
+    return json.dumps(results, indent=2)
+
+
+@mcp.tool()
+async def nautobot_get_devices(
+    name: Optional[str] = None,
+    location: Optional[str] = None,
+    role: Optional[str] = None,
+    platform: Optional[str] = None,
+    status: Optional[str] = None,
+    q: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> str:
+    """Query devices from Nautobot. Returns name, role, platform, location, status, primary IP, serial."""
+    logger.info(f"nautobot_get_devices name={name} location={location} role={role}")
+    filt = _gql_filters(
+        name=name, location=location, role=role, platform=platform,
+        status=status, q=q, limit=limit, offset=offset,
+    )
+    query = f"""{{
+  devices{filt} {{
+    name serial status {{ name }} role {{ name }} platform {{ name }}
+    location {{ name }} device_type {{ model manufacturer {{ name }} }}
+    primary_ip4 {{ address }} primary_ip6 {{ address }} comments
+  }}
+}}"""
+    try:
+        data = await client.graphql(query)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+    devices = data.get("devices", [])
+    return json.dumps({"count": len(devices), "devices": devices}, indent=2)
+
+
+@mcp.tool()
+async def nautobot_get_interfaces(
+    device: Optional[str] = None,
+    name: Optional[str] = None,
+    type: Optional[str] = None,
+    enabled: Optional[bool] = None,
+    status: Optional[str] = None,
+    has_ip_addresses: Optional[bool] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> str:
+    """Query interfaces from Nautobot with VLAN assignments, IPs, and cable peer."""
+    logger.info(f"nautobot_get_interfaces device={device} name={name}")
+    filt = _gql_filters(
+        device=device, name=name, type=type, enabled=enabled,
+        status=status, has_ip_addresses=has_ip_addresses, limit=limit, offset=offset,
+    )
+    query = f"""{{
+  interfaces{filt} {{
+    name type enabled status {{ name }} description mac_address mtu mode label
+    device {{ name }}
+    untagged_vlan {{ vid name }}
+    tagged_vlans {{ vid name }}
+    ip_addresses {{ address }}
+    lag {{ name }}
+    connected_interface {{ name device {{ name }} }}
+  }}
+}}"""
+    try:
+        data = await client.graphql(query)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+    ifaces = data.get("interfaces", [])
+    return json.dumps({"count": len(ifaces), "interfaces": ifaces}, indent=2)
+
+
+@mcp.tool()
+async def nautobot_get_vlans(
+    vid: Optional[int] = None,
+    name: Optional[str] = None,
+    location: Optional[str] = None,
+    vlan_group: Optional[str] = None,
+    status: Optional[str] = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> str:
+    """Query VLANs from Nautobot. Returns VID, name, status, locations, group."""
+    logger.info(f"nautobot_get_vlans vid={vid} name={name}")
+    filt = _gql_filters(
+        vid=vid, name=name, location=location, vlan_group=vlan_group,
+        status=status, limit=limit, offset=offset,
+    )
+    query = f"""{{
+  vlans{filt} {{
+    vid name status {{ name }} locations {{ name }}
+    vlan_group {{ name }} tenant {{ name }} role {{ name }} description
+  }}
+}}"""
+    try:
+        data = await client.graphql(query)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+    vlans = data.get("vlans", [])
+    return json.dumps({"count": len(vlans), "vlans": vlans}, indent=2)
+
+
+@mcp.tool()
+async def nautobot_get_prefixes(
+    prefix: Optional[str] = None,
+    status: Optional[str] = None,
+    location: Optional[str] = None,
+    tenant: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> str:
+    """Query IP prefixes from Nautobot IPAM."""
+    logger.info(f"nautobot_get_prefixes prefix={prefix}")
+    filt = _gql_filters(
+        prefix=prefix, status=status, location=location,
+        tenant=tenant, limit=limit, offset=offset,
+    )
+    query = f"""{{
+  prefixes{filt} {{
+    prefix status {{ name }} locations {{ name }}
+    role {{ name }} tenant {{ name }} description
+  }}
+}}"""
+    try:
+        data = await client.graphql(query)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+    prefixes = data.get("prefixes", [])
+    return json.dumps({"count": len(prefixes), "prefixes": prefixes}, indent=2)
+
+
+@mcp.tool()
+async def nautobot_get_ip_addresses(
+    address: Optional[str] = None,
+    status: Optional[str] = None,
+    q: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> str:
+    """Query IP addresses from Nautobot IPAM with interface/device assignments."""
+    logger.info(f"nautobot_get_ip_addresses address={address} q={q}")
+    filt = _gql_filters(
+        address=address, status=status, q=q, limit=limit, offset=offset,
+    )
+    query = f"""{{
+  ip_addresses{filt} {{
+    address status {{ name }} dns_name description tenant {{ name }}
+    interface_assignments {{ interface {{ name device {{ name }} }} }}
+  }}
+}}"""
+    try:
+        data = await client.graphql(query)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+    ips = data.get("ip_addresses", [])
+    return json.dumps({"count": len(ips), "ip_addresses": ips}, indent=2)
+
+
+@mcp.tool()
+async def nautobot_get_cables(
+    device: Optional[str] = None,
+    status: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> str:
+    """Query cables from Nautobot. Resolves termination endpoints to device+interface names."""
+    logger.info(f"nautobot_get_cables device={device}")
+    filt = _gql_filters(status=status, limit=limit, offset=offset)
+    query = f"""{{
+  cables{filt} {{
+    id type status {{ name }} label color length length_unit
+    termination_a_type termination_a_id termination_b_type termination_b_id
+  }}
+}}"""
+    try:
+        data = await client.graphql(query)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+    cables = data.get("cables", [])
+
+    # Resolve termination UUIDs to names
+    iface_ids: set[str] = set()
+    for c in cables:
+        if c.get("termination_a_type") == "dcim.interface":
+            iface_ids.add(c["termination_a_id"])
+        if c.get("termination_b_type") == "dcim.interface":
+            iface_ids.add(c["termination_b_id"])
+
+    iface_map: dict[str, dict] = {}
+    if iface_ids:
+        # Batch resolve — query interfaces by id
+        for iid in iface_ids:
+            try:
+                q = f'{{ interfaces(id: "{_esc(iid)}") {{ name device {{ name }} }} }}'
+                r = await client.graphql(q)
+                ifaces = r.get("interfaces", [])
+                if ifaces:
+                    iface_map[iid] = ifaces[0]
+            except Exception:
+                pass
+
+    enriched = []
+    for c in cables:
+        entry = {
+            "id": c["id"],
+            "type": c.get("type"),
+            "status": c.get("status"),
+            "label": c.get("label"),
+            "color": c.get("color"),
+        }
+        for side in ("a", "b"):
+            tid = c.get(f"termination_{side}_id")
+            ttype = c.get(f"termination_{side}_type")
+            if ttype == "dcim.interface" and tid in iface_map:
+                info = iface_map[tid]
+                entry[f"termination_{side}"] = {
+                    "device": info.get("device", {}).get("name"),
+                    "interface": info.get("name"),
+                }
+            else:
+                entry[f"termination_{side}"] = {"type": ttype, "id": tid}
+        enriched.append(entry)
+
+    # Filter by device if requested
+    if device:
+        enriched = [
+            c for c in enriched
+            if (c.get("termination_a", {}).get("device") == device
+                or c.get("termination_b", {}).get("device") == device)
+        ]
+
+    return json.dumps({"count": len(enriched), "cables": enriched}, indent=2)
+
+
+@mcp.tool()
+async def nautobot_graphql(query: str, variables: Optional[str] = None) -> str:
+    """Execute an arbitrary GraphQL query against Nautobot. Read-only — Nautobot 3.1.0 has no GraphQL mutations."""
+    logger.info(f"nautobot_graphql query_len={len(query)}")
+    vars_dict = None
+    if variables:
+        try:
+            vars_dict = json.loads(variables)
+        except json.JSONDecodeError as e:
+            return json.dumps({"error": f"Invalid variables JSON: {e}"})
+    try:
+        data = await client.graphql(query, vars_dict)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+    return json.dumps(data, indent=2)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# WRITE TOOLS — REST API (ITSM-gated)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@mcp.tool()
+async def nautobot_create_ip_address(
+    address: str,
+    status: str = "Active",
+    device: Optional[str] = None,
+    interface: Optional[str] = None,
+    dns_name: Optional[str] = None,
+    description: Optional[str] = None,
+    tenant: Optional[str] = None,
+    namespace: str = "Global",
+    cr_number: Optional[str] = None,
+) -> str:
+    """Create an IP address in Nautobot IPAM. Optionally assign to a device interface. ITSM-gated."""
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    logger.info(f"nautobot_create_ip_address {address} cr={cr_number}")
+    try:
+        status_id = await client.resolve_id("status", status)
+        ns_id = await client.resolve_id("namespace", namespace)
+
+        payload: dict = {
+            "address": address,
+            "status": status_id,
+            "namespace": ns_id,
+        }
+        if dns_name:
+            payload["dns_name"] = dns_name
+        if description:
+            payload["description"] = description
+        if tenant:
+            payload["tenant"] = await client.resolve_id("tenant", tenant)
+
+        result = await client.rest_post("ipam/ip-addresses", payload)
+
+        # Assign to interface if specified
+        if device and interface:
+            iface_id = await client.resolve_id("interface", f"{device}:{interface}")
+            await client.rest_post(
+                "ipam/ip-address-to-interface",
+                {"ip_address": result["id"], "interface": iface_id},
+            )
+            result["assigned_to"] = f"{device}:{interface}"
+
+        return json.dumps({"created": True, "ip_address": result}, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_create_vlan(
+    vid: int,
+    name: str,
+    status: str = "Active",
+    location: Optional[str] = None,
+    vlan_group: Optional[str] = None,
+    tenant: Optional[str] = None,
+    description: Optional[str] = None,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Create a VLAN in Nautobot. ITSM-gated."""
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    logger.info(f"nautobot_create_vlan vid={vid} name={name} cr={cr_number}")
+    try:
+        status_id = await client.resolve_id("status", status)
+        payload: dict = {"vid": vid, "name": name, "status": status_id}
+        if vlan_group:
+            payload["vlan_group"] = await client.resolve_id("vlan_group", vlan_group)
+        if tenant:
+            payload["tenant"] = await client.resolve_id("tenant", tenant)
+        if description:
+            payload["description"] = description
+
+        result = await client.rest_post("ipam/vlans", payload)
+
+        # Associate with location if specified
+        if location:
+            loc_id = await client.resolve_id("location", location)
+            try:
+                await client.rest_post(
+                    "ipam/vlan-location-assignments",
+                    {"vlan": result["id"], "location": loc_id},
+                )
+                result["location_assigned"] = location
+            except NautobotError as e:
+                result["location_warning"] = str(e)
+
+        return json.dumps({"created": True, "vlan": result}, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_create_prefix(
+    prefix: str,
+    status: str = "Active",
+    location: Optional[str] = None,
+    tenant: Optional[str] = None,
+    namespace: str = "Global",
+    description: Optional[str] = None,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Create a prefix in Nautobot IPAM. ITSM-gated."""
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    logger.info(f"nautobot_create_prefix {prefix} cr={cr_number}")
+    try:
+        status_id = await client.resolve_id("status", status)
+        ns_id = await client.resolve_id("namespace", namespace)
+        payload: dict = {
+            "prefix": prefix,
+            "status": status_id,
+            "namespace": ns_id,
+        }
+        if tenant:
+            payload["tenant"] = await client.resolve_id("tenant", tenant)
+        if description:
+            payload["description"] = description
+
+        result = await client.rest_post("ipam/prefixes", payload)
+
+        if location:
+            loc_id = await client.resolve_id("location", location)
+            try:
+                await client.rest_post(
+                    "ipam/prefix-location-assignments",
+                    {"prefix": result["id"], "location": loc_id},
+                )
+                result["location_assigned"] = location
+            except NautobotError as e:
+                result["location_warning"] = str(e)
+
+        return json.dumps({"created": True, "prefix": result}, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+# ── Object type → REST endpoint + GraphQL lookup mapping ─────────────
+
+_OBJ_MAP = {
+    "device": {
+        "endpoint": "dcim/devices",
+        "lookup": '{{ devices(name: "{}") {{ id }} }}',
+    },
+    "interface": {
+        "endpoint": "dcim/interfaces",
+        # identifier = "DeviceName:InterfaceName"
+        "lookup": None,  # uses resolve_id("interface", ...)
+    },
+    "ip_address": {
+        "endpoint": "ipam/ip-addresses",
+        "lookup": '{{ ip_addresses(address: "{}") {{ id }} }}',
+    },
+    "vlan": {
+        "endpoint": "ipam/vlans",
+        "lookup": '{{ vlans(vid: {}) {{ id }} }}',
+    },
+    "prefix": {
+        "endpoint": "ipam/prefixes",
+        "lookup": '{{ prefixes(prefix: "{}") {{ id }} }}',
+    },
+    "cable": {
+        "endpoint": "dcim/cables",
+        "lookup": None,  # identifier IS the UUID
+    },
+}
+
+
+@mcp.tool()
+async def nautobot_update_object(
+    object_type: str,
+    identifier: str,
+    updates: str,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Update any Nautobot object via REST PATCH. Resolves by type+name. ITSM-gated.
+
+    object_type: device, interface, ip_address, vlan, prefix, cable
+    identifier: device name, "device:interface", IP address, VLAN vid, prefix, or cable UUID
+    updates: JSON string of fields to update
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    if object_type not in _OBJ_MAP:
+        return json.dumps(
+            {"error": f"Unknown object_type '{object_type}'. Valid: {list(_OBJ_MAP)}"}
+        )
+
+    logger.info(
+        f"nautobot_update_object type={object_type} id={identifier} cr={cr_number}"
+    )
+
+    try:
+        update_dict = json.loads(updates)
+    except json.JSONDecodeError as e:
+        return json.dumps({"error": f"Invalid updates JSON: {e}"})
+
+    try:
+        info = _OBJ_MAP[object_type]
+        endpoint = info["endpoint"]
+
+        # Resolve identifier to UUID
+        if object_type == "interface":
+            obj_id = await client.resolve_id("interface", identifier)
+        elif object_type == "cable":
+            obj_id = identifier  # already a UUID
+        elif object_type == "vlan":
+            q = info["lookup"].format(int(identifier))
+            data = await client.graphql(q)
+            items = _first_list_from(data)
+            if not items:
+                return json.dumps(
+                    {"error": f"VLAN vid={identifier} not found in Nautobot."}
+                )
+            obj_id = items[0]["id"]
+        else:
+            q = info["lookup"].format(_esc(identifier))
+            data = await client.graphql(q)
+            items = _first_list_from(data)
+            if not items:
+                return json.dumps(
+                    {"error": f"{object_type} '{identifier}' not found in Nautobot."}
+                )
+            obj_id = items[0]["id"]
+
+        # Get current state for old values
+        old = await client.rest_get(f"{endpoint}/{obj_id}")
+
+        # Resolve any related object names in updates to UUIDs
+        for field in ("status", "role", "location", "platform", "tenant"):
+            if field in update_dict and isinstance(update_dict[field], str):
+                try:
+                    update_dict[field] = await client.resolve_id(
+                        field, update_dict[field]
+                    )
+                except NautobotError:
+                    pass  # leave as-is, let REST API validate
+
+        result = await client.rest_patch(f"{endpoint}/{obj_id}", update_dict)
+
+        # Build change summary
+        changes = {}
+        for k in update_dict:
+            old_val = old.get(k)
+            new_val = result.get(k)
+            if old_val != new_val:
+                changes[k] = {"old": old_val, "new": new_val}
+
+        return json.dumps(
+            {"updated": True, "object_type": object_type, "id": obj_id, "changes": changes},
+            indent=2,
+        )
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+def _first_list_from(data: dict) -> list:
+    for v in data.values():
+        if isinstance(v, list):
+            return v
+    return []
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# RECONCILIATION TOOL
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@mcp.tool()
+async def nautobot_reconcile(device_name: str, live_interfaces: str) -> str:
+    """Compare live device interfaces (from pyATS) against Nautobot source of truth.
+
+    device_name: Device name in Nautobot
+    live_interfaces: JSON array of live interface objects with keys: name, enabled, description, ip_addresses, mtu
+    """
+    logger.info(f"nautobot_reconcile device={device_name}")
+
+    try:
+        live = json.loads(live_interfaces)
+    except json.JSONDecodeError as e:
+        return json.dumps({"error": f"Invalid live_interfaces JSON: {e}"})
+
+    if not isinstance(live, list):
+        return json.dumps({"error": "live_interfaces must be a JSON array"})
+
+    # Query Nautobot interfaces for this device
+    query = f"""{{
+  interfaces(device: "{_esc(device_name)}") {{
+    name enabled description mtu
+    ip_addresses {{ address }}
+  }}
+}}"""
+    try:
+        data = await client.graphql(query)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+    nautobot_ifaces = data.get("interfaces", [])
+    if not nautobot_ifaces:
+        return json.dumps(
+            {"error": f"No interfaces found for device '{device_name}' in Nautobot."}
+        )
+
+    report = reconcile_interfaces(nautobot_ifaces, live)
+    report["device_name"] = device_name
+    return json.dumps(report, indent=2)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# DESIGN REFERENCE TOOLS — Cisco best practices knowledge base
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@mcp.tool()
+async def cisco_design_reference(
+    feature: Optional[str] = None,
+) -> str:
+    """Query Cisco design best practices for network configuration features.
+
+    Returns best practices, config examples, rationale, and relevant RFCs.
+    Use when building golden config templates, compliance rules, or hardening recommendations.
+
+    feature: Specific feature to look up. If omitted, returns summary of all features.
+    Available features: aaa, ntp, logging, snmp, ssh, vty_lines, spanning_tree, vtp,
+    interfaces_l2_access, interfaces_l2_trunk, management_plane, dhcp_snooping, control_plane_policing
+    """
+    if feature:
+        ref = get_reference(feature)
+        if not ref:
+            available = get_all_features()
+            return json.dumps(
+                {"error": f"Feature '{feature}' not found. Available: {available}"}
+            )
+        return json.dumps(ref, indent=2)
+    else:
+        return json.dumps({"features": get_summary()}, indent=2)
+
+
+@mcp.tool()
+async def golden_config_get_template(
+    template_path: Optional[str] = None,
+) -> str:
+    """Get a golden config Jinja template scaffolding file for review or customization.
+
+    These are starting-point templates based on Cisco IOS-XE best practices.
+    Use during golden config bootstrap to present templates to the user for review and modification.
+
+    template_path: Relative path within the cisco_xe template tree (e.g., 'management/ntp.j2').
+    If omitted, returns the directory listing of all available templates.
+    """
+    import pathlib
+    base = pathlib.Path(__file__).parent / "references" / "templates" / "cisco_xe"
+
+    if not template_path:
+        # Return directory listing
+        templates = []
+        for f in sorted(base.rglob("*.j2")):
+            templates.append(str(f.relative_to(base)))
+        return json.dumps({"templates": templates}, indent=2)
+
+    target = base / template_path
+    if not target.exists():
+        return json.dumps({"error": f"Template '{template_path}' not found.", "available": [str(f.relative_to(base)) for f in sorted(base.rglob('*.j2'))]})
+    return json.dumps({"path": template_path, "content": target.read_text()}, indent=2)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# PLUGIN TOOLS — Golden Config, Firewall Models, BGP/IGP Models
+# ═══════════════════════════════════════════════════════════════════════
+
+
+# ── Golden Config Plugin ─────────────────────────────────────────────
+
+
+@mcp.tool()
+async def nautobot_get_golden_configs(
+    device: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> str:
+    """Query golden config records — backup, intended, and compliance configs per device.
+
+    DEPRECATED: Use nautobot-golden-config-mcp tools instead:
+      golden_config_get_intended(device=) or golden_config_get_backup(device=)
+    """
+    logger.info(f"nautobot_get_golden_configs device={device}")
+    filt = _gql_filters(device=device, limit=limit, offset=offset)
+    query = f"""{{
+  golden_configs{filt} {{
+    device {{ name }}
+    backup_config
+    backup_last_success_date
+    intended_config
+    intended_last_success_date
+    compliance_config
+    compliance_last_success_date
+  }}
+}}"""
+    try:
+        data = await client.graphql(query)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+    configs = data.get("golden_configs", [])
+    return json.dumps({"count": len(configs), "golden_configs": configs}, indent=2)
+
+
+@mcp.tool()
+async def nautobot_get_config_compliance(
+    device: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> str:
+    """Query config compliance status per device and feature. Shows compliant/non-compliant with actual vs intended diffs.
+
+    DEPRECATED: Use nautobot-golden-config-mcp tools instead:
+      golden_config_get_compliance_summary(device=) or golden_config_get_compliance_diff(device=)
+    """
+    logger.info(f"nautobot_get_config_compliance device={device}")
+    filt = _gql_filters(device=device, limit=limit, offset=offset)
+    query = f"""{{
+  config_compliances{filt} {{
+    device {{ name }}
+    rule {{ feature {{ name }} platform {{ name }} config_type match_config }}
+    compliance
+    actual
+    intended
+    missing
+    extra
+    remediation
+    ordered
+  }}
+}}"""
+    try:
+        data = await client.graphql(query)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+    records = data.get("config_compliances", [])
+    return json.dumps({"count": len(records), "config_compliances": records}, indent=2)
+
+
+@mcp.tool()
+async def nautobot_get_compliance_rules(
+    limit: int = 50,
+    offset: int = 0,
+) -> str:
+    """Query compliance features and rules. Shows what config sections are being checked and the match patterns.
+
+    DEPRECATED: Use nautobot-golden-config-mcp tools instead:
+      golden_config_get_settings()
+    """
+    logger.info("nautobot_get_compliance_rules")
+    try:
+        feat_data = await client.graphql(
+            f'{{ compliance_features(limit: {limit}, offset: {offset}) {{ id name slug description }} }}'
+        )
+        rule_data = await client.graphql(
+            f'{{ compliance_rules(limit: {limit}, offset: {offset}) {{ feature {{ name }} platform {{ name }} config_ordered config_remediation match_config config_type custom_compliance description }} }}'
+        )
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+    features = feat_data.get("compliance_features", [])
+    rules = rule_data.get("compliance_rules", [])
+    return json.dumps(
+        {"features_count": len(features), "features": features,
+         "rules_count": len(rules), "rules": rules},
+        indent=2,
+    )
+
+
+@mcp.tool()
+async def nautobot_get_golden_config_settings() -> str:
+    """Query golden config settings — repos, path templates, SoT query, and dynamic group scope.
+
+    DEPRECATED: Use nautobot-golden-config-mcp tools instead:
+      golden_config_get_settings()
+    """
+    logger.info("nautobot_get_golden_config_settings")
+    try:
+        data = await client.rest_get("plugins/golden-config/golden-config-settings")
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+    results = data.get("results", [])
+    return json.dumps({"count": len(results), "settings": results}, indent=2)
+
+
+@mcp.tool()
+async def nautobot_get_git_repositories() -> str:
+    """Query Nautobot git repositories — used for golden config templates, backups, and intended configs."""
+    logger.info("nautobot_get_git_repositories")
+    try:
+        data = await client.rest_get("extras/git-repositories")
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+    results = data.get("results", [])
+    return json.dumps({"count": len(results), "repositories": results}, indent=2)
+
+
+@mcp.tool()
+async def nautobot_get_graphql_queries() -> str:
+    """Query saved GraphQL queries in Nautobot — used as SoT aggregation queries for golden config."""
+    logger.info("nautobot_get_graphql_queries")
+    try:
+        data = await client.rest_get("extras/graphql-queries")
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+    results = data.get("results", [])
+    return json.dumps({"count": len(results), "queries": results}, indent=2)
+
+
+@mcp.tool()
+async def nautobot_create_compliance_feature(
+    name: str,
+    slug: Optional[str] = None,
+    description: Optional[str] = None,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Create a compliance feature (e.g., 'aaa', 'ntp', 'logging', 'snmp', 'acl'). ITSM-gated.
+
+    DEPRECATED: Use nautobot-golden-config-mcp tools instead:
+      golden_config_create_compliance_feature(name=, description=)
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+    logger.info(f"nautobot_create_compliance_feature name={name} cr={cr_number}")
+    try:
+        payload: dict = {"name": name, "slug": slug or name.lower().replace(" ", "_")}
+        if description:
+            payload["description"] = description
+        result = await client.rest_post("plugins/golden-config/compliance-feature", payload)
+        return json.dumps({"created": True, "compliance_feature": result}, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_create_compliance_rule(
+    feature: str,
+    platform: str,
+    match_config: str,
+    config_type: str = "cli",
+    config_ordered: bool = False,
+    config_remediation: bool = False,
+    description: Optional[str] = None,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Create a compliance rule linking a feature to a platform with a config match pattern. ITSM-gated.
+
+    DEPRECATED: Use nautobot-golden-config-mcp tools instead:
+      golden_config_create_compliance_rule(feature=, platform=, match_config=)
+
+    feature: Compliance feature name (e.g., 'aaa')
+    platform: Platform name (e.g., 'cisco_ios')
+    match_config: Config line(s) to match for this feature (regex or literal)
+    config_type: 'cli' (default) or 'json'
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+    logger.info(f"nautobot_create_compliance_rule feature={feature} platform={platform} cr={cr_number}")
+    try:
+        # Resolve feature and platform to UUIDs
+        feat_data = await client.graphql(
+            f'{{ compliance_features(name: "{_esc(feature)}") {{ id }} }}'
+        )
+        feats = feat_data.get("compliance_features", [])
+        if not feats:
+            return json.dumps({"error": f"Compliance feature '{feature}' not found. Create it first."})
+        feat_id = feats[0]["id"]
+
+        plat_id = await client.resolve_id("platform", platform)
+
+        payload: dict = {
+            "feature": feat_id,
+            "platform": plat_id,
+            "match_config": match_config,
+            "config_type": config_type,
+            "config_ordered": config_ordered,
+            "config_remediation": config_remediation,
+        }
+        if description:
+            payload["description"] = description
+        result = await client.rest_post("plugins/golden-config/compliance-rule", payload)
+        return json.dumps({"created": True, "compliance_rule": result}, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_create_git_repository(
+    name: str,
+    remote_url: str,
+    provided_contents: str,
+    branch: str = "main",
+    cr_number: Optional[str] = None,
+) -> str:
+    """Register a git repository in Nautobot for golden config templates, backups, or intended configs. ITSM-gated.
+
+    provided_contents: comma-separated content types. Valid values:
+      nautobot_golden_config.jinjatemplate — Jinja templates for intended config generation
+      nautobot_golden_config.intendedconfigs — Intended config storage
+      nautobot_golden_config.backupconfigs — Backup config storage
+      extras.configcontext — Config contexts
+      extras.job — Jobs
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+    logger.info(f"nautobot_create_git_repository name={name} url={remote_url} cr={cr_number}")
+    try:
+        contents = [c.strip() for c in provided_contents.split(",")]
+        payload: dict = {
+            "name": name,
+            "remote_url": remote_url,
+            "branch": branch,
+            "provided_contents": contents,
+        }
+        result = await client.rest_post("extras/git-repositories", payload)
+        return json.dumps({"created": True, "repository": result}, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_create_graphql_query(
+    name: str,
+    query: str,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Create a saved GraphQL query in Nautobot — used as SoT aggregation query for golden config. ITSM-gated.
+
+    The query should return device data needed by Jinja templates (hostname, interfaces, VLANs, IPs, etc.).
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+    logger.info(f"nautobot_create_graphql_query name={name} cr={cr_number}")
+    try:
+        payload: dict = {"name": name, "query": query}
+        result = await client.rest_post("extras/graphql-queries", payload)
+        return json.dumps({"created": True, "graphql_query": result}, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_update_golden_config_setting(
+    setting_id: str,
+    updates: str,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Update a golden config setting — link repos, set path templates, assign SoT query. ITSM-gated.
+
+    setting_id: UUID of the golden config setting (get from nautobot_get_golden_config_settings)
+    updates: JSON string of fields to update. Common fields:
+      backup_repository: UUID of git repo for backups
+      intended_repository: UUID of git repo for intended configs
+      jinja_repository: UUID of git repo for Jinja templates
+      backup_path_template: Jinja path template (e.g., '{{obj.location.name}}/{{obj.name}}.cfg')
+      intended_path_template: Jinja path template for intended configs
+      jinja_path_template: Jinja path template for templates (e.g., '{{obj.platform.network_driver}}/main.j2')
+      sot_agg_query: UUID of saved GraphQL query for SoT aggregation
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+    logger.info(f"nautobot_update_golden_config_setting id={setting_id} cr={cr_number}")
+    try:
+        update_dict = json.loads(updates)
+    except json.JSONDecodeError as e:
+        return json.dumps({"error": f"Invalid updates JSON: {e}"})
+    try:
+        old = await client.rest_get(f"plugins/golden-config/golden-config-settings/{setting_id}")
+        result = await client.rest_patch(
+            f"plugins/golden-config/golden-config-settings/{setting_id}", update_dict
+        )
+        changes = {}
+        for k in update_dict:
+            if old.get(k) != result.get(k):
+                changes[k] = {"old": old.get(k), "new": result.get(k)}
+        return json.dumps({"updated": True, "changes": changes}, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+# ── Job Management (trigger and monitor Nautobot jobs) ─────────────
+
+
+@mcp.tool()
+async def nautobot_run_job(
+    job_id: str,
+    data: Optional[str] = None,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Trigger a Nautobot job by its UUID. ITSM-gated.
+
+    job_id: UUID of the job (get from nautobot_list_jobs)
+    data: Optional JSON string of job input data (e.g., '{"device": ["uuid1"]}')
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+    logger.info(f"nautobot_run_job job_id={job_id} cr={cr_number}")
+    try:
+        payload: dict = {"data": json.loads(data) if data else {}}
+        result = await client.rest_post(f"extras/jobs/{job_id}/run", payload)
+        return json.dumps({"triggered": True, "job_result": result}, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_get_job_result(job_result_id: str) -> str:
+    """Check the status and result of a Nautobot job run.
+
+    job_result_id: UUID of the job result (returned by nautobot_run_job)
+    """
+    logger.info(f"nautobot_get_job_result id={job_result_id}")
+    try:
+        result = await client.rest_get(f"extras/job-results/{job_result_id}")
+        summary = {
+            "id": result.get("id"),
+            "status": result.get("status", {}).get("value") if isinstance(result.get("status"), dict) else result.get("status"),
+            "name": result.get("name"),
+            "completed": result.get("date_done"),
+            "result": result.get("result"),
+        }
+        return json.dumps(summary, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_list_jobs(
+    q: Optional[str] = None,
+    limit: int = 50,
+) -> str:
+    """List available Nautobot jobs. Use q to search by name (e.g., 'intended', 'backup', 'compliance')."""
+    logger.info(f"nautobot_list_jobs q={q}")
+    try:
+        params = {"limit": limit}
+        if q:
+            params["q"] = q
+        data = await client.rest_get("extras/jobs", params)
+        results = data.get("results", [])
+        jobs = [{"id": j["id"], "name": j.get("name"), "enabled": j.get("enabled")} for j in results]
+        return json.dumps({"count": len(jobs), "jobs": jobs}, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_enable_job(
+    job_id: Optional[str] = None,
+    enable_all: bool = False,
+    enabled: bool = True,
+) -> str:
+    """Enable or disable Nautobot jobs.
+
+    job_id: UUID of a single job to enable/disable (get from nautobot_list_jobs)
+    enable_all: If True, enables ALL disabled jobs in one call. Ignores job_id.
+    enabled: True to enable, False to disable (default: True)
+    """
+    logger.info(f"nautobot_enable_job id={job_id} enable_all={enable_all} enabled={enabled}")
+    try:
+        if enable_all:
+            data = await client.rest_get("extras/jobs", {"limit": 200})
+            results = data.get("results", [])
+            disabled = [j for j in results if not j.get("enabled")]
+            if not disabled:
+                return json.dumps({"message": "All jobs already enabled", "count": 0})
+            updated = []
+            errors = []
+            for job in disabled:
+                try:
+                    r = await client.rest_patch(f"extras/jobs/{job['id']}", {"enabled": enabled})
+                    updated.append({"id": r.get("id"), "name": r.get("name")})
+                except NautobotError as e:
+                    errors.append({"id": job["id"], "name": job.get("name"), "error": str(e)})
+            return json.dumps({
+                "updated": True,
+                "enabled_count": len(updated),
+                "jobs": updated,
+                "errors": errors if errors else None,
+            }, indent=2)
+        elif job_id:
+            result = await client.rest_patch(f"extras/jobs/{job_id}", {"enabled": enabled})
+            return json.dumps({
+                "updated": True,
+                "job": {"id": result.get("id"), "name": result.get("name"), "enabled": result.get("enabled")},
+            }, indent=2)
+        else:
+            return json.dumps({"error": "Provide job_id or set enable_all=True"})
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+# ── Git Repository Sync ───────────────────────────────────────
+
+
+@mcp.tool()
+async def nautobot_sync_git_repository(
+    repository_id: str,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Trigger a git repository sync in Nautobot. ITSM-gated.
+
+    repository_id: UUID of the git repository (get from nautobot_get_git_repositories)
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+    logger.info(f"nautobot_sync_git_repository id={repository_id} cr={cr_number}")
+    try:
+        result = await client.rest_post(f"extras/git-repositories/{repository_id}/sync", {})
+        return json.dumps({"synced": True, "result": result}, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_update_git_repository(
+    repository_id: str,
+    updates: str,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Update a git repository in Nautobot. ITSM-gated.
+
+    repository_id: UUID of the git repository (get from nautobot_get_git_repositories)
+    updates: JSON string of fields to update. Common fields:
+      secrets_group: UUID of secrets group for authentication
+      remote_url: Git remote URL
+      branch: Branch name
+      provided_contents: List of content types
+      name: Display name
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+    logger.info(f"nautobot_update_git_repository id={repository_id} cr={cr_number}")
+    try:
+        update_dict = json.loads(updates)
+    except json.JSONDecodeError as e:
+        return json.dumps({"error": f"Invalid updates JSON: {e}"})
+    try:
+        old = await client.rest_get(f"extras/git-repositories/{repository_id}")
+        result = await client.rest_patch(f"extras/git-repositories/{repository_id}", update_dict)
+        changes = {}
+        for k in update_dict:
+            if old.get(k) != result.get(k):
+                changes[k] = {"old": old.get(k), "new": result.get(k)}
+        return json.dumps({"updated": True, "changes": changes}, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+# ── Config Contexts ──────────────────────────────────────────
+
+
+@mcp.tool()
+async def nautobot_get_config_contexts(
+    name: Optional[str] = None,
+    limit: int = 50,
+) -> str:
+    """Query config contexts from Nautobot. Returns name, data, and role/location/platform assignments."""
+    logger.info(f"nautobot_get_config_contexts name={name}")
+    try:
+        params: dict = {"limit": limit}
+        if name:
+            params["name"] = name
+        data = await client.rest_get("extras/config-contexts", params)
+        results = data.get("results", [])
+        contexts = []
+        for ctx in results:
+            contexts.append({
+                "id": ctx["id"],
+                "name": ctx.get("name"),
+                "roles": [r.get("name") or r.get("display") for r in ctx.get("roles", [])],
+                "locations": [l.get("name") or l.get("display") for l in ctx.get("locations", [])],
+                "platforms": [p.get("name") or p.get("display") for p in ctx.get("platforms", [])],
+                "data_keys": list(ctx.get("data", {}).keys()) if ctx.get("data") else [],
+            })
+        return json.dumps({"count": len(contexts), "config_contexts": contexts}, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_get_config_context_detail(config_context_id: str) -> str:
+    """Get full detail of a config context including its data payload."""
+    logger.info(f"nautobot_get_config_context_detail id={config_context_id}")
+    try:
+        result = await client.rest_get(f"extras/config-contexts/{config_context_id}")
+        return json.dumps(result, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_create_config_context(
+    name: str,
+    data: str,
+    roles: Optional[str] = None,
+    locations: Optional[str] = None,
+    platforms: Optional[str] = None,
+    description: Optional[str] = None,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Create a config context in Nautobot. ITSM-gated.
+
+    name: Display name
+    data: JSON string of the config context data payload
+    roles: Optional comma-separated role names to scope the context to
+    locations: Optional comma-separated location names
+    platforms: Optional comma-separated platform names
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+    logger.info(f"nautobot_create_config_context name={name} cr={cr_number}")
+    try:
+        ctx_data = json.loads(data)
+    except json.JSONDecodeError as e:
+        return json.dumps({"error": f"Invalid data JSON: {e}"})
+    try:
+        payload: dict = {"name": name, "data": ctx_data}
+        if description:
+            payload["description"] = description
+        if roles:
+            role_ids = []
+            for r in roles.split(","):
+                role_ids.append(await client.resolve_id("role", r.strip()))
+            payload["roles"] = role_ids
+        if locations:
+            loc_ids = []
+            for l in locations.split(","):
+                loc_ids.append(await client.resolve_id("location", l.strip()))
+            payload["locations"] = loc_ids
+        if platforms:
+            plat_ids = []
+            for p in platforms.split(","):
+                plat_ids.append(await client.resolve_id("platform", p.strip()))
+            payload["platforms"] = plat_ids
+        result = await client.rest_post("extras/config-contexts", payload)
+        return json.dumps({"created": True, "config_context": result}, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_update_config_context(
+    config_context_id: str,
+    updates: str,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Update a config context in Nautobot. ITSM-gated.
+
+    config_context_id: UUID of the config context
+    updates: JSON string of fields to update. Common fields: data, roles, locations, platforms, name, description
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+    logger.info(f"nautobot_update_config_context id={config_context_id} cr={cr_number}")
+    try:
+        update_dict = json.loads(updates)
+    except json.JSONDecodeError as e:
+        return json.dumps({"error": f"Invalid updates JSON: {e}"})
+    try:
+        result = await client.rest_patch(f"extras/config-contexts/{config_context_id}", update_dict)
+        return json.dumps({"updated": True, "config_context": result}, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+# ── Dynamic Groups ───────────────────────────────────────────
+
+
+@mcp.tool()
+async def nautobot_get_dynamic_group_members(
+    dynamic_group_id: str,
+) -> str:
+    """Get the members of a Nautobot dynamic group. Returns the list of devices that match the group's filter."""
+    logger.info(f"nautobot_get_dynamic_group_members id={dynamic_group_id}")
+    try:
+        data = await client.rest_get(f"extras/dynamic-groups/{dynamic_group_id}/members")
+        results = data.get("results", []) if isinstance(data, dict) else data
+        members = [{"name": m.get("name"), "id": m.get("id")} for m in results if isinstance(m, dict)]
+        return json.dumps({"count": len(members), "members": members}, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+# ── Secrets Management (for Git Repository auth) ────────────────────
+
+
+@mcp.tool()
+async def nautobot_create_secret(
+    name: str,
+    provider: str,
+    parameters: str,
+    description: Optional[str] = None,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Create a secret in Nautobot. Used to store credentials for git repo access. ITSM-gated.
+
+    name: Display name (e.g., 'GitHub Token')
+    provider: Secret provider type. Common values:
+      environment-variable — reads from a Nautobot server env var
+      text-file — reads from a file on the Nautobot server
+    parameters: JSON string of provider-specific parameters.
+      For environment-variable: {"variable": "NAUTOBOT_GIT_TOKEN"}
+      For text-file: {"path": "/opt/nautobot/secrets/github-token"}
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+    logger.info(f"nautobot_create_secret name={name} provider={provider} cr={cr_number}")
+    try:
+        params = json.loads(parameters)
+    except json.JSONDecodeError as e:
+        return json.dumps({"error": f"Invalid parameters JSON: {e}"})
+    try:
+        payload: dict = {"name": name, "provider": provider, "parameters": params}
+        if description:
+            payload["description"] = description
+        result = await client.rest_post("extras/secrets", payload)
+        return json.dumps({"created": True, "secret": result}, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_create_secrets_group(
+    name: str,
+    description: Optional[str] = None,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Create a secrets group in Nautobot. Secrets groups bundle secrets for use with git repos. ITSM-gated."""
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+    logger.info(f"nautobot_create_secrets_group name={name} cr={cr_number}")
+    try:
+        payload: dict = {"name": name}
+        if description:
+            payload["description"] = description
+        result = await client.rest_post("extras/secrets-groups", payload)
+        return json.dumps({"created": True, "secrets_group": result}, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_add_secret_to_group(
+    secrets_group_id: str,
+    secret_id: str,
+    access_type: str,
+    secret_type: str,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Associate a secret with a secrets group. ITSM-gated.
+
+    secrets_group_id: UUID of the secrets group
+    secret_id: UUID of the secret
+    access_type: How the secret is accessed. Values: 'HTTP(S)', 'SSH', 'SNMP', 'REST', 'Generic'
+    secret_type: What the secret represents. Values: 'token', 'username', 'password', 'key', 'secret'
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+    logger.info(f"nautobot_add_secret_to_group group={secrets_group_id} secret={secret_id} cr={cr_number}")
+    try:
+        payload: dict = {
+            "secrets_group": secrets_group_id,
+            "secret": secret_id,
+            "access_type": access_type,
+            "secret_type": secret_type,
+        }
+        result = await client.rest_post("extras/secrets-groups-associations", payload)
+        return json.dumps({"created": True, "association": result}, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+# ── Firewall Models Plugin ───────────────────────────────────────────
+
+
+@mcp.tool()
+async def nautobot_get_firewall_policies(
+    device: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> str:
+    """Query firewall policies with rules, zones, address objects, and device assignments."""
+    logger.info(f"nautobot_get_firewall_policies device={device}")
+    filt = _gql_filters(limit=limit, offset=offset)
+    query = f"""{{
+  policies{filt} {{
+    name status {{ name }} description tenant {{ name }}
+    assigned_devices {{ name }}
+    policy_rules {{
+      name index action log description
+      source_zone {{ name }}
+      destination_zone {{ name }}
+      source_addresses {{ name ip_address {{ address }} prefix {{ prefix }} fqdn {{ name }} }}
+      source_address_groups {{ name }}
+      destination_addresses {{ name ip_address {{ address }} prefix {{ prefix }} fqdn {{ name }} }}
+      destination_address_groups {{ name }}
+      source_services {{ name port ip_protocol }}
+      destination_services {{ name port ip_protocol }}
+    }}
+  }}
+}}"""
+    try:
+        data = await client.graphql(query)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+    policies = data.get("policies", [])
+    # Filter by device if requested
+    if device:
+        policies = [
+            p for p in policies
+            if any(d.get("name") == device for d in p.get("assigned_devices", []))
+        ]
+    return json.dumps({"count": len(policies), "policies": policies}, indent=2)
+
+
+@mcp.tool()
+async def nautobot_get_firewall_zones(
+    limit: int = 50,
+    offset: int = 0,
+) -> str:
+    """Query firewall zones with associated VRFs and interfaces."""
+    logger.info("nautobot_get_firewall_zones")
+    filt = _gql_filters(limit=limit, offset=offset)
+    query = f"""{{
+  zones{filt} {{
+    name status {{ name }} description
+    vrfs {{ name }}
+    interfaces {{ name device {{ name }} }}
+  }}
+}}"""
+    try:
+        data = await client.graphql(query)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+    zones = data.get("zones", [])
+    return json.dumps({"count": len(zones), "zones": zones}, indent=2)
+
+
+@mcp.tool()
+async def nautobot_get_nat_policies(
+    limit: int = 50,
+    offset: int = 0,
+) -> str:
+    """Query NAT policies with rules, original/translated addresses, and device assignments."""
+    logger.info("nautobot_get_nat_policies")
+    filt = _gql_filters(limit=limit, offset=offset)
+    query = f"""{{
+  nat_policies{filt} {{
+    name status {{ name }} description tenant {{ name }}
+    nat_policy_rules {{
+      name index log
+      original_source_addresses {{ name }}
+      original_destination_addresses {{ name }}
+      translated_source_addresses {{ name }}
+      translated_destination_addresses {{ name }}
+      source_zone {{ name }}
+      destination_zone {{ name }}
+    }}
+  }}
+}}"""
+    try:
+        data = await client.graphql(query)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+    policies = data.get("nat_policies", [])
+    return json.dumps({"count": len(policies), "nat_policies": policies}, indent=2)
+
+
+# ── BGP Models Plugin ────────────────────────────────────────────────
+
+
+@mcp.tool()
+async def nautobot_get_bgp_routing(
+    device: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> str:
+    """Query BGP routing instances, peer groups, peer endpoints, and autonomous systems."""
+    logger.info(f"nautobot_get_bgp_routing device={device}")
+    filt = _gql_filters(limit=limit, offset=offset)
+    query = f"""{{
+  bgp_routing_instances{filt} {{
+    device {{ name }}
+    router_id {{ address }}
+    autonomous_system {{ asn description }}
+    status {{ name }}
+    description
+    peer_groups {{
+      name enabled description
+      autonomous_system {{ asn }}
+      source_ip {{ address }}
+      source_interface {{ name }}
+    }}
+    endpoints {{
+      enabled description
+      autonomous_system {{ asn }}
+      source_ip {{ address }}
+      source_interface {{ name }}
+      peer {{ source_ip {{ address }} }}
+      peer_group {{ name }}
+      role {{ name }}
+    }}
+  }}
+}}"""
+    try:
+        data = await client.graphql(query)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+    instances = data.get("bgp_routing_instances", [])
+    if device:
+        instances = [i for i in instances if i.get("device", {}).get("name") == device]
+    return json.dumps({"count": len(instances), "bgp_routing_instances": instances}, indent=2)
+
+
+@mcp.tool()
+async def nautobot_get_autonomous_systems(
+    limit: int = 50,
+    offset: int = 0,
+) -> str:
+    """Query autonomous systems registered in Nautobot BGP models."""
+    logger.info("nautobot_get_autonomous_systems")
+    filt = _gql_filters(limit=limit, offset=offset)
+    query = f"""{{
+  autonomous_systems{filt} {{
+    asn description status {{ name }}
+    provider {{ name }}
+  }}
+}}"""
+    try:
+        data = await client.graphql(query)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+    systems = data.get("autonomous_systems", [])
+    return json.dumps({"count": len(systems), "autonomous_systems": systems}, indent=2)
+
+
+# ── IGP Models Plugin ────────────────────────────────────────────────
+
+
+@mcp.tool()
+async def nautobot_get_ospf_routing(
+    limit: int = 50,
+    offset: int = 0,
+) -> str:
+    """Query OSPF configurations and interface configurations from the IGP models plugin."""
+    logger.info("nautobot_get_ospf_routing")
+    filt = _gql_filters(limit=limit, offset=offset)
+    query = f"""{{
+  ospf_configurations{filt} {{
+    name instance {{ device {{ name }} }} process_id status {{ name }}
+    default_cost default_hello_interval default_dead_interval
+  }}
+  ospf_interface_configurations{filt} {{
+    name
+    interface {{ name device {{ name }} }}
+    ospf_config {{ name }}
+    area cost status {{ name }}
+  }}
+}}"""
+    try:
+        data = await client.graphql(query)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+    return json.dumps({
+        "ospf_configs": data.get("ospf_configurations", []),
+        "ospf_interface_configs": data.get("ospf_interface_configurations", []),
+    }, indent=2)
+
+
+# ── Virtualization ────────────────────────────────────────────────────
+
+
+@mcp.tool()
+async def nautobot_get_virtual_machines(
+    name: Optional[str] = None,
+    cluster: Optional[str] = None,
+    role: Optional[str] = None,
+    status: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> str:
+    """Query virtual machines from Nautobot. Returns name, cluster, role, status, primary IP, vCPUs, memory, disk."""
+    logger.info(f"nautobot_get_virtual_machines name={name} cluster={cluster}")
+    filt = _gql_filters(
+        name=name, cluster=cluster, role=role, status=status,
+        limit=limit, offset=offset,
+    )
+    query = f"""{{
+  virtual_machines{filt} {{
+    id name status {{ name }} role {{ name }} cluster {{ name }}
+    vcpus memory disk comments
+    primary_ip4 {{ address }}
+    interfaces {{ name enabled mac_address ip_addresses {{ address }} }}
+  }}
+}}"""
+    try:
+        data = await client.graphql(query)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+    vms = data.get("virtual_machines", [])
+    return json.dumps({"count": len(vms), "virtual_machines": vms}, indent=2)
+
+
+@mcp.tool()
+async def nautobot_create_virtual_machine(
+    name: str,
+    cluster: str,
+    role: Optional[str] = None,
+    status: str = "Active",
+    vcpus: Optional[int] = None,
+    memory: Optional[int] = None,
+    disk: Optional[int] = None,
+    comments: Optional[str] = None,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Create a virtual machine in Nautobot. ITSM-gated.
+
+    Args:
+        name: VM name (e.g., "otel-collector")
+        cluster: Cluster name the VM belongs to (e.g., "Observability")
+        role: Device role (e.g., "Monitoring")
+        status: Status name (default: Active)
+        vcpus: Number of virtual CPUs
+        memory: Memory in MB
+        disk: Disk in GB
+        comments: Free-text description
+        cr_number: ServiceNow change request number (required if ITSM enabled)
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    logger.info(f"nautobot_create_virtual_machine {name} cluster={cluster} cr={cr_number}")
+    try:
+        status_id = await client.resolve_id("status", status)
+        cluster_id = await client.resolve_id("cluster", cluster)
+
+        payload: dict = {
+            "name": name,
+            "status": status_id,
+            "cluster": cluster_id,
+        }
+        if role:
+            payload["role"] = await client.resolve_id("role", role)
+        if vcpus:
+            payload["vcpus"] = vcpus
+        if memory:
+            payload["memory"] = memory
+        if disk:
+            payload["disk"] = disk
+        if comments:
+            payload["comments"] = comments
+
+        result = await client.rest_post("virtualization/virtual-machines", payload)
+        return json.dumps({"created": True, "virtual_machine": result}, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_create_vm_interface(
+    virtual_machine: str,
+    name: str,
+    enabled: bool = True,
+    description: Optional[str] = None,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Create a network interface on a virtual machine. ITSM-gated.
+
+    Args:
+        virtual_machine: VM name (e.g., "otel-collector")
+        name: Interface name (e.g., "eth0")
+        enabled: Whether the interface is enabled
+        description: Interface description
+        cr_number: ServiceNow change request number
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    logger.info(f"nautobot_create_vm_interface {virtual_machine}:{name} cr={cr_number}")
+    try:
+        vm_id = await client.resolve_id("virtual_machine", virtual_machine)
+
+        payload: dict = {
+            "virtual_machine": vm_id,
+            "name": name,
+            "enabled": enabled,
+        }
+        if description:
+            payload["description"] = description
+
+        result = await client.rest_post("virtualization/interfaces", payload)
+        return json.dumps({"created": True, "vm_interface": result}, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_assign_ip_to_vm(
+    virtual_machine: str,
+    interface: str,
+    address: str,
+    status: str = "Active",
+    namespace: str = "Global",
+    set_primary: bool = True,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Create an IP address and assign it to a VM interface. Optionally set as primary. ITSM-gated.
+
+    Args:
+        virtual_machine: VM name
+        interface: VM interface name (e.g., "eth0")
+        address: IP address in CIDR notation (e.g., "192.168.220.200/24")
+        status: IP status (default: Active)
+        namespace: IPAM namespace (default: Global)
+        set_primary: Set as the VM's primary IPv4 address
+        cr_number: ServiceNow change request number
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    logger.info(f"nautobot_assign_ip_to_vm {virtual_machine}:{interface} {address} cr={cr_number}")
+    try:
+        status_id = await client.resolve_id("status", status)
+        ns_id = await client.resolve_id("namespace", namespace)
+
+        # Create the IP address
+        ip_payload: dict = {
+            "address": address,
+            "status": status_id,
+            "namespace": ns_id,
+        }
+        ip_result = await client.rest_post("ipam/ip-addresses", ip_payload)
+        ip_id = ip_result["id"]
+
+        # Resolve VM interface
+        # Query for the VM interface by VM name + interface name
+        query = f"""{{ vm_interfaces(virtual_machine: "{_esc(virtual_machine)}", name: "{_esc(interface)}") {{ id }} }}"""
+        data = await client.graphql(query)
+        ifaces = data.get("vm_interfaces", [])
+        if not ifaces:
+            return json.dumps({"error": f"VM interface {virtual_machine}:{interface} not found"})
+        iface_id = ifaces[0]["id"]
+
+        # Assign IP to VM interface
+        await client.rest_post(
+            "ipam/ip-address-to-interface",
+            {"ip_address": ip_id, "vm_interface": iface_id},
+        )
+
+        # Set as primary IP if requested
+        if set_primary:
+            vm_query = f"""{{ virtual_machines(name: "{_esc(virtual_machine)}") {{ id }} }}"""
+            vm_data = await client.graphql(vm_query)
+            vms = vm_data.get("virtual_machines", [])
+            if vms:
+                await client.rest_patch(
+                    f"virtualization/virtual-machines/{vms[0]['id']}",
+                    {"primary_ip4": ip_id},
+                )
+
+        return json.dumps({
+            "created": True,
+            "ip_address": address,
+            "assigned_to": f"{virtual_machine}:{interface}",
+            "primary": set_primary,
+        }, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# GENERIC CRUD TOOLS — Registry-embedded for zero-iteration usage
+# ═══════════════════════════════════════════════════════════════════════
+
+# Object type registry: maps type → endpoint, required fields, and resolvable foreign keys
+_OBJECT_REGISTRY: dict[str, dict] = {
+    # ── DCIM ──
+    "device": {
+        "endpoint": "dcim/devices",
+        "required": ["name", "device_type", "role", "location", "status"],
+        "resolve": {"device_type": "device_type", "role": "role", "location": "location", "status": "status", "platform": "platform", "tenant": "tenant"},
+        "lookup": "devices",
+        "lookup_field": "name",
+    },
+    "interface": {
+        "endpoint": "dcim/interfaces",
+        "required": ["device", "name", "type", "status"],
+        "resolve": {"device": "device", "status": "status"},
+        "lookup": "interfaces",
+        "lookup_field": "name",
+        "lookup_extra": "device",
+    },
+    "cable": {
+        "endpoint": "dcim/cables",
+        "required": ["termination_a_type", "termination_a_id", "termination_b_type", "termination_b_id", "status"],
+        "resolve": {"status": "status"},
+        "lookup": None,
+    },
+    "location": {
+        "endpoint": "dcim/locations",
+        "required": ["name", "location_type", "status"],
+        "resolve": {"location_type": "location_type", "status": "status", "parent": "location", "tenant": "tenant"},
+        "lookup": "locations",
+        "lookup_field": "name",
+    },
+    "location_type": {
+        "endpoint": "dcim/location-types",
+        "required": ["name"],
+        "resolve": {},
+        "lookup": "location_types",
+        "lookup_field": "name",
+    },
+    "manufacturer": {
+        "endpoint": "dcim/manufacturers",
+        "required": ["name"],
+        "resolve": {},
+        "lookup": "manufacturers",
+        "lookup_field": "name",
+    },
+    "device_type": {
+        "endpoint": "dcim/device-types",
+        "required": ["model", "manufacturer"],
+        "resolve": {"manufacturer": "manufacturer"},
+        "lookup": "device_types",
+        "lookup_field": "model",
+    },
+    "platform": {
+        "endpoint": "dcim/platforms",
+        "required": ["name"],
+        "resolve": {"manufacturer": "manufacturer"},
+        "lookup": "platforms",
+        "lookup_field": "name",
+    },
+    "rack": {
+        "endpoint": "dcim/racks",
+        "required": ["name", "status", "location"],
+        "resolve": {"status": "status", "location": "location", "tenant": "tenant", "role": "role"},
+        "lookup": "racks",
+        "lookup_field": "name",
+    },
+    "rack_group": {
+        "endpoint": "dcim/rack-groups",
+        "required": ["name", "location"],
+        "resolve": {"location": "location"},
+        "lookup": "rack_groups",
+        "lookup_field": "name",
+    },
+    # ── IPAM ──
+    "ip_address": {
+        "endpoint": "ipam/ip-addresses",
+        "required": ["address", "status", "namespace"],
+        "resolve": {"status": "status", "namespace": "namespace", "tenant": "tenant"},
+        "lookup": "ip_addresses",
+        "lookup_field": "address",
+    },
+    "prefix": {
+        "endpoint": "ipam/prefixes",
+        "required": ["prefix", "status", "namespace"],
+        "resolve": {"status": "status", "namespace": "namespace", "tenant": "tenant"},
+        "lookup": "prefixes",
+        "lookup_field": "prefix",
+    },
+    "vlan": {
+        "endpoint": "ipam/vlans",
+        "required": ["vid", "name", "status"],
+        "resolve": {"status": "status", "vlan_group": "vlan_group", "tenant": "tenant"},
+        "lookup": "vlans",
+        "lookup_field": "vid",
+    },
+    "vrf": {
+        "endpoint": "ipam/vrfs",
+        "required": ["name", "rd"],
+        "resolve": {"namespace": "namespace", "tenant": "tenant"},
+        "lookup": "vrfs",
+        "lookup_field": "name",
+    },
+    "namespace": {
+        "endpoint": "ipam/namespaces",
+        "required": ["name"],
+        "resolve": {},
+        "lookup": None,  # uses REST
+    },
+    "vlan_group": {
+        "endpoint": "ipam/vlan-groups",
+        "required": ["name"],
+        "resolve": {"location": "location"},
+        "lookup": "vlan_groups",
+        "lookup_field": "name",
+    },
+    "route_target": {
+        "endpoint": "ipam/route-targets",
+        "required": ["name"],
+        "resolve": {"tenant": "tenant"},
+        "lookup": None,
+    },
+    "service": {
+        "endpoint": "ipam/services",
+        "required": ["name", "ports"],
+        "resolve": {"device": "device", "virtual_machine": "virtual_machine"},
+        "lookup": None,
+    },
+    # ── Circuits ──
+    "provider": {
+        "endpoint": "circuits/providers",
+        "required": ["name"],
+        "resolve": {},
+        "lookup": "providers",
+        "lookup_field": "name",
+    },
+    "circuit_type": {
+        "endpoint": "circuits/circuit-types",
+        "required": ["name"],
+        "resolve": {},
+        "lookup": "circuit_types",
+        "lookup_field": "name",
+    },
+    "circuit": {
+        "endpoint": "circuits/circuits",
+        "required": ["cid", "status", "provider", "circuit_type"],
+        "resolve": {"status": "status", "provider": "provider", "circuit_type": "circuit_type", "tenant": "tenant"},
+        "lookup": None,
+    },
+    "circuit_termination": {
+        "endpoint": "circuits/circuit-terminations",
+        "required": ["term_side", "circuit"],
+        "resolve": {"location": "location"},
+        "lookup": None,
+    },
+    "provider_network": {
+        "endpoint": "circuits/provider-networks",
+        "required": ["name", "provider"],
+        "resolve": {"provider": "provider"},
+        "lookup": None,
+    },
+    # ── Tenancy ──
+    "tenant": {
+        "endpoint": "tenancy/tenants",
+        "required": ["name"],
+        "resolve": {"tenant_group": "tenant_group"},
+        "lookup": "tenants",
+        "lookup_field": "name",
+    },
+    "tenant_group": {
+        "endpoint": "tenancy/tenant-groups",
+        "required": ["name"],
+        "resolve": {},
+        "lookup": "tenant_groups",
+        "lookup_field": "name",
+    },
+    # ── Virtualization ──
+    "cluster_type": {
+        "endpoint": "virtualization/cluster-types",
+        "required": ["name"],
+        "resolve": {},
+        "lookup": "cluster_types",
+        "lookup_field": "name",
+    },
+    "cluster_group": {
+        "endpoint": "virtualization/cluster-groups",
+        "required": ["name"],
+        "resolve": {},
+        "lookup": "cluster_groups",
+        "lookup_field": "name",
+    },
+    "cluster": {
+        "endpoint": "virtualization/clusters",
+        "required": ["name", "cluster_type"],
+        "resolve": {"cluster_type": "cluster_type", "cluster_group": "cluster_group", "location": "location", "tenant": "tenant"},
+        "lookup": "clusters",
+        "lookup_field": "name",
+    },
+    "virtual_machine": {
+        "endpoint": "virtualization/virtual-machines",
+        "required": ["name", "status", "cluster"],
+        "resolve": {"status": "status", "cluster": "cluster", "role": "role", "tenant": "tenant", "platform": "platform"},
+        "lookup": "virtual_machines",
+        "lookup_field": "name",
+    },
+    # ── Extras ──
+    "tag": {
+        "endpoint": "extras/tags",
+        "required": ["name", "content_types"],
+        "resolve": {},
+        "lookup": "tags",
+        "lookup_field": "name",
+    },
+    "role": {
+        "endpoint": "extras/roles",
+        "required": ["name", "content_types"],
+        "resolve": {},
+        "lookup": "roles",
+        "lookup_field": "name",
+    },
+    "status": {
+        "endpoint": "extras/statuses",
+        "required": ["name", "content_types"],
+        "resolve": {},
+        "lookup": "statuses",
+        "lookup_field": "name",
+    },
+    "contact": {
+        "endpoint": "extras/contacts",
+        "required": ["name"],
+        "resolve": {},
+        "lookup": None,
+    },
+    # ── BGP Plugin ──
+    "autonomous_system": {
+        "endpoint": "plugins/bgp/autonomous-systems",
+        "required": ["asn"],
+        "resolve": {"status": "status", "provider": "provider"},
+        "lookup": "autonomous_systems",
+        "lookup_field": "asn",
+    },
+    "bgp_routing_instance": {
+        "endpoint": "plugins/bgp/routing-instances",
+        "required": ["device", "autonomous_system"],
+        "resolve": {"device": "device", "status": "status"},
+        "lookup": None,
+    },
+    "bgp_peer_group": {
+        "endpoint": "plugins/bgp/peer-groups",
+        "required": ["name", "routing_instance"],
+        "resolve": {},
+        "lookup": None,
+    },
+    "bgp_peering": {
+        "endpoint": "plugins/bgp/peerings",
+        "required": [],
+        "resolve": {"status": "status"},
+        "lookup": None,
+    },
+}
+
+# Fields that are foreign keys and should be auto-resolved from name→UUID
+_RESOLVABLE_TYPES = {
+    "status", "role", "location", "location_type", "platform", "tenant",
+    "tenant_group", "manufacturer", "device_type", "device", "namespace",
+    "vlan_group", "cluster", "cluster_type", "cluster_group",
+    "virtual_machine", "provider", "circuit_type", "vrf",
+}
+
+
+async def _auto_resolve_fields(payload: dict, resolve_map: dict) -> dict:
+    """Resolve string names to UUIDs for foreign key fields."""
+    resolved = dict(payload)
+    for field, resolve_type in resolve_map.items():
+        if field in resolved and isinstance(resolved[field], str):
+            try:
+                resolved[field] = await client.resolve_id(resolve_type, resolved[field])
+            except NautobotError:
+                pass  # leave as-is, let REST API validate
+    return resolved
+
+
+@mcp.tool()
+async def nautobot_create(
+    object_type: str,
+    data: str,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Create any Nautobot object via REST API. Auto-resolves names to UUIDs. ITSM-gated.
+
+    object_type — one of:
+      DCIM:
+        device (required: name, device_type, role, location, status)
+        interface (required: device, name, type, status) — type e.g. "1000base-t", "virtual"
+        cable (required: termination_a_type, termination_a_id, termination_b_type, termination_b_id, status)
+        location (required: name, location_type, status)
+        location_type (required: name)
+        manufacturer (required: name)
+        device_type (required: model, manufacturer)
+        platform (required: name) — optional: manufacturer, network_driver
+        rack (required: name, status, location)
+        rack_group (required: name, location)
+      IPAM:
+        ip_address (required: address, status, namespace) — use nautobot_create_ip_address for interface assignment
+        prefix (required: prefix, status, namespace)
+        vlan (required: vid, name, status)
+        vrf (required: name, rd) — optional: namespace, tenant
+        namespace (required: name)
+        vlan_group (required: name)
+        route_target (required: name)
+        service (required: name, ports) — ports is a list of integers
+      Circuits:
+        provider (required: name)
+        circuit_type (required: name)
+        circuit (required: cid, status, provider, circuit_type)
+        circuit_termination (required: term_side, circuit) — term_side: "A" or "Z"
+        provider_network (required: name, provider)
+      Tenancy:
+        tenant (required: name)
+        tenant_group (required: name)
+      Virtualization:
+        cluster_type (required: name)
+        cluster_group (required: name)
+        cluster (required: name, cluster_type)
+        virtual_machine (required: name, status, cluster)
+      Extras:
+        tag (required: name, content_types) — content_types: list like ["dcim.device"]
+        role (required: name, content_types)
+        status (required: name, content_types)
+        contact (required: name)
+      BGP Plugin:
+        autonomous_system (required: asn)
+        bgp_routing_instance (required: device, autonomous_system)
+        bgp_peer_group (required: name, routing_instance)
+        bgp_peering (required: none — optional: status)
+
+    data — JSON string of fields. Foreign key fields (status, role, location, device, platform,
+           tenant, manufacturer, device_type, cluster, cluster_type, namespace, vlan_group,
+           provider, circuit_type) accept human-readable names and are auto-resolved to UUIDs.
+
+    Examples:
+      nautobot_create("device", '{"name": "SW01", "device_type": "C9300-48T", "role": "Access", "location": "NYC", "status": "Active"}')
+      nautobot_create("interface", '{"device": "SW01", "name": "GigabitEthernet1/0/1", "type": "1000base-t", "status": "Active"}')
+      nautobot_create("vrf", '{"name": "MGMT", "rd": "65000:100", "namespace": "Global"}')
+      nautobot_create("tenant", '{"name": "Acme Corp"}')
+      nautobot_create("circuit", '{"cid": "CKT-001", "status": "Active", "provider": "Lumen", "circuit_type": "MPLS"}')
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    if object_type not in _OBJECT_REGISTRY:
+        return json.dumps({
+            "error": f"Unknown object_type '{object_type}'",
+            "valid_types": sorted(_OBJECT_REGISTRY.keys()),
+        })
+
+    try:
+        payload = json.loads(data)
+    except json.JSONDecodeError as e:
+        return json.dumps({"error": f"Invalid data JSON: {e}"})
+
+    reg = _OBJECT_REGISTRY[object_type]
+
+    # Check required fields
+    missing = [f for f in reg["required"] if f not in payload]
+    if missing:
+        return json.dumps({
+            "error": f"Missing required fields for {object_type}: {missing}",
+            "required": reg["required"],
+        })
+
+    logger.info(f"nautobot_create type={object_type} cr={cr_number}")
+
+    try:
+        # Auto-resolve foreign key names to UUIDs
+        resolved = await _auto_resolve_fields(payload, reg["resolve"])
+        result = await client.rest_post(reg["endpoint"], resolved)
+        return json.dumps({"created": True, "object_type": object_type, "object": result}, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_delete(
+    object_type: str,
+    identifier: str,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Delete any Nautobot object by type and identifier. ITSM-gated.
+
+    object_type — same types as nautobot_create (device, interface, vlan, prefix, ip_address, etc.)
+    identifier — how to find the object:
+      - device: device name (e.g., "SW01")
+      - interface: "device_name:interface_name" (e.g., "SW01:GigabitEthernet1/0/1")
+      - ip_address: address (e.g., "10.0.1.50/24")
+      - vlan: vid as string (e.g., "100")
+      - prefix: prefix (e.g., "10.0.1.0/24")
+      - vrf: name (e.g., "MGMT")
+      - location: name (e.g., "NYC")
+      - cable, tag, role, status, contact: UUID directly
+      - tenant, manufacturer, platform, provider, circuit_type, cluster, cluster_type: name
+      - autonomous_system: ASN as string (e.g., "65000")
+      - For any type: pass a UUID directly if known
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    if object_type not in _OBJECT_REGISTRY:
+        return json.dumps({
+            "error": f"Unknown object_type '{object_type}'",
+            "valid_types": sorted(_OBJECT_REGISTRY.keys()),
+        })
+
+    logger.info(f"nautobot_delete type={object_type} id={identifier} cr={cr_number}")
+
+    reg = _OBJECT_REGISTRY[object_type]
+
+    try:
+        # Resolve identifier to UUID
+        obj_id = await _resolve_identifier(object_type, identifier, reg)
+        await client.rest_delete(f"{reg['endpoint']}/{obj_id}")
+        return json.dumps({"deleted": True, "object_type": object_type, "id": obj_id})
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+async def _resolve_identifier(object_type: str, identifier: str, reg: dict) -> str:
+    """Resolve a human-readable identifier to a UUID."""
+    # If it looks like a UUID already, use it directly
+    if len(identifier) == 36 and identifier.count("-") == 4:
+        return identifier
+
+    # Special cases
+    if object_type == "interface":
+        return await client.resolve_id("interface", identifier)
+
+    if object_type == "vlan":
+        data = await client.graphql(f'{{ vlans(vid: {int(identifier)}) {{ id }} }}')
+        items = _first_list_from(data)
+        if not items:
+            raise NautobotError(f"VLAN vid={identifier} not found.")
+        return items[0]["id"]
+
+    if object_type == "autonomous_system":
+        data = await client.graphql(f'{{ autonomous_systems(asn: {int(identifier)}) {{ id }} }}')
+        items = _first_list_from(data)
+        if not items:
+            raise NautobotError(f"ASN {identifier} not found.")
+        return items[0]["id"]
+
+    if object_type == "namespace":
+        resp = await client.rest_get("ipam/namespaces", {"name": identifier})
+        results = resp.get("results", [])
+        if not results:
+            raise NautobotError(f"Namespace '{identifier}' not found.")
+        return results[0]["id"]
+
+    # Generic GraphQL lookup
+    lookup = reg.get("lookup")
+    lookup_field = reg.get("lookup_field")
+    if lookup and lookup_field:
+        if lookup_field in ("asn", "vid"):
+            q = f'{{ {lookup}({lookup_field}: {int(identifier)}) {{ id }} }}'
+        else:
+            q = f'{{ {lookup}({lookup_field}: "{_esc(identifier)}") {{ id }} }}'
+        data = await client.graphql(q)
+        items = _first_list_from(data)
+        if not items:
+            raise NautobotError(f"{object_type} '{identifier}' not found in Nautobot.")
+        return items[0]["id"]
+
+    # Fallback: try REST list with name filter
+    resp = await client.rest_get(reg["endpoint"], {"name": identifier, "limit": 1})
+    results = resp.get("results", [])
+    if not results:
+        raise NautobotError(f"{object_type} '{identifier}' not found. Pass a UUID if lookup by name fails.")
+    return results[0]["id"]
+
+
+@mcp.tool()
+async def nautobot_get_schema(object_type: str) -> str:
+    """Get the full field schema for any Nautobot object type — required fields, optional fields, and field types.
+
+    Use this when you need to know exactly what fields an object type accepts before creating or updating.
+    Returns the OPTIONS metadata from the Nautobot REST API.
+
+    object_type — same types as nautobot_create (device, interface, vlan, prefix, etc.)
+    """
+    if object_type not in _OBJECT_REGISTRY:
+        return json.dumps({
+            "error": f"Unknown object_type '{object_type}'",
+            "valid_types": sorted(_OBJECT_REGISTRY.keys()),
+        })
+
+    reg = _OBJECT_REGISTRY[object_type]
+    logger.info(f"nautobot_get_schema type={object_type}")
+
+    try:
+        url = f"{client.url}/api/{reg['endpoint'].strip('/')}/"
+        resp = await client.http.request("OPTIONS", url)
+        if resp.status_code != 200:
+            return json.dumps({"error": f"OPTIONS returned {resp.status_code}"})
+        data = resp.json()
+        post_fields = data.get("actions", {}).get("POST", {})
+        if not post_fields:
+            return json.dumps({"error": "No POST schema available (read-only endpoint?)"})
+
+        # Build concise schema
+        schema = {"object_type": object_type, "endpoint": reg["endpoint"], "fields": {}}
+        for field_name, meta in sorted(post_fields.items()):
+            # Skip computed/read-only fields
+            if meta.get("read_only"):
+                continue
+            schema["fields"][field_name] = {
+                "type": meta.get("type", "unknown"),
+                "required": meta.get("required", False),
+                "label": meta.get("label", ""),
+            }
+            if meta.get("choices"):
+                schema["fields"][field_name]["choices"] = [
+                    c.get("value") for c in meta["choices"]
+                ]
+            if meta.get("help_text"):
+                schema["fields"][field_name]["help"] = meta["help_text"]
+
+        schema["auto_resolved_fields"] = list(reg["resolve"].keys())
+        return json.dumps(schema, indent=2)
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+# ── High-Level BGP/Network Tools (reduce LLM context burn) ─────────────────
+
+
+@mcp.tool()
+async def nautobot_get_device_config_context(
+    device: str,
+) -> str:
+    """Get the merged config context for a device as the golden config templates see it.
+
+    DEPRECATED: Use nautobot-golden-config-mcp tools instead:
+      golden_config_get_device_context(device=)
+
+    Args:
+        device: Device name (e.g. 'RR1', 'PE1')
+
+    Returns the full merged config context dict — all config contexts that apply
+    to this device based on role, site, tenant, tags, etc.
+    """
+    logger.info(f"nautobot_get_device_config_context device={device}")
+    try:
+        resp = await client.get(f"/api/dcim/devices/", params={"name": device})
+        devices = resp.get("results", [])
+        if not devices:
+            return json.dumps({"error": f"Device '{device}' not found"})
+        device_id = devices[0]["id"]
+        detail = await client.get(f"/api/dcim/devices/{device_id}/")
+        config_context = detail.get("config_context", {})
+        return json.dumps({"device": device, "config_context": config_context}, indent=2)
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_create_bgp_peering(
+    device: str,
+    local_ip: str,
+    peer_ip: str,
+    peer_asn: int,
+    peer_group: Optional[str] = None,
+    local_asn: Optional[int] = None,
+    description: Optional[str] = None,
+    address_families: Optional[str] = None,
+) -> str:
+    """Create a complete BGP peering in Nautobot in one call.
+
+    Creates the peering object with both endpoints (local and remote),
+    optionally linking to a peer group and adding address families.
+
+    Args:
+        device: Local device name (e.g. 'RR1')
+        local_ip: Local IP with mask (e.g. '10.255.255.2/30')
+        peer_ip: Remote peer IP with mask (e.g. '10.255.255.1/30')
+        peer_asn: Remote autonomous system number
+        peer_group: Optional peer group name to associate with
+        local_asn: Optional local ASN (defaults to device's routing instance ASN)
+        description: Optional peering description
+        address_families: Comma-separated AFI/SAFI (e.g. 'ipv4_unicast,ipv6_unicast'). Default: ipv4_unicast
+    """
+    logger.info(f"nautobot_create_bgp_peering device={device} local={local_ip} peer={peer_ip} as={peer_asn}")
+    afis = (address_families or "ipv4_unicast").split(",")
+    try:
+        # Find the routing instance for the device
+        gql = f"""{{ bgp_routing_instances {{ id device {{ name }} autonomous_system {{ asn }} }} }}"""
+        data = await client.graphql(gql)
+        instances = [i for i in data.get("bgp_routing_instances", []) if i["device"]["name"] == device]
+        if not instances:
+            return json.dumps({"error": f"No BGP routing instance found for device '{device}'"})
+        instance_id = instances[0]["id"]
+
+        # Find peer group if specified
+        peer_group_id = None
+        if peer_group:
+            pg_gql = f"""{{ bgp_peer_groups {{ id name }} }}"""
+            pg_data = await client.graphql(pg_gql)
+            for pg in pg_data.get("bgp_peer_groups", []):
+                if pg["name"] == peer_group:
+                    peer_group_id = pg["id"]
+                    break
+
+        # Find or create the peer ASN
+        asn_resp = await client.get("/api/plugins/bgp/autonomous-systems/", params={"asn": peer_asn})
+        asn_results = asn_resp.get("results", [])
+        if asn_results:
+            peer_asn_id = asn_results[0]["id"]
+        else:
+            asn_create = await client.post("/api/plugins/bgp/autonomous-systems/", json={
+                "asn": peer_asn, "status": "active",
+                "description": f"AS {peer_asn}"
+            })
+            peer_asn_id = asn_create["id"]
+
+        # Find local and peer IPs
+        local_ip_resp = await client.get("/api/ipam/ip-addresses/", params={"address": local_ip})
+        peer_ip_resp = await client.get("/api/ipam/ip-addresses/", params={"address": peer_ip})
+
+        local_ip_id = local_ip_resp["results"][0]["id"] if local_ip_resp.get("results") else None
+        peer_ip_id = peer_ip_resp["results"][0]["id"] if peer_ip_resp.get("results") else None
+
+        if not local_ip_id:
+            return json.dumps({"error": f"Local IP {local_ip} not found in Nautobot. Create the interface and IP first."})
+
+        # Create the peering
+        peering_payload = {"status": "active"}
+        if description:
+            peering_payload["description"] = description
+        peering = await client.post("/api/plugins/bgp/peerings/", json=peering_payload)
+        peering_id = peering["id"]
+
+        # Create endpoint A (local device)
+        ep_a_payload = {
+            "peering": peering_id,
+            "routing_instance": instance_id,
+            "source_ip": local_ip_id,
+            "enabled": True,
+        }
+        if peer_group_id:
+            ep_a_payload["peer_group"] = peer_group_id
+        await client.post("/api/plugins/bgp/peer-endpoints/", json=ep_a_payload)
+
+        # Create endpoint B (remote peer)
+        ep_b_payload = {
+            "peering": peering_id,
+            "autonomous_system": peer_asn_id,
+            "enabled": True,
+        }
+        if peer_ip_id:
+            ep_b_payload["source_ip"] = peer_ip_id
+        await client.post("/api/plugins/bgp/peer-endpoints/", json=ep_b_payload)
+
+        # Add address families to the peer group if specified
+        if peer_group_id and afis:
+            for afi in afis:
+                try:
+                    await client.post("/api/plugins/bgp/address-families/", json={
+                        "routing_instance": instance_id,
+                        "peer_group": peer_group_id,
+                        "afi_safi": afi.strip(),
+                    })
+                except Exception:
+                    pass  # May already exist
+
+        return json.dumps({
+            "success": True,
+            "peering_id": peering_id,
+            "device": device,
+            "local_ip": local_ip,
+            "peer_ip": peer_ip,
+            "peer_asn": peer_asn,
+            "peer_group": peer_group,
+            "address_families": afis,
+        }, indent=2)
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_create_interface(
+    device: str,
+    name: str,
+    interface_type: str = "virtual",
+    ip_address: Optional[str] = None,
+    description: Optional[str] = None,
+    enabled: bool = True,
+) -> str:
+    """Create an interface on a device with optional IP assignment in one call.
+
+    Args:
+        device: Device name (e.g. 'RR1')
+        name: Interface name (e.g. 'Tunnel0', 'Loopback99')
+        interface_type: Interface type (virtual, lag, bridge, 1000base-t, etc.)
+        ip_address: Optional IP with prefix (e.g. '10.255.255.2/30') — creates and assigns
+        description: Optional interface description
+        enabled: Whether interface is enabled (default True)
+    """
+    logger.info(f"nautobot_create_interface device={device} name={name} ip={ip_address}")
+    try:
+        # Find device
+        dev_resp = await client.get("/api/dcim/devices/", params={"name": device})
+        devices = dev_resp.get("results", [])
+        if not devices:
+            return json.dumps({"error": f"Device '{device}' not found"})
+        device_id = devices[0]["id"]
+
+        # Check if interface already exists
+        iface_resp = await client.get("/api/dcim/interfaces/", params={"device": device, "name": name})
+        if iface_resp.get("results"):
+            iface_id = iface_resp["results"][0]["id"]
+            action = "already_exists"
+        else:
+            # Create interface
+            iface_payload = {
+                "device": device_id,
+                "name": name,
+                "type": interface_type,
+                "enabled": enabled,
+                "status": "active",
+            }
+            if description:
+                iface_payload["description"] = description
+            iface = await client.post("/api/dcim/interfaces/", json=iface_payload)
+            iface_id = iface["id"]
+            action = "created"
+
+        # Assign IP if provided
+        ip_action = None
+        if ip_address:
+            # Check if IP already exists
+            ip_resp = await client.get("/api/ipam/ip-addresses/", params={"address": ip_address})
+            if ip_resp.get("results"):
+                ip_id = ip_resp["results"][0]["id"]
+                ip_action = "ip_already_exists"
+            else:
+                # Find or create prefix for the IP
+                ip_payload = {
+                    "address": ip_address,
+                    "status": "active",
+                    "assigned_object_type": "dcim.interface",
+                    "assigned_object_id": iface_id,
+                }
+                if description:
+                    ip_payload["description"] = description
+                await client.post("/api/ipam/ip-addresses/", json=ip_payload)
+                ip_action = "ip_created_and_assigned"
+
+        return json.dumps({
+            "success": True,
+            "device": device,
+            "interface": name,
+            "interface_action": action,
+            "ip_address": ip_address,
+            "ip_action": ip_action,
+        }, indent=2)
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_create_autonomous_system(
+    asn: int,
+    description: Optional[str] = None,
+) -> str:
+    """Create an autonomous system in Nautobot BGP models.
+
+    Args:
+        asn: AS number (e.g. 65099)
+        description: Optional description (e.g. 'NetClaw Protocol Agent')
+    """
+    logger.info(f"nautobot_create_autonomous_system asn={asn}")
+    try:
+        # Check if it already exists
+        resp = await client.get("/api/plugins/bgp/autonomous-systems/", params={"asn": asn})
+        if resp.get("results"):
+            return json.dumps({"success": True, "action": "already_exists", "asn": asn, "id": resp["results"][0]["id"]})
+
+        payload = {"asn": asn, "status": "active"}
+        if description:
+            payload["description"] = description
+        result = await client.post("/api/plugins/bgp/autonomous-systems/", json=payload)
+        return json.dumps({"success": True, "action": "created", "asn": asn, "id": result["id"]})
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_create_bgp_peer_group(
+    name: str,
+    device: str,
+    remote_asn: Optional[int] = None,
+    source_interface: Optional[str] = None,
+    description: Optional[str] = None,
+    address_families: Optional[str] = None,
+) -> str:
+    """Create a BGP peer group on a device's routing instance.
+
+    Args:
+        name: Peer group name (e.g. 'NETCLAW-PEERS')
+        device: Device name (e.g. 'RR1')
+        remote_asn: Optional remote AS for the group
+        source_interface: Optional update-source interface name
+        description: Optional description
+        address_families: Comma-separated AFI/SAFI (e.g. 'ipv4_unicast')
+    """
+    logger.info(f"nautobot_create_bgp_peer_group name={name} device={device}")
+    try:
+        # Find routing instance
+        gql = f"""{{ bgp_routing_instances {{ id device {{ name }} }} }}"""
+        data = await client.graphql(gql)
+        instances = [i for i in data.get("bgp_routing_instances", []) if i["device"]["name"] == device]
+        if not instances:
+            return json.dumps({"error": f"No BGP routing instance for device '{device}'"})
+        instance_id = instances[0]["id"]
+
+        # Check if peer group exists
+        pg_resp = await client.get("/api/plugins/bgp/peer-groups/", params={"name": name})
+        if pg_resp.get("results"):
+            return json.dumps({"success": True, "action": "already_exists", "name": name, "id": pg_resp["results"][0]["id"]})
+
+        # Build payload
+        payload = {
+            "name": name,
+            "routing_instance": instance_id,
+            "enabled": True,
+            "status": "active",
+        }
+        if description:
+            payload["description"] = description
+        if remote_asn:
+            asn_resp = await client.get("/api/plugins/bgp/autonomous-systems/", params={"asn": remote_asn})
+            if asn_resp.get("results"):
+                payload["autonomous_system"] = asn_resp["results"][0]["id"]
+        if source_interface:
+            iface_resp = await client.get("/api/dcim/interfaces/", params={"device": device, "name": source_interface})
+            if iface_resp.get("results"):
+                payload["source_interface"] = iface_resp["results"][0]["id"]
+
+        result = await client.post("/api/plugins/bgp/peer-groups/", json=payload)
+        pg_id = result["id"]
+
+        # Add address families
+        if address_families:
+            for afi in address_families.split(","):
+                try:
+                    await client.post("/api/plugins/bgp/address-families/", json={
+                        "routing_instance": instance_id,
+                        "peer_group": pg_id,
+                        "afi_safi": afi.strip(),
+                    })
+                except Exception:
+                    pass
+
+        return json.dumps({"success": True, "action": "created", "name": name, "id": pg_id})
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def nautobot_render_device_config(
+    device: str,
+) -> str:
+    """Trigger golden config intended job for a device and return the rendered config.
+
+    DEPRECATED: Use nautobot-golden-config-mcp tools instead:
+      golden_config_render_preview(device=) or golden_config_get_intended(device=)
+
+    Args:
+        device: Device name (e.g. 'RR1')
+    """
+    logger.info(f"nautobot_render_device_config device={device}")
+    try:
+        # Get the latest intended config from golden config
+        resp = await client.get("/api/plugins/golden-config/golden-config/", params={"device__name": device})
+        results = resp.get("results", [])
+        if results and results[0].get("intended_config"):
+            return json.dumps({
+                "device": device,
+                "intended_config": results[0]["intended_config"],
+                "last_generated": results[0].get("intended_last_attempt_date"),
+            }, indent=2)
+        return json.dumps({"device": device, "intended_config": None, "message": "No intended config found. Run the golden config intended job first."})
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/mcp-servers/nautobot-routing-mcp/bgp_helpers.py
+++ b/mcp-servers/nautobot-routing-mcp/bgp_helpers.py
@@ -1,0 +1,111 @@
+"""BGP object chain resolution helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from nautobot_client import NautobotClient, NautobotError
+
+
+def _esc(s: str) -> str:
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
+async def find_routing_instance(client: NautobotClient, device: str) -> Optional[str]:
+    """Find the BGP routing instance ID for a device."""
+    data = await client.graphql(
+        f'{{ bgp_routing_instances(device: "{_esc(device)}") {{ id }} }}'
+    )
+    instances = data.get("bgp_routing_instances", [])
+    return instances[0]["id"] if instances else None
+
+
+async def find_or_create_asn(client: NautobotClient, asn: int, description: Optional[str] = None) -> str:
+    """Find an ASN by number or create it. Returns UUID."""
+    resp = await client.rest_get("plugins/bgp/autonomous-systems", {"asn": asn})
+    results = resp.get("results", [])
+    if results:
+        return results[0]["id"]
+    payload = {"asn": asn, "status": {"name": "Active"}}
+    if description:
+        payload["description"] = description
+    result = await client.rest_post("plugins/bgp/autonomous-systems", payload)
+    return result["id"]
+
+
+async def find_ip_id(client: NautobotClient, address: str) -> Optional[str]:
+    """Find an IP address UUID by address string."""
+    data = await client.graphql(f'{{ ip_addresses(address: "{_esc(address)}") {{ id }} }}')
+    ips = data.get("ip_addresses", [])
+    return ips[0]["id"] if ips else None
+
+
+async def find_peer_group(client: NautobotClient, device: str, name: str) -> Optional[str]:
+    """Find a peer group by name within a device's routing instance."""
+    data = await client.graphql(f"""{{
+        bgp_routing_instances(device: "{_esc(device)}") {{
+            peer_groups {{ id name }}
+        }}
+    }}""")
+    instances = data.get("bgp_routing_instances", [])
+    if not instances:
+        return None
+    for pg in instances[0].get("peer_groups", []):
+        if pg["name"] == name:
+            return pg["id"]
+    return None
+
+
+async def find_peering_by_ips(client: NautobotClient, device: str, local_ip: str, peer_ip: str) -> Optional[dict]:
+    """Find an existing peering between local_ip and peer_ip for a device."""
+    data = await client.graphql(f"""{{
+        bgp_routing_instances(device: "{_esc(device)}") {{
+            endpoints {{
+                id
+                source_ip {{ address }}
+                peer {{ source_ip {{ address }} }}
+                peering {{ id }}
+            }}
+        }}
+    }}""")
+    instances = data.get("bgp_routing_instances", [])
+    if not instances:
+        return None
+    for ep in instances[0].get("endpoints", []):
+        ep_ip = ep.get("source_ip", {}).get("address", "")
+        peer_ep_ip = (ep.get("peer") or {}).get("source_ip", {}).get("address", "")
+        if _ip_match(ep_ip, local_ip) and _ip_match(peer_ep_ip, peer_ip):
+            return {"endpoint_id": ep["id"], "peering_id": ep.get("peering", {}).get("id")}
+    return None
+
+
+async def find_endpoint_by_peer_ip(client: NautobotClient, device: str, peer_ip: str) -> Optional[dict]:
+    """Find a local endpoint whose remote peer has the given IP."""
+    data = await client.graphql(f"""{{
+        bgp_routing_instances(device: "{_esc(device)}") {{
+            endpoints {{
+                id
+                peer {{ id source_ip {{ address }} }}
+                peering {{ id }}
+                peer_group {{ id name }}
+            }}
+        }}
+    }}""")
+    instances = data.get("bgp_routing_instances", [])
+    if not instances:
+        return None
+    for ep in instances[0].get("endpoints", []):
+        remote_ip = (ep.get("peer") or {}).get("source_ip", {}).get("address", "")
+        if _ip_match(remote_ip, peer_ip):
+            return {
+                "endpoint_id": ep["id"],
+                "peer_endpoint_id": ep.get("peer", {}).get("id"),
+                "peering_id": ep.get("peering", {}).get("id"),
+                "peer_group": ep.get("peer_group"),
+            }
+    return None
+
+
+def _ip_match(a: str, b: str) -> bool:
+    """Compare IPs ignoring prefix length differences."""
+    return a.split("/")[0] == b.split("/")[0]

--- a/mcp-servers/nautobot-routing-mcp/nautobot_client.py
+++ b/mcp-servers/nautobot-routing-mcp/nautobot_client.py
@@ -1,0 +1,84 @@
+"""Nautobot API client for routing protocol operations."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class NautobotError(Exception):
+    pass
+
+
+class NautobotClient:
+    def __init__(self):
+        self.url = os.environ["NAUTOBOT_URL"].rstrip("/")
+        self.token = os.environ["NAUTOBOT_TOKEN"]
+        verify = os.environ.get("NAUTOBOT_VERIFY_SSL", "false").lower() == "true"
+        timeout = int(os.environ.get("NAUTOBOT_TIMEOUT", "60"))
+
+        self.http = httpx.AsyncClient(
+            headers={
+                "Authorization": f"Token {self.token}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            verify=verify,
+            timeout=timeout,
+        )
+
+    async def graphql(self, query: str, variables: Optional[dict] = None) -> dict[str, Any]:
+        body: dict[str, Any] = {"query": query}
+        if variables:
+            body["variables"] = variables
+        try:
+            resp = await self.http.post(f"{self.url}/api/graphql/", json=body)
+        except (httpx.ConnectError, httpx.TimeoutException) as e:
+            raise NautobotError(f"Nautobot unreachable: {e}")
+        self._check(resp)
+        data = resp.json()
+        if "errors" in data:
+            msgs = "; ".join(e.get("message", str(e)) for e in data["errors"])
+            raise NautobotError(f"GraphQL error: {msgs}")
+        return data.get("data", {})
+
+    async def rest_get(self, endpoint: str, params: Optional[dict] = None) -> dict[str, Any]:
+        return await self._rest("GET", endpoint, params=params)
+
+    async def rest_post(self, endpoint: str, data: dict) -> dict[str, Any]:
+        return await self._rest("POST", endpoint, json_body=data)
+
+    async def rest_patch(self, endpoint: str, data: dict) -> dict[str, Any]:
+        return await self._rest("PATCH", endpoint, json_body=data)
+
+    async def rest_delete(self, endpoint: str) -> None:
+        await self._rest("DELETE", endpoint)
+
+    async def _rest(
+        self, method: str, endpoint: str,
+        params: Optional[dict] = None, json_body: Optional[dict] = None,
+    ) -> dict[str, Any]:
+        url = f"{self.url}/api/{endpoint.strip('/')}/"
+        try:
+            resp = await self.http.request(method, url, params=params, json=json_body)
+        except (httpx.ConnectError, httpx.TimeoutException) as e:
+            raise NautobotError(f"Nautobot unreachable: {e}")
+        self._check(resp)
+        if resp.status_code == 204:
+            return {}
+        return resp.json()
+
+    def _check(self, resp: httpx.Response) -> None:
+        if resp.status_code in (401, 403):
+            raise NautobotError("Authentication failed. Verify NAUTOBOT_TOKEN.")
+        if resp.status_code >= 400:
+            try:
+                detail = resp.json()
+            except Exception:
+                detail = resp.text[:500]
+            raise NautobotError(f"API error ({resp.status_code}): {detail}")

--- a/mcp-servers/nautobot-routing-mcp/requirements.txt
+++ b/mcp-servers/nautobot-routing-mcp/requirements.txt
@@ -1,0 +1,3 @@
+httpx
+fastmcp
+mcp

--- a/mcp-servers/nautobot-routing-mcp/server.py
+++ b/mcp-servers/nautobot-routing-mcp/server.py
@@ -1,0 +1,811 @@
+"""Nautobot Routing MCP Server — BGP and OSPF model management.
+
+One-call tools for BGP peering lifecycle, peer group management, OSPF
+interface configuration, and routing model reconciliation against live state.
+
+Environment Variables:
+    NAUTOBOT_URL          — Nautobot instance URL (required)
+    NAUTOBOT_TOKEN        — Nautobot API token (required)
+    NAUTOBOT_TIMEOUT      — API request timeout in seconds (default: 60)
+    NAUTOBOT_VERIFY_SSL   — Verify SSL certificates (default: false)
+    ITSM_ENABLED          — Require ServiceNow CR for write ops (default: false)
+    ITSM_LAB_MODE         — Bypass ITSM in lab mode (default: true)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from typing import Optional
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from mcp.server.fastmcp import FastMCP
+
+from nautobot_client import NautobotClient, NautobotError
+from bgp_helpers import (
+    find_routing_instance,
+    find_or_create_asn,
+    find_ip_id,
+    find_peer_group,
+    find_peering_by_ips,
+    find_endpoint_by_peer_ip,
+    _esc,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    stream=sys.stderr,
+)
+logger = logging.getLogger("nautobot-routing-mcp")
+
+for var in ("NAUTOBOT_URL", "NAUTOBOT_TOKEN"):
+    if not os.environ.get(var):
+        logger.error(f"Required environment variable {var} is not set.")
+        sys.exit(1)
+
+mcp = FastMCP("nautobot-routing-mcp")
+client = NautobotClient()
+
+ITSM_ENABLED = os.environ.get("ITSM_ENABLED", "false").lower() == "true"
+ITSM_LAB_MODE = os.environ.get("ITSM_LAB_MODE", "true").lower() == "true"
+
+
+def _check_itsm(cr_number: Optional[str]) -> Optional[str]:
+    if ITSM_ENABLED and not ITSM_LAB_MODE:
+        if not cr_number:
+            return "Write operation blocked: ITSM is enabled. Provide a cr_number parameter."
+    return None
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# PHASE 2: BGP READ TOOLS
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@mcp.tool()
+async def routing_get_bgp_summary(device: Optional[str] = None) -> str:
+    """Get the full BGP topology for a device: routing instance, ASN, peers, groups, address families.
+
+    Returns a structured summary equivalent to 'show bgp summary' but from the
+    Nautobot source of truth. If device is omitted, returns all routing instances.
+
+    Args:
+        device: Device name (e.g. 'RR1'). If omitted, returns all BGP instances.
+    """
+    logger.info(f"routing_get_bgp_summary device={device}")
+    try:
+        filt = f'(device: "{_esc(device)}")' if device else ""
+        query = f"""{{
+  bgp_routing_instances{filt} {{
+    device {{ name }}
+    autonomous_system {{ asn description }}
+    router_id {{ address }}
+    status {{ name }}
+    peer_groups {{
+      name
+      autonomous_system {{ asn }}
+      source_ip {{ address }}
+      source_interface {{ name }}
+    }}
+    endpoints {{
+      enabled
+      source_ip {{ address }}
+      autonomous_system {{ asn }}
+      peer_group {{ name }}
+      peer {{ source_ip {{ address }} autonomous_system {{ asn }} }}
+    }}
+  }}
+}}"""
+        data = await client.graphql(query)
+        instances = data.get("bgp_routing_instances", [])
+
+        results = []
+        for inst in instances:
+            dev_name = inst.get("device", {}).get("name")
+            local_asn = inst.get("autonomous_system", {}).get("asn")
+            peers = []
+            for ep in inst.get("endpoints", []):
+                remote = ep.get("peer") or {}
+                remote_ip = remote.get("source_ip", {}).get("address", "")
+                remote_asn = (ep.get("autonomous_system") or remote.get("autonomous_system") or {}).get("asn")
+                peers.append({
+                    "local_ip": ep.get("source_ip", {}).get("address", ""),
+                    "remote_ip": remote_ip,
+                    "remote_asn": remote_asn,
+                    "peer_group": (ep.get("peer_group") or {}).get("name"),
+                    "enabled": ep.get("enabled"),
+                })
+            results.append({
+                "device": dev_name,
+                "local_asn": local_asn,
+                "router_id": inst.get("router_id", {}).get("address"),
+                "peer_count": len(peers),
+                "peer_groups": [pg["name"] for pg in inst.get("peer_groups", [])],
+                "peers": peers,
+            })
+
+        return json.dumps({"count": len(results), "bgp_instances": results}, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def routing_get_bgp_peers(device: str) -> str:
+    """List all BGP peers for a device with remote AS, local/remote IP, peer group, and enabled state.
+
+    Args:
+        device: Device name (e.g. 'RR1')
+    """
+    logger.info(f"routing_get_bgp_peers device={device}")
+    try:
+        query = f"""{{
+  bgp_routing_instances(device: "{_esc(device)}") {{
+    autonomous_system {{ asn }}
+    endpoints {{
+      id enabled description
+      source_ip {{ address }}
+      autonomous_system {{ asn }}
+      peer_group {{ name }}
+      peer {{
+        source_ip {{ address }}
+        autonomous_system {{ asn }}
+        routing_instance {{ device {{ name }} }}
+      }}
+    }}
+  }}
+}}"""
+        data = await client.graphql(query)
+        instances = data.get("bgp_routing_instances", [])
+        if not instances:
+            return json.dumps({"device": device, "error": "No BGP routing instance found for this device."})
+
+        local_asn = instances[0].get("autonomous_system", {}).get("asn")
+        peers = []
+        for ep in instances[0].get("endpoints", []):
+            remote = ep.get("peer") or {}
+            remote_asn = (ep.get("autonomous_system") or remote.get("autonomous_system") or {}).get("asn")
+            peers.append({
+                "local_ip": ep.get("source_ip", {}).get("address", ""),
+                "remote_ip": (remote.get("source_ip") or {}).get("address", ""),
+                "remote_asn": remote_asn,
+                "remote_device": (remote.get("routing_instance") or {}).get("device", {}).get("name"),
+                "peer_group": (ep.get("peer_group") or {}).get("name"),
+                "enabled": ep.get("enabled"),
+                "description": ep.get("description"),
+                "type": "iBGP" if remote_asn == local_asn else "eBGP",
+            })
+
+        return json.dumps({
+            "device": device,
+            "local_asn": local_asn,
+            "peer_count": len(peers),
+            "peers": peers,
+        }, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def routing_get_bgp_peer_detail(device: str, peer_ip: str) -> str:
+    """Get full detail of a specific BGP peering: both endpoints, address families, peer group.
+
+    Args:
+        device: Local device name (e.g. 'RR1')
+        peer_ip: Remote peer IP address (e.g. '100.0.254.1')
+    """
+    logger.info(f"routing_get_bgp_peer_detail device={device} peer_ip={peer_ip}")
+    try:
+        ep_info = await find_endpoint_by_peer_ip(client, device, peer_ip)
+        if not ep_info:
+            return json.dumps({"error": f"No peering found for {device} with peer {peer_ip}"})
+
+        # Get full peering detail
+        peering_id = ep_info["peering_id"]
+        peering = await client.rest_get(f"plugins/bgp/peerings/{peering_id}")
+
+        # Get both endpoints via GraphQL (REST doesn't support peering filter)
+        ep_query = f"""{{ bgp_peer_endpoints {{
+            id enabled description
+            routing_instance {{ device {{ name }} autonomous_system {{ asn }} }}
+            source_ip {{ address }}
+            autonomous_system {{ asn }}
+            peer_group {{ name }}
+            peering {{ id }}
+        }} }}"""
+        ep_data = await client.graphql(ep_query)
+        endpoints = [
+            ep for ep in ep_data.get("bgp_peer_endpoints", [])
+            if ep.get("peering", {}).get("id") == peering_id
+        ]
+
+        result = {
+            "peering_id": peering_id,
+            "status": peering.get("status", {}).get("value") if isinstance(peering.get("status"), dict) else peering.get("status"),
+            "endpoints": endpoints,
+        }
+
+        return json.dumps(result, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def routing_get_peer_groups(device: Optional[str] = None) -> str:
+    """List BGP peer groups with member count and address families.
+
+    Args:
+        device: Device name to filter by (optional). If omitted, returns all peer groups.
+    """
+    logger.info(f"routing_get_peer_groups device={device}")
+    try:
+        filt = f'(device: "{_esc(device)}")' if device else ""
+        query = f"""{{
+  bgp_routing_instances{filt} {{
+    device {{ name }}
+    peer_groups {{
+      id name description enabled
+      autonomous_system {{ asn }}
+      source_ip {{ address }}
+      source_interface {{ name }}
+    }}
+    endpoints {{
+      peer_group {{ id }}
+    }}
+  }}
+}}"""
+        data = await client.graphql(query)
+        instances = data.get("bgp_routing_instances", [])
+
+        groups = []
+        for inst in instances:
+            # Count members per group
+            member_counts: dict[str, int] = {}
+            for ep in inst.get("endpoints", []):
+                pg = ep.get("peer_group")
+                if pg:
+                    member_counts[pg["id"]] = member_counts.get(pg["id"], 0) + 1
+
+            for pg in inst.get("peer_groups", []):
+                groups.append({
+                    "device": inst.get("device", {}).get("name"),
+                    "name": pg["name"],
+                    "remote_asn": (pg.get("autonomous_system") or {}).get("asn"),
+                    "source_ip": (pg.get("source_ip") or {}).get("address"),
+                    "source_interface": (pg.get("source_interface") or {}).get("name"),
+                    "enabled": pg.get("enabled"),
+                    "member_count": member_counts.get(pg["id"], 0),
+                })
+
+        return json.dumps({"count": len(groups), "peer_groups": groups}, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def routing_get_autonomous_systems() -> str:
+    """List all autonomous systems registered in the Nautobot BGP model."""
+    logger.info("routing_get_autonomous_systems")
+    try:
+        query = """{ autonomous_systems { asn description status { name } provider { name } } }"""
+        data = await client.graphql(query)
+        systems = data.get("autonomous_systems", [])
+        return json.dumps({"count": len(systems), "autonomous_systems": systems}, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# PHASE 3: BGP WRITE TOOLS
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@mcp.tool()
+async def routing_create_autonomous_system(
+    asn: int,
+    description: Optional[str] = None,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Create or return an existing autonomous system. Idempotent. ITSM-gated.
+
+    Args:
+        asn: AS number (e.g. 65099)
+        description: Optional description (e.g. 'NetClaw Protocol Agent')
+        cr_number: ServiceNow change request number (required if ITSM enabled)
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    logger.info(f"routing_create_autonomous_system asn={asn}")
+    try:
+        resp = await client.rest_get("plugins/bgp/autonomous-systems", {"asn": asn})
+        results = resp.get("results", [])
+        if results:
+            return json.dumps({"status": "already_exists", "asn": asn, "id": results[0]["id"]})
+
+        payload: dict = {"asn": asn, "status": {"name": "Active"}}
+        if description:
+            payload["description"] = description
+        result = await client.rest_post("plugins/bgp/autonomous-systems", payload)
+        return json.dumps({"status": "created", "asn": asn, "id": result["id"]}, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def routing_create_routing_instance(
+    device: str,
+    asn: int,
+    router_id: Optional[str] = None,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Create a BGP routing instance for a device. Idempotent. ITSM-gated.
+
+    Args:
+        device: Device name (e.g. 'RR1')
+        asn: Local autonomous system number
+        router_id: Router ID IP address (optional, e.g. '100.0.254.5/32')
+        cr_number: ServiceNow change request number (required if ITSM enabled)
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    logger.info(f"routing_create_routing_instance device={device} asn={asn}")
+    try:
+        existing = await find_routing_instance(client, device)
+        if existing:
+            return json.dumps({"status": "already_exists", "device": device, "id": existing})
+
+        # Resolve device ID
+        dev_data = await client.graphql(f'{{ devices(name: "{_esc(device)}") {{ id }} }}')
+        devices = dev_data.get("devices", [])
+        if not devices:
+            return json.dumps({"error": f"Device '{device}' not found"})
+        device_id = devices[0]["id"]
+
+        # Find or create ASN
+        asn_id = await find_or_create_asn(client, asn)
+
+        payload: dict = {
+            "device": device_id,
+            "autonomous_system": asn_id,
+            "status": {"name": "Active"},
+        }
+        if router_id:
+            rid_id = await find_ip_id(client, router_id)
+            if rid_id:
+                payload["router_id"] = rid_id
+
+        result = await client.rest_post("plugins/bgp/routing-instances", payload)
+        return json.dumps({"status": "created", "device": device, "id": result["id"]}, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def routing_create_peering(
+    device: str,
+    local_ip: str,
+    peer_ip: str,
+    peer_asn: int,
+    peer_group: Optional[str] = None,
+    afi: str = "ipv4_unicast",
+    description: Optional[str] = None,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Create a complete BGP peering in one call. Idempotent. ITSM-gated.
+
+    Handles the full object chain: ASN (if new) + Peering + 2 Endpoints + address family.
+    If the peering already exists, returns the existing one.
+
+    Args:
+        device: Local device name (e.g. 'RR1')
+        local_ip: Local source IP with mask (e.g. '10.255.255.2/30')
+        peer_ip: Remote peer IP with mask (e.g. '10.255.255.1/30')
+        peer_asn: Remote autonomous system number
+        peer_group: Optional peer group name to associate the local endpoint with
+        afi: Address family (default: 'ipv4_unicast'). Options: ipv4_unicast, ipv6_unicast, l2_evpn
+        description: Optional peering description
+        cr_number: ServiceNow change request number (required if ITSM enabled)
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    logger.info(f"routing_create_peering device={device} local={local_ip} peer={peer_ip} as={peer_asn}")
+    try:
+        # Idempotency check
+        existing = await find_peering_by_ips(client, device, local_ip, peer_ip)
+        if existing:
+            return json.dumps({
+                "status": "already_exists",
+                "peering_id": existing["peering_id"],
+                "endpoint_id": existing["endpoint_id"],
+            })
+
+        # 1. Find routing instance
+        instance_id = await find_routing_instance(client, device)
+        if not instance_id:
+            return json.dumps({"error": f"No BGP routing instance for device '{device}'. Create one first with routing_create_routing_instance."})
+
+        # 2. Find or create remote ASN
+        asn_id = await find_or_create_asn(client, peer_asn, description=f"AS {peer_asn}")
+
+        # 3. Resolve IPs
+        local_ip_id = await find_ip_id(client, local_ip)
+        if not local_ip_id:
+            return json.dumps({"error": f"Local IP '{local_ip}' not found in Nautobot. Create the interface and IP first."})
+        peer_ip_id = await find_ip_id(client, peer_ip)
+
+        # 4. Find peer group if specified
+        pg_id = None
+        if peer_group:
+            pg_id = await find_peer_group(client, device, peer_group)
+            if not pg_id:
+                return json.dumps({"error": f"Peer group '{peer_group}' not found on device '{device}'."})
+
+        # 5. Create Peering container
+        peering_payload: dict = {"status": {"name": "Active"}}
+        peering = await client.rest_post("plugins/bgp/peerings", peering_payload)
+        peering_id = peering["id"]
+
+        # 6. Create Endpoint A (local)
+        ep_a_payload: dict = {
+            "peering": peering_id,
+            "routing_instance": instance_id,
+            "source_ip": local_ip_id,
+            "enabled": True,
+        }
+        if pg_id:
+            ep_a_payload["peer_group"] = pg_id
+        if description:
+            ep_a_payload["description"] = description
+        ep_a = await client.rest_post("plugins/bgp/peer-endpoints", ep_a_payload)
+
+        # 7. Create Endpoint B (remote)
+        ep_b_payload: dict = {
+            "peering": peering_id,
+            "autonomous_system": asn_id,
+            "enabled": True,
+        }
+        if peer_ip_id:
+            ep_b_payload["source_ip"] = peer_ip_id
+        ep_b = await client.rest_post("plugins/bgp/peer-endpoints", ep_b_payload)
+
+        # 8. Add address family to local endpoint
+        try:
+            await client.rest_post("plugins/bgp/peer-endpoint-address-families", {
+                "peer_endpoint": ep_a["id"],
+                "afi_safi": afi,
+            })
+        except NautobotError:
+            pass  # AFI may already exist or not be supported
+
+        return json.dumps({
+            "status": "created",
+            "peering_id": peering_id,
+            "endpoint_a": ep_a["id"],
+            "endpoint_b": ep_b["id"],
+            "device": device,
+            "local_ip": local_ip,
+            "peer_ip": peer_ip,
+            "peer_asn": peer_asn,
+            "peer_group": peer_group,
+            "afi": afi,
+        }, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def routing_delete_peering(
+    device: str,
+    peer_ip: str,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Delete a BGP peering and both endpoints. ITSM-gated.
+
+    Args:
+        device: Local device name (e.g. 'RR1')
+        peer_ip: Remote peer IP address (e.g. '10.255.255.1')
+        cr_number: ServiceNow change request number (required if ITSM enabled)
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    logger.info(f"routing_delete_peering device={device} peer_ip={peer_ip}")
+    try:
+        ep_info = await find_endpoint_by_peer_ip(client, device, peer_ip)
+        if not ep_info:
+            return json.dumps({"error": f"No peering found for {device} with peer {peer_ip}"})
+
+        peering_id = ep_info["peering_id"]
+        # Deleting the peering cascades to endpoints
+        await client.rest_delete(f"plugins/bgp/peerings/{peering_id}")
+
+        return json.dumps({
+            "status": "deleted",
+            "peering_id": peering_id,
+            "device": device,
+            "peer_ip": peer_ip,
+        })
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def routing_create_peer_group(
+    device: str,
+    name: str,
+    remote_asn: Optional[int] = None,
+    source_interface: Optional[str] = None,
+    afi: str = "ipv4_unicast",
+    description: Optional[str] = None,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Create a BGP peer group on a device. Idempotent. ITSM-gated.
+
+    Args:
+        device: Device name (e.g. 'RR1')
+        name: Peer group name (e.g. 'NETCLAW-PEERS')
+        remote_asn: Optional remote AS for the group
+        source_interface: Optional update-source interface name (e.g. 'Loopback0')
+        afi: Address family (default: 'ipv4_unicast')
+        description: Optional description
+        cr_number: ServiceNow change request number (required if ITSM enabled)
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    logger.info(f"routing_create_peer_group device={device} name={name}")
+    try:
+        # Idempotency check
+        existing = await find_peer_group(client, device, name)
+        if existing:
+            return json.dumps({"status": "already_exists", "name": name, "id": existing})
+
+        # Find routing instance
+        instance_id = await find_routing_instance(client, device)
+        if not instance_id:
+            return json.dumps({"error": f"No BGP routing instance for device '{device}'."})
+
+        payload: dict = {
+            "name": name,
+            "routing_instance": instance_id,
+            "enabled": True,
+        }
+        if description:
+            payload["description"] = description
+        if remote_asn:
+            asn_id = await find_or_create_asn(client, remote_asn)
+            payload["autonomous_system"] = asn_id
+        if source_interface:
+            # Resolve interface ID
+            iface_data = await client.graphql(
+                f'{{ interfaces(device: "{_esc(device)}", name: "{_esc(source_interface)}") {{ id }} }}'
+            )
+            ifaces = iface_data.get("interfaces", [])
+            if ifaces:
+                payload["source_interface"] = ifaces[0]["id"]
+
+        result = await client.rest_post("plugins/bgp/peer-groups", payload)
+        pg_id = result["id"]
+
+        # Add address family
+        try:
+            await client.rest_post("plugins/bgp/peer-group-address-families", {
+                "peer_group": pg_id,
+                "afi_safi": afi,
+            })
+        except NautobotError:
+            pass  # May not be supported or already exists
+
+        return json.dumps({"status": "created", "name": name, "id": pg_id, "afi": afi}, indent=2)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def routing_delete_peer_group(
+    device: str,
+    name: str,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Delete a BGP peer group. Fails if the group still has members. ITSM-gated.
+
+    Args:
+        device: Device name (e.g. 'RR1')
+        name: Peer group name to delete
+        cr_number: ServiceNow change request number (required if ITSM enabled)
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    logger.info(f"routing_delete_peer_group device={device} name={name}")
+    try:
+        pg_id = await find_peer_group(client, device, name)
+        if not pg_id:
+            return json.dumps({"error": f"Peer group '{name}' not found on device '{device}'."})
+
+        await client.rest_delete(f"plugins/bgp/peer-groups/{pg_id}")
+        return json.dumps({"status": "deleted", "name": name, "device": device})
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def routing_add_peer_to_group(
+    device: str,
+    peer_ip: str,
+    group: str,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Move an existing BGP peer into a peer group. ITSM-gated.
+
+    Args:
+        device: Local device name (e.g. 'RR1')
+        peer_ip: Remote peer IP address
+        group: Peer group name to add the peer to
+        cr_number: ServiceNow change request number (required if ITSM enabled)
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    logger.info(f"routing_add_peer_to_group device={device} peer_ip={peer_ip} group={group}")
+    try:
+        ep_info = await find_endpoint_by_peer_ip(client, device, peer_ip)
+        if not ep_info:
+            return json.dumps({"error": f"No peering found for {device} with peer {peer_ip}"})
+
+        pg_id = await find_peer_group(client, device, group)
+        if not pg_id:
+            return json.dumps({"error": f"Peer group '{group}' not found on device '{device}'."})
+
+        await client.rest_patch(
+            f"plugins/bgp/peer-endpoints/{ep_info['endpoint_id']}",
+            {"peer_group": pg_id},
+        )
+        return json.dumps({"status": "updated", "peer_ip": peer_ip, "group": group, "device": device})
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def routing_remove_peer_from_group(
+    device: str,
+    peer_ip: str,
+    cr_number: Optional[str] = None,
+) -> str:
+    """Remove a BGP peer from its peer group. ITSM-gated.
+
+    Args:
+        device: Local device name (e.g. 'RR1')
+        peer_ip: Remote peer IP address
+        cr_number: ServiceNow change request number (required if ITSM enabled)
+    """
+    blocked = _check_itsm(cr_number)
+    if blocked:
+        return json.dumps({"error": blocked})
+
+    logger.info(f"routing_remove_peer_from_group device={device} peer_ip={peer_ip}")
+    try:
+        ep_info = await find_endpoint_by_peer_ip(client, device, peer_ip)
+        if not ep_info:
+            return json.dumps({"error": f"No peering found for {device} with peer {peer_ip}"})
+
+        current_group = (ep_info.get("peer_group") or {}).get("name")
+        if not current_group:
+            return json.dumps({"status": "no_change", "message": "Peer is not in any group."})
+
+        await client.rest_patch(
+            f"plugins/bgp/peer-endpoints/{ep_info['endpoint_id']}",
+            {"peer_group": None},
+        )
+        return json.dumps({"status": "updated", "peer_ip": peer_ip, "removed_from": current_group, "device": device})
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# PHASE 5: RECONCILIATION TOOLS
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@mcp.tool()
+async def routing_reconcile_bgp(device: str, live_peers: str) -> str:
+    """Compare Nautobot BGP model vs live peer data from pyATS. Returns drift report.
+
+    Identifies: peers in Nautobot but not live (documented but not established),
+    peers live but not in Nautobot (undocumented), and ASN mismatches.
+
+    Args:
+        device: Device name (e.g. 'RR1')
+        live_peers: JSON array of live peers from 'show bgp summary'. Each entry:
+                    {"ip": "10.0.0.1", "asn": 65001, "state": "Established"}
+    """
+    logger.info(f"routing_reconcile_bgp device={device}")
+    try:
+        live = json.loads(live_peers)
+    except json.JSONDecodeError as e:
+        return json.dumps({"error": f"Invalid live_peers JSON: {e}"})
+
+    try:
+        # Get Nautobot BGP peers for this device
+        result = await routing_get_bgp_peers(device)
+        nb_data = json.loads(result)
+        if nb_data.get("error"):
+            return json.dumps({"error": nb_data["error"]})
+
+        nb_peers = nb_data.get("peers", [])
+
+        # Build lookup maps (by IP without mask)
+        nb_map: dict[str, dict] = {}
+        for p in nb_peers:
+            ip = p.get("remote_ip", "").split("/")[0]
+            if ip:
+                nb_map[ip] = p
+
+        live_map: dict[str, dict] = {}
+        for p in live:
+            ip = p.get("ip", "").split("/")[0]
+            if ip:
+                live_map[ip] = p
+
+        # Compare
+        in_nautobot_not_live = []
+        for ip, p in nb_map.items():
+            if ip not in live_map:
+                in_nautobot_not_live.append({
+                    "peer_ip": ip,
+                    "asn": p.get("remote_asn"),
+                    "peer_group": p.get("peer_group"),
+                    "status": "documented but not established",
+                })
+
+        in_live_not_nautobot = []
+        for ip, p in live_map.items():
+            if ip not in nb_map:
+                in_live_not_nautobot.append({
+                    "peer_ip": ip,
+                    "asn": p.get("asn"),
+                    "state": p.get("state"),
+                    "status": "undocumented peer",
+                })
+
+        asn_mismatch = []
+        for ip in set(nb_map) & set(live_map):
+            nb_asn = nb_map[ip].get("remote_asn")
+            live_asn = live_map[ip].get("asn")
+            if nb_asn and live_asn and int(nb_asn) != int(live_asn):
+                asn_mismatch.append({
+                    "peer_ip": ip,
+                    "nautobot_asn": nb_asn,
+                    "live_asn": live_asn,
+                })
+
+        return json.dumps({
+            "device": device,
+            "nautobot_peers": len(nb_map),
+            "live_peers": len(live_map),
+            "in_sync": len(in_nautobot_not_live) == 0 and len(in_live_not_nautobot) == 0 and len(asn_mismatch) == 0,
+            "drift": {
+                "in_nautobot_not_live": in_nautobot_not_live,
+                "in_live_not_nautobot": in_live_not_nautobot,
+                "asn_mismatch": asn_mismatch,
+            },
+        }, indent=2, default=str)
+    except NautobotError as e:
+        return json.dumps({"error": str(e)})
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/specs/027-nautobot-mcp-v2/checklists/requirements.md
+++ b/specs/027-nautobot-mcp-v2/checklists/requirements.md
@@ -1,0 +1,47 @@
+# Specification Quality Checklist: Enhanced Nautobot MCP Server v2
+
+**Purpose**: Validate specification completeness and quality before proceeding to implementation
+**Created**: 2026-04-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details in spec (languages, frameworks deferred to plan)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Research Validation
+
+- [x] GraphQL API verified against live Nautobot 3.1.0 instance
+- [x] No GraphQL mutations confirmed (graphene_django 3.2.3)
+- [x] REST API write capabilities confirmed (OPTIONS shows PUT/POST)
+- [x] Nautobot 3.x data model changes documented (locations, not sites)
+- [x] All GraphQL types introspected and field lists captured
+- [x] Sample queries executed and responses verified
+- [x] Existing data inventory documented (3 devices, 34 VLANs, 2 prefixes, 2 cables)
+- [x] Plugin availability confirmed (bgp_models, golden_config, firewall_models, etc.)
+
+## Notes
+
+- All items pass. Spec is ready for implementation.
+- Key architectural decision: GraphQL for reads, REST for writes — driven by Nautobot 3.1.0 not exposing GraphQL mutations.
+- The spec was validated against the live instance at 192.168.3.253 during research phase.

--- a/specs/027-nautobot-mcp-v2/contracts/mcp-tools.md
+++ b/specs/027-nautobot-mcp-v2/contracts/mcp-tools.md
@@ -1,0 +1,667 @@
+# MCP Tool Contracts: Enhanced Nautobot MCP Server v2
+
+**Feature**: 027-nautobot-mcp-v2
+**Date**: 2026-04-09
+**Transport**: stdio
+**Nautobot Version**: 3.1.0 (graphene_django 3.2.3, no GraphQL mutations)
+
+## Read Tools (7) — GraphQL API
+
+### nautobot_get_devices
+
+**Description**: Query devices from Nautobot source of truth. Returns device inventory with role, platform, location, status, primary IP, and serial number. Uses GraphQL for efficient nested queries.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| name | string | No | Filter by device name (exact match) |
+| location | string | No | Filter by location name |
+| role | string | No | Filter by device role name |
+| platform | string | No | Filter by platform name |
+| status | string | No | Filter by status name (e.g., "Active") |
+| q | string | No | General search across device fields |
+| limit | integer | No | Max results (default: 50, max: 200) |
+| offset | integer | No | Pagination offset (default: 0) |
+
+**Returns**: JSON with device list including name, status, role, platform, location, primary_ip4, serial, and device_type.
+
+**Example invocations**:
+- All devices: `nautobot_get_devices()`
+- By name: `nautobot_get_devices(name="HomeSwitch01")`
+- By location: `nautobot_get_devices(location="House")`
+- Search: `nautobot_get_devices(q="switch")`
+
+---
+
+### nautobot_get_interfaces
+
+**Description**: Query interfaces from Nautobot with full detail including VLAN assignments, IP addresses, and cable peer. Uses GraphQL for efficient nested relationship queries.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| device | string | No | Filter by device name |
+| name | string | No | Filter by interface name |
+| type | string | No | Filter by interface type |
+| enabled | boolean | No | Filter by enabled state |
+| status | string | No | Filter by status name |
+| has_ip_addresses | boolean | No | Filter to interfaces with/without IPs |
+| limit | integer | No | Max results (default: 50, max: 500) |
+| offset | integer | No | Pagination offset (default: 0) |
+
+**Returns**: JSON with interface list including name, type, enabled, status, description, mac_address, mtu, mode, untagged_vlan, tagged_vlans, ip_addresses, device name, and connected_endpoint.
+
+**Example invocations**:
+- All interfaces on a device: `nautobot_get_interfaces(device="HomeSwitch01")`
+- Only interfaces with IPs: `nautobot_get_interfaces(device="HomeSwitch01", has_ip_addresses=true)`
+- Disabled interfaces: `nautobot_get_interfaces(device="HomeSwitch01", enabled=false)`
+
+---
+
+### nautobot_get_vlans
+
+**Description**: Query VLANs from Nautobot. Returns VLAN ID, name, status, locations, and group.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| vid | integer | No | Filter by VLAN ID |
+| name | string | No | Filter by VLAN name |
+| location | string | No | Filter by location name |
+| vlan_group | string | No | Filter by VLAN group name |
+| status | string | No | Filter by status name |
+| limit | integer | No | Max results (default: 100, max: 500) |
+| offset | integer | No | Pagination offset (default: 0) |
+
+**Returns**: JSON with VLAN list including vid, name, status, locations, vlan_group, tenant, and role.
+
+**Example invocations**:
+- All VLANs: `nautobot_get_vlans()`
+- By VID: `nautobot_get_vlans(vid=100)`
+- By location: `nautobot_get_vlans(location="House")`
+
+---
+
+### nautobot_get_prefixes
+
+**Description**: Query IP prefixes from Nautobot IPAM. Returns prefix, status, locations, and role.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| prefix | string | No | Filter by prefix (e.g., "192.168.3.0/24") |
+| status | string | No | Filter by status name |
+| location | string | No | Filter by location name |
+| tenant | string | No | Filter by tenant name |
+| limit | integer | No | Max results (default: 50, max: 200) |
+| offset | integer | No | Pagination offset (default: 0) |
+
+**Returns**: JSON with prefix list including prefix, status, locations, role, tenant, and description.
+
+**Example invocations**:
+- All prefixes: `nautobot_get_prefixes()`
+- By prefix: `nautobot_get_prefixes(prefix="192.168.3.0/24")`
+
+---
+
+### nautobot_get_ip_addresses
+
+**Description**: Query IP addresses from Nautobot IPAM. Returns address, status, assigned interface, and device.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| address | string | No | Filter by IP address (e.g., "192.168.3.2/24") |
+| device | string | No | Filter by device name (via interface assignment) |
+| interface | string | No | Filter by interface name |
+| status | string | No | Filter by status name |
+| q | string | No | General search |
+| limit | integer | No | Max results (default: 50, max: 500) |
+| offset | integer | No | Pagination offset (default: 0) |
+
+**Returns**: JSON with IP address list including address, status, dns_name, description, tenant, and parent interface/device.
+
+**Example invocations**:
+- All IPs: `nautobot_get_ip_addresses()`
+- By device: `nautobot_get_ip_addresses(device="HomeSwitch01")`
+- Search: `nautobot_get_ip_addresses(q="192.168.3")`
+
+---
+
+### nautobot_get_cables
+
+**Description**: Query cables from Nautobot. Returns cable endpoints, type, status, and label. Resolves termination UUIDs to human-readable device + interface names.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| device | string | No | Filter cables connected to this device |
+| status | string | No | Filter by status name |
+| limit | integer | No | Max results (default: 50, max: 200) |
+| offset | integer | No | Pagination offset (default: 0) |
+
+**Returns**: JSON with cable list including id, type, status, label, color, and resolved termination_a/termination_b (device name + interface name).
+
+**Example invocations**:
+- All cables: `nautobot_get_cables()`
+- By device: `nautobot_get_cables(device="HomeSwitch01")`
+
+---
+
+### nautobot_graphql
+
+**Description**: Execute an arbitrary GraphQL query against Nautobot. Use for advanced queries, plugin data (BGP models, golden config, firewall models), custom fields, or any data not covered by the structured tools. Read-only — Nautobot 3.1.0 has no GraphQL mutations.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| query | string | Yes | GraphQL query string |
+| variables | string | No | JSON string of GraphQL variables |
+
+**Returns**: Raw GraphQL response data as JSON.
+
+**Example invocations**:
+- Plugin query: `nautobot_graphql(query="{ bgp_routing_instances { device { name } router_id autonomous_system { asn } } }")`
+- With variables: `nautobot_graphql(query="query($name: String) { devices(name: $name) { name serial } }", variables="{\"name\": \"HomeSwitch01\"}")`
+
+---
+
+## Write Tools (5) — REST API
+
+> **ITSM Gating**: All write tools require ServiceNow CR approval when ITSM_ENABLED=true and ITSM_LAB_MODE is not true.
+
+### nautobot_create_ip_address
+
+**Description**: Create an IP address in Nautobot IPAM via REST API. Optionally assign to an interface. Resolves names to UUIDs automatically.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| address | string | Yes | IP address with prefix length (e.g., "10.0.1.50/24") |
+| status | string | No | Status name (default: "Active") |
+| device | string | No | Device name to assign IP to (requires interface) |
+| interface | string | No | Interface name to assign IP to (requires device) |
+| dns_name | string | No | DNS hostname |
+| description | string | No | Description |
+| tenant | string | No | Tenant name |
+| namespace | string | No | IPAM namespace (default: "Global") |
+| cr_number | string | Conditional | ServiceNow CR (required if ITSM_ENABLED) |
+
+**Returns**: JSON with created IP address details including Nautobot ID.
+
+---
+
+### nautobot_create_vlan
+
+**Description**: Create a VLAN in Nautobot via REST API. Resolves location and status names to UUIDs automatically.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| vid | integer | Yes | VLAN ID (1-4094) |
+| name | string | Yes | VLAN name |
+| status | string | No | Status name (default: "Active") |
+| location | string | No | Location name to associate |
+| vlan_group | string | No | VLAN group name |
+| tenant | string | No | Tenant name |
+| description | string | No | Description |
+| cr_number | string | Conditional | ServiceNow CR (required if ITSM_ENABLED) |
+
+**Returns**: JSON with created VLAN details including Nautobot ID.
+
+---
+
+### nautobot_create_prefix
+
+**Description**: Create a prefix in Nautobot IPAM via REST API.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| prefix | string | Yes | Network prefix (e.g., "10.0.1.0/24") |
+| status | string | No | Status name (default: "Active") |
+| location | string | No | Location name |
+| tenant | string | No | Tenant name |
+| namespace | string | No | IPAM namespace (default: "Global") |
+| description | string | No | Description |
+| cr_number | string | Conditional | ServiceNow CR (required if ITSM_ENABLED) |
+
+**Returns**: JSON with created prefix details including Nautobot ID.
+
+---
+
+### nautobot_update_object
+
+**Description**: Update any Nautobot object (device, interface, IP, VLAN, prefix, cable) via REST API PATCH. Resolves the object by type + name/identifier, then applies partial updates.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| object_type | string | Yes | Object type: "device", "interface", "ip_address", "vlan", "prefix", "cable" |
+| identifier | string | Yes | Object identifier — device name, interface "device:interface_name", IP address, VLAN "vid", prefix, or cable UUID |
+| updates | string | Yes | JSON string of fields to update (e.g., '{"description": "new desc", "enabled": false}') |
+| cr_number | string | Conditional | ServiceNow CR (required if ITSM_ENABLED) |
+
+**Returns**: JSON with updated object showing old and new values for changed fields.
+
+**Example invocations**:
+- Update interface: `nautobot_update_object(object_type="interface", identifier="HomeSwitch01:GigabitEthernet1/0/4", updates='{"description": "Server port", "enabled": true}')`
+- Update VLAN: `nautobot_update_object(object_type="vlan", identifier="100", updates='{"name": "server_net"}')`
+
+---
+
+### nautobot_reconcile
+
+**Description**: Compare live device state against Nautobot source of truth and produce a structured diff report. Accepts live interface data (from pyATS) as JSON input, queries Nautobot internally for the SoT state, and returns categorized differences.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| device_name | string | Yes | Device name in Nautobot to reconcile against |
+| live_interfaces | string | Yes | JSON string of live interface data from pyATS. Expected format: array of objects with keys: name, enabled, description, ip_addresses (array of strings), mtu, type |
+
+**Returns**: JSON diff report with sections:
+- `matches` — interfaces present in both with identical fields
+- `mismatches` — interfaces present in both with field-level differences (showing nautobot vs live values)
+- `device_only` — interfaces on live device but not in Nautobot
+- `nautobot_only` — interfaces in Nautobot but not on live device
+- `summary` — counts for each category
+
+**Example invocation**:
+```
+nautobot_reconcile(
+  device_name="HomeSwitch01",
+  live_interfaces='[{"name": "GigabitEthernet1/0/1", "enabled": true, "description": "Server port", "ip_addresses": [], "mtu": 9198}]'
+)
+```
+
+---
+
+## Connection Test Tool (1)
+
+### nautobot_test_connection
+
+**Description**: Test connectivity to the Nautobot API. Verifies both GraphQL and REST endpoints are reachable and the token is valid.
+
+**Parameters**: None.
+
+**Returns**: JSON with connection status, Nautobot URL, API version, and GraphQL availability.
+
+---
+
+## Virtualization Tools (4) — GraphQL reads + REST writes
+
+### nautobot_get_virtual_machines
+
+**Description**: Query virtual machines from Nautobot. Returns name, cluster, role, status, primary IP, vCPUs, memory, disk, and interfaces.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| name | string | No | Filter by VM name |
+| cluster | string | No | Filter by cluster name |
+| role | string | No | Filter by role name |
+| status | string | No | Filter by status name |
+| limit | integer | No | Max results (default: 50) |
+| offset | integer | No | Pagination offset (default: 0) |
+
+**Returns**: JSON with VM list including name, status, role, cluster, vcpus, memory, disk, primary_ip4, and interfaces with IPs.
+
+**Example invocations**:
+- All VMs: `nautobot_get_virtual_machines()`
+- By cluster: `nautobot_get_virtual_machines(cluster="Observability")`
+
+---
+
+### nautobot_create_virtual_machine
+
+**Description**: Create a virtual machine in Nautobot. ITSM-gated.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| name | string | Yes | VM name (e.g., "otel-collector") |
+| cluster | string | Yes | Cluster name the VM belongs to |
+| role | string | No | Device role name (e.g., "Monitoring") |
+| status | string | No | Status name (default: "Active") |
+| vcpus | integer | No | Number of virtual CPUs |
+| memory | integer | No | Memory in MB |
+| disk | integer | No | Disk in GB |
+| comments | string | No | Free-text description |
+| cr_number | string | Conditional | ServiceNow CR (required if ITSM_ENABLED) |
+
+**Returns**: JSON with created VM details including Nautobot ID.
+
+---
+
+### nautobot_create_vm_interface
+
+**Description**: Create a network interface on a virtual machine. ITSM-gated.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| virtual_machine | string | Yes | VM name |
+| name | string | Yes | Interface name (e.g., "eth0") |
+| enabled | boolean | No | Whether the interface is enabled (default: true) |
+| description | string | No | Interface description |
+| cr_number | string | Conditional | ServiceNow CR (required if ITSM_ENABLED) |
+
+**Returns**: JSON with created VM interface details.
+
+---
+
+### nautobot_assign_ip_to_vm
+
+**Description**: Create an IP address and assign it to a VM interface. Optionally set as the VM's primary IPv4 address. ITSM-gated.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| virtual_machine | string | Yes | VM name |
+| interface | string | Yes | VM interface name (e.g., "eth0") |
+| address | string | Yes | IP address in CIDR notation (e.g., "192.168.220.200/24") |
+| status | string | No | IP status (default: "Active") |
+| namespace | string | No | IPAM namespace (default: "Global") |
+| set_primary | boolean | No | Set as VM's primary IPv4 (default: true) |
+| cr_number | string | Conditional | ServiceNow CR (required if ITSM_ENABLED) |
+
+**Returns**: JSON with IP address, assignment confirmation, and primary status.
+
+---
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| NAUTOBOT_URL | Yes | Nautobot base URL (e.g., https://192.168.3.253) |
+| NAUTOBOT_TOKEN | Yes | Nautobot API token with read+write permissions |
+| NAUTOBOT_VERIFY_SSL | No | Verify SSL certificates (default: false for self-signed) |
+| NAUTOBOT_TIMEOUT | No | Request timeout in seconds (default: 30) |
+| ITSM_ENABLED | No | Enable ITSM gating for write operations (default: false) |
+| ITSM_LAB_MODE | No | Bypass ITSM gating for lab use (default: true) |
+
+## Error Responses
+
+All tools return structured error messages for:
+- **Connection failure**: "Nautobot API unreachable at {url}: {detail}"
+- **Authentication failure**: "Nautobot authentication failed. Verify NAUTOBOT_TOKEN is correct."
+- **GraphQL error**: "Nautobot GraphQL error: {errors}" (passes through GraphQL error messages)
+- **REST write error**: "Nautobot REST API error ({status_code}): {detail}"
+- **ITSM blocked**: "Write operation blocked: ITSM is enabled. Provide a cr_number parameter with a valid ServiceNow Change Request number."
+- **Not found**: "No {object_type} found matching '{identifier}' in Nautobot." (not treated as error)
+- **Timeout**: "Nautobot query timed out after {timeout}s. Try narrowing filters or increasing NAUTOBOT_TIMEOUT."
+- **Permission denied**: "Nautobot token does not have write permission. Contact your Nautobot admin."
+
+
+---
+
+## High-Level Network Tools (6) — Reduce LLM Context Burn
+
+> Added 2026-05-10. These tools combine multiple API calls into single operations
+> to prevent the LLM from spiraling through raw REST/GraphQL calls.
+
+### nautobot_get_device_config_context
+
+**Description**: Get the merged config context for a device as the golden config templates see it. Returns the full merged dict — all config contexts that apply based on role, site, tenant, tags, etc.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| device | string | Yes | Device name (e.g., "RR1") |
+
+**Returns**: JSON with device name and full merged config_context dict.
+
+---
+
+### nautobot_create_interface
+
+**Description**: Create an interface on a device with optional IP assignment in one call. Idempotent — returns existing interface if already present.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| device | string | Yes | Device name (e.g., "RR1") |
+| name | string | Yes | Interface name (e.g., "Tunnel0", "Loopback99") |
+| interface_type | string | No | Interface type (default: "virtual") |
+| ip_address | string | No | IP with prefix (e.g., "10.255.255.2/30") — creates and assigns |
+| description | string | No | Interface description |
+| enabled | boolean | No | Whether interface is enabled (default: true) |
+
+**Returns**: JSON with interface action (created/already_exists) and IP action (created/already_exists/null).
+
+---
+
+### nautobot_create_autonomous_system
+
+**Description**: Create an autonomous system in Nautobot BGP models. Idempotent — returns existing if already present.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| asn | integer | Yes | AS number (e.g., 65099) |
+| description | string | No | Description (e.g., "NetClaw Protocol Agent") |
+
+**Returns**: JSON with action (created/already_exists), ASN, and Nautobot ID.
+
+---
+
+### nautobot_create_bgp_peer_group
+
+**Description**: Create a BGP peer group on a device's routing instance. Includes optional remote ASN, source interface, and address family assignment in one call.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| name | string | Yes | Peer group name (e.g., "NETCLAW-PEERS") |
+| device | string | Yes | Device name (e.g., "RR1") |
+| remote_asn | integer | No | Remote AS for the group |
+| source_interface | string | No | Update-source interface name |
+| description | string | No | Description |
+| address_families | string | No | Comma-separated AFI/SAFI (e.g., "ipv4_unicast") |
+
+**Returns**: JSON with action (created/already_exists), name, and Nautobot ID.
+
+---
+
+### nautobot_create_bgp_peering
+
+**Description**: Create a complete BGP peering in Nautobot in one call. Creates the peering object with both endpoints (local and remote), optionally linking to a peer group and adding address families.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| device | string | Yes | Local device name (e.g., "RR1") |
+| local_ip | string | Yes | Local IP with mask (e.g., "10.255.255.2/30") |
+| peer_ip | string | Yes | Remote peer IP with mask (e.g., "10.255.255.1/30") |
+| peer_asn | integer | Yes | Remote autonomous system number |
+| peer_group | string | No | Peer group name to associate with |
+| local_asn | integer | No | Local ASN (defaults to device's routing instance ASN) |
+| description | string | No | Peering description |
+| address_families | string | No | Comma-separated AFI/SAFI (default: "ipv4_unicast") |
+
+**Returns**: JSON with peering_id, device, local_ip, peer_ip, peer_asn, peer_group, and address_families.
+
+---
+
+### nautobot_render_device_config
+
+**Description**: Get the latest golden config intended (rendered) config for a device. Returns what the templates produce — the config that SHOULD be on the device.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| device | string | Yes | Device name (e.g., "RR1") |
+
+**Returns**: JSON with device name, intended_config text, and last_generated timestamp. Returns null if no intended config exists (run the golden config intended job first).
+
+---
+
+## BGP/Routing Read Tools (3) — GraphQL API
+
+### nautobot_get_bgp_routing
+
+**Description**: Query BGP routing instances, peer groups, peer endpoints, and autonomous systems for a device or all devices.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| device | string | No | Filter by device name |
+| limit | integer | No | Max results (default: 50) |
+| offset | integer | No | Pagination offset (default: 0) |
+
+**Returns**: JSON with BGP routing instances including device, router_id, autonomous_system, peer_groups (with ASN, source_ip, source_interface), and endpoints (with peer IP, peer_group, role).
+
+---
+
+### nautobot_get_autonomous_systems
+
+**Description**: Query autonomous systems registered in Nautobot BGP models.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| limit | integer | No | Max results (default: 50) |
+| offset | integer | No | Pagination offset (default: 0) |
+
+**Returns**: JSON with autonomous system list including ASN, description, and status.
+
+---
+
+### nautobot_get_ospf_routing
+
+**Description**: Query OSPF routing instances and areas for a device or all devices.
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| device | string | No | Filter by device name |
+| limit | integer | No | Max results (default: 50) |
+| offset | integer | No | Pagination offset (default: 0) |
+
+**Returns**: JSON with OSPF instances including device, router_id, areas, and interfaces.
+
+---
+
+## Golden Config Tools (Deprecated — Moving to nautobot-golden-config-mcp)
+
+> These tools remain in nautobot-mcp-v2 for backward compatibility but will be
+> superseded by the dedicated `nautobot-golden-config-mcp` server (spec 028).
+
+### nautobot_get_golden_configs
+
+**Description**: Get golden config records (intended, backup, compliance) for devices.
+
+### nautobot_get_config_compliance
+
+**Description**: Get compliance results per device per feature.
+
+### nautobot_get_compliance_rules
+
+**Description**: Get compliance rules (feature + platform + match_config).
+
+### nautobot_get_golden_config_settings
+
+**Description**: Get golden config settings (repos, paths, SoT query).
+
+### nautobot_create_compliance_feature
+
+**Description**: Create a compliance feature (e.g., "observability").
+
+### nautobot_create_compliance_rule
+
+**Description**: Create a compliance rule linking feature to platform.
+
+### nautobot_update_golden_config_setting
+
+**Description**: Update golden config settings (link repos, set paths).
+
+### nautobot_get_config_contexts
+
+**Description**: List config contexts with metadata.
+
+### nautobot_get_config_context_detail
+
+**Description**: Get full config context data by name.
+
+### nautobot_create_config_context
+
+**Description**: Create a new config context.
+
+### nautobot_update_config_context
+
+**Description**: Update an existing config context.
+
+---
+
+## Firewall Plugin Tools (3) — GraphQL reads
+
+### nautobot_get_firewall_policies
+
+**Description**: Query firewall policies with rules, zones, and address objects.
+
+### nautobot_get_firewall_zones
+
+**Description**: Query firewall zones with VRFs and interfaces.
+
+### nautobot_get_nat_policies
+
+**Description**: Query NAT policies and rules.
+
+---
+
+## Generic CRUD Tools (3) — REST API
+
+### nautobot_create
+
+**Description**: Create any Nautobot object via REST API. Uses the schema registry to resolve field names to UUIDs automatically.
+
+### nautobot_delete
+
+**Description**: Delete a Nautobot object by type and identifier.
+
+### nautobot_get_schema
+
+**Description**: Get the REST API schema for a Nautobot endpoint (fields, types, choices, required).
+
+---
+
+## Tool Count Summary
+
+| Category | Count | Notes |
+|----------|-------|-------|
+| Read (GraphQL) | 7 | Core DCIM/IPAM queries |
+| Write (REST) | 5 | IP, VLAN, prefix, update, reconcile |
+| Connection | 1 | Test connectivity |
+| Virtualization | 4 | VMs, interfaces, IP assignment |
+| High-Level Network | 6 | BGP peering, interface+IP, config context (NEW) |
+| BGP/Routing Read | 3 | BGP instances, ASNs, OSPF |
+| Golden Config (deprecated) | 11 | Moving to nautobot-golden-config-mcp |
+| Firewall | 3 | Policy, zones, NAT reads |
+| Generic CRUD | 3 | Create/delete/schema for any object |
+| **Total** | **43** | |

--- a/specs/027-nautobot-mcp-v2/data-model.md
+++ b/specs/027-nautobot-mcp-v2/data-model.md
@@ -1,0 +1,129 @@
+# Data Model: Enhanced Nautobot MCP Server v2
+
+**Feature**: 027-nautobot-mcp-v2
+**Date**: 2026-04-09
+
+## Entities
+
+### NautobotConfig
+
+Runtime configuration sourced from environment variables.
+
+| Field | Type | Source | Default | Validation |
+|-------|------|--------|---------|------------|
+| url | str | `NAUTOBOT_URL` | (required) | Must be valid HTTP/HTTPS URL |
+| token | str | `NAUTOBOT_TOKEN` | (required) | Non-empty string |
+| verify_ssl | bool | `NAUTOBOT_VERIFY_SSL` | `false` | "true"/"false" |
+| timeout | int | `NAUTOBOT_TIMEOUT` | `30` | Positive integer (seconds) |
+| itsm_enabled | bool | `ITSM_ENABLED` | `false` | "true"/"false" |
+| itsm_lab_mode | bool | `ITSM_LAB_MODE` | `true` | "true"/"false" |
+
+**Validation rules**:
+- `url` must not have a trailing slash
+- Server must fail to start if `NAUTOBOT_URL` or `NAUTOBOT_TOKEN` are not set
+- ITSM gating is active when `itsm_enabled=true` AND `itsm_lab_mode=false`
+
+### GraphQL Query Patterns
+
+Nautobot 3.1.0 GraphQL queries follow this pattern:
+
+```
+POST /api/graphql/
+Authorization: Token <token>
+Content-Type: application/json
+
+{"query": "{ devices(name: \"HomeSwitch01\") { name status { name } } }"}
+```
+
+Filter arguments use Django-style lookups:
+- Exact: `name: "HomeSwitch01"`
+- Contains (case-insensitive): `name__ic: "switch"`
+- Starts with: `name__isw: "Home"`
+- Regex: `name__re: "^Home.*01$"`
+- Pagination: `limit: 50, offset: 0`
+- Boolean: `has_primary_ip: true`
+- Search: `q: "switch"`
+
+### REST API Write Patterns
+
+Nautobot 3.1.0 REST writes follow this pattern:
+
+```
+POST /api/dcim/interfaces/
+Authorization: Token <token>
+Content-Type: application/json
+
+{"device": "<uuid>", "name": "Gi1/0/49", "type": "1000base-t", "status": "<uuid>"}
+```
+
+Related objects require UUIDs. Resolution flow:
+1. User provides human-readable name (e.g., status="Active")
+2. Server queries GraphQL: `{ statuses(name: "Active") { id } }` (or uses REST lookup)
+3. Server substitutes UUID into REST payload
+4. Server issues REST POST/PATCH
+
+### REST Endpoint Map
+
+| Object Type | REST Endpoint | Create | Update | Delete |
+|-------------|---------------|--------|--------|--------|
+| Device | /api/dcim/devices/ | POST | PATCH /{id}/ | DELETE /{id}/ |
+| Interface | /api/dcim/interfaces/ | POST | PATCH /{id}/ | DELETE /{id}/ |
+| IP Address | /api/ipam/ip-addresses/ | POST | PATCH /{id}/ | DELETE /{id}/ |
+| IP-to-Interface | /api/ipam/ip-address-to-interface/ | POST | — | DELETE /{id}/ |
+| Prefix | /api/ipam/prefixes/ | POST | PATCH /{id}/ | DELETE /{id}/ |
+| VLAN | /api/ipam/vlans/ | POST | PATCH /{id}/ | DELETE /{id}/ |
+| Cable | /api/dcim/cables/ | POST | PATCH /{id}/ | DELETE /{id}/ |
+| Location | /api/dcim/locations/ | — | — | — |
+| Status | (lookup only) | — | — | — |
+| Role | (lookup only) | — | — | — |
+
+### ReconciliationReport
+
+Output of the reconcile tool.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| device_name | str | Device being reconciled |
+| timestamp | str | ISO 8601 timestamp of reconciliation |
+| matches | list[InterfaceMatch] | Interfaces matching between live and SoT |
+| mismatches | list[InterfaceMismatch] | Interfaces with field-level differences |
+| device_only | list[InterfaceRecord] | Interfaces on live device but not in Nautobot |
+| nautobot_only | list[InterfaceRecord] | Interfaces in Nautobot but not on live device |
+| summary | dict | Counts: {matches, mismatches, device_only, nautobot_only, total_live, total_nautobot} |
+
+### InterfaceMismatch
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | str | Interface name |
+| differences | list[FieldDiff] | Per-field differences |
+
+### FieldDiff
+
+| Field | Type | Description |
+|-------|------|-------------|
+| field | str | Field name (e.g., "enabled", "description", "mtu") |
+| live | any | Value from live device |
+| nautobot | any | Value from Nautobot |
+
+## Nautobot 3.1.0 GraphQL Type Reference
+
+Verified via introspection on 192.168.3.253:
+
+### DeviceType fields (used)
+`id`, `name`, `serial`, `status { name }`, `role { name }`, `platform { name }`, `location { name }`, `device_type { model manufacturer { name } }`, `primary_ip4 { address }`, `primary_ip6 { address }`, `interfaces { ... }`, `comments`
+
+### InterfaceType fields (used)
+`id`, `name`, `type`, `enabled`, `status { name }`, `description`, `mac_address`, `mtu`, `mode`, `device { name }`, `untagged_vlan { vid name }`, `tagged_vlans { vid name }`, `ip_addresses { address }`, `cable { id }`, `connected_endpoint`, `label`, `lag { name }`
+
+### VLANType fields (used)
+`id`, `vid`, `name`, `status { name }`, `locations { name }`, `vlan_group { name }`, `tenant { name }`, `role { name }`, `description`
+
+### PrefixType fields (used)
+`id`, `prefix`, `status { name }`, `locations { name }`, `role { name }`, `tenant { name }`, `description`
+
+### IPAddressType fields (used)
+`id`, `address`, `status { name }`, `dns_name`, `description`, `tenant { name }`, `interface_assignments { interface { name device { name } } }`
+
+### CableType fields (used)
+`id`, `type`, `status { name }`, `label`, `color`, `length`, `length_unit`, `termination_a_type`, `termination_a_id`, `termination_b_type`, `termination_b_id`

--- a/specs/027-nautobot-mcp-v2/plan.md
+++ b/specs/027-nautobot-mcp-v2/plan.md
@@ -1,0 +1,79 @@
+# Implementation Plan: Enhanced Nautobot MCP Server v2
+
+**Branch**: `027-nautobot-mcp-v2` | **Date**: 2026-04-09 | **Spec**: `specs/027-nautobot-mcp-v2/spec.md`
+**Input**: Feature specification from `/specs/027-nautobot-mcp-v2/spec.md`
+
+## Summary
+
+Replace the existing mcp-nautobot (v1, 5 REST-only IPAM tools) with a comprehensive Nautobot 3.1.0 MCP server using GraphQL for reads (7 tools) and REST API for writes (5 tools) plus a connection test tool. Covers devices, interfaces, VLANs, prefixes, IP addresses, cables, raw GraphQL, ITSM-gated writes, and live-vs-SoT reconciliation. Python 3.10+ with FastMCP, httpx, stdio transport.
+
+## Technical Context
+
+**Language/Version**: Python 3.10+ (3.13 in Docker)
+**Primary Dependencies**: FastMCP (mcp SDK), httpx (async HTTP), python-dotenv
+**Storage**: N/A (stateless proxy to Nautobot API)
+**Testing**: Manual validation against live Nautobot at 192.168.3.253
+**Target Platform**: Linux (Docker container, stdio MCP transport)
+**Project Type**: MCP server (stdio transport)
+**Performance Goals**: Query responses within 3 seconds (SC-001)
+**Constraints**: GraphQL for reads only (no mutations in Nautobot 3.1.0), REST for writes
+**Scale/Scope**: 13 tools (7 read, 5 write, 1 connection test), ~3 source files
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Safety-First Operations | PASS | Read tools are read-only via GraphQL. Write tools are ITSM-gated. |
+| II. Read-Before-Write | PASS | Write tools resolve existing state via GraphQL before REST writes. Update tool returns old+new values. |
+| III. ITSM-Gated Changes | PASS | All write tools require cr_number when ITSM_ENABLED=true and ITSM_LAB_MODE=false. |
+| IV. Immutable Audit Trail | PASS | All operations logged to stderr. GAIT integration at skill level. |
+| V. MCP-Native Integration | PASS | FastMCP server with stdio transport, proper JSON-RPC lifecycle. |
+| VI. Multi-Vendor Neutrality | PASS | Nautobot is vendor-neutral SoT. Reconciliation works with any pyATS-supported device. |
+| VII. Skill Modularity | PASS | Replaces v1 in same slot. Companion skill in workspace/skills/. |
+| VIII. Verify After Every Change | PASS | Write tools query the object after creation/update to confirm. Reconciliation enables verification. |
+| IX. Security by Default | PASS | Credentials from env vars only. SSL verification configurable. |
+| X. Observability as First-Class | PASS | Connection test tool. Stderr logging. HUD update. |
+| XI. Artifact Coherence | PENDING | Will be completed during implementation. |
+| XII. Documentation-as-Code | PENDING | README and SKILL.md created during implementation. |
+| XIII. Credential Safety | PASS | NAUTOBOT_URL and NAUTOBOT_TOKEN from env vars. Never logged. |
+| XIV. Human-in-the-Loop | PASS | Write operations gated by ITSM. Reconciliation reports diff before any writes. |
+| XV. Backwards Compatibility | PASS | Replaces v1 with superset. All v1 query capabilities preserved. |
+| XVI. Spec-Driven Development | PASS | Full SDD workflow. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/027-nautobot-mcp-v2/
+├── spec.md
+├── plan.md              # This file
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── mcp-tools.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+mcp-servers/nautobot-mcp-v2/
+├── server.py            # FastMCP server with all 13 tool definitions
+├── nautobot_client.py   # GraphQL + REST client (reads and writes)
+├── reconcile.py         # Reconciliation logic (diff engine)
+├── requirements.txt     # Python dependencies
+└── README.md            # MCP server documentation
+
+workspace/skills/nautobot-sot/
+└── SKILL.md             # Skill documentation
+```
+
+**Structure Decision**: New directory `nautobot-mcp-v2/` alongside the existing `mcp-nautobot/`. The v1 directory is preserved for reference but the openclaw.json entry is updated to point to v2. Three source files: server (tool definitions), client (API communication), reconcile (diff logic).
+
+## Complexity Tracking
+
+> No constitution violations. All principles satisfied by design.

--- a/specs/027-nautobot-mcp-v2/quickstart.md
+++ b/specs/027-nautobot-mcp-v2/quickstart.md
@@ -1,0 +1,107 @@
+# Quickstart: Enhanced Nautobot MCP Server v2
+
+**Feature**: 027-nautobot-mcp-v2
+**Date**: 2026-04-09
+
+## Prerequisites
+
+1. A running Nautobot 3.1.0 instance with GraphQL and REST API enabled
+2. A valid Nautobot API token with read+write permissions
+3. Python 3.10+
+4. Network connectivity from the MCP server host to the Nautobot instance
+
+## Setup
+
+### 1. Install dependencies
+
+```bash
+cd mcp-servers/nautobot-mcp-v2/
+pip install -r requirements.txt
+```
+
+### 2. Configure environment variables
+
+```bash
+export NAUTOBOT_URL="https://192.168.3.253"
+export NAUTOBOT_TOKEN="your-nautobot-api-token"
+
+# Optional
+export NAUTOBOT_VERIFY_SSL="false"     # Set to false for self-signed certs
+export NAUTOBOT_TIMEOUT="30"           # Query timeout in seconds
+export ITSM_ENABLED="false"           # Enable ITSM gating for writes
+export ITSM_LAB_MODE="true"           # Bypass ITSM in lab environments
+```
+
+### 3. Register in openclaw.json
+
+Replace the existing `nautobot-mcp` entry in `config/openclaw.json`:
+
+```json
+{
+  "nautobot-mcp": {
+    "command": "python3",
+    "args": ["-u", "mcp-servers/nautobot-mcp-v2/server.py"],
+    "env": {
+      "NAUTOBOT_URL": "${NAUTOBOT_URL}",
+      "NAUTOBOT_TOKEN": "${NAUTOBOT_TOKEN}",
+      "NAUTOBOT_VERIFY_SSL": "${NAUTOBOT_VERIFY_SSL:-false}",
+      "NAUTOBOT_TIMEOUT": "${NAUTOBOT_TIMEOUT:-30}",
+      "ITSM_ENABLED": "${ITSM_ENABLED:-false}",
+      "ITSM_LAB_MODE": "${ITSM_LAB_MODE:-true}"
+    }
+  }
+}
+```
+
+### 4. Run the server (standalone test)
+
+```bash
+python3 -u mcp-servers/nautobot-mcp-v2/server.py
+```
+
+The server communicates via stdio. It will wait for JSON-RPC messages on stdin.
+
+## Usage Examples
+
+Once registered with an MCP client (OpenClaw TUI, Slack, Discord):
+
+**Read queries (GraphQL)**:
+- "Show me all devices in Nautobot"
+- "What interfaces does HomeSwitch01 have?"
+- "Show VLANs at location House"
+- "What IP addresses are assigned to HomeSwitch02?"
+- "Show me all cables"
+- "What prefixes are in Nautobot?"
+
+**Raw GraphQL**:
+- "Run this GraphQL query: { bgp_routing_instances { device { name } router_id } }"
+
+**Write operations (REST API)**:
+- "Create VLAN 200 named Guest at location House"
+- "Add IP address 10.0.1.50/24 to HomeSwitch01 GigabitEthernet1/0/48"
+- "Update the description on HomeSwitch01 GigabitEthernet1/0/4 to 'Server port'"
+
+**Reconciliation**:
+- "Reconcile HomeSwitch01 interfaces against Nautobot"
+- "Compare live state of HomeSwitch02 with the source of truth"
+
+## Verification
+
+1. Test connection: the `nautobot_test_connection` tool should return connected=true
+2. Query devices: `nautobot_get_devices()` should return HomeSwitch01, HomeSwitch02, pfSense-FW01
+3. Query interfaces: `nautobot_get_interfaces(device="HomeSwitch01")` should return all switch interfaces
+4. Query VLANs: `nautobot_get_vlans()` should return 34 VLANs
+5. Check stderr output for connection and query logs
+
+## Docker Usage
+
+In the Docker container, the server runs via the openclaw.json registration. The environment variables are passed from the host `.env` file through `docker-compose.yml`.
+
+```bash
+# Rebuild after adding v2 server
+docker compose up -d --build
+
+# Test via TUI
+docker compose exec -it netclaw openclaw tui
+# Then ask: "Show me all devices in Nautobot"
+```

--- a/specs/027-nautobot-mcp-v2/research.md
+++ b/specs/027-nautobot-mcp-v2/research.md
@@ -1,0 +1,143 @@
+# Research: Enhanced Nautobot MCP Server v2
+
+**Feature**: 027-nautobot-mcp-v2
+**Date**: 2026-04-09
+
+## R1: Nautobot 3.1.0 API Architecture
+
+**Decision**: Use GraphQL (POST /api/graphql/) for all reads, REST API (POST/PATCH/DELETE to /api/dcim/*, /api/ipam/*) for all writes.
+
+**Rationale**: Verified against live instance at 192.168.3.253. Nautobot 3.1.0 uses graphene_django 3.2.3 which exposes GraphQL queries but **no mutations**. The `__schema { mutationType }` introspection returns null. REST API endpoints confirm PUT and POST actions via OPTIONS requests. This hybrid approach gives us the best of both worlds: efficient field selection and nested queries for reads, and full CRUD for writes.
+
+**Alternatives considered**:
+- REST-only (like v1): Rejected because GraphQL provides dramatically better query efficiency — one request can fetch a device with all its interfaces, IPs, and VLANs instead of 4+ REST calls.
+- GraphQL-only: Not possible — Nautobot 3.1.0 has no GraphQL mutations.
+- Wait for Nautobot to add GraphQL mutations: Unknown timeline, blocks all write functionality.
+
+## R2: Nautobot 3.x Data Model Changes
+
+**Decision**: Use `locations` throughout, never `site`. Use `status` as a nested object with `name` field.
+
+**Rationale**: Nautobot 3.x replaced the `site` model with a hierarchical `locations` model. Verified via GraphQL introspection:
+- DeviceType has `location { name }` (singular)
+- VLANType has `locations { name }` (plural, many-to-many)
+- PrefixType has `locations { name }` (plural)
+- InterfaceType has no direct location (inherited from device)
+
+Status is always a nested object: `status { name }` returns strings like "Active", "Connected".
+
+**Alternatives considered**:
+- Support both `site` and `location`: Rejected — Nautobot 3.x removed `site` entirely.
+
+## R3: GraphQL Query Patterns
+
+**Decision**: Use parameterized GraphQL queries with filter arguments. Nautobot supports Django-style lookups.
+
+**Rationale**: Verified via introspection. The `devices` query accepts filters including:
+- `name`, `location`, `role`, `platform`, `status`, `tenant` — exact match by name/slug
+- `name__ic`, `name__isw`, `name__re` — case-insensitive contains, starts-with, regex
+- `q` — general search across multiple fields
+- `limit`, `offset` — pagination
+- `has_interfaces`, `has_primary_ip` — boolean existence filters
+
+Example working query:
+```graphql
+{
+  devices(name: "HomeSwitch01") {
+    name status { name } role { name } platform { name }
+    location { name } primary_ip4 { address } serial
+    interfaces { name type enabled status { name } description
+      mac_address mtu mode
+      untagged_vlan { vid name }
+      tagged_vlans { vid name }
+      ip_addresses { address }
+    }
+  }
+}
+```
+
+**Alternatives considered**:
+- Using GraphQL variables ($name: String): Supported but adds complexity. Will use for the raw query tool; structured tools will use string interpolation with proper escaping.
+
+## R4: REST API Write Patterns
+
+**Decision**: Use REST API for all create/update/delete operations. Look up related object IDs by name before writes.
+
+**Rationale**: REST API endpoints confirmed via OPTIONS:
+- `POST /api/dcim/devices/` — create device
+- `PATCH /api/dcim/devices/{id}/` — partial update
+- `POST /api/dcim/interfaces/` — create interface
+- `POST /api/ipam/ip-addresses/` — create IP
+- `POST /api/ipam/vlans/` — create VLAN
+- `POST /api/ipam/prefixes/` — create prefix
+- `POST /api/dcim/cables/` — create cable
+
+REST writes require UUIDs for related objects (status, role, location, device). The server must resolve human-readable names to UUIDs via GraphQL lookup before issuing REST writes. Example: to create an interface, we need the device UUID, which we get from `{ devices(name: "HomeSwitch01") { id } }`.
+
+**Alternatives considered**:
+- Require users to provide UUIDs: Terrible UX. The agent should resolve names automatically.
+- Cache all UUIDs at startup: Fragile — data changes. Better to look up on demand.
+
+## R5: Cable Endpoint Resolution
+
+**Decision**: Use REST API to resolve cable endpoints since GraphQL CableType only exposes `termination_a_type`/`termination_b_type` and `termination_a_id`/`termination_b_id` as raw content-type strings and UUIDs.
+
+**Rationale**: GraphQL CableType fields are:
+- `termination_a_type` → "dcim.interface"
+- `termination_a_id` → UUID string
+- `termination_b_type` → "dcim.interface"
+- `termination_b_id` → UUID string
+
+To get human-readable cable endpoints (device name + interface name), we need to resolve these UUIDs. Two approaches:
+1. Query cables via GraphQL, then resolve endpoint UUIDs via additional GraphQL queries
+2. Query cables via REST API which includes nested endpoint details
+
+Will use approach 1 (GraphQL + resolution) for consistency, falling back to REST if needed.
+
+**Alternatives considered**:
+- REST-only for cables: Would work but breaks the GraphQL-for-reads pattern.
+
+## R6: Authentication
+
+**Decision**: Use `Authorization: Token <token>` header for both GraphQL and REST requests. Token from NAUTOBOT_TOKEN env var.
+
+**Rationale**: Standard Nautobot authentication. Same token works for both GraphQL and REST. Verified working on live instance.
+
+## R7: HTTP Client
+
+**Decision**: Use `httpx` with async support, same as v1.
+
+**Rationale**: Already a dependency of v1. Supports async, SSL verification toggle, timeouts. No reason to change.
+
+## R8: ITSM Gating Pattern
+
+**Decision**: Follow the same ITSM gating pattern as aruba-cx-mcp and other write-capable NetClaw MCP servers.
+
+**Rationale**: Environment variables:
+- `ITSM_ENABLED` — when true, all writes require a `cr_number` parameter
+- `ITSM_LAB_MODE` — when true, bypasses ITSM gating for lab/dev use
+
+Each write tool accepts an optional `cr_number` parameter. If ITSM is enabled and no CR is provided, the tool returns an error message. The CR number is logged to GAIT.
+
+## R9: Reconciliation Architecture
+
+**Decision**: Reconciliation is a tool within this MCP server that orchestrates data from two sources: Nautobot (via GraphQL) and live device state (passed as input from the agent, which gets it from pyATS MCP).
+
+**Rationale**: The reconciliation tool does NOT call pyATS directly — it accepts structured device data as input. The agent orchestrates: (1) call pyATS MCP to get live state, (2) call nautobot-mcp-v2 to get SoT state, (3) call nautobot-mcp-v2 reconcile tool with both datasets. This keeps the MCP server focused and avoids cross-MCP dependencies.
+
+Alternative approach: a single reconcile tool that accepts just a device name and internally queries both Nautobot GraphQL and the live device data passed as a JSON parameter. This is simpler for the agent.
+
+**Decision**: Use the single-tool approach — the reconcile tool accepts device_name + live_interfaces (JSON from pyATS), queries Nautobot internally, and returns the diff.
+
+## R10: Existing Data in Nautobot
+
+**Verified data on 192.168.3.253**:
+- 3 devices: HomeSwitch01 (FOC1733X062), HomeSwitch02 (FOC1724V1R9), pfSense-FW01
+- All at location "House", all status "Active"
+- HomeSwitch01/02: role "home_switch", platform "cisco_ios"
+- pfSense-FW01: role "firewall", no platform set
+- 34 VLANs (1, 2, 3, 13-17, 30-31, 35, 100-104, 220-229, 300, 310-316, 3000)
+- 2 prefixes: 192.168.3.0/24, 192.168.100.0/24
+- 2 cables (interface-to-interface)
+- Interfaces with full detail: type, enabled, status, description, MAC, MTU, mode, VLAN assignments
+- Plugins: bgp_models, golden_config, firewall_models, igp_models, ssot, device_onboarding, design_builder

--- a/specs/027-nautobot-mcp-v2/spec.md
+++ b/specs/027-nautobot-mcp-v2/spec.md
@@ -1,0 +1,186 @@
+# Feature Specification: Enhanced Nautobot MCP Server v2
+
+**Feature Branch**: `027-nautobot-mcp-v2`
+**Created**: 2026-04-09
+**Status**: Complete (base), Extended (virtualization tools added 2026-05-02)
+**Input**: User description: "Rewrite the Nautobot MCP server to use GraphQL for reads and REST API for writes, add device/interface/VLAN/prefix/cable queries, write operations with approval gating, and reconciliation between live device config and Nautobot source of truth. Target: Nautobot 3.1.0."
+
+## Context
+
+The existing mcp-nautobot (v1) provides 5 tools using the REST API: get_ip_addresses, get_prefixes, get_ip_address_by_id, search_ip_addresses, and test_connection. It covers only IPAM IP/prefix queries.
+
+The v2 server replaces v1 with a complete Nautobot integration:
+- **GraphQL API** (POST /api/graphql/) for all read operations — efficient field selection, nested relationships, single-request multi-entity queries
+- **REST API** (POST/PUT/PATCH to /api/dcim/*, /api/ipam/*) for all write operations — Nautobot 3.1.0 does not expose GraphQL mutations
+- Covers devices, interfaces, VLANs, prefixes, IP addresses, and cables
+- ITSM-gated write operations
+- Live-vs-SoT reconciliation using pyATS data
+
+### Nautobot 3.1.0 API Facts (verified against live instance at 192.168.3.253)
+
+- GraphQL via graphene_django 3.2.3 — queries only, no mutations
+- `locations` replaces the deprecated `site` field (Nautobot 3.x change)
+- REST API supports POST (create), PUT (replace), PATCH (partial update), DELETE on all DCIM/IPAM endpoints
+- Authentication: `Authorization: Token <token>` header on all requests
+- GraphQL filters support Django-style lookups (__ic, __isw, __re, etc.)
+- Pagination via `limit`/`offset` on GraphQL queries
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Query Devices and Interfaces (Priority: P1)
+
+As a network engineer, I want to query Nautobot for device inventory (devices, interfaces, IP assignments) using natural language so I can understand what the source of truth says about my network without navigating the Nautobot web UI.
+
+**Why this priority**: Device and interface queries are the foundational read operations. Every other capability (writes, reconciliation) depends on being able to read the current SoT state. The existing v1 server only covers IP addresses and prefixes — devices and interfaces are the most critical gap.
+
+**Independent Test**: Can be fully tested by asking "show me all devices at location House" or "what interfaces does HomeSwitch01 have?" and verifying structured results return from Nautobot's GraphQL API.
+
+**Acceptance Scenarios**:
+
+1. **Given** Nautobot has device records, **When** the operator requests "show all devices", **Then** the system returns device name, role, platform, location, status, primary IP, and serial number for each device.
+2. **Given** Nautobot has interface records for a device, **When** the operator requests "show interfaces on HomeSwitch01", **Then** the system returns interface name, type, enabled state, status, description, MAC address, MTU, mode, untagged VLAN, tagged VLANs, and assigned IPs.
+3. **Given** a device name that does not exist in Nautobot, **When** the operator queries that device, **Then** the system returns a clear "not found" message rather than an error.
+4. **Given** Nautobot has multiple devices, **When** the operator queries with filters (location, role, platform, status), **Then** only matching devices are returned.
+
+---
+
+### User Story 2 - Query VLANs, Prefixes, IP Addresses, and Cables (Priority: P2)
+
+As a network engineer, I want to query Nautobot for VLANs, prefixes, IP addresses, and cable connections so I can verify Layer 2 segmentation, IP allocation, and physical topology against the source of truth.
+
+**Why this priority**: VLANs, prefixes, and cables complete the read-side picture. Prefixes and IPs exist in v1 but lack GraphQL efficiency and nested relationship data. VLANs and cables are new and essential for reconciliation (US5).
+
+**Independent Test**: Can be tested by asking "show VLANs at location House" or "show cables connected to HomeSwitch01" and verifying results.
+
+**Acceptance Scenarios**:
+
+1. **Given** Nautobot has VLAN records, **When** the operator requests "show all VLANs", **Then** the system returns VLAN ID (vid), name, status, locations, VLAN group, tenant, and role.
+2. **Given** Nautobot has prefix records, **When** the operator requests "show prefixes", **Then** the system returns prefix, status, locations, role, and tenant.
+3. **Given** Nautobot has IP address records, **When** the operator requests "show IP addresses on HomeSwitch01", **Then** the system returns address, status, DNS name, description, assigned interface, and VRF.
+4. **Given** Nautobot has cable records, **When** the operator requests "show cables", **Then** the system returns cable ID, type, status, label, and termination endpoints (device + interface on each side).
+5. **Given** a query for VLANs filtered by location, **When** no VLANs exist for that location, **Then** the system returns a clear "no VLANs found" message.
+
+---
+
+### User Story 3 - Create and Update Records with Approval Gating (Priority: P3)
+
+As a network engineer, I want to create and update Nautobot records (IP addresses, VLANs, prefixes, interfaces, cables) through natural language with ITSM approval gating so that the source of truth stays current while maintaining change control.
+
+**Why this priority**: Write operations are the key differentiator from v1 (read-only). They enable the agent to fix SoT drift discovered during reconciliation. However, reads must work first, and writes require careful safety controls. Writes use the REST API since Nautobot 3.1.0 has no GraphQL mutations.
+
+**Independent Test**: Can be tested in lab mode by asking "add VLAN 200 named Guest at location House" and verifying the record appears in Nautobot. Production mode requires a ServiceNow CR number.
+
+**Acceptance Scenarios**:
+
+1. **Given** ITSM is disabled (lab mode), **When** the operator requests "create IP address 10.0.1.50/24 on HomeSwitch01 GigabitEthernet1/0/1", **Then** the IP is created in Nautobot via REST API and confirmation is returned.
+2. **Given** ITSM is enabled, **When** the operator requests a write operation without a CR number, **Then** the operation is blocked with a message explaining that a ServiceNow CR is required.
+3. **Given** ITSM is enabled and a valid CR number is provided, **When** the operator requests "add VLAN 200 named Guest, CR CHG0012345", **Then** the VLAN is created and the CR number is logged in the audit trail.
+4. **Given** the operator requests creation of a record that already exists, **When** the REST API returns a conflict, **Then** the system returns a clear conflict message with the existing record details.
+5. **Given** the operator requests an update to a device field, **When** the REST API succeeds, **Then** the system returns both old and new values for the changed fields.
+
+---
+
+### User Story 4 - Raw GraphQL Query (Priority: P4)
+
+As a power user, I want to execute arbitrary GraphQL queries against Nautobot so I can access any data model — including custom fields, relationships, plugin models (BGP, golden config, firewall), and computed fields — without waiting for new tools to be added.
+
+**Why this priority**: A generic GraphQL tool provides escape-hatch flexibility for advanced users and future-proofs the server against Nautobot schema changes and plugin additions. Lower priority because the structured tools (US1-US2) cover 90% of use cases.
+
+**Independent Test**: Can be tested by passing a raw GraphQL query string and verifying the response matches Nautobot's GraphQL explorer output.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid GraphQL query string, **When** the operator invokes the raw query tool, **Then** the system returns the GraphQL response data as structured JSON.
+2. **Given** a GraphQL query with variables, **When** the operator provides both query and variables, **Then** the system correctly substitutes variables and returns results.
+3. **Given** an invalid GraphQL query, **When** the query is executed, **Then** the system returns the GraphQL error messages without exposing internal details.
+
+---
+
+### User Story 5 - Live Config vs. Nautobot Reconciliation (Priority: P5)
+
+As a network engineer, I want to compare live device state (from pyATS) against Nautobot's source of truth so I can identify drift — undocumented interfaces, IP mismatches, missing VLANs, stale cables — and optionally fix the SoT.
+
+**Why this priority**: Reconciliation is the highest-value workflow but depends on all previous stories (reads for Nautobot state, writes to fix drift). It also requires pyATS MCP to be functional for live device data. This is the capstone feature.
+
+**Independent Test**: Can be tested by asking "reconcile HomeSwitch01 interfaces against Nautobot" and verifying a diff report is generated showing matches, mismatches, and missing records.
+
+**Acceptance Scenarios**:
+
+1. **Given** pyATS can reach HomeSwitch01 and Nautobot has records for it, **When** the operator requests "reconcile HomeSwitch01 interfaces", **Then** the system returns a structured diff showing: interfaces in both (with field-level comparison), interfaces only on device, and interfaces only in Nautobot.
+2. **Given** a reconciliation finds IP address drift (device has 10.0.1.1/24 but Nautobot says 10.0.1.2/24), **When** the diff is presented, **Then** the mismatch is clearly flagged with both values and the operator can choose to update Nautobot.
+3. **Given** a reconciliation finds an interface on the device that is not in Nautobot, **When** the operator approves, **Then** the missing interface is created in Nautobot via REST API with data from the live device.
+4. **Given** ITSM is enabled, **When** reconciliation proposes SoT updates, **Then** all writes require CR approval before execution.
+
+---
+
+### Edge Cases
+
+- What happens when the Nautobot GraphQL endpoint is unreachable or returns a connection timeout?
+- How does the system handle GraphQL queries that exceed Nautobot's max query depth or complexity limits?
+- What happens when the API token has read-only permissions and a REST write is attempted?
+- How does the system handle Nautobot custom fields that vary between deployments?
+- What happens when reconciliation runs against a device that exists in pyATS testbed but not in Nautobot?
+- What happens when Nautobot returns paginated results exceeding the requested limit?
+- How does the system handle the Nautobot 3.x `locations` model (which replaced `sites`)?
+- What happens when a REST write requires a related object ID (e.g., status, role) that must be looked up first?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST use Nautobot's GraphQL API (POST to /api/graphql/) for all read operations.
+- **FR-002**: System MUST use Nautobot's REST API (POST/PATCH/DELETE to /api/dcim/*, /api/ipam/*) for all write operations, since Nautobot 3.1.0 does not expose GraphQL mutations.
+- **FR-003**: System MUST support querying devices with filtering by name, location, role, platform, status, and tenant.
+- **FR-004**: System MUST support querying interfaces with filtering by device, name, type, enabled state, and status.
+- **FR-005**: System MUST support querying VLANs with filtering by vid, name, location, VLAN group, and tenant.
+- **FR-006**: System MUST support querying prefixes with filtering by prefix, status, location, and tenant.
+- **FR-007**: System MUST support querying IP addresses with filtering by address, device, interface, status, and tenant.
+- **FR-008**: System MUST support querying cables with filtering by device and status.
+- **FR-009**: System MUST support a raw GraphQL query tool for arbitrary read queries.
+- **FR-010**: System MUST support creating and updating IP addresses, VLANs, prefixes, interfaces, and cables via REST API.
+- **FR-011**: All write operations MUST be gated by ITSM approval when ITSM_ENABLED is true. Lab mode (ITSM_LAB_MODE=true) bypasses gating.
+- **FR-012**: System MUST support reconciliation between live device state (via pyATS) and Nautobot records, producing a structured diff report.
+- **FR-013**: System MUST authenticate using a Nautobot API token via Authorization header, read from NAUTOBOT_TOKEN environment variable.
+- **FR-014**: System MUST handle API errors gracefully, returning descriptive messages without exposing credentials or internal details.
+- **FR-015**: System MUST support pagination via limit/offset parameters on all list queries.
+- **FR-016**: All connection credentials (NAUTOBOT_URL, NAUTOBOT_TOKEN) MUST be read from environment variables at runtime.
+- **FR-017**: System MUST log all operations to stderr for debugging.
+- **FR-018**: System MUST be backwards-compatible — the v2 server replaces v1 in openclaw.json with a superset of capabilities.
+- **FR-019**: System MUST use `locations` (not the deprecated `site`) for all location-based queries and writes, per Nautobot 3.x data model.
+- **FR-020**: For REST writes that require related object IDs (status, role, location), the system MUST look up the ID by name/slug automatically so the operator can use human-readable names.
+
+### Key Entities
+
+- **Device**: A network device in Nautobot with name, role, platform, location, status, primary IP, serial number, and custom fields.
+- **Interface**: A physical or virtual interface on a device with name, type, enabled state, status, description, MAC address, MTU, mode (ACCESS/TAGGED/TAGGED_ALL), untagged VLAN, tagged VLANs, and IP assignments.
+- **IP Address**: An IP address/prefix assigned to an interface with address, status, DNS name, description, and tenant.
+- **Prefix**: A network prefix in IPAM with prefix, status, locations, role, and tenant.
+- **VLAN**: A Layer 2 VLAN with vid, name, status, locations, VLAN group, tenant, and role.
+- **Cable**: A physical or logical connection between two endpoints (termination_a/b as device+interface pairs) with type, status, label, and color.
+- **Reconciliation Report**: A structured diff comparing live device state against Nautobot records, categorized as match/mismatch/device-only/nautobot-only.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Operators can query any Nautobot object type (device, interface, VLAN, prefix, IP, cable) and receive results within 3 seconds.
+- **SC-002**: Write operations correctly create/update Nautobot records when verified through the Nautobot web UI or subsequent read query.
+- **SC-003**: ITSM gating blocks 100% of write operations when enabled and no CR is provided.
+- **SC-004**: Reconciliation correctly identifies all interface/IP/VLAN differences between a live device and Nautobot when tested against HomeSwitch01/02.
+- **SC-005**: The raw GraphQL tool successfully executes any valid query that works in Nautobot's GraphQL explorer (/api/graphql/).
+- **SC-006**: All v1 capabilities (IP address queries, prefix queries, search, connection test) continue to work via the new tools.
+- **SC-007**: All artifact coherence checklist items are complete (README, install.sh, SOUL.md, SKILL.md, .env.example, TOOLS.md, config/openclaw.json, HUD).
+- **SC-008**: 100% of write operations are recorded in the GAIT audit trail.
+
+## Assumptions
+
+- Nautobot instance is running version 3.1.0 with GraphQL enabled (graphene_django 3.2.3, queries only).
+- The Nautobot API token has both read and write permissions. If the token is read-only, write operations will fail with a clear permission error.
+- Nautobot 3.1.0 does NOT expose GraphQL mutations — all writes go through the REST API.
+- Nautobot 3.x uses `locations` (not `sites`) — the v2 server must use the 3.x data model throughout.
+- pyATS MCP server is functional and can reach the same devices that are registered in Nautobot (required for reconciliation only).
+- The Nautobot instance at 192.168.3.253 is the target deployment with 3 devices (HomeSwitch01, HomeSwitch02, pfSense-FW01), 34 VLANs, 2 prefixes, and 2 cables.
+- ITSM gating follows the same pattern as other NetClaw write-capable MCP servers (ITSM_ENABLED, ITSM_LAB_MODE environment variables).
+- The v2 server replaces the v1 mcp-nautobot entry in openclaw.json — it is not an additional server.
+- Reconciliation compares interface names, IP addresses, enabled state, and description. VLAN assignment comparison is a stretch goal.
+- Installed Nautobot plugins (bgp_models, golden_config, firewall_models, igp_models, ssot, device_onboarding) are accessible via the raw GraphQL tool but do not get dedicated structured tools in v2.

--- a/specs/027-nautobot-mcp-v2/tasks.md
+++ b/specs/027-nautobot-mcp-v2/tasks.md
@@ -1,0 +1,263 @@
+# Tasks: Enhanced Nautobot MCP Server v2
+
+**Input**: Design documents from `/specs/027-nautobot-mcp-v2/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/mcp-tools.md, quickstart.md
+
+**Tests**: Not explicitly requested. Test tasks omitted.
+
+**Organization**: Tasks grouped by user story for independent implementation.
+
+## Format: `[ID] [P?] [Story] Description`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Project directory, dependencies, and skeleton
+
+- [x] T001 Create directory `mcp-servers/nautobot-mcp-v2/`
+- [x] T002 Create `mcp-servers/nautobot-mcp-v2/requirements.txt` with dependencies: mcp, httpx, python-dotenv
+- [x] T003 [P] Create skill directory `workspace/skills/nautobot-sot/`
+
+---
+
+## Phase 2: Foundational (Blocking)
+
+**Purpose**: Nautobot client and server skeleton — BLOCKS all user stories
+
+- [x] T004 Implement NautobotClient class in `mcp-servers/nautobot-mcp-v2/nautobot_client.py` with:
+  - Config from env vars (NAUTOBOT_URL, NAUTOBOT_TOKEN, NAUTOBOT_VERIFY_SSL, NAUTOBOT_TIMEOUT)
+  - httpx.AsyncClient setup with auth header, SSL config, timeout
+  - `graphql(query, variables)` method — POST to /api/graphql/ with JSON body, return data dict
+  - `rest_get(endpoint, params)` method — GET to /api/{endpoint}/, return response dict
+  - `rest_post(endpoint, data)` method — POST to /api/{endpoint}/, return response dict
+  - `rest_patch(endpoint_with_id, data)` method — PATCH to /api/{endpoint}/{id}/, return response dict
+  - `resolve_id(object_type, name)` method — GraphQL lookup to resolve human-readable name to UUID for status, role, location, device, namespace
+  - Error handling: connection errors, auth failures (401/403), timeouts, GraphQL errors. Never expose token in errors.
+- [x] T005 Create FastMCP server skeleton in `mcp-servers/nautobot-mcp-v2/server.py`:
+  - Initialize FastMCP("nautobot-mcp-v2"), configure logging to stderr
+  - Validate required env vars on startup (NAUTOBOT_URL, NAUTOBOT_TOKEN)
+  - Import and instantiate NautobotClient
+  - ITSM gating helper: `check_itsm(cr_number)` returns error string if blocked, None if allowed
+- [x] T006 [P] Implement `nautobot_test_connection` tool in `server.py` — call GraphQL `{ __typename }` and REST `/api/status/`, return connection status
+
+**Checkpoint**: Client can make authenticated GraphQL and REST requests. Server skeleton runs via stdio.
+
+---
+
+## Phase 3: User Story 1 — Query Devices and Interfaces (P1) 🎯 MVP
+
+**Goal**: Query devices and interfaces from Nautobot via GraphQL.
+
+**Independent Test**: `nautobot_get_devices()` returns HomeSwitch01, HomeSwitch02, pfSense-FW01.
+
+- [x] T007 [US1] Implement `nautobot_get_devices` tool in `server.py`:
+  - Build GraphQL query with fields: name, serial, status{name}, role{name}, platform{name}, location{name}, device_type{model, manufacturer{name}}, primary_ip4{address}, primary_ip6{address}, comments
+  - Apply filters: name, location, role, platform, status, q, limit, offset
+  - Format response with device count and data array
+- [x] T008 [US1] Implement `nautobot_get_interfaces` tool in `server.py`:
+  - Build GraphQL query with fields: name, type, enabled, status{name}, description, mac_address, mtu, mode, device{name}, untagged_vlan{vid,name}, tagged_vlans{vid,name}, ip_addresses{address}, label, lag{name}
+  - Apply filters: device, name, type, enabled, status, has_ip_addresses, limit, offset
+  - Format response with interface count and data array
+
+**Checkpoint**: US1 complete. Can query devices and interfaces.
+
+---
+
+## Phase 4: User Story 2 — Query VLANs, Prefixes, IPs, Cables (P2)
+
+**Goal**: Complete read coverage for all core Nautobot objects.
+
+- [x] T009 [P] [US2] Implement `nautobot_get_vlans` tool in `server.py`:
+  - GraphQL fields: vid, name, status{name}, locations{name}, vlan_group{name}, tenant{name}, role{name}, description
+  - Filters: vid, name, location, vlan_group, status, limit, offset
+- [x] T010 [P] [US2] Implement `nautobot_get_prefixes` tool in `server.py`:
+  - GraphQL fields: prefix, status{name}, locations{name}, role{name}, tenant{name}, description
+  - Filters: prefix, status, location, tenant, limit, offset
+- [x] T011 [P] [US2] Implement `nautobot_get_ip_addresses` tool in `server.py`:
+  - GraphQL fields: address, status{name}, dns_name, description, tenant{name}, ip_address_assignments{interface{name, device{name}}}
+  - Filters: address, status, q, limit, offset
+  - Note: device/interface filtering requires post-query filtering on interface_assignments or using the q search
+- [x] T012 [P] [US2] Implement `nautobot_get_cables` tool in `server.py`:
+  - GraphQL fields: id, type, status{name}, label, color, length, length_unit, termination_a_type, termination_a_id, termination_b_type, termination_b_id
+  - Filters: status, limit, offset
+  - Resolve termination UUIDs to device+interface names via additional GraphQL query
+  - Device filter: post-query filter on resolved endpoint names
+
+**Checkpoint**: US2 complete. Full read coverage for devices, interfaces, VLANs, prefixes, IPs, cables.
+
+---
+
+## Phase 5: User Story 3 — Write Operations with ITSM Gating (P3)
+
+**Goal**: Create and update Nautobot records via REST API with ITSM approval gating.
+
+- [x] T013 [US3] Implement `nautobot_create_ip_address` tool in `server.py`:
+  - Check ITSM gating via `check_itsm(cr_number)`
+  - Resolve status name to UUID via `resolve_id("status", status)`
+  - Resolve namespace name to UUID via `resolve_id("namespace", namespace)`
+  - POST to /api/ipam/ip-addresses/ with {address, status, namespace, dns_name, description, tenant}
+  - If device+interface provided: resolve device+interface to interface UUID, then POST to /api/ipam/ip-address-to-interface/ to create assignment
+  - Return created IP details
+- [x] T014 [P] [US3] Implement `nautobot_create_vlan` tool in `server.py`:
+  - Check ITSM gating
+  - Resolve status, location UUIDs
+  - POST to /api/ipam/vlans/ with {vid, name, status, description, tenant}
+  - If location provided: POST to /api/ipam/vlan-location-assignments/ to associate
+  - Return created VLAN details
+- [x] T015 [P] [US3] Implement `nautobot_create_prefix` tool in `server.py`:
+  - Check ITSM gating
+  - Resolve status, namespace UUIDs
+  - POST to /api/ipam/prefixes/ with {prefix, status, namespace, description, tenant}
+  - Return created prefix details
+- [x] T016 [US3] Implement `nautobot_update_object` tool in `server.py`:
+  - Check ITSM gating
+  - Resolve object to UUID based on object_type + identifier:
+    - device: GraphQL lookup by name
+    - interface: GraphQL lookup by device name + interface name
+    - ip_address: GraphQL lookup by address
+    - vlan: GraphQL lookup by vid
+    - prefix: GraphQL lookup by prefix
+    - cable: direct UUID
+  - GET current state via REST for old values
+  - PATCH to appropriate REST endpoint with updates JSON
+  - Return old + new values for changed fields
+
+**Checkpoint**: US3 complete. Can create IPs, VLANs, prefixes and update any object with ITSM gating.
+
+---
+
+## Phase 6: User Story 4 — Raw GraphQL (P4)
+
+**Goal**: Expose arbitrary GraphQL query capability.
+
+- [x] T017 [US4] Implement `nautobot_graphql` tool in `server.py`:
+  - Accept query string and optional variables JSON string
+  - Parse variables from JSON string if provided
+  - Call NautobotClient.graphql(query, variables)
+  - Return raw GraphQL response data
+  - Handle GraphQL errors (return error messages, not stack traces)
+
+**Checkpoint**: US4 complete. Power users can run any GraphQL query.
+
+---
+
+## Phase 7: User Story 5 — Reconciliation (P5)
+
+**Goal**: Compare live device state against Nautobot SoT.
+
+- [x] T018 [US5] Create reconciliation engine in `mcp-servers/nautobot-mcp-v2/reconcile.py`:
+  - `reconcile_interfaces(nautobot_interfaces, live_interfaces)` function
+  - Match by interface name (case-insensitive)
+  - Compare fields: enabled, description, mtu, ip_addresses
+  - Categorize: matches, mismatches (with per-field diffs), device_only, nautobot_only
+  - Return ReconciliationReport dict
+- [x] T019 [US5] Implement `nautobot_reconcile` tool in `server.py`:
+  - Accept device_name and live_interfaces (JSON string)
+  - Parse live_interfaces JSON
+  - Query Nautobot interfaces for device via GraphQL
+  - Call reconcile_interfaces() from reconcile.py
+  - Return structured diff report with summary
+
+**Checkpoint**: US5 complete. Can reconcile live device state against Nautobot.
+
+---
+
+## Phase 7b: Virtualization (Post-MVP Extension)
+
+**Goal**: Manage virtual machines in Nautobot for tracking containers, VMs, and cloud instances.
+
+- [x] T030 [P] Add `cluster` and `virtual_machine` to resolve_id query map in `nautobot_client.py`
+- [x] T031 Implement `nautobot_get_virtual_machines` tool in `server.py`:
+  - GraphQL fields: id, name, status{name}, role{name}, cluster{name}, vcpus, memory, disk, comments, primary_ip4{address}, interfaces{name, enabled, mac_address, ip_addresses{address}}
+  - Filters: name, cluster, role, status, limit, offset
+- [x] T032 Implement `nautobot_create_virtual_machine` tool in `server.py`:
+  - Check ITSM gating
+  - Resolve status, cluster, role UUIDs
+  - POST to /api/virtualization/virtual-machines/
+  - Return created VM details
+- [x] T033 [P] Implement `nautobot_create_vm_interface` tool in `server.py`:
+  - Check ITSM gating
+  - Resolve virtual_machine UUID
+  - POST to /api/virtualization/interfaces/
+  - Return created interface details
+- [x] T034 Implement `nautobot_assign_ip_to_vm` tool in `server.py`:
+  - Check ITSM gating
+  - Create IP address via REST
+  - Resolve VM interface via GraphQL (vm_interfaces query)
+  - POST to /api/ipam/ip-address-to-interface/ with vm_interface
+  - Optionally PATCH VM to set primary_ip4
+  - Return assignment confirmation
+
+**Checkpoint**: Can create VMs, interfaces, and assign IPs. Used by deploy-observability skill to register containers in Nautobot.
+
+---
+
+## Phase 8: Polish & Artifact Coherence
+
+**Purpose**: Documentation, configuration, and artifact coherence.
+
+- [x] T020 [P] Create `mcp-servers/nautobot-mcp-v2/README.md` with tool inventory (13 tools), env vars, transport, install instructions, examples
+- [x] T021 [P] Create `workspace/skills/nautobot-sot/SKILL.md` with purpose, tools used, workflow steps, env vars
+- [x] T022 [P] Update `.env.example` with NAUTOBOT_URL, NAUTOBOT_TOKEN, NAUTOBOT_VERIFY_SSL, NAUTOBOT_TIMEOUT, ITSM_ENABLED, ITSM_LAB_MODE
+- [x] T023 [P] Update `workspace-override/TOOLS.md` with nautobot-mcp-v2 entry (32 tools)
+- [x] T024 [P] Update `workspace-override/SOUL.md` with nautobot-sot skill and v2 capabilities
+- [x] T025 [P] Update `README.md` with v2 description, updated tool/skill counts
+- [x] T026 Update `config/openclaw.json` to point nautobot-mcp at v2 server.py with new env vars
+- [x] T027 [P] Update `scripts/install.sh` with v2 dependency installation
+- [x] T028 [P] Update `ui/netclaw-visual/` HUD with updated Nautobot node (v2 capabilities)
+- [x] T029 [P] Update `Dockerfile` to install v2 requirements and copy v2 server files
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies
+- **Foundational (Phase 2)**: Depends on Setup — BLOCKS all user stories
+- **US1 (Phase 3)**: Depends on Foundational. MVP target.
+- **US2 (Phase 4)**: Depends on Foundational. Can run in parallel with US1.
+- **US3 (Phase 5)**: Depends on Foundational (needs resolve_id). Can start after Phase 2.
+- **US4 (Phase 6)**: Depends on Foundational only. Can run in parallel with US1-US3.
+- **US5 (Phase 7)**: Depends on US1 (needs interface query). Should follow Phase 3.
+- **Polish (Phase 8)**: Depends on all user stories.
+
+### Parallel Opportunities
+
+- T001, T002, T003 (Setup) — all parallel
+- T004 and T006 partially parallel (T006 needs client from T004)
+- T009, T010, T011, T012 (US2 tools) — all parallel
+- T013, T014, T015 (US3 create tools) — T014 and T015 parallel, T013 first (establishes pattern)
+- T017 (US4) — independent of US1-US3
+- All Phase 8 tasks marked [P] — parallel
+
+## Implementation Strategy
+
+### MVP First (US1 Only)
+
+1. Phase 1: Setup (T001-T003)
+2. Phase 2: Foundational (T004-T006)
+3. Phase 3: US1 — devices + interfaces (T007-T008)
+4. **STOP and VALIDATE**: Test against live Nautobot at 192.168.3.253
+5. Deploy if ready
+
+### Incremental Delivery
+
+1. Setup + Foundational → Foundation ready
+2. US1 (devices + interfaces) → MVP!
+3. US2 (VLANs + prefixes + IPs + cables) → Full read coverage
+4. US3 (writes with ITSM) → SoT management
+5. US4 (raw GraphQL) → Power user escape hatch
+6. US5 (reconciliation) → Capstone workflow
+7. Phase 8 (Polish) → Feature complete
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- v2 server lives in new directory; v1 preserved for reference
+- openclaw.json entry name stays "nautobot-mcp" — just points to new server
+- ITSM defaults: ITSM_ENABLED=false, ITSM_LAB_MODE=true (safe for home lab)
+- All GraphQL queries verified working against live Nautobot 3.1.0 at 192.168.3.253

--- a/specs/028-nautobot-golden-config-mcp/spec.md
+++ b/specs/028-nautobot-golden-config-mcp/spec.md
@@ -1,0 +1,180 @@
+# Feature Specification: nautobot-golden-config-mcp
+
+**Spec**: `028-nautobot-golden-config-mcp`
+**Created**: 2026-04-09 (originally golden-config-bootstrap skill)
+**Updated**: 2026-05-10 (rewritten as standalone MCP server)
+**Status**: In Progress
+**Server Location**: `mcp-servers/nautobot-golden-config-mcp/server.py`
+
+## Context
+
+The Nautobot Golden Config plugin is the config management engine for the lab. It generates intended configs from Jinja templates + config contexts, pulls backups from devices, diffs them for compliance, and can remediate drift.
+
+Currently, the golden config tools are scattered across `nautobot-mcp-v2` (read tools) and the `golden-config-bootstrap` skill (orchestration logic). The LLM burns excessive context navigating raw Nautobot APIs to accomplish config lifecycle tasks.
+
+**This spec defines a standalone MCP server** (`nautobot-golden-config-mcp`) that provides high-level, purpose-built tools for the config lifecycle pipeline. The LLM calls one tool instead of 10+ API calls.
+
+## Design Principles
+
+1. **One tool = one workflow step** — no multi-call sequences for common operations
+2. **Nautobot is the engine** — this MCP server orchestrates Nautobot's golden config jobs, it doesn't bypass them
+3. **PyATS is for verification only** — config pushes go through Nautobot's Nornir/NAPALM backend, not direct pyATS
+4. **Idempotent** — calling a tool twice with the same params produces the same result
+5. **SoT-first** — tools that modify config contexts or templates update Nautobot first, then trigger regeneration
+
+## Tools
+
+### Config Lifecycle (Core Pipeline)
+
+| Tool | Purpose | Nautobot Action |
+|------|---------|-----------------|
+| `golden_config_generate_intended` | Render intended config for device(s) from templates + SoT data | Triggers IntendedJob |
+| `golden_config_backup` | Pull running config from device(s) into Nautobot | Triggers BackupJob |
+| `golden_config_compliance` | Compare intended vs backup, produce compliance results | Triggers ComplianceJob |
+| `golden_config_remediate` | Push intended config to non-compliant device(s) to fix drift | Triggers ConfigPlanDeploy or direct push |
+| `golden_config_full_pipeline` | Run all three (intended → backup → compliance) in sequence for device(s) | Triggers all three jobs sequentially |
+
+### Config Inspection
+
+| Tool | Purpose | Returns |
+|------|---------|---------|
+| `golden_config_get_intended` | Get the rendered intended config for a device | The full intended config text |
+| `golden_config_get_backup` | Get the latest backup config for a device | The full backup config text |
+| `golden_config_get_compliance_diff` | Get the compliance diff for a device (what's different) | Per-feature diffs: missing lines, extra lines, ordered/unordered |
+| `golden_config_get_compliance_summary` | Get compliance status across all devices or filtered | Table: device, feature, compliant (yes/no), last run |
+
+### Template Management
+
+| Tool | Purpose | Returns |
+|------|---------|---------|
+| `golden_config_get_templates` | List templates that apply to a device (based on platform/role) | Template file paths and content |
+| `golden_config_render_preview` | Render a template with a device's config context (dry run, no save) | The rendered config text |
+| `golden_config_update_template` | Update a template file in the git repo | Commits the change via GitHub MCP or direct git |
+
+### Config Context Management
+
+| Tool | Purpose | Returns |
+|------|---------|---------|
+| `golden_config_get_device_context` | Get the merged config context as templates see it | Full merged dict |
+| `golden_config_update_device_context` | Update a device-specific config context | Updates the config context in Nautobot |
+| `golden_config_add_context_key` | Add a key to a config context (e.g., add `ip_sla` block to observability context) | Updated context |
+
+### Setup & Wiring
+
+| Tool | Purpose | Returns |
+|------|---------|---------|
+| `golden_config_get_settings` | Get the current golden config settings (repos, paths, SoT query) | Settings object |
+| `golden_config_create_compliance_feature` | Create a compliance feature (e.g., 'observability', 'bgp', 'ospf') | Feature ID |
+| `golden_config_create_compliance_rule` | Create a compliance rule linking feature to platform with match_config | Rule ID |
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `NAUTOBOT_URL` | Yes | `http://localhost:8080` | Nautobot instance URL |
+| `NAUTOBOT_TOKEN` | Yes | — | Nautobot API token |
+| `NAUTOBOT_TIMEOUT` | No | `60` | API request timeout (seconds) |
+| `GOLDEN_CONFIG_POLL_INTERVAL` | No | `5` | Seconds between job status polls |
+| `GOLDEN_CONFIG_JOB_TIMEOUT` | No | `300` | Max seconds to wait for a job to complete |
+
+## Server Structure
+
+```
+mcp-servers/nautobot-golden-config-mcp/
+├── server.py              # FastMCP server with all tools
+├── nautobot_client.py     # Shared Nautobot REST/GraphQL client
+├── job_runner.py          # Job trigger + poll-until-complete logic
+├── requirements.txt       # httpx, fastmcp, mcp
+└── __init__.py
+```
+
+## Key Implementation Details
+
+### Job Runner Pattern
+
+Golden config operations are async jobs in Nautobot. The pattern:
+1. POST to `/api/extras/jobs/<job-id>/run/` with device filter
+2. Poll `/api/extras/job-results/<result-id>/` until status is "completed" or "failed"
+3. Return the result
+
+```python
+async def run_job_and_wait(job_class_path: str, data: dict, timeout: int = 300) -> dict:
+    """Trigger a Nautobot job and wait for completion."""
+    # Find job by class_path
+    # POST to run endpoint
+    # Poll until complete or timeout
+    # Return result
+```
+
+### Device Filtering
+
+Most tools accept an optional `device` parameter. When provided:
+- Filter by device name for single-device operations
+- When omitted, operate on all devices in the golden config scope
+
+### Compliance Diff Format
+
+The compliance diff should be human-readable:
+```
+Device: RR1
+Feature: observability
+Status: NON-COMPLIANT
+
+Missing (should be on device but isn't):
++ logging trap informational
+
+Extra (on device but not in intended):
+- logging host 192.168.220.200 transport udp port 1514
+```
+
+## Relationship to Other MCP Servers
+
+| Server | Responsibility |
+|--------|---------------|
+| `nautobot-mcp-v2` | SoT CRUD: devices, interfaces, IPs, BGP, VLANs, config contexts (create/read/update) |
+| `nautobot-golden-config-mcp` | Config lifecycle: generate intended, backup, compliance, remediate, template management |
+| `pyATS MCP` | Ad-hoc show commands, troubleshooting, verification (NOT config pushes) |
+
+## Migration from nautobot-mcp-v2
+
+These tools currently in nautobot-mcp-v2 should be **deprecated** (kept for backward compat) and replaced by this server:
+
+- `nautobot_get_golden_configs` → `golden_config_get_intended` / `golden_config_get_backup`
+- `nautobot_get_config_compliance` → `golden_config_get_compliance_summary`
+- `nautobot_get_compliance_rules` → `golden_config_get_settings`
+- `nautobot_get_golden_config_settings` → `golden_config_get_settings`
+- `nautobot_create_compliance_feature` → `golden_config_create_compliance_feature`
+- `nautobot_create_compliance_rule` → `golden_config_create_compliance_rule`
+- `nautobot_update_golden_config_setting` → `golden_config_get_settings` (read) + direct update
+- `nautobot_render_device_config` → `golden_config_render_preview`
+- `nautobot_get_device_config_context` → `golden_config_get_device_context`
+
+## Success Criteria
+
+- **SC-001**: LLM can run the full config pipeline (intended → backup → compliance) in 3 tool calls or fewer
+- **SC-002**: LLM can check compliance status for a device in 1 tool call
+- **SC-003**: LLM can view the compliance diff (what's wrong) in 1 tool call
+- **SC-004**: LLM can remediate a non-compliant device in 1 tool call
+- **SC-005**: LLM can preview what a template renders for a device in 1 tool call
+- **SC-006**: LLM can update a config context and regenerate intended config in 2 tool calls
+- **SC-007**: No more than 200 tokens of context burned per golden config operation (vs 2000+ currently)
+
+## Workflow Example: Fix Syslog Drift
+
+Before (current — LLM spirals through 15+ calls):
+```
+nautobot_graphql → find device → nautobot_get_golden_configs → parse response →
+nautobot_get_config_compliance → parse → figure out what's wrong → nautobot_run_job →
+poll job → poll again → get result → parse compliance → ...
+```
+
+After (with this MCP server):
+```
+golden_config_get_compliance_diff(device="RR1")
+→ "RR1 missing: logging trap informational"
+
+golden_config_remediate(device="RR1")
+→ "Pushed intended config. RR1 now compliant."
+```
+
+Two calls. Done.

--- a/specs/028-nautobot-golden-config-mcp/tasks.md
+++ b/specs/028-nautobot-golden-config-mcp/tasks.md
@@ -1,0 +1,99 @@
+# Tasks: nautobot-golden-config-mcp
+
+**Input**: `specs/028-nautobot-golden-config-mcp/spec.md`
+**Output**: `mcp-servers/nautobot-golden-config-mcp/`
+**Prerequisites**: Nautobot running with golden config plugin, git repos registered
+
+---
+
+## Phase 1: Server Scaffold
+
+- [x] T001 Create `mcp-servers/nautobot-golden-config-mcp/` directory structure
+- [x] T002 Create `server.py` with FastMCP scaffold, env var loading, logging
+- [x] T003 Create `nautobot_client.py` — shared async HTTP client (REST + GraphQL) with auth
+- [x] T004 Create `job_runner.py` — trigger job + poll-until-complete pattern
+- [x] T005 Create `requirements.txt` (httpx, fastmcp, mcp)
+- [x] T006 Register in `config/openclaw.json` with `.venv/bin/python3` path
+
+**Checkpoint**: Server starts, connects to Nautobot, no tools yet.
+
+---
+
+## Phase 2: Config Lifecycle Tools (Core)
+
+- [x] T007 Implement `golden_config_generate_intended(device=)` — triggers IntendedJob, waits, returns status
+- [x] T008 Implement `golden_config_backup(device=)` — triggers BackupJob, waits, returns status
+- [x] T009 Implement `golden_config_compliance(device=)` — triggers ComplianceJob, waits, returns summary
+- [x] T010 Implement `golden_config_full_pipeline(device=)` — runs intended → backup → compliance in sequence
+- [x] T011 Implement `golden_config_remediate(device=)` — pushes intended config to fix drift
+
+**Checkpoint**: LLM can run the full pipeline in 1-3 tool calls. SC-001 met.
+
+---
+
+## Phase 3: Config Inspection Tools
+
+- [x] T012 Implement `golden_config_get_intended(device=)` — returns rendered intended config text
+- [x] T013 Implement `golden_config_get_backup(device=)` — returns latest backup config text
+- [x] T014 Implement `golden_config_get_compliance_diff(device=)` — returns per-feature diffs (missing/extra lines)
+- [x] T015 Implement `golden_config_get_compliance_summary(device=, feature=)` — returns compliance table
+
+**Checkpoint**: LLM can inspect compliance state in 1 call. SC-002, SC-003 met.
+
+---
+
+## Phase 4: Template & Context Tools
+
+- [x] T016 Implement `golden_config_get_templates(device=)` — lists templates for a device's platform/role
+- [x] T017 Implement `golden_config_render_preview(device=)` — renders template with device context (no save)
+- [x] T018 Implement `golden_config_get_device_context(device=)` — returns merged config context
+- [x] T019 Implement `golden_config_update_device_context(device=, key=, value=)` — updates a config context key
+- [x] T020 Implement `golden_config_update_template(path=, content=)` — commits template change to git
+
+**Checkpoint**: LLM can preview and modify templates/contexts. SC-005, SC-006 met.
+
+---
+
+## Phase 5: Setup Tools
+
+- [x] T021 Implement `golden_config_get_settings()` — returns current GC settings (repos, paths, query)
+- [x] T022 Implement `golden_config_create_compliance_feature(name=, description=)` — creates feature
+- [x] T023 Implement `golden_config_create_compliance_rule(feature=, platform=, match_config=)` — creates rule
+
+**Checkpoint**: LLM can set up golden config from scratch.
+
+---
+
+## Phase 6: Integration & Deprecation
+
+- [x] T024 Add deprecation warnings to golden config tools in nautobot-mcp-v2 (point to new server)
+- [x] T025 Update `workspace/skills/golden-config-bootstrap/SKILL.md` to reference new MCP server tools
+- [x] T026 Update `workspace/user/TOOLS.md` with golden config MCP server documentation
+- [x] T027 Test full pipeline: update config context → generate intended → compliance → remediate
+
+**Checkpoint**: End-to-end workflow works. SC-007 met (context burn < 200 tokens per operation).
+
+---
+
+## Phase 7: Observability Template Integration
+
+- [x] T028 Test: update observability config context (add mgmt_vrf) → regenerate intended → compliance shows drift → remediate pushes to all devices
+- [x] T029 Test: add new template section (ip_sla.j2) → regenerate → compliance detects missing IP SLA config → remediate deploys
+
+**T028 Results:** Context update → regenerate → compliance workflow verified end-to-end against live Nautobot. Context update correctly finds role-matched context with key-preference logic. Intended regeneration and compliance jobs complete in ~5s each. Drift detection requires template to reference the new key (expected — tools work, template authoring is separate).
+
+**T029 Results:** Full IP SLA workflow verified: create feature + rule → update context → prepare template → regenerate → compliance detects new feature (13 total). Compliance correctly reports compliant when both intended and backup are empty for the match pattern. Once template is committed to git via GitHub MCP, intended will render IP SLA config and compliance will detect drift against backup. All tools in the chain work correctly.
+
+**Checkpoint**: The syslog/SNMP/IP SLA deployment that currently requires manual Ansible runs can be done entirely through NetClaw + golden config MCP.
+
+---
+
+## Execution Order
+
+```
+Phase 1 (scaffold) → Phase 2 (core lifecycle) → Phase 3 (inspection) → Phase 4 (templates) → Phase 5 (setup) → Phase 6 (integration)
+                                                                                                                         ↓
+                                                                                                                   Phase 7 (test with observability)
+```
+
+Phase 2 is the highest value — once the LLM can run intended/backup/compliance/remediate in single calls, the config management workflow is unblocked.

--- a/specs/030-nautobot-routing-mcp/spec.md
+++ b/specs/030-nautobot-routing-mcp/spec.md
@@ -1,0 +1,294 @@
+# Feature Specification: nautobot-routing-mcp
+
+**Spec**: `030-nautobot-routing-mcp`
+**Created**: 2026-05-11
+**Status**: Planned
+**Server Location**: `mcp-servers/nautobot-routing-mcp/server.py`
+
+## Context
+
+The Nautobot BGP Models plugin has a deeply nested object graph:
+
+```
+AutonomousSystem
+  └─ RoutingInstance (per device)
+       ├─ PeerGroup
+       │    ├─ PeerGroupAddressFamily (afi_safi per group)
+       │    └─ PeerGroupTemplate
+       ├─ AddressFamily (afi_safi per instance)
+       └─ (linked via PeerEndpoint)
+
+Peering (abstract container — no device affinity)
+  ├─ PeerEndpoint A (local side)
+  │    ├─ routing_instance → device
+  │    ├─ source_ip / source_interface
+  │    ├─ peer_group
+  │    ├─ autonomous_system (remote AS override)
+  │    └─ PeerEndpointAddressFamily
+  └─ PeerEndpoint B (remote side)
+       └─ (same structure)
+```
+
+Creating a single BGP peering in Nautobot requires understanding this chain and making 5-8 API calls in the correct order. The LLM burns 2000+ tokens navigating this. The existing tools in nautobot-mcp-v2 (`nautobot_create_bgp_peering`, `nautobot_create_bgp_peer_group`, `nautobot_create_autonomous_system`) attempt to simplify this but use inconsistent patterns (old `client.get()`/`client.post()` methods) and don't cover the full model.
+
+The IGP Models plugin (OSPF) has a simpler but still multi-object model:
+```
+OSPFConfiguration (per device, process_id)
+  └─ OSPFInterfaceConfiguration (interface + area + cost)
+```
+
+**This spec defines a standalone MCP server** that provides high-level, one-call tools for routing protocol management in Nautobot.
+
+## Design Principles
+
+1. **One tool = one routing operation** — creating a peering is one call, not five
+2. **Topology-aware reads** — return the full routing picture for a device in one query
+3. **Relationship-aware writes** — tools handle the object chain internally
+4. **Reconciliation-ready** — tools that compare Nautobot model vs live device state
+5. **Idempotent** — creating a peering that already exists returns the existing one
+
+## Data Model (Nautobot BGP Models 2.3.2)
+
+### REST Endpoints (`/api/plugins/bgp/`)
+| Endpoint | Objects | Lab Count |
+|----------|---------|-----------|
+| `autonomous-systems` | ASN definitions | ~5 |
+| `routing-instances` | Per-device BGP process (device + ASN + router_id) | ~10 |
+| `peer-groups` | Peer group definitions (per routing instance) | ~10 |
+| `peer-group-templates` | Reusable peer group config templates | 0 |
+| `peerings` | Abstract peering container (status only) | 58 |
+| `peer-endpoints` | One side of a peering (routing_instance, source_ip, peer_group) | 116 |
+| `address-families` | AFI/SAFI per routing instance | 3 |
+| `peer-group-address-families` | AFI/SAFI per peer group | ~10 |
+| `peer-endpoint-address-families` | AFI/SAFI per endpoint | ~100 |
+
+### Key Relationships
+- A **Peering** has exactly 2 **PeerEndpoints** (A and B)
+- Each **PeerEndpoint** belongs to a **RoutingInstance** (which belongs to a device)
+- A **PeerEndpoint** optionally references a **PeerGroup**
+- **AddressFamilies** can be attached at instance, group, or endpoint level
+- The `peer` field on a PeerEndpoint points to the OTHER endpoint in the same Peering
+
+## Tools
+
+### BGP Topology (Read)
+
+| Tool | Purpose | Returns |
+|------|---------|---------|
+| `routing_get_bgp_summary(device=)` | Full BGP topology for a device: peers, groups, AFIs, ASNs | Structured summary like `show bgp summary` |
+| `routing_get_bgp_peers(device=)` | List all BGP peers for a device with remote AS, state, group | Peer table |
+| `routing_get_bgp_peer_detail(device, peer_ip)` | Full detail of a specific peering: both endpoints, AFIs, group | Complete peering object |
+| `routing_get_peer_groups(device=)` | List peer groups with member count, AFIs, templates | Group table |
+| `routing_get_autonomous_systems()` | List all ASNs in the model | ASN table |
+
+### BGP Write (ITSM-gated)
+
+| Tool | Purpose | Creates |
+|------|---------|---------|
+| `routing_create_peering(device, local_ip, peer_ip, peer_asn, peer_group=, afi=, description=)` | Create a complete BGP peering in one call | ASN (if new) + Peering + 2 Endpoints + AFIs |
+| `routing_delete_peering(device, peer_ip)` | Remove a peering and both endpoints | Deletes Peering + Endpoints |
+| `routing_create_peer_group(device, name, remote_asn=, source_interface=, afi=, route_map_in=, route_map_out=)` | Create a peer group with AFIs | PeerGroup + PeerGroupAddressFamilies |
+| `routing_delete_peer_group(device, name)` | Remove a peer group (fails if members exist) | Deletes PeerGroup |
+| `routing_add_peer_to_group(device, peer_ip, group)` | Move an existing peer into a group | Updates PeerEndpoint.peer_group |
+| `routing_remove_peer_from_group(device, peer_ip)` | Remove peer from its group | Clears PeerEndpoint.peer_group |
+| `routing_create_autonomous_system(asn, description=)` | Create or return existing ASN | AutonomousSystem |
+| `routing_create_routing_instance(device, asn, router_id=)` | Create BGP routing instance for a device | RoutingInstance |
+
+### OSPF Topology (Read)
+
+| Tool | Purpose | Returns |
+|------|---------|---------|
+| `routing_get_ospf_summary(device=)` | OSPF config for a device: process, areas, interfaces, costs | Structured summary |
+| `routing_get_ospf_interfaces(device=, area=)` | List OSPF-enabled interfaces with area, cost, timers | Interface table |
+
+### OSPF Write (ITSM-gated)
+
+| Tool | Purpose | Creates |
+|------|---------|---------|
+| `routing_create_ospf_instance(device, process_id, router_id=)` | Create OSPF process on a device | OSPFConfiguration |
+| `routing_add_ospf_interface(device, interface, area, cost=, network_type=)` | Add interface to OSPF | OSPFInterfaceConfiguration |
+| `routing_remove_ospf_interface(device, interface)` | Remove interface from OSPF | Deletes OSPFInterfaceConfiguration |
+
+### Reconciliation
+
+| Tool | Purpose | Returns |
+|------|---------|---------|
+| `routing_reconcile_bgp(device, live_peers)` | Compare Nautobot BGP model vs live peer data (from pyATS) | Drift report: missing peers, extra peers, ASN mismatches |
+| `routing_reconcile_ospf(device, live_neighbors)` | Compare Nautobot OSPF model vs live neighbor data | Drift report: missing interfaces, area mismatches |
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `NAUTOBOT_URL` | Yes | `http://localhost:8080` | Nautobot instance URL |
+| `NAUTOBOT_TOKEN` | Yes | — | Nautobot API token |
+| `NAUTOBOT_TIMEOUT` | No | `60` | API request timeout (seconds) |
+| `ITSM_ENABLED` | No | `false` | Require ServiceNow CR for writes |
+| `ITSM_LAB_MODE` | No | `true` | Bypass ITSM in lab mode |
+
+## Server Structure
+
+```
+mcp-servers/nautobot-routing-mcp/
+├── server.py              # FastMCP server with all tools
+├── nautobot_client.py     # Shared async HTTP client (same pattern as golden-config-mcp)
+├── bgp_helpers.py         # BGP object chain resolution helpers
+├── requirements.txt       # httpx, fastmcp, mcp
+└── __init__.py
+```
+
+## Key Implementation Details
+
+### BGP Peering Creation Chain
+
+```python
+async def _create_full_peering(device, local_ip, peer_ip, peer_asn, peer_group=None, afi="ipv4_unicast"):
+    """Create the full BGP peering object chain."""
+    # 1. Find or create remote ASN
+    asn_id = await _find_or_create_asn(peer_asn)
+    
+    # 2. Find local device's routing instance
+    instance_id = await _find_routing_instance(device)
+    
+    # 3. Find local and peer IP IDs
+    local_ip_id = await _find_ip(local_ip)
+    peer_ip_id = await _find_ip(peer_ip)  # may be None for external peers
+    
+    # 4. Find peer group if specified
+    pg_id = await _find_peer_group(device, peer_group) if peer_group else None
+    
+    # 5. Create the Peering container
+    peering_id = await _create_peering()
+    
+    # 6. Create Endpoint A (local)
+    ep_a_id = await _create_endpoint(peering_id, instance_id, local_ip_id, pg_id)
+    
+    # 7. Create Endpoint B (remote)
+    ep_b_id = await _create_endpoint(peering_id, None, peer_ip_id, asn_override=asn_id)
+    
+    # 8. Add address families to endpoint
+    await _add_endpoint_afi(ep_a_id, afi)
+    
+    return peering_id
+```
+
+### Idempotency Pattern
+
+All write tools check for existing objects before creating:
+```python
+# Check if peering already exists between these IPs
+existing = await _find_peering_by_ips(device, local_ip, peer_ip)
+if existing:
+    return {"status": "already_exists", "peering_id": existing["id"]}
+```
+
+### BGP Summary Query (Efficient)
+
+Instead of N+1 queries, use a single GraphQL query to get the full topology:
+```graphql
+{
+  bgp_routing_instances(device: "RR1") {
+    device { name }
+    autonomous_system { asn }
+    router_id { address }
+    peer_groups { name autonomous_system { asn } }
+    endpoints {
+      source_ip { address }
+      peer { source_ip { address } }
+      peer_group { name }
+      autonomous_system { asn }
+      enabled
+    }
+  }
+}
+```
+
+### Reconciliation Format
+
+```json
+{
+  "device": "RR1",
+  "nautobot_peers": 12,
+  "live_peers": 10,
+  "drift": {
+    "in_nautobot_not_live": [
+      {"peer_ip": "10.255.255.1", "asn": 65099, "status": "documented but not established"}
+    ],
+    "in_live_not_nautobot": [
+      {"peer_ip": "192.168.1.1", "asn": 64512, "status": "undocumented peer"}
+    ],
+    "asn_mismatch": [],
+    "group_mismatch": []
+  }
+}
+```
+
+## Relationship to Other MCP Servers
+
+| Server | Responsibility |
+|--------|---------------|
+| `nautobot-mcp-v2` | Generic SoT CRUD (devices, interfaces, IPs, VLANs). BGP/OSPF read tools deprecated → point here |
+| `nautobot-routing-mcp` | Routing protocol model management (BGP peerings, OSPF, reconciliation) |
+| `nautobot-golden-config-mcp` | Config lifecycle (templates render FROM the routing model, this server manages the model) |
+| `protocol-mcp` | Live BGP/OSPF participation (scapy speakers). Uses routing-mcp to document peers in Nautobot |
+| `pyATS MCP` | Collect live state (`show bgp summary`, `show ip ospf neighbor`) for reconciliation input |
+
+## Migration from nautobot-mcp-v2
+
+These tools should be deprecated in nautobot-mcp-v2:
+
+| Current Tool | Replacement |
+|-------------|-------------|
+| `nautobot_get_bgp_routing` | `routing_get_bgp_summary` |
+| `nautobot_get_autonomous_systems` | `routing_get_autonomous_systems` |
+| `nautobot_get_ospf_routing` | `routing_get_ospf_summary` |
+| `nautobot_create_bgp_peering` | `routing_create_peering` |
+| `nautobot_create_autonomous_system` | `routing_create_autonomous_system` |
+| `nautobot_create_bgp_peer_group` | `routing_create_peer_group` |
+
+Also remove from `_OBJECT_REGISTRY`:
+- `autonomous_system`
+- `bgp_routing_instance`
+- `bgp_peer_group`
+- `bgp_peering`
+
+(Keep in registry for `nautobot_delete` backward compat, but add deprecation notes.)
+
+## Success Criteria
+
+- **SC-001**: LLM can create a full BGP peering (ASN + peering + endpoints + AFI) in 1 tool call
+- **SC-002**: LLM can get the complete BGP topology for a device in 1 tool call
+- **SC-003**: LLM can reconcile Nautobot BGP model vs live state in 1 tool call (given pyATS output)
+- **SC-004**: LLM can manage peer groups (create, add/remove members) in 1 tool call each
+- **SC-005**: LLM can add/remove OSPF interfaces in 1 tool call
+- **SC-006**: Idempotent — creating an existing peering returns it without error
+- **SC-007**: No more than 200 tokens of context burned per routing operation
+
+## Workflow Examples
+
+### Before (nautobot-mcp-v2 — 8+ calls, LLM confusion):
+```
+nautobot_graphql → find routing instance → nautobot_get_autonomous_systems → 
+nautobot_create_autonomous_system → nautobot_graphql → find IPs →
+nautobot_create_bgp_peering → (fails on missing field) → retry → ...
+```
+
+### After (nautobot-routing-mcp — 1 call):
+```
+routing_create_peering(device="RR1", local_ip="10.255.255.2/30", 
+                       peer_ip="10.255.255.1/30", peer_asn=65099,
+                       peer_group="NETCLAW-PEERS", afi="ipv4_unicast")
+→ {"created": true, "peering_id": "...", "endpoints": [...]}
+```
+
+### Reconciliation workflow:
+```
+# Step 1: Get live state via pyATS
+pyats_run_command(device="RR1", command="show bgp summary")
+
+# Step 2: Compare against Nautobot model
+routing_reconcile_bgp(device="RR1", live_peers='[{"ip":"10.0.0.1","asn":65001,"state":"Established"},...]')
+
+# Step 3: Fix drift
+routing_create_peering(device="RR1", local_ip="...", peer_ip="10.0.0.5", peer_asn=65005)
+```

--- a/specs/030-nautobot-routing-mcp/tasks.md
+++ b/specs/030-nautobot-routing-mcp/tasks.md
@@ -1,0 +1,102 @@
+# Tasks: nautobot-routing-mcp
+
+**Input**: `specs/030-nautobot-routing-mcp/spec.md`
+**Output**: `mcp-servers/nautobot-routing-mcp/`
+**Prerequisites**: Nautobot running with BGP Models + IGP Models plugins, lab devices with BGP/OSPF
+
+---
+
+## Phase 1: Server Scaffold
+
+- [x] T001 Create `mcp-servers/nautobot-routing-mcp/` directory structure
+- [x] T002 Create `server.py` with FastMCP scaffold, env var loading, logging
+- [x] T003 Create `nautobot_client.py` — shared async HTTP client (reuse pattern from golden-config-mcp)
+- [x] T004 Create `bgp_helpers.py` — BGP object chain resolution (find_or_create_asn, find_routing_instance, find_peering_by_ips)
+- [x] T005 Create `requirements.txt` (httpx, fastmcp, mcp)
+- [x] T006 Register in `config/openclaw.json` with `.venv/bin/python3` path
+- [x] T007 Add to `.gitignore` exceptions
+
+**Checkpoint**: Server starts, connects to Nautobot, no tools yet.
+
+---
+
+## Phase 2: BGP Read Tools
+
+- [x] T008 Implement `routing_get_bgp_summary(device=)` — full BGP topology via single GraphQL query
+- [x] T009 Implement `routing_get_bgp_peers(device=)` — peer table with remote AS, source IP, group, enabled
+- [x] T010 Implement `routing_get_bgp_peer_detail(device, peer_ip)` — both endpoints, AFIs, full peering object
+- [x] T011 Implement `routing_get_peer_groups(device=)` — groups with member count, AFIs
+- [x] T012 Implement `routing_get_autonomous_systems()` — all ASNs in the model
+
+**Checkpoint**: LLM can get complete BGP topology in 1 call. SC-002 met.
+
+---
+
+## Phase 3: BGP Write Tools
+
+- [x] T013 Implement `routing_create_autonomous_system(asn, description=)` — idempotent ASN creation
+- [x] T014 Implement `routing_create_routing_instance(device, asn, router_id=)` — idempotent instance creation
+- [x] T015 Implement `routing_create_peering(device, local_ip, peer_ip, peer_asn, peer_group=, afi=, description=)` — full chain in one call
+- [x] T016 Implement `routing_delete_peering(device, peer_ip)` — find and delete peering + endpoints
+- [x] T017 Implement `routing_create_peer_group(device, name, remote_asn=, source_interface=, afi=)` — group + AFIs
+- [x] T018 Implement `routing_delete_peer_group(device, name)` — delete group (fail if members)
+- [x] T019 Implement `routing_add_peer_to_group(device, peer_ip, group)` — update endpoint's peer_group
+- [x] T020 Implement `routing_remove_peer_from_group(device, peer_ip)` — clear endpoint's peer_group
+
+**Checkpoint**: LLM can create full peering in 1 call. SC-001, SC-004, SC-006 met.
+
+---
+
+## Phase 4: OSPF Tools
+
+- [-] T021-T025 SKIPPED — IGP Models plugin not installed in lab. OSPF tools deferred.
+
+**Note**: OSPF is configured on devices via golden config templates, but the Nautobot IGP Models plugin is not deployed. These tools can be added when the plugin is installed.
+
+---
+
+## Phase 5: Reconciliation Tools
+
+- [x] T026 Implement `routing_reconcile_bgp(device, live_peers)` — compare model vs pyATS output
+- [-] T027 SKIPPED — routing_reconcile_ospf deferred (no IGP Models plugin)
+
+**Checkpoint**: LLM can detect routing drift in 1 call. SC-003 met.
+
+---
+
+## Phase 6: Integration & Deprecation
+
+- [x] T028 Registered in openclaw.json and .gitignore
+- [ ] T029 Update `workspace/user/TOOLS.md` with routing MCP server documentation
+- [ ] T030 Test: create peering for NetClaw Protocol MCP (RR1 ↔ 10.255.255.1, AS 65099)
+- [x] T031 Test: reconcile BGP for RR1 against simulated live peer data
+- [-] T032 SKIPPED — no IGP Models plugin
+
+**Checkpoint**: End-to-end workflows verified. SC-007 met.
+
+---
+
+## Execution Order
+
+```
+Phase 1 (scaffold) → Phase 2 (BGP reads) → Phase 3 (BGP writes) → Phase 4 (OSPF) → Phase 5 (reconciliation) → Phase 6 (integration)
+```
+
+Phase 2+3 are highest value — once the LLM can read and write BGP peerings in single calls, the Protocol MCP ↔ Nautobot SoT workflow is unblocked.
+
+---
+
+## Test Data (Lab)
+
+The Nautobot Workshop lab has:
+- **58 peerings** across 10 IOS devices (iBGP via RR1, eBGP PE↔CE)
+- **116 peer endpoints** (2 per peering)
+- **~5 ASNs** (65000 for SP, 65001/65002 for CEs, 65099 for NetClaw)
+- **OSPF** on all SP core devices (P1-P4, PE1-PE3, RR1) in area 0
+- **EVPN/VXLAN** BGP on DC fabric (separate from SP BGP)
+
+Good test cases:
+- `routing_get_bgp_summary(device="RR1")` — should show all iBGP clients + NetClaw eBGP peer
+- `routing_create_peering(device="RR1", local_ip="10.255.255.2/30", peer_ip="10.255.255.1/30", peer_asn=65099)` — NetClaw peering
+- `routing_reconcile_bgp(device="PE1", live_peers=...)` — compare model vs live
+- `routing_get_ospf_interfaces(device="P1")` — should show all P1 OSPF interfaces in area 0


### PR DESCRIPTION
Three purpose-built MCP servers for Nautobot integration:

## nautobot-mcp-v2 (32 tools)
GraphQL reads + REST writes for Nautobot 3.1.0. Covers devices, interfaces, VLANs, prefixes, IPs, cables, config contexts, BGP/OSPF models, firewall policies, virtualization, git repos, jobs, secrets, and generic CRUD. Includes Cisco design reference KB and interface reconciliation.

## nautobot-golden-config-mcp (17 tools)
Golden config lifecycle in single calls:
- Config Lifecycle: generate_intended, backup, compliance, full_pipeline, remediate
- Config Inspection: get_intended, get_backup, get_compliance_diff, get_compliance_summary
- Template & Context: get_templates, render_preview, get/update_device_context, update_template
- Setup: get_settings, create_compliance_feature, create_compliance_rule

Tested against Nautobot 2.4.10 + golden config 2.5.1. Full pipeline (intended -> backup -> compliance) completes in ~15s per device.

## nautobot-routing-mcp (14 tools)
BGP model management with one-call peering lifecycle:
- BGP Reads: summary, peers, peer_detail, groups, ASNs
- BGP Writes: create/delete peering, groups, ASN, routing_instance, add/remove from group
- Reconciliation: compare Nautobot BGP model vs live peer state

Handles the full Peering -> PeerEndpoint -> RoutingInstance -> ASN chain in a single tool call. Idempotent creates, cascading deletes. Tested against Nautobot 2.4.10 + BGP Models 2.3.2.