### PR TITLE
Add Forward MCP integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,11 @@ yarn-error.log*
 # OpenClaw
 .openclaw/
 
+# Local agent state and audit harnesses
+.gait/
+memory/
+.pytest_cache/
+
 # Diagrams (generated)
 *.drawio.bak
 

--- a/README.md
+++ b/README.md
@@ -287,6 +287,67 @@ NetClaw integrates with IP Fabric's network assurance platform through **10 MCP 
 
 ---
 
+## Forward MCP Integration
+
+NetClaw integrates with the upstream Forward MCP server for snapshot
+assurance, path search, NQE, NQE diffs, snapshot diffs, config search, config
+diffs, checks, vulnerabilities, blast radius, missing-device evidence, device
+inventory, and hardware/OS support checks.
+
+| Capability | Tools | Description |
+|------------|-------|-------------|
+| **Snapshot Assurance** | `list_networks`, `list_snapshots`, `get_latest_snapshot` | Discover networks and point-in-time snapshots |
+| **Path Analysis** | `list_l7_applications`, `search_paths_bulk`, `search_paths` | Trace reachability and app-aware paths through Forward snapshots |
+| **Topology** | `get_snapshot_topology`, `search_nqe_queries`, `run_nqe_query_by_id` | Fetch native Forward topology links and enrich with NQE peer evidence when needed |
+| **Blast Radius** | `suggest_blast_radius_sources`, `get_blast_radius` | Analyze source exposure to bounded destination subnets |
+| **NQE Analysis** | `get_device_basic_info`, `search_nqe_queries`, `run_nqe_query_by_id`, `run_nqe_query`, `start_nqe_query` | Discover built-in Forward NQE IDs, execute them, or run bounded/ad-hoc NQE through sync or async native NQE APIs |
+| **Checks and Intent** | `list_predefined_checks`, `list_checks`, `get_check` | Review predefined checks and snapshot intent status |
+| **CVE Posture** | `search_nqe_queries`, `run_nqe_query_by_id`, `get_nqe_diff`, `get_snapshot_diff` | Review CVE exposure through built-in Forward NQE and snapshot diffs |
+| **Diff Analysis** | `get_snapshot_diff_summary`, `get_snapshot_diff`, `get_nqe_diff`, `get_config_diff` | Compare route, ACL, NAT, interface, check, NQE, and config diffs between snapshots |
+| **Configuration Analysis** | `search_configs`, `get_config_diff` | Search configs and compare snapshot diffs |
+| **Lifecycle Support** | `get_device_hardware`, `get_hardware_support`, `get_os_support` | Review hardware and OS support posture |
+| **Collection Workflows** | `list_classic_devices`, `upsert_classic_devices`, `get_collector_status`, `start_collection_task`, `get_collector_task`, `wait_for_latest_snapshot` | Prepare lab/admin networks for collection and monitor snapshot creation |
+
+### Enable Forward Integration
+
+```bash
+# During installation
+./scripts/install.sh
+# Answer "y" to "Enable Forward MCP Integration?"
+
+# Or enable for existing installation
+./scripts/forward-enable.sh
+```
+
+NetClaw installs the `netclaw` branch of Forward MCP by default. Set
+`FORWARD_MCP_REF=main` to use upstream main, or override `FORWARD_MCP_REPO` to
+point at a fork.
+
+For Forward SaaS, use `https://fwd.app` as the API base URL and set a
+`FORWARD_INSTANCE_ID` so local cache state is partitioned for that account.
+
+Example queries:
+
+```
+/forward list networks
+/forward get latest snapshot for network 101
+/forward search paths from 10.0.1.10 to 10.0.2.20
+/forward show failed checks for snapshot 123
+/forward show CVE violations by device for network 101
+/forward find NQE queries for BGP peer state
+/forward run the built-in CDP and LLDP NQE query for snapshot 123
+/forward write a bounded NQE query to list devices with their platform and type
+/forward summarize diffs between snapshots 123 and 124
+/forward show route diff prefixes between snapshots 123 and 124
+/forward show collector readiness for network 101
+/forward compare config diff between snapshots 123 and 124
+/forward compare NQE query FQ_xxx between snapshots 123 and 124
+```
+
+**Full documentation:** [docs/FORWARD.md](docs/FORWARD.md) | [Skill Definition](workspace/skills/forward/SKILL.md)
+
+---
+
 ## Architecture
 
 ```
@@ -336,6 +397,7 @@ Human (Slack / WebEx / WebChat) --> NetClaw (CCIE Agent on OpenClaw)
                                 |
                                 |-- NETWORK INTELLIGENCE:
                                 |     MCP: IP Fabric          --> Network assurance, path analysis, diagrams, intent (10 tools, remote HTTP)
+                                |     MCP: Forward          --> Snapshot assurance, paths, NQE, snapshot/config diffs, lifecycle support
                                 |     MCP: ThousandEyes (community) --> Tests, agents, path vis, dashboards (9 tools, stdio)
                                 |     MCP: ThousandEyes (official)  --> Alerts, outages, BGP, instant tests, endpoints (~20 tools, remote HTTP)
                                 |

--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -31,6 +31,24 @@
     "mode": "hobby"
   },
   "mcpServers": {
+    "forward-mcp": {
+      "command": "mcp-servers/forward-mcp/forward-mcp",
+      "env": {
+        "FORWARD_API_BASE_URL": "${FORWARD_API_BASE_URL}",
+        "FORWARD_API_KEY": "${FORWARD_API_KEY}",
+        "FORWARD_API_SECRET": "${FORWARD_API_SECRET}",
+        "FORWARD_INSTANCE_ID": "${FORWARD_INSTANCE_ID}",
+        "FORWARD_DEFAULT_NETWORK_ID": "${FORWARD_DEFAULT_NETWORK_ID}",
+        "FORWARD_DEFAULT_SNAPSHOT_ID": "${FORWARD_DEFAULT_SNAPSHOT_ID}",
+        "FORWARD_DEFAULT_QUERY_LIMIT": "${FORWARD_DEFAULT_QUERY_LIMIT:-10000}",
+        "FORWARD_CA_CERT_PATH": "${FORWARD_CA_CERT_PATH}",
+        "FORWARD_LOCK_DIR": "${FORWARD_LOCK_DIR:-/tmp}",
+        "FORWARD_BLOOM_ENABLED": "${FORWARD_BLOOM_ENABLED:-true}",
+        "FORWARD_BLOOM_INDEX_PATH": "${FORWARD_BLOOM_INDEX_PATH:-/tmp/forward-bloom-indexes}",
+        "FORWARD_SEMANTIC_CACHE_ENABLED": "${FORWARD_SEMANTIC_CACHE_ENABLED:-true}",
+        "FORWARD_SEMANTIC_CACHE_DISK_PATH": "${FORWARD_SEMANTIC_CACHE_DISK_PATH:-/tmp/forward-cache}"
+      }
+    },
     "suzieq-mcp": {
       "command": "python3",
       "args": [

--- a/docs/FORWARD.md
+++ b/docs/FORWARD.md
@@ -1,0 +1,483 @@
+# Forward MCP Integration Guide
+
+NetClaw uses the upstream Forward MCP server to query Forward
+snapshots, paths, device inventory, NQE results, NQE diffs, snapshot diffs,
+configuration search, config diffs, checks, vulnerabilities, blast radius,
+missing-device evidence, collection tasks, app-aware paths, and lifecycle
+support data.
+
+Source: <https://github.com/forwardnetworks/forward-mcp>
+
+## Install
+
+For an existing NetClaw install:
+
+```bash
+./scripts/forward-enable.sh
+```
+
+The script clones `forwardnetworks/forward-mcp`, builds the Go stdio MCP server,
+creates local cache/lock directories, writes Forward environment variables to
+`~/.openclaw/.env`, and runs a local `get_default_settings` smoke test.
+
+By default, NetClaw installs the `netclaw` branch of Forward MCP. Override the
+repo or ref when needed:
+
+```bash
+FORWARD_MCP_REPO=https://github.com/forwardnetworks/forward-mcp.git \
+FORWARD_MCP_REF=main \
+./scripts/forward-enable.sh
+```
+
+## Requirements
+
+- Go 1.25 or later
+- CGO enabled
+- Git
+- Network access from the NetClaw host to the Forward API
+- Forward credentials
+
+Forward MCP enforces TLS certificate verification. For private CA deployments,
+set `FORWARD_CA_CERT_PATH`; do not disable verification.
+
+## Environment
+
+Store credentials in `~/.openclaw/.env`, not in repository files:
+
+```bash
+FORWARD_API_BASE_URL=https://fwd.app
+FORWARD_API_KEY=your-api-key-or-username
+FORWARD_API_SECRET=your-api-secret-or-password
+FORWARD_INSTANCE_ID=your-account-or-org-label
+FORWARD_DEFAULT_NETWORK_ID=
+FORWARD_DEFAULT_SNAPSHOT_ID=
+FORWARD_COLLECTION_NETWORK_ID=
+FORWARD_CA_CERT_PATH=
+FORWARD_LOCK_DIR=$HOME/.openclaw/forward/locks
+FORWARD_BLOOM_INDEX_PATH=$HOME/.openclaw/forward/bloom-indexes
+FORWARD_SEMANTIC_CACHE_DISK_PATH=$HOME/.openclaw/forward/cache
+```
+
+Upstream Forward MCP sends `FORWARD_API_KEY:FORWARD_API_SECRET` as Basic Auth.
+Use the Forward credential form your deployment supports.
+
+For Forward SaaS, use `FORWARD_API_BASE_URL=https://fwd.app`. Set
+`FORWARD_INSTANCE_ID` when you use more than one SaaS account or org from the
+same NetClaw host; upstream uses this value to partition local NQE/cache state.
+Use `FORWARD_DEFAULT_NETWORK_ID` for the safe read-only demo network. Use
+`FORWARD_COLLECTION_NETWORK_ID` only for an admin/test network where collection
+setup and collection-start workflows are allowed.
+
+## SaaS Read-Only Workflow
+
+Use this path to validate a Forward SaaS account without writing credentials to
+the repo or shell history:
+
+```bash
+read -r -p "Forward username or API key: " FORWARD_API_KEY
+read -r -s -p "Forward password or API secret: " FORWARD_API_SECRET
+echo
+
+export FORWARD_API_BASE_URL=https://fwd.app
+export FORWARD_API_KEY
+export FORWARD_API_SECRET
+export FORWARD_INSTANCE_ID=forward-saas
+export FORWARD_DEFAULT_NETWORK_ID=<network-id>
+export FORWARD_LOCK_DIR=$HOME/.openclaw/forward/locks
+export FORWARD_BLOOM_ENABLED=false
+export FORWARD_SEMANTIC_CACHE_ENABLED=false
+
+python3 scripts/mcp-call.py ./mcp-servers/forward-mcp/forward-mcp \
+  get_default_settings '{}'
+python3 scripts/mcp-call.py ./mcp-servers/forward-mcp/forward-mcp \
+  list_networks '{"limit":5}'
+python3 scripts/mcp-call.py ./mcp-servers/forward-mcp/forward-mcp \
+  get_latest_snapshot '{"network_id":"<network-id>"}'
+python3 scripts/mcp-call.py ./mcp-servers/forward-mcp/forward-mcp \
+  list_devices '{"network_id":"<network-id>","limit":5}'
+python3 scripts/mcp-call.py ./mcp-servers/forward-mcp/forward-mcp \
+  get_device_basic_info '{"network_id":"<network-id>","snapshot_id":"<snapshot-id>","options":{"limit":5}}'
+
+unset FORWARD_API_KEY FORWARD_API_SECRET
+```
+
+Expected result: the server returns defaults, at least one accessible network,
+the latest processed snapshot for the selected network, a bounded device list,
+and a bounded NQE-backed device inventory result.
+
+## MCP Registration
+
+NetClaw registers the server as `forward-mcp` in `config/openclaw.json`:
+
+```json
+{
+  "command": "mcp-servers/forward-mcp/forward-mcp",
+  "env": {
+    "FORWARD_API_BASE_URL": "${FORWARD_API_BASE_URL}",
+    "FORWARD_API_KEY": "${FORWARD_API_KEY}",
+    "FORWARD_API_SECRET": "${FORWARD_API_SECRET}",
+    "FORWARD_INSTANCE_ID": "${FORWARD_INSTANCE_ID}"
+  }
+}
+```
+
+## Primary Workflows
+
+| Workflow | Preferred tools |
+|----------|-----------------|
+| Networks and defaults | `list_networks`, `get_default_settings`, `set_default_network` |
+| Collection setup | `list_classic_devices`, `upsert_classic_devices`, `list_cli_credentials`, `create_cli_credential` |
+| Collection control | `get_collector_status`, `start_collection_task`, `get_collector_task`, `wait_for_latest_snapshot`, `start_collection`, `cancel_collection` |
+| Snapshots | `list_snapshots`, `get_latest_snapshot` |
+| Devices | `list_devices`, `get_device_basic_info`, `get_missing_devices` |
+| Paths | `list_l7_applications`, `search_paths_bulk`, `search_paths` |
+| Topology | `get_snapshot_topology`, `search_nqe_queries`, `run_nqe_query_by_id` |
+| NQE | `search_nqe_queries`, `list_nqe_queries`, `run_nqe_query_by_id`, `run_nqe_query`, `start_nqe_query`, `get_nqe_query_status`, `get_nqe_query_result` |
+| Checks and intent | `list_predefined_checks`, `list_checks`, `get_check` |
+| CVE posture | `search_nqe_queries`, `run_nqe_query_by_id`, `get_nqe_diff`, `get_snapshot_diff` |
+| NQE and intent/check diffs | `get_nqe_diff` |
+| Snapshot diffs | `get_snapshot_diff_summary`, `get_snapshot_diff` |
+| Large NQE results | `get_nqe_result_summary`, `get_nqe_result_chunks`, `analyze_nqe_result_sql` |
+| Configs | `search_configs`, `get_config_diff` |
+| Lifecycle support | `get_device_hardware`, `get_hardware_support`, `get_os_support` |
+| Locations | `list_locations`, `get_device_locations` |
+
+NQE note: first-class tools such as `get_device_basic_info`,
+`get_device_hardware`, `get_hardware_support`, and `get_os_support` work
+without query-library discovery. Query discovery tools may need a local index
+first. In a persistent OpenClaw session, run `hydrate_database` and then
+`refresh_query_index` if `search_nqe_queries` or `list_nqe_queries` reports an
+empty query index. With one-shot `scripts/mcp-call.py`, prefer first-class tools
+or a known query ID because upstream hydration runs in the background.
+
+NQE catalog note: Forward MCP ships a bundled NQE catalog in its own
+`spec/NQELibrary.json`. NetClaw should not maintain a separate copy of that
+catalog. Use `search_nqe_queries` or `list_nqe_queries` to find the built-in
+`FQ_...` query ID, then execute it with `run_nqe_query_by_id`. For topology
+work, start with `get_snapshot_topology` for native directed links, then enrich
+with NQE when protocol or neighbor evidence is needed. The built-in
+`/L2/CDP and LLDP` query is commonly useful:
+`FQ_08cb4fd1d50cb521e25a43714e85f23c1e664b34`. Forward also models protocol
+peer relationships in NQE, so topology and relationship workflows should include
+relevant peer queries such as `/L3/BGP/Established BGP Peerings`
+(`FQ_e3d40e190d769a6221ddcc21555473cf04e1384e`) when those protocols are in
+use.
+
+Ad-hoc NQE note: use `run_nqe_query` only when no built-in query fits and the
+expected result is small enough for a bounded synchronous call. Use
+`start_nqe_query`, then poll `get_nqe_query_status` and fetch
+`get_nqe_query_result`, for long-running NQE or large result sets. These tools
+run raw NQE source or query IDs through Forward's native NQE APIs and do not
+save raw source to the NQE Library. Keep ad-hoc queries narrow, set limits, and
+use `all_results: true` only when the user needs the complete table.
+
+NQE construction note: build raw NQE incrementally and prefer schema-native
+surfaces over custom wrappers. Useful surfaces for demo questions are:
+
+- On-prem VIPs and backend rewrites:
+  `network.devices[].natEntries[]`, filtered with `natType == NatType.LB`, then
+  `headerMatches` and `rewrites`.
+- Cloud load balancers:
+  `network.cloudAccounts[].vpcs[].loadBalancers[]` and, for GCP external load
+  balancers, `network.cloudAccounts[].externalLoadBalancers[]`.
+- VIP route propagation:
+  `network.devices[].networkInstances[].afts.ipv4Unicast.ipEntries[]`, filtered
+  with `targetVip in route.prefix`, then `route.nextHops[]`.
+
+Example for VIPs in the same subnet:
+
+```nqe
+targetSubnet = ipSubnet("110.240.240.0/24");
+foreach device in network.devices
+foreach natEntry in device.natEntries
+where natEntry.natType == NatType.LB
+foreach vip in natEntry.headerMatches.ipv4Dst
+where vip in targetSubnet
+foreach rewrite in natEntry.rewrites
+select {
+  LoadBalancer: device.name,
+  Vip: vip,
+  Ports: natEntry.headerMatches.tpDst,
+  Backends: rewrite.ipv4Dst
+}
+```
+
+Example for how a VIP is propagated through routing:
+
+```nqe
+targetVip = ipSubnet("110.240.240.240/32");
+foreach device in network.devices
+foreach vrf in device.networkInstances
+where isPresent(vrf.afts.ipv4Unicast)
+foreach route in vrf.afts.ipv4Unicast.ipEntries
+where targetVip in route.prefix
+where length(route.prefix) >= 24
+foreach nextHop in route.nextHops
+select {
+  Device: device.name,
+  Vrf: vrf.name,
+  Prefix: route.prefix,
+  OriginProtocol: nextHop.originProtocol,
+  NextHopType: nextHop.nextHopType,
+  NextHopIp: nextHop.ipAddress,
+  Interface: nextHop.interfaceName
+}
+```
+
+Diff note: use `get_snapshot_diff_summary` for a broad snapshot overview across
+generally available route, ACL, NAT, ARP, MAC, interface, file/config, check,
+inventory-query, routing-loop, and vulnerability domains. Use
+`get_snapshot_diff` for a focused domain such as `routes`, `acl`, `nat`,
+`interfaces`, `checks`, or `vulnerabilities`. Use `get_nqe_diff` for arbitrary
+query-result drift between two snapshots, including intent/check-style NQE
+queries. Use `get_config_diff` when the request is specifically configuration
+drift. `get_nqe_diff` supports filtering and sorting on the `ChangeType` column
+for `ADDED`, `DELETED`, and `MODIFIED` rows.
+
+## Query Examples by Use Case
+
+### Network and Snapshot Discovery
+
+```
+/forward list networks
+/forward show current Forward defaults
+/forward use network 101 by default
+/forward show latest snapshot for network 101
+/forward list the five most recent snapshots for network 101
+```
+
+### Path Analysis
+
+```
+/forward search paths from 10.0.1.10 to 10.0.2.20
+/forward trace a TCP path from 10.0.1.10 to 10.0.2.20 port 443
+/forward list L7 applications and trace SSH from 10.0.1.10 to 10.0.2.20
+/forward find violations only for traffic from 10.0.1.10 to 10.0.2.20
+```
+
+Use `search_paths_bulk` first for agent workflows because it handles one or
+many path queries with bounded result controls. Use `search_paths` only for a
+single one-off trace.
+
+### Blast Radius
+
+```
+/forward find blast-radius sources matching leaf01
+/forward show blast radius from leaf01 to 0.0.0.0/0 in snapshot 123
+/forward show host-centric blast radius from leaf01 to 10.0.0.0/8
+```
+
+Use `suggest_blast_radius_sources` when the source location is uncertain. Use
+`get_blast_radius` with `source_device` for a device source, or with raw Forward
+`LocationFilter` JSON in `source` when the source is not a single device. Keep
+destination subnets, timeout, and paging bounded.
+
+### Device, Config, and Lifecycle Posture
+
+```
+/forward list first 10 devices in snapshot 123
+/forward show missing devices for network 101 in snapshot 123
+/forward show basic device inventory for snapshot 123
+/forward search configs for "router bgp"
+/forward check hardware support for snapshot 123
+/forward check OS support for snapshot 123
+```
+
+### Checks and CVEs
+
+```
+/forward show failed checks for snapshot 123
+/forward get details for check check-1 in snapshot 123
+/forward show CVE violations by device for network 101
+/forward show CVE-2024-12345 exposure using the Forward CVE NQE queries
+```
+
+Use `list_checks` first for snapshot intent status, then `get_check` for a
+specific failed or warning check. Use `list_predefined_checks` when the user
+asks what built-in checks are available.
+
+Use NQE for CVE posture wherever possible. Useful built-in query paths include:
+
+- `/Security/CVEs/CVE violations by CVE`
+- `/Security/CVEs/CVE violations by device`
+- `/Security/CVEs/CVE violation details by device`
+- `/Security/CVEs/Vendor CVE metadata`
+- `/Security/CVEs/CVE Configuration Analysis Statistics`
+
+Use `search_nqe_queries` to discover the current query IDs, then
+`run_nqe_query_by_id` with bounded result options. Use `get_nqe_diff` for CVE
+query drift between snapshots. Use `get_snapshot_diff` with
+`diff_type: "vulnerabilities"` when the user asks for the Forward vulnerability
+diff domain.
+
+### Snapshot Diff Analysis
+
+```
+/forward summarize diffs between snapshots 123 and 124
+/forward show route diff prefixes between snapshots 123 and 124
+/forward show ACL diffs between snapshots 123 and 124
+/forward show interface diffs for device leaf01 between snapshots 123 and 124
+/forward show check diff counts between snapshots 123 and 124
+```
+
+Recommended flow:
+
+1. Run `get_snapshot_diff_summary` with a bounded `include` list.
+2. Pick the interesting domain and run `get_snapshot_diff`.
+3. For route diffs, use `view: "prefixes"` or `view: "devices"` with a limit.
+4. For arbitrary NQE or intent-style checks, use `get_nqe_diff`.
+5. For literal config text drift, use `get_config_diff`.
+
+### Collection Readiness and Lab Onboarding
+
+```
+/forward show collector status for network 101
+/forward list collection sources for network 101
+/forward list CLI credentials for network 101
+/forward add lab devices to network 101
+/forward start a collection task for network 101
+/forward show collector task task-123
+/forward wait for the latest snapshot for network 101
+```
+
+Collection tools are intended for lab/admin networks. Before starting a
+collection, verify collector assignment with `get_collector_status`, verify
+sources with `list_classic_devices`, and confirm the user expects a new
+collection run. Prefer `start_collection_task` and `get_collector_task` for new
+workflows; keep `start_collection` for legacy deployments.
+
+Collector bootstrap is separate from collection control. Anyone can install or
+onboard a collector, but a network admin must assign that collector to the
+target network before collection can use it. The stable Linux collector download
+URL is `https://fwd.app/api/software/client?type=LINUX`.
+
+### Lab Topology Drawing
+
+Use this path when the user asks NetClaw to recreate or draw a real or
+emulated network shape:
+
+1. Use the available source system to identify node names, management IPs, and
+   physical links. This may be a lab backend, source of truth, device discovery,
+   or existing inventory.
+2. Verify a Forward collector is assigned and can reach the target management
+   network. If no collector is assigned or routed to the devices, install a
+   collector if needed and have a network admin assign it to the network.
+3. Use Forward MCP collection tools to onboard those nodes and create a
+   processed snapshot.
+4. Use Forward NQE discovery for link and peer evidence. Prefer
+   `search_nqe_queries` for CDP/LLDP and protocol peers, or run the built-in
+   `/L2/CDP and LLDP` and relevant peer query IDs when available.
+5. If Forward returns only management-plane neighbors or incomplete link data,
+   use the originating topology source as the edge source and Forward as the
+   collected assurance source.
+6. Render the normalized node/edge list with Draw.io, Markmap, or another
+   NetClaw diagram skill. Do not infer links from device names or management
+   IPs.
+
+## Snapshot Handling
+
+Forward tools use explicit snapshot IDs for repeatable answers. Prefer this
+sequence:
+
+1. `list_networks` or `get_default_settings` to establish the network.
+2. `get_latest_snapshot` for the active point in time.
+3. `list_snapshots` when a comparison needs a before/after pair.
+4. Pass both snapshot IDs explicitly to diff tools.
+
+For pre/post change demos, record the selected snapshots outside the query
+result and keep the diff call bounded with `limit`, `offset`, and domain
+filters.
+
+## Cross-Platform Composition
+
+Forward data can be combined with other NetClaw skills:
+
+| Integration | Forward Provides | Partner Provides | Use Case |
+|-------------|------------------|------------------|----------|
+| Lab or inventory source | Collection target, snapshot, NQE, path, and diff validation | Device list, management reachability, credentials, and physical link facts | Collect a real or emulated network, validate it, and draw the topology |
+| Batfish | Snapshot and path results | Offline config analysis | Compare modeled reachability with config-derived expectations |
+| pyATS | Assurance snapshot and diffs | Live CLI verification | Confirm a Forward finding against device show commands |
+| NetBox | Device and location facts | Source-of-truth intent | Reconcile discovered devices and metadata |
+| Draw.io | Structured topology facts | Diagram rendering | Produce human-readable topology or change diagrams |
+
+## Troubleshooting
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| "forward-mcp binary is not installed" | Server was not built | Run `./scripts/forward-enable.sh` |
+| "Another instance is already running" | Forward MCP instance lock is active | Use a unique `FORWARD_LOCK_DIR` for one-shot tests or stop the old process |
+| "Authentication failed" | Invalid key/secret or unsupported credential form | Regenerate the API credential and update `~/.openclaw/.env` |
+| "TLS certificate" | Private deployment uses an untrusted CA | Set `FORWARD_CA_CERT_PATH` to the CA bundle |
+| Empty query index | Local NQE query library has not hydrated | Use first-class NQE tools or hydrate in a persistent OpenClaw session |
+| No processed snapshot | Collection has not completed | Check collector status, sources, and schedules, then wait for a processed snapshot |
+
+## Safety
+
+Default Forward workflows in NetClaw should be read-only. Require explicit
+human confirmation before using any Forward tool that creates, updates, deletes,
+clears, or rebuilds remote data.
+
+Mutating or sensitive tools include:
+
+- `create_network`, `update_network`
+- `upsert_classic_devices`, `delete_classic_devices`
+- `create_cli_credential`, `delete_cli_credential`
+- `start_collection_task`, `start_collection`, `cancel_collection`
+- `delete_snapshot`
+- `create_location`, `update_location`, `delete_location`
+- `update_device_locations`, `create_locations_bulk`
+- `create_entity`, `delete_entity`, `create_relation`, `delete_relation`
+- `add_observation`, `delete_observation`
+- `clear_cache`
+- `initialize_query_index`, `hydrate_database`, `refresh_query_index`,
+  `build_bloom_filter`, `set_default_network`
+
+Creating new Forward networks requires full org admin privileges. Updating an
+existing Forward network requires network admin privileges. Installing or
+onboarding a collector is not org-admin-only, but assigning that collector to a
+target network requires network admin privileges.
+
+## Security Considerations
+
+- Store credentials in `~/.openclaw/.env`; never commit them.
+- Use `FORWARD_INSTANCE_ID` to partition local cache state across SaaS accounts
+  or orgs.
+- Use read-only credentials for discovery, path, NQE, diff, and lifecycle
+  workflows.
+- Use admin credentials only for lab/admin networks that need collection source
+  or collection-start workflows.
+- Treat topology, config, and path data as sensitive network information.
+
+## Verification
+
+Local build and smoke test:
+
+```bash
+cd mcp-servers/forward-mcp
+make test-quick
+CGO_ENABLED=1 go build -o forward-mcp ./cmd/server
+cd ../..
+mkdir -p "$HOME/.openclaw/forward/locks"
+python3 scripts/mcp-call.py \
+  "FORWARD_LOCK_DIR=$HOME/.openclaw/forward/locks ./mcp-servers/forward-mcp/forward-mcp" \
+  get_default_settings '{}'
+```
+
+Credentialed read-only smoke tests:
+
+```bash
+set -a
+source ~/.openclaw/.env
+set +a
+
+python3 scripts/mcp-call.py ./mcp-servers/forward-mcp/forward-mcp list_networks '{"limit":5}'
+python3 scripts/mcp-call.py ./mcp-servers/forward-mcp/forward-mcp get_latest_snapshot '{"network_id":"<network-id>"}'
+python3 scripts/mcp-call.py ./mcp-servers/forward-mcp/forward-mcp list_devices '{"network_id":"<network-id>","limit":5}'
+python3 scripts/mcp-call.py ./mcp-servers/forward-mcp/forward-mcp get_device_basic_info '{"network_id":"<network-id>","snapshot_id":"<snapshot-id>","options":{"limit":5}}'
+python3 scripts/mcp-call.py ./mcp-servers/forward-mcp/forward-mcp list_l7_applications '{}'
+python3 scripts/mcp-call.py ./mcp-servers/forward-mcp/forward-mcp list_checks '{"snapshot_id":"<snapshot-id>","statuses":["FAIL"]}'
+python3 scripts/mcp-call.py ./mcp-servers/forward-mcp/forward-mcp get_missing_devices '{"network_id":"<network-id>","snapshot_id":"<snapshot-id>"}'
+python3 scripts/mcp-call.py ./mcp-servers/forward-mcp/forward-mcp get_snapshot_diff_summary '{"before_snapshot":"<before-snapshot-id>","after_snapshot":"<after-snapshot-id>","include":["files","interfaces","acl","routes","checks","vulnerabilities"]}'
+python3 scripts/mcp-call.py ./mcp-servers/forward-mcp/forward-mcp get_snapshot_diff '{"before_snapshot":"<before-snapshot-id>","after_snapshot":"<after-snapshot-id>","diff_type":"routes","view":"prefixes","limit":5}'
+python3 scripts/mcp-call.py ./mcp-servers/forward-mcp/forward-mcp get_nqe_diff '{"before_snapshot":"<before-snapshot-id>","after_snapshot":"<after-snapshot-id>","query_id":"<query-id>","options":{"limit":5}}'
+```

