### PR TITLE
feat: add layered memory integration to SOUL.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ Auto-generated from all feature plans. Last updated: 2026-06-20
 - N/A (stateless proxy to Check Point APIs) (031-checkpoint-mcp-integration)
 - Python 3.11+ + FastMCP, sqlite3 (stdlib), chromadb, sentence-transformers, torch (CPU) (033-memory-mcp)
 - SQLite (facts, decisions, links) + ChromaDB (embedded sessions) in ~/.openclaw/memory/ (033-memory-mcp)
+- Markdown (SOUL.md), Python 3.10+ (Memory MCP already implemented) + Memory MCP Server (Feature 033), GAIT, OpenClaw workspace (034-layered-memory-integration)
+- SQLite (facts, decisions, links), ChromaDB (session embeddings), MEMORY.md (long-term) (034-layered-memory-integration)
 
 - Python 3.10+ + FastMCP (MCP framework), grpcio + grpcio-tools (gRPC transport), pygnmi (gNMI client library), protobuf, cryptography (TLS handling) (003-gnmi-mcp-server)
 
@@ -61,9 +63,9 @@ cd src [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLO
 Python 3.10+: Follow standard conventions
 
 ## Recent Changes
+- 034-layered-memory-integration: Added Markdown (SOUL.md), Python 3.10+ (Memory MCP already implemented) + Memory MCP Server (Feature 033), GAIT, OpenClaw workspace
 - 033-memory-mcp: Added Python 3.11+ + FastMCP, sqlite3 (stdlib), chromadb, sentence-transformers, torch (CPU)
 - 031-checkpoint-mcp-integration: Added Node.js 18+ (Check Point MCPs are NPM packages), Bash (install scripts) + @chkp/* NPM packages (15 total), npx (MCP execution)
-- 027-netshell-security: Added Bash (installation scripts), Python 3.10+ (DefenseClaw requires), Go 1.25+, Node.js 20+ + DefenseClaw (Cisco), Docker (container runtime)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/034-layered-memory-integration/checklists/requirements.md
+++ b/specs/034-layered-memory-integration/checklists/requirements.md
@@ -1,0 +1,55 @@
+# Specification Quality Checklist: Layered Memory Integration
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Validation Notes
+
+**Validation Date**: 2026-06-20
+**Validator**: Claude (Spec Generation)
+
+### Items Verified
+
+1. **No implementation details**: Spec mentions "Memory MCP" and "MEMORY.md" as logical systems without specifying SQLite, ChromaDB, or other technologies.
+
+2. **User value focus**: All 6 user stories describe what network engineers need and why, not how to implement.
+
+3. **Testable requirements**: Each FR-XXX is verifiable through specific acceptance scenarios.
+
+4. **Measurable success criteria**: SC-001 through SC-007 include specific percentages, time bounds, and counts.
+
+5. **Technology-agnostic success criteria**: Verified - no mention of specific technologies in success criteria.
+
+6. **Edge cases covered**: 4 edge cases identified covering failure scenarios and conflict resolution.
+
+7. **Clear scope**: Feature is bounded to SOUL.md updates and memory layer orchestration; implementation of Memory MCP itself is out of scope (Feature 033).
+
+### Ready for Next Phase
+
+This specification is complete and ready for `/speckit.plan` to generate implementation tasks.

--- a/specs/034-layered-memory-integration/contracts/soul-memory-section.md
+++ b/specs/034-layered-memory-integration/contracts/soul-memory-section.md
@@ -1,0 +1,127 @@
+# SOUL.md Memory Section Contract
+
+**Feature**: 034-layered-memory-integration
+**Date**: 2026-06-20
+**Purpose**: Define the exact content to be added to SOUL.md for layered memory integration
+
+## Insertion Point
+
+Insert this section after "### GAIT: Always-On Audit Trail" and before "### Gathering State" in SOUL.md.
+
+---
+
+## Content to Insert
+
+```markdown
+### Layered Memory: Your Two-Tier Brain
+
+You have a **two-tier memory system** that works like a human brain:
+
+**Tier 1 — Working Memory (Memory MCP)**
+Fast, structured, queryable. Use for:
+- Recent facts about devices and their states
+- Operational decisions with full context
+- Entity relationships (what peers with what, what depends on what)
+- Semantic search across past troubleshooting sessions
+
+**Tier 2 — Long-Term Memory (MEMORY.md)**
+Consolidated, narrative, human-readable. Use for:
+- Patterns learned from repeated issues
+- Significant architectural decisions
+- Permanent infrastructure facts
+- Institutional knowledge that survives database resets
+
+#### Storing Memory
+
+**During Active Sessions:**
+- When you discover device state → `memory_record_fact entity="..." key="..." value="..."`
+- When you make/recommend a change → `memory_record_decision context="..." decision="..." rationale="..." entities=[...]`
+- When you learn a relationship → `memory_link_entities subject="..." predicate="..." object="..."`
+- Log every memory operation to GAIT: `GAIT: memory_record_fact: pe2/bgp_state`
+
+**At Session End:**
+- Store session summary → `memory_store_session summary="..." entities=[...] topics=[...]`
+- Check for patterns: If same issue type occurred 3+ times, consolidate to MEMORY.md
+- If you made a significant decision (with CR number or high impact), add to MEMORY.md
+
+**NEVER store credentials, passwords, API keys, or tokens in memory. Ever.**
+
+#### Retrieving Memory
+
+**When asked about a specific entity:**
+1. First: `memory_get_facts entity="..."` — get current structured facts
+2. If no results: Search MEMORY.md for the entity name
+3. Present Memory MCP facts as "Current State"
+4. Present MEMORY.md content as "Historical Context"
+
+**When asked "What do you remember about X?":**
+1. `memory_recall query="..."` — semantic search across sessions
+2. Also grep MEMORY.md for keywords
+3. Combine and present relevant findings
+
+**When doing impact analysis:**
+1. `memory_query_graph entity="..." direction="incoming"` — find dependencies
+2. Report what services/devices depend on the entity
+
+#### Memory Fallback
+
+If Memory MCP is unavailable:
+- Inform the user: "Memory MCP is currently unavailable. Using MEMORY.md only."
+- Continue with MEMORY.md for context
+- Do NOT halt the session
+
+#### Memory Tools Quick Reference
+
+| Tool | When to Use |
+|------|-------------|
+| `memory_record_fact` | Discovered device state, config value, observation |
+| `memory_get_facts` | Need current facts about an entity |
+| `memory_invalidate` | Fact is no longer true (device decommissioned, state changed) |
+| `memory_timeline` | Need historical view of an entity's facts |
+| `memory_store_session` | End of session — summarize what happened |
+| `memory_recall` | "What do you remember about..." questions |
+| `memory_record_decision` | Made or recommended a configuration change |
+| `memory_get_decisions` | "Why was X changed?" questions |
+| `memory_link_entities` | Discovered relationship (peering, dependency, connectivity) |
+| `memory_query_graph` | Impact analysis, topology questions |
+
+#### Standard Predicates for Links
+
+- `peers_with` — BGP/OSPF peering relationship
+- `depends_on` — Service depends on infrastructure
+- `connects_to` — Physical or logical connectivity
+- `managed_by` — Management/control relationship
+- `caused` — Incident causality
+- `fixed_by` — Resolution relationship
+
+#### MEMORY.md Structure
+
+When consolidating to MEMORY.md, use these sections:
+
+```text
+## Patterns
+[Recurring issues with resolution strategies]
+
+## Decisions
+[Significant changes with context and rationale]
+
+## Infrastructure
+[Permanent facts about devices and topology]
+
+## Preferences
+[User/operational preferences learned during sessions]
+```
+
+---
+```
+
+## Validation Criteria
+
+1. Section appears after GAIT section in SOUL.md
+2. All 10 Memory MCP tools are referenced
+3. Two-tier architecture clearly explained
+4. Store vs Retrieve flows documented
+5. Credential exclusion explicitly stated
+6. Fallback behavior defined
+7. GAIT logging requirement included
+8. MEMORY.md section structure documented

--- a/specs/034-layered-memory-integration/data-model.md
+++ b/specs/034-layered-memory-integration/data-model.md
@@ -1,0 +1,267 @@
+# Data Model: Layered Memory Integration
+
+**Feature**: 034-layered-memory-integration
+**Date**: 2026-06-20
+
+## Entity Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                      LAYERED MEMORY SYSTEM                          │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│  ┌─────────────────────────────────────────────────────────────┐   │
+│  │              TIER 1: MEMORY MCP (Working Memory)             │   │
+│  │  ┌─────────┐  ┌──────────┐  ┌────────┐  ┌───────────────┐   │   │
+│  │  │  FACT   │  │ DECISION │  │  LINK  │  │    SESSION    │   │   │
+│  │  │         │  │          │  │        │  │   (ChromaDB)  │   │   │
+│  │  │ entity  │  │ context  │  │subject │  │               │   │   │
+│  │  │ key     │  │ decision │  │predicate│ │  summary      │   │   │
+│  │  │ value   │  │ rationale│  │object  │  │  entities[]   │   │   │
+│  │  │ meta    │  │ entities │  │meta    │  │  topics[]     │   │   │
+│  │  │ valid_* │  │ cr_number│  │        │  │  embedding    │   │   │
+│  │  └─────────┘  └──────────┘  └────────┘  └───────────────┘   │   │
+│  └─────────────────────────────────────────────────────────────┘   │
+│                              │                                      │
+│                              │ consolidation                        │
+│                              ▼                                      │
+│  ┌─────────────────────────────────────────────────────────────┐   │
+│  │            TIER 2: MEMORY.md (Long-Term Memory)              │   │
+│  │  ┌─────────────────────────────────────────────────────┐    │   │
+│  │  │ ## Patterns                                          │    │   │
+│  │  │ - Recurring issue summaries                          │    │   │
+│  │  │ - Resolution strategies                              │    │   │
+│  │  │                                                      │    │   │
+│  │  │ ## Decisions                                         │    │   │
+│  │  │ - Significant configuration changes                  │    │   │
+│  │  │ - Architectural decisions                            │    │   │
+│  │  │                                                      │    │   │
+│  │  │ ## Infrastructure                                    │    │   │
+│  │  │ - Device roles and locations                         │    │   │
+│  │  │ - Network topology facts                             │    │   │
+│  │  │ - Operational preferences                            │    │   │
+│  │  └─────────────────────────────────────────────────────┘    │   │
+│  └─────────────────────────────────────────────────────────────┘   │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Tier 1: Memory MCP Entities
+
+### Fact (SQLite)
+
+Represents a key-value observation about a network entity with temporal validity.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| id | string | Unique identifier (hex) |
+| entity | string | Entity name (lowercase normalized) |
+| key | string | Fact type (e.g., "bgp_state", "location") |
+| value | string/json | Fact value |
+| metadata | json | Optional structured metadata |
+| valid_from | timestamp | When fact became valid |
+| valid_to | timestamp | When fact was invalidated (null if current) |
+| superseded_by | string | ID of fact that replaced this one |
+| invalidation_reason | string | Why fact was invalidated |
+
+**Lifecycle**:
+```
+Created → Current (valid_to=null)
+    │
+    ├─── Superseded → valid_to set, superseded_by points to new fact
+    │
+    └─── Invalidated → valid_to set, invalidation_reason recorded
+```
+
+### Decision (SQLite)
+
+Represents an operational decision with audit trail.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| id | string | Unique identifier (dec_xxx) |
+| context | string | What situation prompted the decision |
+| decision | string | What was decided |
+| rationale | string | Why this choice was made |
+| created_at | timestamp | When decision was recorded |
+| cr_number | string | Optional ServiceNow change request |
+
+**Relationships**:
+- Decision → Entity (many-to-many via decision_entities table)
+
+### Entity Link (SQLite)
+
+Represents a relationship between two entities.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| id | string | Unique identifier (link_xxx) |
+| subject | string | Source entity (lowercase) |
+| predicate | string | Relationship type |
+| object | string | Target entity (lowercase) |
+| metadata | json | Optional relationship metadata |
+| created_at | timestamp | When link was created |
+
+**Standard Predicates**:
+- `peers_with` - BGP/OSPF peering
+- `depends_on` - Service dependency
+- `connects_to` - Physical/logical connectivity
+- `managed_by` - Management relationship
+- `caused` - Incident causality
+- `fixed_by` - Resolution relationship
+
+### Session (ChromaDB)
+
+Represents a troubleshooting session summary for semantic retrieval.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| id | string | Unique identifier (sess_xxx) |
+| summary | string | Natural language session summary |
+| entities | array | Related entity names |
+| topics | array | Topic tags (e.g., "bgp", "mtu") |
+| embedding | vector | 384-dimension sentence embedding |
+| created_at | timestamp | When session was stored |
+
+## Tier 2: MEMORY.md Structure
+
+MEMORY.md is a markdown file with standard sections:
+
+```markdown
+# Network Memory
+
+## Patterns
+
+### [Pattern Name]
+- **First Observed**: [date]
+- **Occurrences**: [count]
+- **Entities**: [list]
+- **Summary**: [description]
+- **Resolution**: [what fixed it]
+
+## Decisions
+
+### [Decision Title] ([CR Number])
+- **Date**: [date]
+- **Context**: [situation]
+- **Decision**: [what was decided]
+- **Rationale**: [why]
+- **Affected**: [entities]
+
+## Infrastructure
+
+### [Device/System Name]
+- **Role**: [function]
+- **Location**: [site/rack]
+- **Key Facts**: [important attributes]
+- **Notes**: [operational knowledge]
+
+## Preferences
+
+- [User/operational preferences discovered during sessions]
+```
+
+## Query Patterns
+
+### Entity Lookup
+
+```
+1. Query Memory MCP: memory_get_facts(entity="pe2")
+2. If results: Return as "Current State"
+3. If no results: Search MEMORY.md for "pe2"
+4. If found: Return as "Historical Context"
+5. If both: Combine with clear labels
+```
+
+### Semantic Recall
+
+```
+1. Query Memory MCP: memory_recall(query="BGP troubleshooting")
+2. Return top 3-5 semantically similar sessions
+3. Also grep MEMORY.md for keywords
+4. Combine results with relevance scores
+```
+
+### Decision Audit
+
+```
+1. Query Memory MCP: memory_get_decisions(entity="pe2")
+2. Return all decisions affecting pe2
+3. Include CR numbers for ServiceNow cross-reference
+```
+
+### Impact Analysis
+
+```
+1. Query Memory MCP: memory_query_graph(entity="pe2", direction="incoming")
+2. Find all entities that depend on pe2
+3. Return dependency tree with depth
+```
+
+## Consolidation Rules
+
+### Pattern Detection → MEMORY.md
+
+Trigger: Same (entity_type, key, issue_pattern) occurs 3+ times
+
+```python
+# Pseudocode
+if count(similar_facts) >= 3:
+    pattern = {
+        "name": generate_pattern_name(facts),
+        "first_observed": min(fact.valid_from for fact in facts),
+        "occurrences": len(facts),
+        "entities": unique(fact.entity for fact in facts),
+        "summary": summarize(facts),
+        "resolution": extract_resolution(related_decisions)
+    }
+    append_to_memory_md("## Patterns", pattern)
+```
+
+### Decision Consolidation → MEMORY.md
+
+Trigger: Decision with cr_number OR high_impact flag
+
+```python
+# Pseudocode
+if decision.cr_number or decision.high_impact:
+    entry = {
+        "title": decision.decision[:50],
+        "cr_number": decision.cr_number,
+        "date": decision.created_at,
+        "context": decision.context,
+        "decision": decision.decision,
+        "rationale": decision.rationale,
+        "affected": decision.entities
+    }
+    append_to_memory_md("## Decisions", entry)
+```
+
+## Data Flow Summary
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    SESSION LIFECYCLE                             │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  SESSION START                                                   │
+│  ├── GAIT branch created                                        │
+│  ├── memory_get_facts for mentioned entities                    │
+│  └── Search MEMORY.md for context                               │
+│                                                                  │
+│  DURING SESSION                                                  │
+│  ├── memory_record_fact when state discovered                   │
+│  ├── memory_record_decision when changes made                   │
+│  ├── memory_link_entities when relationships found              │
+│  └── GAIT: log each memory operation                            │
+│                                                                  │
+│  SESSION END                                                     │
+│  ├── memory_store_session with summary                          │
+│  ├── Check for patterns (3+ similar facts)                      │
+│  ├── Consolidate patterns → MEMORY.md                           │
+│  ├── Consolidate significant decisions → MEMORY.md              │
+│  ├── GAIT: log consolidation                                    │
+│  └── GAIT commit                                                │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```

--- a/specs/034-layered-memory-integration/plan.md
+++ b/specs/034-layered-memory-integration/plan.md
@@ -1,0 +1,91 @@
+# Implementation Plan: Layered Memory Integration
+
+**Branch**: `034-layered-memory-integration` | **Date**: 2026-06-20 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/034-layered-memory-integration/spec.md`
+
+## Summary
+
+Integrate Memory MCP Server (Feature 033) with existing MEMORY.md system in SOUL.md as a layered memory architecture. The system mimics human brain organization with two tiers:
+
+1. **Working Memory (Memory MCP)**: SQLite for structured facts/decisions/links, ChromaDB for semantic session search
+2. **Long-Term Memory (MEMORY.md)**: Consolidated knowledge distilled from patterns and significant events
+
+All operations logged to GAIT audit trail with timestamps. SOUL.md updated with clear instructions for when to use each system.
+
+## Technical Context
+
+**Language/Version**: Markdown (SOUL.md), Python 3.10+ (Memory MCP already implemented)
+**Primary Dependencies**: Memory MCP Server (Feature 033), GAIT, OpenClaw workspace
+**Storage**: SQLite (facts, decisions, links), ChromaDB (session embeddings), MEMORY.md (long-term)
+**Testing**: Manual verification via 10 representative scenarios
+**Target Platform**: OpenClaw/NetClaw agent running via Slack or CLI
+**Project Type**: Agent behavior configuration (SOUL.md update)
+**Performance Goals**: Memory MCP queries < 2 seconds in 95% of cases
+**Constraints**: No credentials/secrets in memory storage, graceful degradation if Memory MCP unavailable
+**Scale/Scope**: Single SOUL.md file update, affects all NetClaw sessions
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Safety-First Operations | ✅ PASS | Memory operations are read/write to local storage only |
+| II. Read-Before-Write | ✅ PASS | Memory MCP queries before MEMORY.md updates |
+| III. ITSM-Gated Changes | N/A | No device changes involved |
+| IV. Immutable Audit Trail | ✅ PASS | FR-011 requires GAIT logging for all memory ops |
+| V. MCP-Native Integration | ✅ PASS | Uses Memory MCP Server (Feature 033) |
+| VII. Skill Modularity | ✅ PASS | Memory skills compose with existing skills |
+| IX. Security by Default | ✅ PASS | FR-012 excludes credentials from memory storage |
+| XI. Full-Stack Artifact Coherence | ⚠️ REQUIRES | SOUL.md, TOOLS.md updates needed |
+| XII. Documentation-as-Code | ✅ PASS | Quickstart and spec docs included |
+| XIII. Credential Safety | ✅ PASS | FR-012 explicitly forbids credential storage |
+| XVI. Spec-Driven Development | ✅ PASS | Following SDD workflow |
+
+**Gate Result**: PASS - All applicable principles satisfied or planned for.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/034-layered-memory-integration/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── soul-memory-section.md
+└── tasks.md             # Phase 2 output
+```
+
+### Source Code (repository root)
+
+```text
+# Primary deliverables - SOUL.md integration
+~/.openclaw/workspace/
+├── SOUL.md              # UPDATED: Add layered memory instructions
+├── MEMORY.md            # EXISTING: Long-term memory file
+└── memory/              # EXISTING: Session logs (YYYY-MM-DD.md)
+
+# Memory MCP Server (Feature 033 - already exists)
+mcp-servers/memory-mcp/
+├── memory_mcp_server.py # 10 MCP tools
+├── storage/
+│   ├── sqlite_store.py  # Facts, decisions, links
+│   └── chroma_store.py  # Semantic session search
+└── embeddings/
+    └── embedder.py      # all-MiniLM-L6-v2
+
+# Data storage
+~/.openclaw/memory/
+├── memory.db            # SQLite database
+└── chroma/              # ChromaDB vector store
+```
+
+**Structure Decision**: This is primarily a documentation/configuration update. The Memory MCP server already exists from Feature 033. Main deliverable is SOUL.md section updates.
+
+## Complexity Tracking
+
+No violations requiring justification. Implementation is straightforward SOUL.md update.

--- a/specs/034-layered-memory-integration/quickstart.md
+++ b/specs/034-layered-memory-integration/quickstart.md
@@ -1,0 +1,200 @@
+# Quickstart: Layered Memory Integration
+
+**Feature**: 034-layered-memory-integration
+**Date**: 2026-06-20
+
+## Overview
+
+NetClaw now has a two-tier memory system that works like a human brain:
+
+| Tier | System | Purpose | Speed |
+|------|--------|---------|-------|
+| 1 | Memory MCP | Working memory - facts, decisions, relationships, semantic search | Fast (< 2s) |
+| 2 | MEMORY.md | Long-term memory - consolidated patterns and institutional knowledge | File read |
+
+## Prerequisites
+
+- Memory MCP Server (Feature 033) installed and configured
+- SOUL.md updated with layered memory section
+- GAIT enabled for audit logging
+
+## How It Works
+
+### Storing Memory
+
+**During your session**, NetClaw automatically:
+1. Records facts when discovering device states
+2. Logs decisions when making configuration changes
+3. Tracks relationships when learning about topology
+4. Logs all operations to GAIT
+
+**At session end**, NetClaw:
+1. Stores a session summary for semantic search
+2. Checks for recurring patterns (3+ similar issues)
+3. Consolidates important patterns/decisions to MEMORY.md
+
+### Retrieving Memory
+
+**When you ask about a device**:
+```
+You: What do you know about PE2?
+
+NetClaw:
+1. Queries Memory MCP for facts about PE2
+2. If found: Returns as "Current State"
+3. If not found: Searches MEMORY.md
+4. Returns as "Historical Context"
+```
+
+**When you ask about past work**:
+```
+You: What do you remember about BGP troubleshooting?
+
+NetClaw:
+1. Performs semantic search via memory_recall
+2. Returns top matching sessions
+3. Also searches MEMORY.md for keywords
+```
+
+**When you ask about impact**:
+```
+You: What depends on PE2?
+
+NetClaw:
+1. Queries entity graph for incoming relationships
+2. Returns services/devices that depend on PE2
+```
+
+## Example Session
+
+```
+Session Start
+├── GAIT: branch created
+├── NetClaw queries memory for mentioned entities
+│
+├── You: Check BGP status on PE2
+│   └── NetClaw: memory_record_fact entity="pe2" key="bgp_state" value="established"
+│       GAIT: memory_record_fact: pe2/bgp_state
+│
+├── You: PE2 peers with RR1, right?
+│   └── NetClaw: memory_link_entities subject="pe2" predicate="peers_with" object="rr1"
+│       GAIT: memory_link_entities: pe2 peers_with rr1
+│
+├── You: Increase the hold timer to 180s
+│   └── NetClaw: memory_record_decision
+│       context="BGP session flapping during maintenance"
+│       decision="Increased hold timer from 90s to 180s"
+│       rationale="Reduce flap frequency"
+│       entities=["pe2", "rr1"]
+│       GAIT: memory_record_decision: dec_abc123
+│
+Session End
+├── NetClaw: memory_store_session
+│   summary="Troubleshot BGP on PE2. Increased hold timer to 180s to reduce flapping."
+│   entities=["pe2", "rr1"]
+│   topics=["bgp", "hold-timer", "troubleshooting"]
+│   GAIT: memory_store_session: sess_xyz789
+│
+├── Pattern check: Is this the 3rd+ BGP flapping issue?
+│   └── If yes: Consolidate pattern to MEMORY.md
+│
+└── GAIT: commit
+```
+
+## Testing the Integration
+
+### Test 1: Record and Retrieve a Fact
+
+```
+You: Remember that R1's status is online
+
+NetClaw: [Records fact to Memory MCP]
+
+You: What do you know about R1?
+
+NetClaw:
+Current State (Memory MCP):
+- status: online (recorded just now)
+```
+
+### Test 2: Semantic Session Recall
+
+```
+You: What do you remember about BGP problems?
+
+NetClaw: [Performs semantic search]
+Found 2 relevant sessions:
+1. "Troubleshot BGP flapping on PE2..." (0.89 similarity)
+2. "Fixed BGP convergence issue..." (0.75 similarity)
+```
+
+### Test 3: Entity Relationships
+
+```
+You: Record that web-service depends on PE2
+
+NetClaw: [Creates link]
+
+You: What would be affected if we take down PE2?
+
+NetClaw: [Queries graph]
+Entities depending on PE2:
+- web-service (depends_on)
+- rr1 (peers_with - bidirectional)
+```
+
+### Test 4: Fallback Behavior
+
+```
+[Memory MCP unavailable]
+
+You: What do you know about R1?
+
+NetClaw:
+⚠️ Memory MCP is currently unavailable. Using MEMORY.md only.
+
+Historical Context (MEMORY.md):
+- R1 is a PE router in DC-East
+- Last known issue: collision errors on Eth0/2 (2026-03-14)
+```
+
+## Memory Tool Reference
+
+| Tool | Example |
+|------|---------|
+| Record a fact | `memory_record_fact entity="pe2" key="bgp_state" value="established"` |
+| Get facts | `memory_get_facts entity="pe2"` |
+| Invalidate fact | `memory_invalidate fact_id="abc123" reason="Device decommissioned"` |
+| View timeline | `memory_timeline entity="pe2" key="bgp_state"` |
+| Store session | `memory_store_session summary="..." entities=["pe2"] topics=["bgp"]` |
+| Semantic search | `memory_recall query="BGP troubleshooting" top_k=5` |
+| Record decision | `memory_record_decision context="..." decision="..." rationale="..."` |
+| Query decisions | `memory_get_decisions entity="pe2"` |
+| Link entities | `memory_link_entities subject="pe2" predicate="peers_with" object="rr1"` |
+| Query graph | `memory_query_graph entity="pe2" direction="both" depth=2` |
+
+## Troubleshooting
+
+### Memory MCP Not Responding
+
+1. Check if memory-mcp is in `~/.openclaw/config/openclaw.json`
+2. Verify the server path is correct
+3. Restart the OpenClaw gateway
+
+### Facts Not Being Recorded
+
+1. Check GAIT log for memory operations
+2. Verify Memory MCP tools are available to the agent
+3. Ensure fact doesn't contain credentials (filtered)
+
+### Semantic Search Returns Empty
+
+1. First session? No sessions stored yet
+2. Check ChromaDB directory exists: `~/.openclaw/memory/chroma/`
+3. Embeddings may still be loading (cold start)
+
+### MEMORY.md Not Being Updated
+
+1. Consolidation happens at session end, not during
+2. Pattern threshold is 3+ similar issues
+3. Check GAIT log for consolidation entries

--- a/specs/034-layered-memory-integration/research.md
+++ b/specs/034-layered-memory-integration/research.md
@@ -1,0 +1,181 @@
+# Research: Layered Memory Integration
+
+**Feature**: 034-layered-memory-integration
+**Date**: 2026-06-20
+
+## Research Questions Resolved
+
+### Q1: How does Memory MCP Server work?
+
+**Decision**: Use existing Memory MCP Server (Feature 033) with 10 MCP tools
+
+**Rationale**: Feature 033 already implemented the complete Memory MCP server with:
+- SQLite storage for facts, decisions, and entity links
+- ChromaDB with all-MiniLM-L6-v2 embeddings for semantic session search
+- Graceful degradation when embeddings unavailable
+- 115 tests passing
+
+**Alternatives Considered**:
+- Build new memory system → Rejected: Duplicates Feature 033 work
+- Use only MEMORY.md → Rejected: No structured queries or semantic search
+
+### Q2: What Memory MCP tools are available?
+
+**Decision**: Use all 10 tools from Memory MCP Server
+
+**Tools Available**:
+| Tool | Purpose |
+|------|---------|
+| `memory_record_fact` | Store fact with temporal validity |
+| `memory_get_facts` | Query current facts for entity |
+| `memory_invalidate` | Explicitly invalidate a fact |
+| `memory_timeline` | View historical facts including invalidated |
+| `memory_store_session` | Store session summary for semantic search |
+| `memory_recall` | Natural language search across sessions |
+| `memory_record_decision` | Log decision with context and rationale |
+| `memory_get_decisions` | Query decisions by entity or time |
+| `memory_link_entities` | Create relationship between entities |
+| `memory_query_graph` | Traverse entity relationships |
+
+### Q3: How should Memory MCP and MEMORY.md interact?
+
+**Decision**: Two-tier architecture with clear separation
+
+**Rationale**: Each system has distinct strengths:
+- Memory MCP: Fast structured queries, semantic search, temporal tracking
+- MEMORY.md: Human-readable, narrative context, survives database reset
+
+**Interaction Pattern**:
+```
+STORING:
+  Session events → Memory MCP (immediate)
+  Patterns/significant decisions → MEMORY.md (session end)
+
+RETRIEVING:
+  Specific entity query → Memory MCP first, fallback to MEMORY.md
+  "What do you remember about X?" → Semantic search + MEMORY.md
+  Historical context → MEMORY.md first, then Memory MCP timeline
+```
+
+### Q4: When should consolidation to MEMORY.md occur?
+
+**Decision**: At the end of each session (natural checkpoint)
+
+**Rationale**:
+- Provides consistent timing for consolidation
+- Aligns with existing session log pattern
+- Allows batch processing of patterns
+- Doesn't interrupt active troubleshooting
+
+**Trigger Conditions for Consolidation**:
+1. Pattern detected: Same issue type 3+ times
+2. Significant decision: High-impact configuration change
+3. New permanent knowledge: Infrastructure facts unlikely to change
+
+### Q5: How should memory operations be audited?
+
+**Decision**: Log to GAIT audit trail only
+
+**Rationale**:
+- Consistent with NetClaw's existing audit pattern
+- Non-intrusive to user experience
+- Enables post-session review
+- Maintains audit trail integrity
+
+**GAIT Log Format**:
+```
+GAIT: memory_record_fact: {entity}/{key}
+GAIT: memory_store_session: {session_id}
+GAIT: memory_record_decision: {decision_id}
+GAIT: memory_link_entities: {subject} {predicate} {object}
+GAIT: memory_invalidate: {fact_id}
+GAIT: memory_consolidate: {pattern_summary}
+```
+
+### Q6: What should NOT be stored in memory?
+
+**Decision**: Exclude credentials and secrets only
+
+**Rationale**:
+- Network IPs, hostnames, configs are operationally valuable
+- Only passwords, API keys, tokens, certificates are security-sensitive
+- Aligns with principle XIII (Credential Safety)
+
+**Exclusion Patterns**:
+- Any value containing "password", "secret", "token", "key", "certificate"
+- Values matching API key patterns (sk-, pk-, etc.)
+- Environment variable values from .env files
+
+## Technology Decisions
+
+### Storage Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    LAYERED MEMORY                           │
+├─────────────────────────────────────────────────────────────┤
+│  TIER 1: Working Memory (Memory MCP)                        │
+│  ┌─────────────────┐  ┌─────────────────┐                   │
+│  │    SQLite       │  │    ChromaDB     │                   │
+│  │  - Facts        │  │  - Sessions     │                   │
+│  │  - Decisions    │  │  - Embeddings   │                   │
+│  │  - Links        │  │  - Semantic     │                   │
+│  └─────────────────┘  └─────────────────┘                   │
+│                                                              │
+│  TIER 2: Long-Term Memory (MEMORY.md)                       │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │  - Consolidated patterns                             │    │
+│  │  - Significant decisions                             │    │
+│  │  - Infrastructure facts                              │    │
+│  │  - Narrative institutional knowledge                 │    │
+│  └─────────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Query Flow
+
+```
+User asks about entity
+        │
+        ▼
+┌───────────────────┐
+│ Query Memory MCP  │
+│ memory_get_facts  │
+└─────────┬─────────┘
+          │
+    ┌─────┴─────┐
+    │ Results?  │
+    └─────┬─────┘
+          │
+    Yes   │   No
+    ▼     │   ▼
+┌─────────┐   ┌────────────┐
+│ Return  │   │ Search     │
+│ facts   │   │ MEMORY.md  │
+│ as      │   │ for entity │
+│ current │   └──────┬─────┘
+│ state   │          │
+└────┬────┘          ▼
+     │         ┌───────────┐
+     │         │ Return as │
+     │         │ historical│
+     │         │ context   │
+     │         └─────┬─────┘
+     │               │
+     ▼               ▼
+┌─────────────────────────┐
+│ Combine in response     │
+│ MCP = "Current state"   │
+│ MEMORY.md = "History"   │
+└─────────────────────────┘
+```
+
+## Best Practices Identified
+
+1. **Always query Memory MCP first** for entity-specific questions
+2. **Use semantic search** for "what do you remember about" questions
+3. **Record facts during discovery** not after the session
+4. **Record decisions when made** with full context
+5. **Consolidate at session end** not during active work
+6. **Never store credentials** in any memory tier
+7. **Log all operations to GAIT** for audit compliance

--- a/specs/034-layered-memory-integration/spec.md
+++ b/specs/034-layered-memory-integration/spec.md
@@ -1,0 +1,178 @@
+# Feature Specification: Layered Memory Integration
+
+**Feature Branch**: `034-layered-memory-integration`
+**Created**: 2026-06-20
+**Status**: Draft
+**Input**: Integrate Memory MCP Server with existing MEMORY.md system in SOUL.md as a layered memory architecture mimicking human brain organization.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Record Facts During Operation (Priority: P1)
+
+As a network engineer working with NetClaw, I want the agent to automatically record facts about network entities during troubleshooting sessions so that specific device states, configurations, and observations are preserved for future reference.
+
+**Why this priority**: Recording facts is the foundation of the memory system. Without capturing information during sessions, there is nothing to retrieve later. This enables all other memory capabilities.
+
+**Independent Test**: Can be fully tested by asking NetClaw to troubleshoot a device, then immediately querying what facts were recorded about that device.
+
+**Acceptance Scenarios**:
+
+1. **Given** a troubleshooting session is active, **When** the agent discovers a device state (e.g., "PE2 BGP state is established"), **Then** this fact is automatically recorded to Memory MCP with the entity name, key, value, and timestamp.
+
+2. **Given** a fact already exists for an entity/key pair, **When** the agent discovers a new value for the same fact, **Then** the old fact is superseded (not deleted) and the new fact becomes current.
+
+3. **Given** the Memory MCP is unavailable, **When** the agent attempts to record a fact, **Then** the operation fails gracefully without interrupting the user's workflow.
+
+---
+
+### User Story 2 - Query Recent Facts First (Priority: P1)
+
+As a network engineer, I want NetClaw to check Memory MCP first when I ask about a device so that I get the most recent, specific information before falling back to consolidated knowledge.
+
+**Why this priority**: The retrieval order is critical to providing accurate, up-to-date information. Recent facts in Memory MCP should take precedence over older consolidated knowledge.
+
+**Independent Test**: Can be tested by recording a fact about a device, then asking NetClaw about that device and verifying it returns the Memory MCP fact rather than (or in addition to) MEMORY.md content.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fact exists in Memory MCP for entity "PE2", **When** the user asks "What do you know about PE2?", **Then** the agent queries Memory MCP first and includes those facts in the response.
+
+2. **Given** Memory MCP has no facts about "R1" but MEMORY.md contains historical knowledge, **When** the user asks about R1, **Then** the agent falls back to MEMORY.md and returns that information.
+
+3. **Given** both Memory MCP and MEMORY.md have information about the same entity, **When** the user asks about it, **Then** Memory MCP facts are presented as "current state" and MEMORY.md as "historical context".
+
+---
+
+### User Story 3 - Semantic Session Recall (Priority: P2)
+
+As a network engineer, I want to search for past troubleshooting sessions using natural language so that I can find relevant prior work even if I don't remember exact device names or dates.
+
+**Why this priority**: Semantic search enables finding relevant past work without exact keyword matches, which is how engineers naturally think about problems ("that BGP issue we had last month").
+
+**Independent Test**: Can be tested by storing several session summaries, then querying with natural language that doesn't exactly match any summary text.
+
+**Acceptance Scenarios**:
+
+1. **Given** multiple session summaries are stored in Memory MCP, **When** the user asks "What do you remember about BGP troubleshooting?", **Then** the agent performs semantic search and returns the most relevant sessions.
+
+2. **Given** a query has low semantic similarity to any stored sessions, **When** the search returns few/no results, **Then** the agent falls back to searching MEMORY.md for related keywords.
+
+3. **Given** semantic search is unavailable (embeddings not loaded), **When** the user requests session recall, **Then** the agent informs them and offers keyword-based search as an alternative.
+
+---
+
+### User Story 4 - Record Decisions with Rationale (Priority: P2)
+
+As a network engineer, I want NetClaw to record operational decisions with full context so that future sessions (and auditors) can understand why changes were made.
+
+**Why this priority**: Decision audit trails are essential for compliance and institutional knowledge. They answer "why was this changed?" months later.
+
+**Independent Test**: Can be tested by making a configuration decision, then querying decisions for that entity and verifying context/rationale are preserved.
+
+**Acceptance Scenarios**:
+
+1. **Given** the agent recommends or executes a configuration change, **When** the change is approved, **Then** the decision is recorded with context, rationale, affected entities, and optional change request number.
+
+2. **Given** a decision was recorded for entity "PE2", **When** the user asks "Why was PE2's hold timer changed?", **Then** the agent queries Memory MCP decisions and returns the full context.
+
+3. **Given** multiple decisions affect the same entity, **When** querying decisions, **Then** they are returned in chronological order with clear timestamps.
+
+---
+
+### User Story 5 - Consolidate Patterns to Long-Term Memory (Priority: P3)
+
+As a network engineer, I want NetClaw to periodically consolidate important patterns from Memory MCP into MEMORY.md so that critical institutional knowledge is preserved in human-readable format.
+
+**Why this priority**: While Memory MCP stores structured data, MEMORY.md provides narrative context that's easier for humans to read and survives even if the database is reset.
+
+**Independent Test**: Can be tested by recording repeated similar facts/decisions, then triggering consolidation and verifying a pattern entry appears in MEMORY.md.
+
+**Acceptance Scenarios**:
+
+1. **Given** the same type of issue has been recorded 3+ times for similar entities, **When** consolidation runs, **Then** a pattern entry is written to MEMORY.md summarizing the recurring issue.
+
+2. **Given** a significant decision was made with high impact, **When** consolidation runs, **Then** the decision is summarized in MEMORY.md with a reference to query Memory MCP for full details.
+
+3. **Given** MEMORY.md already contains an entry about a topic, **When** new related information should be consolidated, **Then** the existing entry is updated rather than duplicated.
+
+---
+
+### User Story 6 - Track Entity Relationships (Priority: P3)
+
+As a network engineer, I want NetClaw to track relationships between network entities so that impact analysis and topology understanding are available across sessions.
+
+**Why this priority**: Understanding "what depends on what" is critical for impact analysis but often lost between sessions.
+
+**Independent Test**: Can be tested by recording several entity links, then querying the graph for a device and verifying relationships are returned.
+
+**Acceptance Scenarios**:
+
+1. **Given** the agent learns that PE2 peers with RR1, **When** this relationship is recorded, **Then** it can be queried from either entity's perspective.
+
+2. **Given** a service depends on multiple devices, **When** the user asks about impact of taking down one device, **Then** the agent queries the entity graph to identify affected services.
+
+3. **Given** a relationship already exists, **When** the same relationship is recorded again, **Then** no duplicate is created.
+
+---
+
+### Edge Cases
+
+- What happens when Memory MCP database is corrupted or missing? System should fall back to MEMORY.md only with a warning.
+- How does system handle conflicting information between Memory MCP and MEMORY.md? Memory MCP is treated as "current truth" while MEMORY.md is "historical context".
+- What happens when MEMORY.md file doesn't exist? System should create it on first consolidation.
+- How are facts invalidated when a device is decommissioned? Explicit invalidation with reason, facts remain in timeline for history.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Agent MUST query Memory MCP for entity facts before consulting MEMORY.md when answering questions about specific entities.
+- **FR-002**: Agent MUST record discovered facts to Memory MCP during active troubleshooting sessions.
+- **FR-003**: Agent MUST use semantic search via Memory MCP's `memory_recall` tool when users ask about past sessions or troubleshooting history.
+- **FR-004**: Agent MUST fall back to MEMORY.md when Memory MCP returns no results or is unavailable.
+- **FR-005**: Agent MUST record operational decisions with context, rationale, and affected entities.
+- **FR-006**: Agent MUST track entity relationships (peering, dependencies, connectivity) in Memory MCP's graph.
+- **FR-007**: Agent MUST consolidate repeated patterns and significant decisions to MEMORY.md at the end of each session.
+- **FR-008**: SOUL.md MUST contain clear instructions defining when to use Memory MCP vs MEMORY.md.
+- **FR-009**: System MUST present Memory MCP data as "current state" and MEMORY.md as "consolidated knowledge" when both contain relevant information.
+- **FR-010**: System MUST gracefully degrade to MEMORY.md-only operation if Memory MCP is unavailable.
+- **FR-011**: Agent MUST log all memory operations (fact recording, decision logging, consolidation, failures) to GAIT audit trail.
+- **FR-012**: Agent MUST NOT record credentials, secrets, passwords, API keys, or tokens to Memory MCP or MEMORY.md.
+
+### Key Entities
+
+- **Memory MCP**: Structured storage system providing fast access to facts, decisions, entity graphs, and semantic session search
+- **MEMORY.md**: Markdown file containing consolidated long-term knowledge distilled from patterns and significant events
+- **Fact**: A key-value observation about a network entity with temporal validity (valid_from, valid_to)
+- **Decision**: An operational choice with context, rationale, affected entities, and optional change request reference
+- **Entity Link**: A relationship between two entities (subject, predicate, object) such as "peers_with" or "depends_on"
+- **Session Summary**: A natural language description of a troubleshooting session stored for semantic retrieval
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: When asked about a specific device, agent returns Memory MCP facts within 2 seconds in 95% of queries.
+- **SC-002**: Users can find relevant past sessions via natural language search with at least 80% relevance accuracy.
+- **SC-003**: All operational decisions are recorded with context, achieving 100% audit trail completeness.
+- **SC-004**: Repeated patterns (3+ occurrences) are automatically consolidated to MEMORY.md at session end.
+- **SC-005**: Entity relationship queries return accurate results, enabling impact analysis for at least 90% of topology questions.
+- **SC-006**: System continues to function (with reduced capability) when Memory MCP is unavailable, achieving 99.9% availability for basic memory operations.
+- **SC-007**: SOUL.md instructions are unambiguous, verified by testing that the agent correctly chooses Memory MCP vs MEMORY.md in 10 representative scenarios.
+
+## Clarifications
+
+### Session 2026-06-20
+
+- Q: When should consolidation from Memory MCP to MEMORY.md occur? → A: At the end of each session (natural checkpoint)
+- Q: How should users/operators be informed about memory operations? → A: Log to GAIT audit trail only (standard NetClaw pattern)
+- Q: Should the agent avoid recording certain types of sensitive information? → A: Exclude credentials/secrets only (passwords, keys, tokens)
+
+## Assumptions
+
+- Memory MCP Server (Feature 033) is installed and configured in the OpenClaw deployment
+- MEMORY.md file exists at the standard workspace location (`~/.openclaw/workspace/MEMORY.md`)
+- The agent has access to both Memory MCP tools and file read/write capabilities
+- Consolidation to MEMORY.md can be triggered manually or at session end (not real-time)
+- The existing SOUL.md structure supports adding new memory-related instructions
+- Network engineers are the primary users and understand basic memory concepts (facts, decisions, relationships)

--- a/specs/034-layered-memory-integration/tasks.md
+++ b/specs/034-layered-memory-integration/tasks.md
@@ -1,0 +1,248 @@
+# Tasks: Layered Memory Integration
+
+**Input**: Design documents from `/specs/034-layered-memory-integration/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Manual verification via 10 representative scenarios (no automated tests required for this documentation update)
+
+**Organization**: Tasks grouped by user story - primary deliverable is SOUL.md update
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1-US6)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **SOUL.md**: `~/.openclaw/workspace/SOUL.md` (production) or project copy
+- **MEMORY.md**: `~/.openclaw/workspace/MEMORY.md`
+- **Config**: `~/.openclaw/config/openclaw.json`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Verify prerequisites and prepare for SOUL.md update
+
+- [ ] T001 Verify Memory MCP server exists at mcp-servers/memory-mcp/memory_mcp_server.py
+- [ ] T002 Verify Memory MCP is registered in ~/.openclaw/config/openclaw.json
+- [ ] T003 [P] Verify MEMORY.md exists at ~/.openclaw/workspace/MEMORY.md (create if missing)
+- [ ] T004 [P] Backup current SOUL.md to ~/.openclaw/workspace/SOUL.md.backup
+
+---
+
+## Phase 2: Foundational (SOUL.md Core Section)
+
+**Purpose**: Add the layered memory section to SOUL.md - BLOCKS all user story validation
+
+**⚠️ CRITICAL**: This section must be added before any memory behavior can be tested
+
+- [ ] T005 Read contracts/soul-memory-section.md to get exact content to insert
+- [ ] T006 Locate insertion point in SOUL.md (after "### GAIT: Always-On Audit Trail")
+- [ ] T007 Insert "### Layered Memory: Your Two-Tier Brain" section from contract
+- [ ] T008 Verify SOUL.md markdown structure is valid (no broken headings)
+- [ ] T009 Restart OpenClaw gateway to pick up SOUL.md changes
+
+**Checkpoint**: SOUL.md now contains layered memory instructions
+
+---
+
+## Phase 3: User Story 1 - Record Facts During Operation (Priority: P1) 🎯 MVP
+
+**Goal**: Agent automatically records facts about network entities during troubleshooting
+
+**Independent Test**: Ask NetClaw to check a device, then query `memory_get_facts` for that device
+
+### Implementation for User Story 1
+
+- [ ] T010 [US1] Verify SOUL.md section includes `memory_record_fact` tool reference
+- [ ] T011 [US1] Verify SOUL.md includes instruction: "When you discover device state → memory_record_fact"
+- [ ] T012 [US1] Verify SOUL.md includes GAIT logging instruction for fact recording
+- [ ] T013 [US1] Manual test: Ask "Check BGP status on PE2" - verify fact is recorded
+- [ ] T014 [US1] Manual test: Query `memory_get_facts entity="pe2"` - verify fact returned
+
+**Checkpoint**: Facts are automatically recorded during troubleshooting
+
+---
+
+## Phase 4: User Story 2 - Query Recent Facts First (Priority: P1)
+
+**Goal**: Agent queries Memory MCP before MEMORY.md when asked about entities
+
+**Independent Test**: Record a fact, then ask about that device - should return Memory MCP fact first
+
+### Implementation for User Story 2
+
+- [ ] T015 [US2] Verify SOUL.md section includes query order instructions (Memory MCP → MEMORY.md)
+- [ ] T016 [US2] Verify SOUL.md includes presentation labels ("Current State" vs "Historical Context")
+- [ ] T017 [US2] Manual test: Add fact via `memory_record_fact`, then ask "What do you know about X?"
+- [ ] T018 [US2] Manual test: Verify Memory MCP facts shown as "Current State"
+- [ ] T019 [US2] Manual test: Verify MEMORY.md content shown as "Historical Context" when applicable
+
+**Checkpoint**: Query order is Memory MCP first, MEMORY.md fallback
+
+---
+
+## Phase 5: User Story 3 - Semantic Session Recall (Priority: P2)
+
+**Goal**: Users can search past sessions with natural language
+
+**Independent Test**: Store sessions, then query with semantic search
+
+### Implementation for User Story 3
+
+- [ ] T020 [US3] Verify SOUL.md section includes `memory_store_session` tool reference
+- [ ] T021 [US3] Verify SOUL.md section includes `memory_recall` tool reference
+- [ ] T022 [US3] Verify SOUL.md includes semantic search instructions
+- [ ] T023 [US3] Manual test: Store session via `memory_store_session summary="..." entities=[...] topics=[...]`
+- [ ] T024 [US3] Manual test: Query via `memory_recall query="..."` - verify semantic results
+
+**Checkpoint**: Semantic session search working
+
+---
+
+## Phase 6: User Story 4 - Record Decisions with Rationale (Priority: P2)
+
+**Goal**: Operational decisions recorded with full context for audit
+
+**Independent Test**: Make a decision, then query decisions for that entity
+
+### Implementation for User Story 4
+
+- [ ] T025 [US4] Verify SOUL.md section includes `memory_record_decision` tool reference
+- [ ] T026 [US4] Verify SOUL.md includes instruction: "When you make/recommend a change → memory_record_decision"
+- [ ] T027 [US4] Verify SOUL.md includes CR number field mention
+- [ ] T028 [US4] Manual test: Record decision with context, rationale, entities
+- [ ] T029 [US4] Manual test: Query `memory_get_decisions entity="..."` - verify decision returned
+
+**Checkpoint**: Decisions recorded with full audit trail
+
+---
+
+## Phase 7: User Story 5 - Consolidate Patterns to Long-Term Memory (Priority: P3)
+
+**Goal**: Patterns consolidated from Memory MCP to MEMORY.md at session end
+
+**Independent Test**: Create 3+ similar facts, end session, check MEMORY.md for pattern
+
+### Implementation for User Story 5
+
+- [ ] T030 [US5] Verify SOUL.md section includes consolidation instructions (at session end)
+- [ ] T031 [US5] Verify SOUL.md includes pattern threshold (3+ occurrences)
+- [ ] T032 [US5] Verify SOUL.md includes MEMORY.md section structure for patterns
+- [ ] T033 [US5] Manual test: Verify consolidation happens at session end (not during)
+
+**Checkpoint**: Patterns consolidated to MEMORY.md
+
+---
+
+## Phase 8: User Story 6 - Track Entity Relationships (Priority: P3)
+
+**Goal**: Entity relationships tracked for impact analysis
+
+**Independent Test**: Create links, then query graph for dependencies
+
+### Implementation for User Story 6
+
+- [ ] T034 [US6] Verify SOUL.md section includes `memory_link_entities` tool reference
+- [ ] T035 [US6] Verify SOUL.md section includes `memory_query_graph` tool reference
+- [ ] T036 [US6] Verify SOUL.md includes standard predicates list
+- [ ] T037 [US6] Manual test: Create link via `memory_link_entities subject="..." predicate="..." object="..."`
+- [ ] T038 [US6] Manual test: Query via `memory_query_graph entity="..." direction="both"`
+
+**Checkpoint**: Entity relationships tracked and queryable
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validation, documentation, and edge case testing
+
+- [ ] T039 [P] Verify credential exclusion: Test that passwords/keys are NOT stored
+- [ ] T040 [P] Verify GAIT logging: Check audit trail for all memory operations
+- [ ] T041 [P] Test fallback behavior: Disable Memory MCP, verify MEMORY.md-only mode works
+- [ ] T042 Update TOOLS.md with Memory MCP integration notes in TOOLS.md
+- [ ] T043 Run 10 representative scenarios from spec SC-007 for validation
+- [ ] T044 Update README.md with layered memory capability mention
+- [ ] T045 Run quickstart.md validation scenarios
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - verify prerequisites
+- **Foundational (Phase 2)**: Depends on Setup - BLOCKS all user stories
+- **User Stories (Phase 3-8)**: All depend on Foundational phase
+  - US1 and US2 are both P1 - complete both for MVP
+  - US3 and US4 are both P2 - complete after P1 stories
+  - US5 and US6 are both P3 - complete after P2 stories
+- **Polish (Phase 9)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 (Record Facts)**: Can start after Foundational - No dependencies
+- **US2 (Query Facts)**: Can start after Foundational - Tests build on US1 data
+- **US3 (Semantic Recall)**: Can start after Foundational - Independent
+- **US4 (Record Decisions)**: Can start after Foundational - Independent
+- **US5 (Consolidate Patterns)**: Can start after Foundational - Tests need US1 data
+- **US6 (Track Relationships)**: Can start after Foundational - Independent
+
+### Parallel Opportunities
+
+- T003 and T004 (Setup) can run in parallel
+- US1 and US2 validation can run sequentially (US2 builds on US1 data)
+- US3, US4, US6 can run in parallel (independent)
+- T039, T040, T041 (Polish) can run in parallel
+
+---
+
+## Parallel Example: Setup Phase
+
+```bash
+# Launch backup and MEMORY.md check together:
+Task T003: "Verify MEMORY.md exists at ~/.openclaw/workspace/MEMORY.md"
+Task T004: "Backup current SOUL.md to ~/.openclaw/workspace/SOUL.md.backup"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 & 2 Only)
+
+1. Complete Phase 1: Setup (T001-T004)
+2. Complete Phase 2: Foundational - Add SOUL.md section (T005-T009)
+3. Complete Phase 3: User Story 1 - Record Facts (T010-T014)
+4. Complete Phase 4: User Story 2 - Query Facts (T015-T019)
+5. **STOP and VALIDATE**: Test fact recording and retrieval
+6. Deploy if ready - basic memory working
+
+### Incremental Delivery
+
+1. MVP (US1 + US2) → Facts can be recorded and queried
+2. Add US3 + US4 → Semantic search and decisions
+3. Add US5 + US6 → Consolidation and relationships
+4. Polish → Full validation suite
+
+### Single Developer Strategy
+
+Execute phases sequentially in priority order:
+1. Setup + Foundational → SOUL.md ready
+2. US1 → US2 → MVP complete
+3. US3 → US4 → Full feature set
+4. US5 → US6 → Advanced features
+5. Polish → Production ready
+
+---
+
+## Notes
+
+- Primary deliverable is SOUL.md update - all tasks verify content or test behavior
+- Manual tests validate that the agent follows SOUL.md instructions
+- Memory MCP server already exists (Feature 033) - this feature integrates it
+- GAIT logging must be verified for audit compliance
+- Credential exclusion is security-critical (FR-012)
+- 10 representative scenarios (SC-007) are the acceptance test


### PR DESCRIPTION
- Add two-tier memory architecture instructions to SOUL.md
- Tier 1: Memory MCP (SQLite/ChromaDB) for working memory
- Tier 2: MEMORY.md for long-term consolidated knowledge
- Include all 10 Memory MCP tool references
- Define store/retrieve workflows and fallback behavior
- Add credential exclusion requirement (FR-012)
- Complete SDD artifacts: spec, plan, research, data-model, contracts, tasks