### PR TITLE
docs(infrahub): update netclaw for reworked infrahub-mcp + infrahub-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ NetClaw ships with the full set of OpenClaw workspace markdown files. These are 
 | 5 | Cisco ISE | [automateyournetwork/ISE_MCP](https://github.com/automateyournetwork/ISE_MCP) | stdio (Python) | Identity policy, posture, TrustSec, endpoint control |
 | 6 | NetBox | [netboxlabs/netbox-mcp-server](https://github.com/netboxlabs/netbox-mcp-server) | stdio (Python) | Read-write DCIM/IPAM source of truth |
 | 7 | Nautobot | [aiopnet/mcp-nautobot](https://github.com/aiopnet/mcp-nautobot) | stdio (Python) | IPAM source of truth — IP addresses, prefixes, VRF/tenant/site filtering (5 tools, alternative to NetBox) |
-| 8 | OpsMill Infrahub | [opsmill/infrahub-mcp](https://github.com/opsmill/infrahub-mcp) | stdio (Python) | Schema-driven SoT: nodes, GraphQL queries, versioned branches (10 tools) | `INFRAHUB_ADDRESS`, `INFRAHUB_API_TOKEN` |
+| 8 | OpsMill Infrahub | [opsmill/infrahub-mcp](https://github.com/opsmill/infrahub-mcp) | stdio (Python) | Schema-driven SoT: nodes, search, GraphQL queries, and branch-isolated writes via Proposed Changes (10 tools + resources/prompts) | `INFRAHUB_ADDRESS`, `INFRAHUB_API_TOKEN` |
 | 9 | Itential IAP | [itential/itential-mcp](https://github.com/itential/itential-mcp) | stdio (Python) | Network automation orchestration: config mgmt, compliance, workflows, golden config, lifecycle (65+ tools) | `ITENTIAL_MCP_PLATFORM_HOST`, `ITENTIAL_MCP_PLATFORM_USER`, `ITENTIAL_MCP_PLATFORM_PASSWORD` |
 | 10 | ServiceNow | [echelon-ai-labs/servicenow-mcp](https://github.com/echelon-ai-labs/servicenow-mcp) | stdio (Python) | Incidents, change requests, CMDB |
 | 11 | Microsoft Graph | [@anthropic-ai/microsoft-graph-mcp](https://www.npmjs.com/package/@anthropic-ai/microsoft-graph-mcp) | npx | OneDrive, SharePoint, Visio, Teams, Exchange via Graph API |
@@ -500,7 +500,7 @@ HumanRail MCP runs via FastMCP streamable HTTP (Python) on port 8100 (`git clone
 |-------|-------------|
 | **netbox-reconcile** | Diffs NetBox intent vs device reality. Detects 7 discrepancy types: IP_DRIFT, MISSING_INTERFACE, UNDOCUMENTED_LINK, CABLE_MISMATCH, VLAN_MISMATCH, STATUS_MISMATCH, MTU_MISMATCH. Opens ServiceNow incidents for CRITICAL findings. Generates Markmap drift summary. GAIT audit. |
 | **nautobot-sot** | Nautobot IPAM source of truth (5 tools, alternative to NetBox): query IP addresses with filtering by status (active/reserved/deprecated), role (loopback/secondary/anycast), VRF, tenant; look up network prefixes by site and role; full-text search across all IP data; retrieve IP details by Nautobot UUID; verify API connectivity. Supports pagination (up to 1000 results). Integrates with pyATS topology for intended-vs-actual reconciliation. |
-| **infrahub-sot** | OpsMill Infrahub schema-driven source of truth (10 tools): get_schema_mapping for all available kinds, get_nodes/get_node_details for infrastructure objects (InfraDevice, InfraInterface, InfraIPAddress, InfraPrefix), get_related_nodes for relationship traversal, query_graphql for custom queries and mutations, get_branches/branch_create/branch_delete for versioned change management, branch_diff for change review. Supports GraphQL-based schema introspection and branch-based workflows for safe infrastructure changes. |
+| **infrahub-sot** | OpsMill Infrahub schema-driven source of truth (10 tools). Read: `get_schema` (kind catalog + per-kind schema), `get_nodes` (typed/filtered/paged reads of InfraDevice, InfraInterface, InfraIPAddress, InfraPrefix…), `search_nodes` (fuzzy substring), `query_graphql` (read-only), `get_session_info`. Write (branch-isolated): `node_upsert`, `node_delete`, `mutate_graphql`, `propose_changes`, `reset_session_branch`. Writes never touch the default branch — they land on an auto-created `mcp/session-*` branch and are submitted as a **Proposed Change** for human review. Also exposes MCP resources (`infrahub://schema`, `graphql-schema`, `branches`) and prompts. Pairs with the [infrahub-skills](https://github.com/opsmill/infrahub-skills) plugin for authoring schemas, checks, transforms, and generators. |
 | **aci-fabric-audit** | ACI fabric health: node status, firmware, policy tree walk (Tenant/VRF/BD/EPG), contract analysis, fault analysis with health scores, endpoint learning verification. Severity-rated consolidated report. GAIT audit. |
 | **aci-change-deploy** | Safe ACI policy changes: ServiceNow CR gating, pre-change fault baseline, dependency-ordered deployment (Tenant > VRF > BD > AP > EPG), post-change fault delta, automatic rollback on fault increase. GAIT audit. |
 | **ise-posture-audit** | ISE audit: authorization policy review (default-allow detection), posture compliance assessment, profiling coverage analysis, TrustSec SGT matrix analysis (permit-all detection), active session health. |
@@ -1370,24 +1370,22 @@ nautobot-sot
 ### Infrahub Infrastructure Audit
 ```
 infrahub-sot
---> get_schema_mapping: discover all available schema kinds
---> get_nodes(kind="InfraDevice"): retrieve full device inventory
---> get_related_nodes per device: interfaces, IPs, connections
---> branch_create("audit-2024"): isolated branch for analysis
---> query_graphql: custom queries for cross-referencing relationships
+--> get_schema (no kind) / read infrahub://schema: discover all available schema kinds
+--> get_nodes(kind="InfraDevice"): retrieve full device inventory (filtered/paged)
+--> get_schema(kind="InfraDevice"): relationships to traverse (interfaces, IPs, connections)
+--> query_graphql: read-only custom queries for cross-referencing relationships
 --> Report: infrastructure inventory with relationship completeness
 --> GAIT audit trail
 ```
 
-### Infrahub Branch-Based Change
+### Infrahub Branch-Isolated Change
 ```
 infrahub-sot
---> get_branches: list existing branches and their status
---> branch_create("vlan-changes"): create isolated change branch
---> get_nodes(kind="InfraVLAN", branch="vlan-changes"): current VLAN state
---> query_graphql: mutation to create/update VLANs on branch
---> branch_diff: review all changes before merge
---> Report: branch change summary with before/after comparison
+--> get_session_info: show the active mcp/session-* branch (none yet on a fresh session)
+--> get_nodes(kind="InfraVLAN"): current VLAN state
+--> node_upsert / mutate_graphql: create/update VLANs — first write auto-creates the session branch (never the default)
+--> propose_changes: open a Proposed Change from the session branch for human review
+--> Report: change summary + Proposed Change link (human reviews and merges in Infrahub)
 --> GAIT audit trail
 ```
 
@@ -2047,7 +2045,7 @@ netclaw/
 │   ├── thousandeyes-mcp-community/     # ThousandEyes monitoring (9 read-only tools)
 │   ├── radkit-mcp-server-community/   # Cisco RADKit cloud-relayed device access (5 tools)
 │   ├── mcp-nautobot/                  # Nautobot IPAM source of truth (5 tools)
-│   ├── infrahub-mcp/                 # OpsMill Infrahub schema-driven SoT (10 tools)
+│   ├── infrahub-mcp/                 # OpsMill Infrahub schema-driven SoT — read + branch-isolated writes (10 tools)
 │   ├── itential-mcp/                 # Itential IAP network automation (65+ tools)
 │   ├── junos-mcp-server/            # Juniper JunOS PyEZ/NETCONF (10 tools)
 │   ├── mcp-cvp-fun/                # Arista CloudVision Portal (4 tools)
@@ -2105,7 +2103,7 @@ netclaw/
 8. **Clones GAIT MCP** — `git clone` + `pip3 install gait-ai fastmcp`
 9. **Clones NetBox MCP** — `git clone` + `pip3 install` dependencies
 10. **Clones Nautobot MCP** — `git clone` + `pip3 install -e .` for Nautobot IPAM source of truth (5 tools: IP addresses, prefixes, VRF/tenant/site filtering, search, connection test). Python 3.13+ required; falls back to core deps on older Python. Alternative to NetBox.
-11. **Clones Infrahub MCP** — `git clone` + `pip3 install -e .` for OpsMill Infrahub schema-driven source of truth (10 tools: nodes, GraphQL queries, versioned branches). Requires Infrahub instance with API token.
+11. **Clones Infrahub MCP** — `git clone` + `uv sync` (pip fallback) for OpsMill Infrahub schema-driven source of truth (10 tools: nodes, search, GraphQL, and branch-isolated writes via Proposed Changes). Requires Python 3.13+ and an Infrahub instance with API token. Now also published to PyPI (`pip install infrahub-mcp`) and as a Docker image (`registry.opsmill.io/opsmill/infrahub-mcp`).
 12. **Installs Itential MCP** — `pip3 install itential-mcp` (falls back to `git clone` + `pip3 install -e .`) for Itential Automation Platform network orchestration (65+ tools: config mgmt, compliance, workflows, golden config, lifecycle). Requires IAP instance with credentials.
 13. **Clones ServiceNow MCP** — `git clone` + `pip3 install` dependencies
 14. **Clones ACI MCP** — `git clone` + `pip3 install` dependencies
@@ -2199,7 +2197,7 @@ Optional (for full feature set):
 - Arista CloudVision Portal with service account token, Python 3.12+ and `uv` (for CVP device inventory, events, connectivity monitoring, tag management)
 - AWS account with IAM credentials (`AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`) for AWS cloud skills
 - graphviz (`apt install graphviz` or `brew install graphviz`) for AWS architecture diagrams
-- OpsMill Infrahub instance + API token (optional — schema-driven source of truth alternative)
+- OpsMill Infrahub instance + API token (optional — schema-driven source of truth alternative; Python 3.13+ for the MCP server)
 - Itential Automation Platform instance + credentials (optional — network orchestration, compliance, golden config)
 - Google Cloud project with service account or `gcloud` CLI (for GCP Compute, Monitoring, Logging skills)
 - Microsoft 365 tenant with Azure AD app registration (for Graph/Visio/Teams skills)
@@ -2341,13 +2339,13 @@ Ask NetClaw anything you'd ask a senior network engineer:
 --> nautobot-sot: search_ip_addresses(query="core-rtr-01"), matching IPs with device assignment details
 
 "What schema kinds are available in Infrahub?"
---> infrahub-sot: get_schema_mapping, list all available kinds with descriptions and relationships
+--> infrahub-sot: get_schema (no kind) / read infrahub://schema, list all available kinds with descriptions and relationships
 
 "Show me all devices in Infrahub"
 --> infrahub-sot: get_nodes(kind="InfraDevice"), device inventory with platform, role, site, and status
 
-"Create a branch for VLAN changes"
---> infrahub-sot: branch_create("vlan-update"), query_graphql on branch to stage changes, branch_diff to review, GAIT audit
+"Add a VLAN to Infrahub"
+--> infrahub-sot: node_upsert stages the change on an auto-created mcp/session-* branch (never the default), then propose_changes opens a Proposed Change for human review, GAIT audit
 
 "Check the health of our Itential platform"
 --> itential-automation: get_health, status of adapters, applications, system components, GAIT audit

--- a/SOUL-SKILLS.md
+++ b/SOUL-SKILLS.md
@@ -276,10 +276,11 @@ Alternative to NetBox for orgs running Nautobot.
 
 ### infrahub-sot
 Infrahub SoT operations:
-- `get_schema_mapping` — discover node types, attributes, relationships first
-- `get_node_filters` — learn supported filter syntax before queries
-- Branch for changes — never mutate directly on main branch
-- `get_related_nodes` — traverse relationships instead of multiple queries
+- `get_schema` — discover node types, attributes, relationships, and filters first
+- `get_nodes` / `search_nodes` — typed/filtered/paged reads and fuzzy substring search
+- `query_graphql` — read-only custom queries
+- Branch-isolated writes — `node_upsert` / `node_delete` / `mutate_graphql` land on an auto-created `mcp/session-*` branch, never the default
+- `propose_changes` — open a Proposed Change for human review (agent never merges)
 
 ### aci-fabric-audit
 ACI fabric health, policy audit, fault analysis:

--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -193,6 +193,16 @@
         "SPLUNK_VERIFY_SSL": "${SPLUNK_VERIFY_SSL:-true}"
       }
     },
+    "infrahub-mcp": {
+      "command": "uvx",
+      "args": [
+        "infrahub-mcp"
+      ],
+      "env": {
+        "INFRAHUB_ADDRESS": "${INFRAHUB_ADDRESS}",
+        "INFRAHUB_API_TOKEN": "${INFRAHUB_API_TOKEN}"
+      }
+    },
     "terraform-mcp": {
       "url": "mcp://terraform.io/mcp",
       "env": {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -342,7 +342,7 @@ echo ""
 
 log_step "12/$TOTAL_STEPS Installing OpsMill Infrahub MCP Server..."
 echo "  Source: https://github.com/opsmill/infrahub-mcp"
-echo "  Infrahub infrastructure source of truth — schema-driven nodes, GraphQL, versioned branches (10 tools)"
+echo "  Infrahub infrastructure source of truth — nodes, search, GraphQL, and branch-isolated writes via Proposed Changes (10 tools)"
 
 INFRAHUB_MCP_DIR="$MCP_DIR/infrahub-mcp"
 if [ -d "$INFRAHUB_MCP_DIR" ]; then
@@ -360,23 +360,23 @@ if [ -d "$INFRAHUB_MCP_DIR" ]; then
             log_info "Installing Infrahub MCP via uv sync..."
             cd "$INFRAHUB_MCP_DIR" && uv sync 2>/dev/null && cd "$NETCLAW_DIR" || {
                 log_warn "uv sync failed — trying pip install..."
-                pip3 install fastmcp infrahub-sdk 2>/dev/null || \
-                    pip3 install --break-system-packages fastmcp infrahub-sdk 2>/dev/null || \
+                pip3 install infrahub-mcp 2>/dev/null || \
+                    pip3 install --break-system-packages infrahub-mcp 2>/dev/null || \
                     log_warn "Infrahub MCP deps install failed"
                 cd "$NETCLAW_DIR"
             }
         else
-            log_info "uv not found — installing core dependencies via pip..."
-            pip3 install fastmcp infrahub-sdk 2>/dev/null || \
-                pip3 install --break-system-packages fastmcp infrahub-sdk 2>/dev/null || \
+            log_info "uv not found — installing Infrahub MCP package via pip..."
+            pip3 install infrahub-mcp 2>/dev/null || \
+                pip3 install --break-system-packages infrahub-mcp 2>/dev/null || \
                 log_warn "Infrahub MCP deps install failed"
         fi
         log_info "Infrahub MCP installed (stdio transport via FastMCP)"
     else
         log_warn "Python 3.13+ required for Infrahub MCP (found 3.$PY_MINOR)"
-        log_info "Installing core dependencies..."
-        pip3 install fastmcp infrahub-sdk 2>/dev/null || \
-            pip3 install --break-system-packages fastmcp infrahub-sdk 2>/dev/null || \
+        log_info "Installing Infrahub MCP package..."
+        pip3 install infrahub-mcp 2>/dev/null || \
+            pip3 install --break-system-packages infrahub-mcp 2>/dev/null || \
             log_warn "Infrahub core deps install failed"
         log_info "Infrahub MCP installed (some features may require Python 3.13+)"
     fi
@@ -2996,7 +2996,7 @@ echo "  │   Cisco ISE           Identity, posture, TrustSec"
 echo "  │   Infoblox DDI        DNS, DHCP, IPAM records, scopes, utilization"
 echo "  │   NetBox              DCIM/IPAM source of truth (read-write)"
 echo "  │   Nautobot            IPAM/DCIM source of truth — IP addresses, prefixes, VRF/tenant (5 tools)"
-echo "  │   Infrahub            Schema-driven SoT — nodes, GraphQL, versioned branches (10 tools)"
+echo "  │   Infrahub            Schema-driven SoT — nodes, GraphQL, branch-isolated writes (10 tools)"
 echo "  │   ServiceNow          ITSM: incidents, changes, CMDB"
 echo "  │"
 echo "  │ NETWORK ORCHESTRATION:"
@@ -3123,7 +3123,7 @@ echo "  │"
 echo "  │ Domain Skills:"
 echo "  │   netbox-reconcile       Source of truth drift detection"
 echo "  │   nautobot-sot           Nautobot IPAM — IP addresses, prefixes, VRF/tenant/site queries"
-echo "  │   infrahub-sot           Infrahub SoT — schema-driven nodes, GraphQL, versioned branches"
+echo "  │   infrahub-sot           Infrahub SoT — nodes, GraphQL, branch-isolated writes + Proposed Changes"
 echo "  │   aci-fabric-audit       ACI fabric health & policy audit"
 echo "  │   aci-change-deploy      Safe ACI policy changes"
 echo "  │   ise-posture-audit      ISE posture & TrustSec audit"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -337,51 +337,32 @@ fi
 echo ""
 
 # ═══════════════════════════════════════════
-# Step 12: Infrahub MCP (clone + uv sync)
+# Step 12: Infrahub MCP (pip install)
 # ═══════════════════════════════════════════
 
 log_step "12/$TOTAL_STEPS Installing OpsMill Infrahub MCP Server..."
 echo "  Source: https://github.com/opsmill/infrahub-mcp"
 echo "  Infrahub infrastructure source of truth — nodes, search, GraphQL, and branch-isolated writes via Proposed Changes (10 tools)"
 
-INFRAHUB_MCP_DIR="$MCP_DIR/infrahub-mcp"
-if [ -d "$INFRAHUB_MCP_DIR" ]; then
-    log_info "Infrahub MCP already cloned, pulling latest..."
-    git -C "$INFRAHUB_MCP_DIR" pull --quiet 2>/dev/null || true
-else
-    git clone https://github.com/opsmill/infrahub-mcp.git "$INFRAHUB_MCP_DIR" 2>/dev/null
-fi
-
-if [ -d "$INFRAHUB_MCP_DIR" ]; then
-    PY_MINOR=$(python3 -c 'import sys; print(sys.version_info.minor)' 2>/dev/null || echo "0")
-    if [ "$PY_MINOR" -ge 13 ]; then
-        log_info "Python 3.$PY_MINOR detected (3.13+ required for Infrahub MCP)"
-        if command -v uv &> /dev/null; then
-            log_info "Installing Infrahub MCP via uv sync..."
-            cd "$INFRAHUB_MCP_DIR" && uv sync 2>/dev/null && cd "$NETCLAW_DIR" || {
-                log_warn "uv sync failed — trying pip install..."
-                pip3 install infrahub-mcp 2>/dev/null || \
-                    pip3 install --break-system-packages infrahub-mcp 2>/dev/null || \
-                    log_warn "Infrahub MCP deps install failed"
-                cd "$NETCLAW_DIR"
-            }
+PY_MINOR=$(python3 -c 'import sys; print(sys.version_info.minor)' 2>/dev/null || echo "0")
+if [ "$PY_MINOR" -ge 13 ]; then
+    log_info "Python 3.$PY_MINOR detected (3.13+ required for Infrahub MCP)"
+    pip3 install infrahub-mcp 2>/dev/null || \
+        pip3 install --break-system-packages infrahub-mcp 2>/dev/null || {
+        log_warn "pip install infrahub-mcp failed — trying from source..."
+        INFRAHUB_MCP_DIR="$MCP_DIR/infrahub-mcp"
+        if [ -d "$INFRAHUB_MCP_DIR" ]; then
+            git -C "$INFRAHUB_MCP_DIR" pull --quiet 2>/dev/null || true
         else
-            log_info "uv not found — installing Infrahub MCP package via pip..."
-            pip3 install infrahub-mcp 2>/dev/null || \
-                pip3 install --break-system-packages infrahub-mcp 2>/dev/null || \
-                log_warn "Infrahub MCP deps install failed"
+            git clone https://github.com/opsmill/infrahub-mcp.git "$INFRAHUB_MCP_DIR" 2>/dev/null
         fi
-        log_info "Infrahub MCP installed (stdio transport via FastMCP)"
-    else
-        log_warn "Python 3.13+ required for Infrahub MCP (found 3.$PY_MINOR)"
-        log_info "Installing Infrahub MCP package..."
-        pip3 install infrahub-mcp 2>/dev/null || \
-            pip3 install --break-system-packages infrahub-mcp 2>/dev/null || \
-            log_warn "Infrahub core deps install failed"
-        log_info "Infrahub MCP installed (some features may require Python 3.13+)"
-    fi
+        if [ -d "$INFRAHUB_MCP_DIR" ] && command -v uv &> /dev/null; then
+            cd "$INFRAHUB_MCP_DIR" && uv sync 2>/dev/null; cd "$NETCLAW_DIR"
+        fi
+    }
+    log_info "Infrahub MCP installed (launched via 'uvx infrahub-mcp' — stdio transport)"
 else
-    log_warn "Infrahub MCP clone failed"
+    log_warn "Python 3.13+ required for Infrahub MCP (found 3.$PY_MINOR) — skipping"
 fi
 
 echo ""
@@ -2638,21 +2619,15 @@ else
     SERVERS_FAIL=$((SERVERS_FAIL + 1))
 fi
 
-# Infrahub MCP is git-cloned with uv sync / pip
-if [ -d "$INFRAHUB_MCP_DIR" ]; then
-    if python3 -c "import infrahub_sdk" 2>/dev/null; then
-        log_info "Infrahub MCP: OK (infrahub_sdk importable)"
-        SERVERS_OK=$((SERVERS_OK + 1))
-    elif [ -f "$INFRAHUB_MCP_DIR/src/infrahub_mcp/server.py" ]; then
-        log_info "Infrahub MCP: OK (server.py found)"
-        SERVERS_OK=$((SERVERS_OK + 1))
-    else
-        log_info "Infrahub MCP: CLONED (server script location may vary)"
-        SERVERS_OK=$((SERVERS_OK + 1))
-    fi
+# Infrahub MCP is pip-installed / launched via uvx, check via command or import
+if command -v infrahub-mcp &> /dev/null; then
+    log_info "Infrahub MCP: OK (cli entry point)"
+    SERVERS_OK=$((SERVERS_OK + 1))
+elif python3 -c "import infrahub_mcp" 2>/dev/null; then
+    log_info "Infrahub MCP: OK (module importable)"
+    SERVERS_OK=$((SERVERS_OK + 1))
 else
-    log_warn "Infrahub MCP: NOT INSTALLED (git clone failed)"
-    SERVERS_FAIL=$((SERVERS_FAIL + 1))
+    log_warn "Infrahub MCP: NOT INSTALLED (pip3 install infrahub-mcp)"
 fi
 
 # Itential MCP is pip-installed, check via command or import

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -169,8 +169,11 @@ echo ""
 # --- OpsMill Infrahub ---
 if yesno "Do you have an OpsMill Infrahub instance? (schema-driven infrastructure source of truth)"; then
     echo ""
-    echo -e "  Infrahub MCP provides schema-driven infrastructure queries with versioned branches."
-    echo -e "  10 tools: nodes, schemas, GraphQL, branches."
+    echo -e "  Infrahub MCP provides schema-driven infrastructure queries and safe, branch-isolated changes."
+    echo -e "  10 tools: nodes, search, schema, read-only GraphQL, plus writes that land on an auto-created"
+    echo -e "  session branch and are submitted as a Proposed Change for human review."
+    echo -e "  Tip: pair with the infrahub-skills plugin (npx skills add opsmill/infrahub-skills) for authoring"
+    echo -e "  schemas, checks, transforms, and generators."
     echo -e "  Get your API token from: ${BOLD}Infrahub UI → Settings → API Tokens${NC}"
     echo ""
     prompt INFRAHUB_ADDR "Infrahub URL (http://infrahub.example.com:8000)" ""

--- a/ui/netclaw-visual/server.js
+++ b/ui/netclaw-visual/server.js
@@ -32,7 +32,7 @@ const INTEGRATION_CATALOG = [
   { id: 'asa', name: 'Cisco ASA', category: 'Security', prefixes: ['pyats-asa-'], color: '#ef476f', transport: 'stdio', toolEstimate: 20, description: 'Firewall session, failover, and dataplane health views.' },
   { id: 'netbox', name: 'NetBox', category: 'Source of Truth', prefixes: ['netbox-'], color: '#00bbf9', transport: 'stdio', toolEstimate: 12, description: 'Intent reconciliation between live device state and documented truth.' },
   { id: 'nautobot', name: 'Nautobot', category: 'Source of Truth', prefixes: ['nautobot-'], color: '#00f5d4', transport: 'stdio', toolEstimate: 8, description: 'Alternative SoT and IPAM access pattern.' },
-  { id: 'infrahub', name: 'Infrahub', category: 'Source of Truth', prefixes: ['infrahub-'], color: '#06d6a0', transport: 'stdio', toolEstimate: 8, description: 'Schema-driven, branchable infrastructure state.' },
+  { id: 'infrahub', name: 'Infrahub', category: 'Source of Truth', prefixes: ['infrahub-'], color: '#06d6a0', transport: 'stdio', toolEstimate: 10, description: 'Schema-driven SoT with branch-isolated writes submitted as Proposed Changes.' },
   { id: 'infoblox', name: 'Infoblox', category: 'Source of Truth', prefixes: ['infoblox-'], color: '#73d2de', transport: 'stdio', toolEstimate: 10, description: 'DNS, DHCP, and IPAM operations.' },
   { id: 'servicenow', name: 'ServiceNow', category: 'Governance', prefixes: ['servicenow-'], color: '#ffd166', transport: 'stdio', toolEstimate: 12, description: 'Change gating and ITSM workflow integration.' },
   { id: 'gait', name: 'GAIT', category: 'Governance', prefixes: ['gait-'], color: '#f4a261', transport: 'stdio', toolEstimate: 9, description: 'Git-backed audit history and turn tracking.' },

--- a/workspace/skills/infrahub-sot/SKILL.md
+++ b/workspace/skills/infrahub-sot/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: infrahub-sot
-description: "OpsMill Infrahub — infrastructure source of truth with versioned branches, schema-driven nodes, GraphQL queries, relationship traversal. Use when querying Infrahub for device inventory, browsing infrastructure schemas, creating a branch for a change proposal, running GraphQL queries against Infrahub, or reconciling Infrahub data with live device state."
-version: 1.0.0
+description: "OpsMill Infrahub — infrastructure source of truth with schema-driven nodes, GraphQL queries, and branch-isolated changes. Use when querying Infrahub for device/IPAM inventory, browsing infrastructure schemas, running GraphQL queries, or making infrastructure changes safely via an auto-created session branch and a Proposed Change for human review."
+version: 2.0.0
 license: Apache-2.0
 tags: [opsmill, infrahub, source-of-truth, infrastructure, graphql, schema, branches, ipam, dcim]
 ---
@@ -11,94 +11,154 @@ tags: [opsmill, infrahub, source-of-truth, infrastructure, graphql, schema, bran
 ## MCP Server
 
 - **Repository**: [opsmill/infrahub-mcp](https://github.com/opsmill/infrahub-mcp)
-- **Transport**: stdio via FastMCP (also supports HTTP on configurable port)
-- **Requires**: `INFRAHUB_ADDRESS`, `INFRAHUB_API_TOKEN`
+- **Version**: 1.1.7+ (reworked — first stable release + production hardening)
+- **Distribution**: PyPI (`pip install infrahub-mcp`), Docker (`registry.opsmill.io/opsmill/infrahub-mcp`), or from source
+- **Entry point**: `infrahub-mcp` console script
+- **Transport**: `stdio` (default) or `streamable-http` (remote clients / auth modes)
+- **Requires**: `INFRAHUB_ADDRESS` + (`INFRAHUB_API_TOKEN` *or* `INFRAHUB_USERNAME`+`INFRAHUB_PASSWORD`)
 - **Python**: 3.13+
-- **Dependencies**: `fastmcp`, `infrahub_sdk`
+- **Dependencies**: `fastmcp>=3.2.0`, `infrahub-sdk>=1.20.0`
+- **Docs**: [docs.infrahub.app/mcp](https://docs.infrahub.app/mcp) (per-client setup, auth, configuration)
+
+> **What changed in the rework**: the server moved to a modular `src/infrahub_mcp/` layout on
+> FastMCP 3.x, added a **branch-isolated write model** (writes never touch the default branch),
+> exposes **MCP resources and prompts** in addition to tools, serializes schema output with **TOON**
+> internally to cut tokens, and ships as a **PyPI package + Docker image** with optional auth,
+> rate limiting, caching, and OpenTelemetry/Prometheus observability. The old read-only tool
+> surface (`get_node_filters`, `get_related_nodes`, `get_schema_mapping`, `get_schemas`,
+> `get_graphql_schema`, `get_branches`, `branch_create`) has been replaced — see the table below.
 
 ## How Infrahub Differs
 
 Infrahub is not just another IPAM/DCIM tool. Key differentiators:
 
 - **Schema-driven** — define your own infrastructure models (not just built-in IPAM/DCIM). Devices, circuits, IP addresses, services, cloud resources — any infrastructure object can be modeled.
-- **Versioned branches** — Git-like branching for infrastructure data. Make changes on a branch, review diffs, merge when approved. No more "who changed this in production?"
+- **Versioned branches** — Git-like branching for infrastructure data. Changes are made on a branch, reviewed as a diff, and merged when approved. No more "who changed this in production?"
 - **GraphQL-native** — full GraphQL API for flexible queries, not just REST. Query exactly the fields you need, traverse relationships in a single request.
 - **Relationship-first** — rich relationship model between objects with relationship-level filters and traversal.
 
+## Safety Model: Branch-Isolated Writes
+
+The reworked server makes destructive operations safe by construction:
+
+- **Writes never hit the default branch.** On the first write in a session, the server lazily
+  auto-creates a session branch named `mcp/session-YYYYMMDD-<hex>` (pattern configurable via
+  `INFRAHUB_MCP_BRANCH_PATTERN`). All `node_upsert` / `node_delete` / `mutate_graphql` land there.
+- **Human review is mandatory to merge.** `propose_changes` opens a **Proposed Change** (PR) from
+  the session branch to the default branch — a human reviews and merges it in the Infrahub UI. The
+  agent never merges.
+- **Session-branch recovery.** Stale/merged/deleted session branches are validated before reuse and
+  auto-recovered on the next write; `reset_session_branch` clears or switches the active branch.
+- **Read-only mode.** Setting `INFRAHUB_MCP_READ_ONLY=true` hides all write tools and blocks GraphQL
+  mutations — use it for pure analysis/audit connections.
+
 ## MCP Tools (10 tools)
 
-### Node Operations (3 tools)
+### Read Tools (5)
 
 | Tool | Parameters | What It Does |
 |------|-----------|--------------|
-| `get_nodes` | `kind, branch?, filters?, partial_match?` | Retrieve all objects of a specific kind with optional filtering and partial matching |
-| `get_node_filters` | `kind, branch?` | List available filters for a kind — attribute filters (`attr__value`), relationship filters (`rel__attr__value`) |
-| `get_related_nodes` | `kind, relation, filters?, branch?` | Traverse a relationship from a node kind — get connected objects (peers, members, interfaces, etc.) |
+| `get_nodes` | `kind, filters?, partial_match?, include_attributes?, offset?, limit?, branch?` | Typed read of nodes of a kind. Supports attribute/relationship filters (`attr__value`, `rel__attr__value`), partial matching, and paging (returns `total_count`/`has_more`). |
+| `search_nodes` | `kind, value, branch?` | Find nodes of a kind by partial substring via Infrahub's `any__value` filter. Works on concrete and abstract/generic kinds. |
+| `get_schema` | `kind?, branch?` | Discover schema kinds (catalog) or, given a `kind`, its attributes/relationships/filter-map (TOON-encoded). Tool fallback for clients without MCP resources. |
+| `get_session_info` | none | Report current session state — active `session_branch`, `infrahub_address`, `has_session_branch`. Call before writes to know the target branch. |
+| `query_graphql` | `query, branch?` | Execute a **read-only** GraphQL query (mutations are rejected here). |
 
-### Schema Operations (3 tools)
-
-| Tool | Parameters | What It Does |
-|------|-----------|--------------|
-| `get_schema_mapping` | `branch?` | List all schema node kinds and generics available in Infrahub (discover what data types exist) |
-| `get_schema` | `kind, branch?` | Full schema for a specific kind — attributes, relationships, their types (understand the data model) |
-| `get_schemas` | `branch?, exclude_profiles?, exclude_templates?` | Retrieve all schemas, optionally excluding profiles and templates |
-
-### GraphQL Operations (2 tools)
+### Write Tools (5) — hidden when `INFRAHUB_MCP_READ_ONLY=true`
 
 | Tool | Parameters | What It Does |
 |------|-----------|--------------|
-| `get_graphql_schema` | none | Retrieve the full GraphQL schema from Infrahub (SDL format) |
-| `query_graphql` | `query, branch?` | Execute an arbitrary GraphQL query against Infrahub — full flexibility for complex queries |
+| `node_upsert` | `kind, data, ...` | Create or update a node on the active session branch. |
+| `node_delete` | `kind, id` | Delete a node on the active session branch. |
+| `mutate_graphql` | `mutation, ...` | Execute a GraphQL mutation (relationship edits / bulk ops typed tools can't express). Branch/schema-management mutations are blocked. |
+| `propose_changes` | `title?, description?` | Open a Proposed Change from the session branch to the default branch for human review. |
+| `reset_session_branch` | `branch?` | Clear the cached session branch (next write creates a fresh one) or point the session at a named branch. Rejects the default branch and merged/read-only branches. |
 
-### Branch Operations (2 tools)
+### Resources (3 + 1 template)
 
-| Tool | Parameters | What It Does |
-|------|-----------|--------------|
-| `get_branches` | none | List all branches in Infrahub with their details |
-| `branch_create` | `name, sync_with_git?` | Create a new branch for isolated infrastructure changes |
+| Resource URI | Content |
+|--------------|---------|
+| `infrahub://schema` | Kind catalog (JSON) |
+| `infrahub://schema/{kind}` | Per-kind schema + filter map (template) |
+| `infrahub://graphql-schema` | Full GraphQL SDL (text) |
+| `infrahub://branches` | All branches including the session branch (JSON) |
+
+### Prompts (4)
+
+`infrahub_agent` (system prompt; read-only vs read-write aware), `answer_infra_question`,
+`make_infra_change`, `explore_schema`.
 
 ## Workflow: Discover Available Data
 
 When first connecting to Infrahub:
 
-1. **List kinds**: `get_schema_mapping` — what infrastructure types are modeled?
+1. **List kinds**: read resource `infrahub://schema` (or `get_schema` with no `kind`) — what infrastructure types are modeled?
 2. **Inspect schema**: `get_schema(kind="InfraDevice")` — what attributes and relationships does a device have?
-3. **List filters**: `get_node_filters(kind="InfraDevice")` — how can I query devices?
-4. **Get nodes**: `get_nodes(kind="InfraDevice")` — list all devices
-5. **Report**: infrastructure data model overview with node counts per kind
+3. **Get nodes**: `get_nodes(kind="InfraDevice")` — list all devices (page with `offset`/`limit`).
+4. **Report**: infrastructure data model overview with node counts per kind.
 
 ## Workflow: Infrastructure Audit
 
 When auditing infrastructure state in Infrahub:
 
-1. **Schema overview**: `get_schema_mapping` — discover all kinds
-2. **Device inventory**: `get_nodes(kind="InfraDevice")` — all devices
-3. **IP addresses**: `get_nodes(kind="InfraIPAddress")` — all IPs (if IPAM is modeled)
-4. **Prefixes**: `get_nodes(kind="InfraPrefix")` — all subnets
-5. **Relationships**: `get_related_nodes(kind="InfraDevice", relation="interfaces")` — device interfaces
-6. **Report**: infrastructure inventory from Infrahub with relationship context
+1. **Schema overview**: `get_schema` (no kind) — discover all kinds.
+2. **Device inventory**: `get_nodes(kind="InfraDevice")` — all devices.
+3. **IP addresses**: `get_nodes(kind="InfraIPAddress")` — all IPs (if IPAM is modeled).
+4. **Prefixes**: `get_nodes(kind="InfraPrefix")` — all subnets.
+5. **Search**: `search_nodes(kind="InfraDevice", value="core")` — fuzzy find by substring.
+6. **Report**: infrastructure inventory from Infrahub with relationship context.
 
-## Workflow: Branch-Based Change
+## Workflow: Branch-Isolated Change
 
-When proposing an infrastructure change:
+When proposing an infrastructure change (the safe write path):
 
-1. **List branches**: `get_branches` — see existing branches
-2. **Create branch**: `branch_create(name="change-123-add-vlan")` — isolate changes
-3. **Query current state**: `get_nodes(kind="InfraVLAN", branch="change-123-add-vlan")` — view on branch
-4. **Make changes via GraphQL**: `query_graphql(query="mutation { ... }", branch="change-123-add-vlan")`
-5. **Verify**: `get_nodes` on branch — confirm changes look correct
-6. **Merge**: (via Infrahub UI/API — merge branch to main)
-7. **Report**: change summary with before/after branch comparison
+1. **Check session**: `get_session_info` — see the active session branch (or that none exists yet).
+2. **Make changes**: `node_upsert(...)`, `node_delete(...)`, or `mutate_graphql(...)`. The first
+   write **auto-creates** the `mcp/session-*` branch — you never edit the default branch directly.
+3. **Verify**: `get_nodes(...)` on the session branch — confirm changes look correct.
+4. **Propose**: `propose_changes(title="Add VLAN 200", description="...")` — opens a Proposed
+   Change for human review.
+5. **Human merges** in the Infrahub UI. To start a fresh unrelated change, call
+   `reset_session_branch`.
+6. **Report**: change summary + the Proposed Change link for review.
 
 ## Workflow: GraphQL Exploration
 
 When building custom queries:
 
-1. **Schema**: `get_graphql_schema` — full SDL schema, understand query structure
-2. **Test query**: `query_graphql(query="{ InfraDevice { edges { node { name { value } } } } }")`
-3. **Filtered query**: `query_graphql(query="{ InfraDevice(name__value: \"core-rtr\") { ... } }")`
-4. **Nested relationships**: traverse in a single query via GraphQL nesting
-5. **Report**: custom data extraction with exactly the fields needed
+1. **Schema**: read resource `infrahub://graphql-schema` — full SDL, understand query structure.
+2. **Test query**: `query_graphql(query="{ InfraDevice { edges { node { name { value } } } } }")`.
+3. **Filtered query**: `query_graphql(query="{ InfraDevice(name__value: \"core-rtr\") { ... } }")`.
+4. **Mutations** go through `mutate_graphql` (write tool) and land on the session branch — never `query_graphql`.
+5. **Report**: custom data extraction with exactly the fields needed.
+
+## Companion: infrahub-skills Plugin
+
+The MCP server is for **live data** — querying and changing a running Infrahub instance. For
+**authoring the artifacts** that define and validate that data, use the OpsMill
+[**infrahub-skills**](https://github.com/opsmill/infrahub-skills) plugin (`infrahub@opsmill`, 12
+skills). Rule of thumb: **`infrahub-sot` (this skill / the MCP) reads and changes live data;
+`infrahub-skills` writes the files** (schemas, checks, transforms, generators) that shape it.
+
+| Need | Use |
+|------|-----|
+| Query live nodes / IPAM, run GraphQL, make a branch-isolated change | **`infrahub-sot`** (this skill, MCP-backed) |
+| Analyze/correlate live data, drift & impact analysis | `infrahub-analyzing-data` (also MCP-backed) |
+| Design/validate schema YAML (nodes, generics, relationships) | `infrahub-managing-schemas` |
+| Populate object data YAML (devices, sites, orgs) | `infrahub-managing-objects` |
+| Write validation checks for Proposed Change pipelines | `infrahub-managing-checks` |
+| Build transforms / Jinja2 config artifacts | `infrahub-managing-transforms` |
+| Build design-driven generators | `infrahub-managing-generators` |
+| Custom web-UI menus | `infrahub-managing-menus` |
+| Audit an Infrahub repo against best practices | `infrahub-auditing-repo` |
+| Import CSV/TSV into object YAML | `infrahub-importing-data` |
+| File a bug/feature to the right `opsmill/infrahub-*` repo | `infrahub-reporting-issues` |
+| Collect a redacted diagnostic bundle for support | `infrahub-collecting-diagnostics` |
+
+Install: `npx skills add opsmill/infrahub-skills` (cross-tool) or, in Claude Code,
+`/plugin marketplace add opsmill/claude-marketplace` then `/plugin install infrahub@opsmill`.
+Only `infrahub-analyzing-data` requires a connected Infrahub MCP server; the rest are
+file-authoring/reading and pair naturally with this skill's live-data workflows.
 
 ## Integration with Other Skills
 
@@ -113,8 +173,8 @@ When building custom queries:
 | `meraki-network-ops` | Infrahub planned state vs Meraki actual DHCP/VLAN assignments |
 | `aws-network-ops` | Infrahub cloud model vs AWS VPC actual state |
 | `radkit-remote-access` | Use Infrahub to identify device IPs, then RADKit for remote CLI access |
-| `servicenow-change-workflow` | Infrahub branches map to ServiceNow CRs — create branch per change |
-| `gait-session-tracking` | Record all Infrahub queries, branch operations, and infrastructure changes |
+| `servicenow-change-workflow` | Infrahub Proposed Changes map to ServiceNow CRs — one session branch per change |
+| `gait-session-tracking` | Record all Infrahub queries, session-branch writes, and Proposed Changes |
 
 ## Infrahub vs NetBox vs Nautobot
 
@@ -126,22 +186,36 @@ NetClaw supports all three source-of-truth platforms:
 | Data model | Fixed DCIM/IPAM + custom fields | Fixed DCIM/IPAM + Jobs + custom fields | Fully schema-driven (define any model) |
 | Versioning | No branching | No branching | Git-like branches for data |
 | API | REST + GraphQL | REST + GraphQL | GraphQL-native |
-| MCP tools | Read-write via FastMCP | Read-only IPAM (5 tools) | Read + GraphQL mutations + branches (10 tools) |
-| Use when | Standard IPAM/DCIM | Standard IPAM/DCIM (NTC ecosystem) | Custom infrastructure models, versioned changes |
+| MCP tools | Read-write via FastMCP | Read-only IPAM (5 tools) | Read + branch-isolated write + Proposed Changes (10 tools) |
+| Use when | Standard IPAM/DCIM | Standard IPAM/DCIM (NTC ecosystem) | Custom infrastructure models, versioned & reviewed changes |
 
 ## Important Rules
 
-- **Discover before querying** — always call `get_schema_mapping` first to learn what kinds exist. Don't guess kind names.
-- **Use filters** — call `get_node_filters` to learn valid filter syntax before using `get_nodes` with filters.
-- **Branch for changes** — create a branch before making mutations via `query_graphql`. Never mutate main directly.
-- **GraphQL mutations require authorization** — ensure the API token has write permissions for mutation queries.
-- **Partial matching** — use `partial_match=True` in `get_nodes` for fuzzy matching on filter values.
-- **Relationship traversal** — use `get_related_nodes` to follow relationships; use `get_schema` to discover relationship names first.
-- **Record in GAIT** — log all Infrahub queries, branch operations, and infrastructure changes.
+- **Discover before querying** — read `infrahub://schema` (or `get_schema` with no kind) first to learn what kinds exist. Don't guess kind names, then `get_schema(kind=...)` for its filters.
+- **Never write on the default branch** — use the write tools (`node_upsert` / `node_delete` / `mutate_graphql`). They land on the auto-created session branch by design; `query_graphql` is read-only.
+- **Always propose, never merge** — finish a change with `propose_changes` and hand the Proposed Change to a human. The agent does not merge to the default branch.
+- **Check the session first** — `get_session_info` before writes to see the target branch; `reset_session_branch` to start a clean, unrelated change.
+- **Mutations need write permission** — the token/user must have write rights for `node_upsert`, `node_delete`, and `mutate_graphql`.
+- **Read-only when auditing** — connect with `INFRAHUB_MCP_READ_ONLY=true` for pure analysis so write tools are unavailable.
+- **Partial matching** — use `partial_match=True` in `get_nodes`, or `search_nodes`, for fuzzy value matching.
+- **Record in GAIT** — log all Infrahub queries, session-branch writes, and Proposed Changes.
 
 ## Environment Variables
 
-- `INFRAHUB_ADDRESS` — Infrahub instance URL (e.g., `http://infrahub.example.com:8000`)
-- `INFRAHUB_API_TOKEN` — Infrahub API authentication token
-- `MCP_HOST` — Server bind address when running in HTTP mode (default: `0.0.0.0`, optional)
-- `MCP_PORT` — Server port when running in HTTP mode (default: `8001`, optional)
+**Connection / credentials** (consumed by `infrahub-sdk`; no prefix):
+
+- `INFRAHUB_ADDRESS` — **required**, Infrahub instance URL (e.g., `http://infrahub.example.com:8000`)
+- `INFRAHUB_API_TOKEN` — API token auth, **or**
+- `INFRAHUB_USERNAME` + `INFRAHUB_PASSWORD` — username/password auth (one auth method required)
+
+**Server behavior** (pydantic-settings, prefix `INFRAHUB_MCP_`; defaults shown):
+
+- `INFRAHUB_MCP_READ_ONLY` (`false`) — hide write tools and block GraphQL mutations
+- `INFRAHUB_MCP_BRANCH_PATTERN` (`mcp/session-{date}-{hex}`) — session-branch naming; `INFRAHUB_MCP_MAX_BRANCH_RETRIES` (`5`)
+- `INFRAHUB_MCP_LOG_LEVEL` (`info`)
+- Rate limiting / retries: `INFRAHUB_MCP_RATE_LIMIT_RPS`, `INFRAHUB_MCP_RATE_LIMIT_BURST`, `INFRAHUB_MCP_RETRY_MAX_ATTEMPTS`, `INFRAHUB_MCP_RETRY_BASE_DELAY`
+- Caching: `INFRAHUB_MCP_CACHE_ENABLED` (`false`), `INFRAHUB_MCP_CACHE_LIST_TTL`, `INFRAHUB_MCP_CACHE_READ_TTL`
+- Observability: `INFRAHUB_MCP_OTEL_ENABLED`, `INFRAHUB_MCP_PROMETHEUS_ENABLED`
+- Auth (non-`none` modes require `streamable-http`): `INFRAHUB_MCP_AUTH_MODE` (`none`|`oidc`|`token-passthrough`|`basic-passthrough`) plus OIDC settings (`INFRAHUB_MCP_OIDC_CONFIG_URL`, `INFRAHUB_MCP_OIDC_CLIENT_ID`, `INFRAHUB_MCP_OIDC_BASE_URL`, …)
+
+**Transport flags**: `--transport {stdio,streamable-http}` (default `stdio`), `--host` (default `127.0.0.1`), `--port` (default `8001`).


### PR DESCRIPTION
## Summary
The `infrahub-mcp` server was reworked (v1.1.7): a new tool surface, a branch-isolated write model, and PyPI/Docker distribution. This refreshes every netclaw reference so operators get accurate guidance, and points them at the `infrahub-skills` plugin for authoring work.

## Key Changes
- **`infrahub-sot` skill rewritten (v1.0.0 → 2.0.0)**: new 10-tool surface — read (`get_schema`, `get_nodes`, `search_nodes`, `query_graphql`, `get_session_info`) + branch-isolated write (`node_upsert`, `node_delete`, `mutate_graphql`, `propose_changes`, `reset_session_branch`) — plus MCP resources/prompts, the session-branch → Proposed Change safety model, and the `INFRAHUB_MCP_` config family.
- **Docs refreshed everywhere**: README integration table, skill description, directory layout, install/prereq steps, and example workflows; `SOUL-SKILLS.md` operations; and the visual-UI catalog entry (`toolEstimate` 8 → 10). All pre-rework tool names removed from the live docs.
- **Installer**: the pip path now installs the published `infrahub-mcp` package (correct pinned deps + the `infrahub-mcp` console script) instead of bare dependencies, and notes PyPI/Docker as install options.
- **Safety model surfaced**: the setup prompt and docs explain that writes never touch the default branch — they land on an auto-created `mcp/session-*` branch and are submitted as a Proposed Change for human review.
- **`infrahub-skills` companion**: guidance on the split — the MCP / `infrahub-sot` reads and changes live data; the `infrahub-skills` plugin authors the files (schemas, checks, transforms, generators) — with install commands.

## Documentation Updates
This PR is itself a documentation/config refresh. Primary docs: `workspace/skills/infrahub-sot/SKILL.md`, `README.md`, `SOUL-SKILLS.md`.

## Test Plan
- `bash -n scripts/install.sh` and `bash -n scripts/setup.sh` — pass.
- `node --check ui/netclaw-visual/server.js` — pass.
- Grep confirms no pre-rework tool names remain in the live docs (only the intentional "removed tools" migration note in the skill).

---
Opened from fork `BeArchiTek/netclaw` (branch `docs/infrahub-mcp-rework`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