--- a/scripts/forward-enable.sh
+++ b/scripts/forward-enable.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# Enable Forward MCP integration for existing NetClaw installations.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+log_step()  { echo -e "${CYAN}[STEP]${NC} $1"; }
+
+NETCLAW_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MCP_DIR="$NETCLAW_DIR/mcp-servers"
+FORWARD_MCP_DIR="$MCP_DIR/forward-mcp"
+FORWARD_MCP_BIN="$FORWARD_MCP_DIR/forward-mcp"
+FORWARD_MCP_REPO="${FORWARD_MCP_REPO:-https://github.com/forwardnetworks/forward-mcp.git}"
+FORWARD_MCP_REF="${FORWARD_MCP_REF:-netclaw}"
+OPENCLAW_DIR="$HOME/.openclaw"
+OPENCLAW_ENV="$OPENCLAW_DIR/.env"
+OPENCLAW_CONFIG="$OPENCLAW_DIR/openclaw.json"
+FORWARD_STATE_DIR="$OPENCLAW_DIR/forward"
+FORWARD_LOCK_DIR="$FORWARD_STATE_DIR/locks"
+FORWARD_BLOOM_INDEX_PATH="$FORWARD_STATE_DIR/bloom-indexes"
+FORWARD_CACHE_PATH="$FORWARD_STATE_DIR/cache"
+
+set_env_var() {
+    local key="$1" val="$2"
+    local tmp
+    [ -z "$val" ] && return
+    tmp="$(mktemp)"
+    grep -v "^${key}=" "$OPENCLAW_ENV" > "$tmp" 2>/dev/null || true
+    printf '%s=%s\n' "$key" "$val" >> "$tmp"
+    mv "$tmp" "$OPENCLAW_ENV"
+}
+
+set_env_placeholder() {
+    local key="$1" val="$2"
+    if ! grep -q "^${key}=" "$OPENCLAW_ENV" 2>/dev/null; then
+        set_env_var "$key" "$val"
+    fi
+}
+
+go_major() {
+    go version | awk '{print $3}' | sed 's/^go//' | cut -d. -f1
+}
+
+go_minor() {
+    go version | awk '{print $3}' | sed 's/^go//' | cut -d. -f2
+}
+
+checkout_forward_ref() {
+    local dir="$1" repo="$2" ref="$3"
+    if [ -d "$dir/.git" ]; then
+        log_info "Updating existing checkout at $dir"
+        git -C "$dir" remote set-url origin "$repo"
+        git -C "$dir" fetch origin --tags
+    else
+        log_info "Cloning forward-mcp into $dir"
+        git clone "$repo" "$dir"
+    fi
+
+    if git -C "$dir" rev-parse --verify --quiet "origin/$ref" >/dev/null; then
+        git -C "$dir" checkout -B "$ref" "origin/$ref"
+    else
+        git -C "$dir" checkout "$ref"
+    fi
+}
+
+echo "========================================="
+echo "  Forward MCP Integration"
+echo "  for NetClaw"
+echo "========================================="
+echo ""
+echo "  Source: https://github.com/forwardnetworks/forward-mcp"
+echo "  Ref: $FORWARD_MCP_REF"
+echo ""
+
+log_step "1/5 Checking prerequisites..."
+
+missing=0
+for bin in git go; do
+    if ! command -v "$bin" >/dev/null 2>&1; then
+        log_error "$bin is required."
+        missing=1
+    fi
+done
+
+if command -v go >/dev/null 2>&1; then
+    major="$(go_major)"
+    minor="$(go_minor)"
+    if [ "$major" -lt 1 ] || { [ "$major" -eq 1 ] && [ "$minor" -lt 25 ]; }; then
+        log_error "Go 1.25 or later is required. Found: $(go version)"
+        missing=1
+    else
+        log_info "Go version: $(go version)"
+    fi
+fi
+
+if [ "$(go env CGO_ENABLED)" = "0" ]; then
+    log_error "CGO must be enabled for forward-mcp."
+    missing=1
+fi
+
+if [ "$missing" -eq 1 ]; then
+    log_error "Install missing prerequisites and re-run."
+    exit 1
+fi
+
+log_step "2/5 Installing forward-mcp..."
+mkdir -p "$MCP_DIR" "$OPENCLAW_DIR" "$FORWARD_LOCK_DIR" "$FORWARD_BLOOM_INDEX_PATH" "$FORWARD_CACHE_PATH"
+[ -f "$OPENCLAW_ENV" ] || touch "$OPENCLAW_ENV"
+
+log_info "Using forward-mcp repo: $FORWARD_MCP_REPO"
+log_info "Using forward-mcp ref: $FORWARD_MCP_REF"
+checkout_forward_ref "$FORWARD_MCP_DIR" "$FORWARD_MCP_REPO" "$FORWARD_MCP_REF"
+
+log_info "Building forward-mcp binary"
+CGO_ENABLED=1 go -C "$FORWARD_MCP_DIR" build -o "$FORWARD_MCP_BIN" ./cmd/server
+
+log_step "3/5 Configuring environment..."
+
+set_env_var "FORWARD_LOCK_DIR" "$FORWARD_LOCK_DIR"
+set_env_var "FORWARD_BLOOM_ENABLED" "${FORWARD_BLOOM_ENABLED:-true}"
+set_env_var "FORWARD_BLOOM_INDEX_PATH" "$FORWARD_BLOOM_INDEX_PATH"
+set_env_var "FORWARD_SEMANTIC_CACHE_ENABLED" "${FORWARD_SEMANTIC_CACHE_ENABLED:-true}"
+set_env_var "FORWARD_SEMANTIC_CACHE_DISK_PATH" "$FORWARD_CACHE_PATH"
+
+read -r -p "Configure Forward credentials now? [Y/n] " config_now
+if [[ ! "$config_now" =~ ^[Nn]$ ]]; then
+    read -r -p "Forward API base URL (e.g., https://fwd.app): " forward_url
+    if [ -n "$forward_url" ]; then
+        set_env_var "FORWARD_API_BASE_URL" "${forward_url%/}"
+    fi
+
+    read -r -p "Forward API key or username: " forward_key
+    if [ -n "$forward_key" ]; then
+        set_env_var "FORWARD_API_KEY" "$forward_key"
+    fi
+
+    read -r -sp "Forward API secret or password: " forward_secret
+    echo ""
+    if [ -n "$forward_secret" ]; then
+        set_env_var "FORWARD_API_SECRET" "$forward_secret"
+    fi
+
+    read -r -p "Default Forward network ID (optional): " forward_network
+    set_env_var "FORWARD_DEFAULT_NETWORK_ID" "$forward_network"
+
+    read -r -p "Default Forward snapshot ID (optional): " forward_snapshot
+    set_env_var "FORWARD_DEFAULT_SNAPSHOT_ID" "$forward_snapshot"
+
+    read -r -p "Forward collection/admin network ID (optional): " forward_collection_network
+    set_env_var "FORWARD_COLLECTION_NETWORK_ID" "$forward_collection_network"
+
+    read -r -p "Forward instance ID for local cache partitioning (optional): " forward_instance
+    set_env_var "FORWARD_INSTANCE_ID" "$forward_instance"
+
+    read -r -p "Custom CA certificate path (optional): " forward_ca
+    set_env_var "FORWARD_CA_CERT_PATH" "$forward_ca"
+else
+    log_info "Skipping credential prompts. Set FORWARD_API_* in $OPENCLAW_ENV later."
+    set_env_placeholder "FORWARD_API_BASE_URL" "https://fwd.example.com"
+    set_env_placeholder "FORWARD_API_KEY" "your-api-key-or-username"
+    set_env_placeholder "FORWARD_API_SECRET" "your-api-secret-or-password"
+    set_env_placeholder "FORWARD_INSTANCE_ID" "default"
+fi
+
+log_step "4/5 Checking NetClaw config..."
+if [ -f "$OPENCLAW_CONFIG" ]; then
+    if grep -q '"forward-mcp"' "$OPENCLAW_CONFIG"; then
+        log_info "forward-mcp is present in $OPENCLAW_CONFIG"
+    else
+        log_warn "forward-mcp is not present in $OPENCLAW_CONFIG"
+        log_info "Copy config/openclaw.json or add the forward-mcp block from this repo."
+    fi
+else
+    log_warn "$OPENCLAW_CONFIG not found. Run ./scripts/install.sh first."
+fi
+
+log_step "5/5 Running local smoke test..."
+if python3 "$NETCLAW_DIR/scripts/mcp-call.py" \
+    "FORWARD_LOCK_DIR=$FORWARD_LOCK_DIR FORWARD_BLOOM_ENABLED=false FORWARD_SEMANTIC_CACHE_ENABLED=false $FORWARD_MCP_BIN" \
+    get_default_settings '{}' >/dev/null; then
+    log_info "forward-mcp responded to get_default_settings"
+else
+    log_warn "Smoke test failed. Check $FORWARD_MCP_BIN and Forward environment variables."
+fi
+
+echo ""
+echo "Forward MCP integration is installed."
+echo ""
+echo "Next steps:"
+echo "  1. Restart the OpenClaw gateway."
+echo "  2. Verify MCP registration with your OpenClaw MCP list command."
+echo "  3. Try: /forward list networks"
+echo ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2227,6 +2227,169 @@ fi
 
 echo ""
 
+# ═══════════════════════════════════════════
+# Step 50h: Forward MCP Integration
+# ═══════════════════════════════════════════
+
+log_step "50h/$TOTAL_STEPS Forward MCP Integration..."
+echo "  Source: https://github.com/forwardnetworks/forward-mcp"
+echo "  Snapshot assurance, path search, NQE, config search, config diffs"
+echo ""
+
+read -r -p "Enable Forward MCP Integration? [y/N] " enable_forward
+
+if [[ "$enable_forward" =~ ^[Yy]$ ]]; then
+    FORWARD_MCP_DIR="$MCP_DIR/forward-mcp"
+    FORWARD_MCP_BIN="$FORWARD_MCP_DIR/forward-mcp"
+    FORWARD_MCP_REPO="${FORWARD_MCP_REPO:-https://github.com/forwardnetworks/forward-mcp.git}"
+    FORWARD_MCP_REF="${FORWARD_MCP_REF:-netclaw}"
+    FORWARD_STATE_DIR="$HOME/.openclaw/forward"
+    FORWARD_LOCK_DIR="$FORWARD_STATE_DIR/locks"
+    FORWARD_BLOOM_INDEX_PATH="$FORWARD_STATE_DIR/bloom-indexes"
+    FORWARD_CACHE_PATH="$FORWARD_STATE_DIR/cache"
+    OPENCLAW_ENV="$HOME/.openclaw/.env"
+
+    forward_set_env_var() {
+        local key="$1" val="$2" tmp
+        [ -z "$val" ] && return
+        mkdir -p "$(dirname "$OPENCLAW_ENV")"
+        [ -f "$OPENCLAW_ENV" ] || touch "$OPENCLAW_ENV"
+        tmp="$(mktemp)"
+        grep -v "^${key}=" "$OPENCLAW_ENV" > "$tmp" 2>/dev/null || true
+        printf '%s=%s\n' "$key" "$val" >> "$tmp"
+        mv "$tmp" "$OPENCLAW_ENV"
+    }
+
+    forward_set_env_placeholder() {
+        local key="$1" val="$2"
+        if ! grep -q "^${key}=" "$OPENCLAW_ENV" 2>/dev/null; then
+            forward_set_env_var "$key" "$val"
+        fi
+    }
+
+    forward_go_major() {
+        go version | awk '{print $3}' | sed 's/^go//' | cut -d. -f1
+    }
+
+    forward_go_minor() {
+        go version | awk '{print $3}' | sed 's/^go//' | cut -d. -f2
+    }
+
+    forward_checkout_ref() {
+        local dir="$1" repo="$2" ref="$3"
+        if [ -d "$dir/.git" ]; then
+            log_info "Updating existing checkout at $dir"
+            git -C "$dir" remote set-url origin "$repo"
+            git -C "$dir" fetch origin --tags
+        else
+            log_info "Cloning forward-mcp into $dir"
+            git clone "$repo" "$dir"
+        fi
+
+        if git -C "$dir" rev-parse --verify --quiet "origin/$ref" >/dev/null; then
+            git -C "$dir" checkout -B "$ref" "origin/$ref"
+        else
+            git -C "$dir" checkout "$ref"
+        fi
+    }
+
+    if ! command -v go >/dev/null 2>&1; then
+        log_error "Go 1.25 or later is required for forward-mcp"
+        exit 1
+    fi
+
+    forward_go_major_version="$(forward_go_major)"
+    forward_go_minor_version="$(forward_go_minor)"
+    if [ "$forward_go_major_version" -lt 1 ] || { [ "$forward_go_major_version" -eq 1 ] && [ "$forward_go_minor_version" -lt 25 ]; }; then
+        log_error "Go 1.25 or later is required for forward-mcp. Found: $(go version)"
+        exit 1
+    fi
+
+    if [ "$(go env CGO_ENABLED)" = "0" ]; then
+        log_error "CGO must be enabled for forward-mcp"
+        exit 1
+    fi
+
+    mkdir -p "$FORWARD_LOCK_DIR" "$FORWARD_BLOOM_INDEX_PATH" "$FORWARD_CACHE_PATH"
+
+    log_info "Using forward-mcp repo: $FORWARD_MCP_REPO"
+    log_info "Using forward-mcp ref: $FORWARD_MCP_REF"
+    forward_checkout_ref "$FORWARD_MCP_DIR" "$FORWARD_MCP_REPO" "$FORWARD_MCP_REF"
+
+    log_info "Building forward-mcp..."
+    if CGO_ENABLED=1 go -C "$FORWARD_MCP_DIR" build -o "$FORWARD_MCP_BIN" ./cmd/server; then
+        log_info "forward-mcp built: $FORWARD_MCP_BIN"
+    else
+        log_error "forward-mcp build failed"
+        exit 1
+    fi
+
+    forward_set_env_var "FORWARD_LOCK_DIR" "$FORWARD_LOCK_DIR"
+    forward_set_env_var "FORWARD_BLOOM_ENABLED" "true"
+    forward_set_env_var "FORWARD_BLOOM_INDEX_PATH" "$FORWARD_BLOOM_INDEX_PATH"
+    forward_set_env_var "FORWARD_SEMANTIC_CACHE_ENABLED" "true"
+    forward_set_env_var "FORWARD_SEMANTIC_CACHE_DISK_PATH" "$FORWARD_CACHE_PATH"
+
+    read -r -p "Configure Forward credentials now? [y/N] " config_forward
+    if [[ "$config_forward" =~ ^[Yy]$ ]]; then
+        read -r -p "Forward API base URL (e.g., https://fwd.app): " forward_url
+        if [ -n "$forward_url" ]; then
+            forward_set_env_var "FORWARD_API_BASE_URL" "${forward_url%/}"
+            log_info "Set FORWARD_API_BASE_URL"
+        fi
+
+        read -r -p "Forward API key or username: " forward_key
+        if [ -n "$forward_key" ]; then
+            forward_set_env_var "FORWARD_API_KEY" "$forward_key"
+            log_info "Set FORWARD_API_KEY"
+        fi
+
+        read -r -sp "Forward API secret or password: " forward_secret
+        echo ""
+        if [ -n "$forward_secret" ]; then
+            forward_set_env_var "FORWARD_API_SECRET" "$forward_secret"
+            log_info "Set FORWARD_API_SECRET=***"
+        fi
+
+        read -r -p "Default Forward network ID (optional): " forward_network
+        forward_set_env_var "FORWARD_DEFAULT_NETWORK_ID" "$forward_network"
+
+        read -r -p "Default Forward snapshot ID (optional): " forward_snapshot
+        forward_set_env_var "FORWARD_DEFAULT_SNAPSHOT_ID" "$forward_snapshot"
+
+        read -r -p "Forward collection/admin network ID (optional): " forward_collection_network
+        forward_set_env_var "FORWARD_COLLECTION_NETWORK_ID" "$forward_collection_network"
+
+        read -r -p "Forward instance ID for local cache partitioning (optional): " forward_instance
+        forward_set_env_var "FORWARD_INSTANCE_ID" "$forward_instance"
+
+        read -r -p "Custom CA certificate path (optional): " forward_ca
+        forward_set_env_var "FORWARD_CA_CERT_PATH" "$forward_ca"
+
+        log_info "Forward credentials configured in ~/.openclaw/.env"
+    else
+        log_info "Skipping credential configuration. Set FORWARD_API_* variables in ~/.openclaw/.env later."
+        forward_set_env_placeholder "FORWARD_API_BASE_URL" "https://fwd.example.com"
+        forward_set_env_placeholder "FORWARD_API_KEY" "your-api-key-or-username"
+        forward_set_env_placeholder "FORWARD_API_SECRET" "your-api-secret-or-password"
+        forward_set_env_placeholder "FORWARD_INSTANCE_ID" "default"
+    fi
+
+    if python3 "$NETCLAW_DIR/scripts/mcp-call.py" \
+        "FORWARD_LOCK_DIR=$FORWARD_LOCK_DIR FORWARD_BLOOM_ENABLED=false FORWARD_SEMANTIC_CACHE_ENABLED=false $FORWARD_MCP_BIN" \
+        get_default_settings '{}' >/dev/null; then
+        log_info "forward-mcp responded to get_default_settings"
+    else
+        log_warn "forward-mcp smoke test failed; verify environment and run scripts/forward-enable.sh later"
+    fi
+
+    log_info "Forward integration enabled. Use /forward skill to query."
+else
+    log_info "Skipping Forward integration. Run scripts/forward-enable.sh later to enable."
+fi
+
+echo ""
+
 log_step "51/$TOTAL_STEPS Deploying skills and configuration..."
 
 PYATS_SCRIPT="$PYATS_MCP_DIR/pyats_mcp_server.py"

--- a/workspace/skills/forward/SKILL.md
+++ b/workspace/skills/forward/SKILL.md
@@ -1,0 +1,308 @@
+---
+name: forward
+description: Forward snapshot assurance, path search, app-aware path search, NQE, checks, vulnerabilities, diffs, configuration, lifecycle, collection, and topology workflows through the upstream forward-mcp server.
+version: 1.0.0
+license: Apache-2.0
+author: forward
+tags: [forward, assurance, nqe, paths, diffs, collection]
+mcp_servers: [forward-mcp]
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - mcp-servers/forward-mcp/forward-mcp
+      env:
+        - FORWARD_API_BASE_URL
+        - FORWARD_API_KEY
+        - FORWARD_API_SECRET
+        - FORWARD_INSTANCE_ID
+        - FORWARD_DEFAULT_NETWORK_ID
+---
+
+# Forward Skill
+
+**Skill**: `/forward`
+**MCP Server**: `forward-mcp`
+**Source**: <https://github.com/forwardnetworks/forward-mcp>
+
+## Use When
+
+Use this skill for Forward snapshot assurance, collection, and analysis:
+
+- Discover Forward networks, snapshots, and devices
+- Verify paths and reachability
+- Discover and run NQE checks
+- Review predefined checks, failed checks, and vulnerability analysis
+- Compare NQE, snapshot, and config diffs
+- Search configurations
+- Analyze blast radius for a source location to destination IPv4 subnets
+- Review hardware and OS lifecycle support
+- Find missing devices inferred during collection
+- Support lab or real-network collection workflows
+
+## Startup
+
+1. Start with `get_default_settings` to see configured defaults.
+2. If no default network is set, use `list_networks` with a small limit and ask
+   the user which network to use.
+3. Prefer explicit `network_id` and `snapshot_id` values for repeatable results.
+4. Use bounded limits by default. Use `all_results` only when the user needs the
+   complete dataset.
+5. In Forward SaaS, prefer `FORWARD_API_BASE_URL=https://fwd.app` and set
+   `FORWARD_INSTANCE_ID` for local cache partitioning when multiple SaaS orgs or
+   accounts are used on the same NetClaw host.
+
+## Tool Routing
+
+| User intent | Preferred tools |
+|-------------|-----------------|
+| "List Forward networks" | `list_networks` |
+| "Use this network by default" | `set_default_network` |
+| "Show collection sources" | `list_classic_devices`, `get_classic_device` |
+| "Add lab devices" | `upsert_classic_devices` |
+| "Show collector status" | `get_collector_status` |
+| "Start collection" | `start_collection_task`, `get_collector_task`, then `wait_for_latest_snapshot`; use `start_collection` only for legacy flows |
+| "Show snapshots" | `list_snapshots`, `get_latest_snapshot` |
+| "List devices" | `list_devices`, `get_device_basic_info` |
+| "Find missing collection neighbors" | `get_missing_devices` |
+| "Trace paths" | `search_paths_bulk`, then `search_paths` for one-off traces |
+| "Trace app-aware paths" | `list_l7_applications`, then `search_paths_bulk` or `search_paths` with `app_id`, `url`, or `domain` |
+| "Show blast radius" | `suggest_blast_radius_sources`, then `get_blast_radius` |
+| "Find NQE checks" | `search_nqe_queries`, `list_nqe_queries` |
+| "Run an NQE check" | `run_nqe_query_by_id`; use `start_nqe_query` for long-running checks |
+| "Write or run ad-hoc NQE" | Prefer `search_nqe_queries` first; use `run_nqe_query` only when no built-in query fits and async NQE for long-running or large results |
+| "Show predefined checks" | `list_predefined_checks` |
+| "Show failed checks or intent status" | `list_checks`, then `get_check` |
+| "Show vulnerabilities or CVE exposure" | `search_nqe_queries`, then `run_nqe_query_by_id` with the `/Security/CVEs/...` query IDs |
+| "Draw topology from Forward" | `get_snapshot_topology`, then search NQE for CDP/LLDP and protocol-peer evidence when needed |
+| "Summarize large results" | `get_nqe_result_summary`, `get_nqe_result_chunks`, `analyze_nqe_result_sql` |
+| "Search configs" | `search_configs` |
+| "Compare NQE or intent/check results" | `get_nqe_diff` |
+| "Summarize snapshot diffs" | `get_snapshot_diff_summary` |
+| "Show route, ACL, NAT, interface, check, or vulnerability diffs" | `get_snapshot_diff` |
+| "Compare snapshots/configs" | `get_config_diff` |
+| "Check hardware or OS support" | `get_device_hardware`, `get_hardware_support`, `get_os_support` |
+| "Show locations" | `list_locations`, `get_device_locations` |
+
+## NQE Discovery Notes
+
+Forward MCP owns the NQE catalog. Do not copy catalog contents into NetClaw.
+For natural-language NQE requests:
+
+1. Prefer first-class tools when they match the intent, such as
+   `get_device_basic_info`, `get_device_hardware`, `get_hardware_support`, or
+   `get_os_support`.
+2. Otherwise use `search_nqe_queries` with the user's intent.
+3. Use `list_nqe_queries` only when the directory or query family is already
+   known.
+4. Preserve the returned `FQ_...` query ID in the answer and execute it with
+   `run_nqe_query_by_id`.
+5. Keep limits bounded unless the user asks for complete data.
+
+Use `run_nqe_query` for ad-hoc NQE source only after checking whether a
+built-in query already answers the question and the expected result fits a
+bounded synchronous call. For long-running or large queries, use
+`start_nqe_query`, poll `get_nqe_query_status`, then fetch rows with
+`get_nqe_query_result`. These execute raw NQE or query IDs through Forward's
+native NQE APIs; they do not create or save a new query in the NQE Library. Keep
+ad-hoc queries narrow, set limits by default, and explain when the result is
+from custom source rather than a built-in Forward query. Use `all_results: true`
+only when the user needs the complete table.
+
+### Constructing Ad-Hoc NQE
+
+Prefer built-in query IDs when they fit. When a question needs raw NQE, build it
+incrementally and execute it through Forward MCP:
+
+1. Start with a tiny selector such as
+   `foreach d in network.devices select { Name: d.name }`.
+2. Add one model surface at a time, then run `start_nqe_query`, poll
+   `get_nqe_query_status`, and page with `get_nqe_query_result`.
+3. Keep filters inside NQE instead of post-processing large result sets.
+4. Use schema-native types and OneOf patterns. Enumerations can be compared as
+   `NatType.LB`; data-bearing OneOf values use `when ... is`.
+
+Useful raw NQE patterns:
+
+On-prem load balancer VIPs, DNAT-style rewrites, and backend targets:
+
+```nqe
+foreach device in network.devices
+foreach natEntry in device.natEntries
+where natEntry.natType == NatType.LB
+foreach rewrite in natEntry.rewrites
+select {
+  LoadBalancer: device.name,
+  Vip: natEntry.headerMatches.ipv4Dst,
+  Ports: natEntry.headerMatches.tpDst,
+  Backends: rewrite.ipv4Dst,
+  BackendPorts: rewrite.tpDst
+}
+```
+
+Other VIPs in the same subnet:
+
+```nqe
+targetSubnet = ipSubnet("110.240.240.0/24");
+foreach device in network.devices
+foreach natEntry in device.natEntries
+where natEntry.natType == NatType.LB
+foreach vip in natEntry.headerMatches.ipv4Dst
+where vip in targetSubnet
+foreach rewrite in natEntry.rewrites
+select {
+  LoadBalancer: device.name,
+  Vip: vip,
+  Ports: natEntry.headerMatches.tpDst,
+  Backends: rewrite.ipv4Dst
+}
+```
+
+Cloud VPC load balancers:
+
+```nqe
+foreach cloudAccount in network.cloudAccounts
+foreach vpc in cloudAccount.vpcs
+foreach loadBalancer in vpc.loadBalancers
+foreach rule in loadBalancer.loadBalancerRules
+foreach backend in rule.backends
+let server = when backend is
+               server(backendServerData) -> backendServerData;
+               otherwise -> null : BackendServer
+where isPresent(server)
+select {
+  CloudAccount: cloudAccount.name,
+  Vpc: vpc.name,
+  LoadBalancer: loadBalancer.name,
+  FrontendIps: rule.frontendIps,
+  FrontendPorts: rule.frontendPorts,
+  BackendIps: server.backendIps,
+  BackendPorts: server.backendPorts
+}
+```
+
+VIP route propagation:
+
+```nqe
+targetVip = ipSubnet("110.240.240.240/32");
+foreach device in network.devices
+foreach vrf in device.networkInstances
+where isPresent(vrf.afts.ipv4Unicast)
+foreach route in vrf.afts.ipv4Unicast.ipEntries
+where targetVip in route.prefix
+where length(route.prefix) >= 24
+foreach nextHop in route.nextHops
+select {
+  Device: device.name,
+  Vrf: vrf.name,
+  Prefix: route.prefix,
+  OriginProtocol: nextHop.originProtocol,
+  NextHopType: nextHop.nextHopType,
+  NextHopIp: nextHop.ipAddress,
+  Interface: nextHop.interfaceName
+}
+```
+
+For topology, start with `get_snapshot_topology` for native directed links.
+Then search for both link evidence and protocol-peer evidence when needed.
+CDP/LLDP can describe physical neighbors; peer queries such as BGP can describe
+relationships Forward models beyond discovery protocols.
+
+If `search_nqe_queries` or `list_nqe_queries` reports that the query index is
+empty, do this only in a persistent OpenClaw session and only after user
+confirmation:
+
+1. Run `hydrate_database` with `regenerate_embeddings: false`.
+2. Run `refresh_query_index`.
+3. Retry `search_nqe_queries` or `list_nqe_queries`.
+
+## Safety Rules
+
+Default to read-only Forward tools. Require explicit human confirmation before
+tools that create, update, delete, clear, hydrate, rebuild, start/cancel
+collection, or set persistent defaults. This includes collector/source,
+credential, network, snapshot, location, entity/relation, observation, local
+cache/index, and `set_default_network` operations. Creating new Forward
+networks requires full org admin privileges; do not use `create_network` unless
+the user explicitly confirms that role. Updating an existing Forward network
+requires network admin privileges.
+
+Never put Forward credentials in repository files. Use `~/.openclaw/.env`.
+For private CA deployments, use `FORWARD_CA_CERT_PATH`; do not disable TLS
+verification.
+
+## Workflows
+
+### Diffs
+
+1. Use `get_snapshot_diff_summary` first for a bounded overview.
+2. Use `get_snapshot_diff` for focused route, ACL, NAT, interface, check,
+   file/config, inventory-query, routing-loop, or vulnerability diffs.
+3. Use `get_nqe_diff` for arbitrary NQE and intent-style query diffs.
+4. Use `get_config_diff` when the user specifically asks for config text drift.
+
+### Blast Radius
+
+1. Use `suggest_blast_radius_sources` if the source name or location filter is
+   uncertain.
+2. Use `get_blast_radius` with `source_device` for a device source, or `source`
+   when the prompt already supplies Forward `LocationFilter` JSON.
+3. Keep `dst_subnets`, `timeout_seconds`, and `paging_options` bounded.
+4. Use blast radius for security/exposure questions; use NQE for tabular
+   snapshot facts and `search_paths_bulk` for specific path traces.
+
+### Checks and CVEs
+
+1. Use `list_checks` with `statuses` such as `FAIL`, `WARN`, or `ERROR` to
+   triage intent/check state for a snapshot.
+2. Use `get_check` for the detailed rows behind a specific failed check.
+3. Use `list_predefined_checks` when the user asks what built-in checks exist.
+4. Use NQE for CVE posture. Prefer `search_nqe_queries` for natural-language
+   discovery, then `run_nqe_query_by_id`.
+5. Useful built-in CVE query paths include `/Security/CVEs/CVE violations by
+   CVE`, `/Security/CVEs/CVE violations by device`,
+   `/Security/CVEs/CVE violation details by device`, and
+   `/Security/CVEs/Vendor CVE metadata`.
+6. Use `get_nqe_diff` for CVE query drift between snapshots. Use
+   `get_snapshot_diff` with `diff_type: "vulnerabilities"` for the Forward
+   vulnerability diff domain.
+
+### Collection and Lab Demo
+
+1. Treat collection setup and start/cancel actions as admin workflows.
+2. Use them only on lab/admin networks or after explicit user confirmation.
+3. Treat collector installation/onboarding as a separate prerequisite. Anyone
+   can install or onboard a collector, but a network admin must assign that
+   collector to the target network. The stable Linux collector download URL is
+   `https://fwd.app/api/software/client?type=LINUX`.
+4. Before starting collection, run `get_collector_status` and
+   `list_classic_devices`.
+5. Prefer `start_collection_task`, poll it with `get_collector_task`, then use
+   `wait_for_latest_snapshot`. Use `start_collection` only when task creation is
+   unavailable in the target deployment.
+
+### Topology Drawing
+
+1. Prefer Forward NQE evidence for collected topology questions: link queries
+   plus relevant protocol-peer queries.
+2. If the NQE result only shows management-plane neighbors or incomplete links in
+   a real or emulated network, use the originating topology source as the edge
+   source and Forward as the collected assurance source.
+3. Use the available lab backend, source-of-truth, inventory, or discovery tool
+   to identify device names, management IPs, physical links, and credentials
+   before Forward collection.
+4. Before `start_collection`, confirm the assigned Forward collector can reach
+   the target management network. If not, the missing step is collector
+   installation, assignment, or routing.
+5. Render a normalized node/edge list with Draw.io, Markmap, or another diagram
+   skill. Never infer links from names or management IPs alone.
+
+## Result Discipline
+
+- Summarize large tables before presenting them.
+- Preserve network IDs, snapshot IDs, query IDs, and device names in the answer.
+- When a path or NQE result is inconclusive, say what data was missing and which
+  next read-only Forward tool should be run.
+- For config and NQE diffs, separate intended changes from unexpected changes.
+- For snapshot diffs, start with counts/summary and drill into the changed
+  domain that matters.


### PR DESCRIPTION
## Summary
- Adds Forward MCP registration, installer prompt, enablement script, and Forward skill/docs.
- Uses the Forward MCP netclaw branch for collection, collector status, snapshot/topology/NQE/config/diff, checks, blast-radius, missing-device, app-aware path, and lab-demo workflows.
- Routes NQE workflows through Forward MCP query discovery and native sync/async NQE execution instead of copying the catalog into NetClaw.
- Adds schema-native raw NQE guidance for VIP/LB NAT rewrites, cloud load balancers, and VIP route propagation.
- Documents collector bootstrap/admin permissions and keeps credentials in ~/.openclaw/.env.

## Validation
- go test ./... in mcp-servers/forward-mcp
- go build -o forward-mcp ./cmd/server in mcp-servers/forward-mcp
- jq empty config/openclaw.json
- bash -n scripts/forward-enable.sh scripts/install.sh
- git diff --check
- Live SaaS smoke: native topology returned directed links from latest snapshot 1322821 in network 235937.
- Live SaaS smoke: sync and async raw NQE executed through Forward MCP against snapshot 1322821.
- Live SaaS smoke: NQE returned load-balancer VIP/NAT rewrite rows, same-subnet VIP rows, cloud VPC load-balancer rows, and VIP route propagation rows using native NQE model surfaces.