### PR TITLE
docs(047): reconcile skill/MCP inventory counts across README, SOUL, mcp-servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ memory/
 
 # Cloned MCP servers (installed by install.sh)
 mcp-servers/*
+# Directory-level documentation (tracked in repo)
+!mcp-servers/README.md
 # Built-in MCP servers (tracked in repo)
 !mcp-servers/protocol-mcp/
 !mcp-servers/suzieq-mcp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # netclaw Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-07-05
+Auto-generated from all feature plans. Last updated: 2026-07-07
 
 ## Active Technologies
 - N/A (stateless server; subscription state held in-memory during runtime) (003-gnmi-mcp-server)
@@ -59,6 +59,8 @@ Auto-generated from all feature plans. Last updated: 2026-07-05
 - N/A — all new state (sticky alert flags, live-mode status, session history buffer, manual zoom groupings) is in-memory for the lifetime of the running skill process; nothing persists across a NetClaw restart (045-ue5-digital-twin)
 - Python 3.10+ (skill logic, consistent with the rest of NetClaw) + Three.js r147 pinned (`three@0.147.0` — last release with both classic UMD core and non-module OrbitControls/GLTFLoader addons) vendored as static JS, the newly vendored community `sketchfab-mcp-server` (Node.js, `mcp-servers/sketchfab-mcp-server/`, registered as `sketchfab-mcp` in `config/openclaw.json`) for real-stencil model search/download, and NetClaw's existing topology-source skills/MCP servers (CML lab tooling, `gns3-mcp-server`, `clab-mcp-server`, `eve-ng-mcp-server`, `nautobot-mcp-v2`, `netbox-mcp-server`, `infrahub-mcp`, `ipfabric` integration, `forward-mcp`) consumed as-is, not modified (046-threejs-network-viz)
 - N/A for rendering itself; generated visualizations are written as timestamped, uniquely-named `.html` files to a persistent NetClaw workspace output directory (per Clarification session 2026-07-05) — never overwritten, never ephemeral (046-threejs-network-viz)
+- Python 3.10+ (matches every other script in `scripts/`, e.g. `scan-all-mcp-source.py`, `register-all-mcps.py`) + None beyond the Python standard library (`os`, `json`, `re`) — no new third-party packages (047-docs-inventory-reconciliation)
+- N/A (reads existing `workspace/skills/` directory tree and `config/openclaw.json`; writes no persistent state) (047-docs-inventory-reconciliation)
 
 - Python 3.10+ + FastMCP (MCP framework), grpcio + grpcio-tools (gRPC transport), pygnmi (gNMI client library), protobuf, cryptography (TLS handling) (003-gnmi-mcp-server)
 
@@ -78,9 +80,9 @@ cd src [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLO
 Python 3.10+: Follow standard conventions
 
 ## Recent Changes
+- 047-docs-inventory-reconciliation: Added Python 3.10+ (matches every other script in `scripts/`, e.g. `scan-all-mcp-source.py`, `register-all-mcps.py`) + None beyond the Python standard library (`os`, `json`, `re`) — no new third-party packages
 - 046-threejs-network-viz: Added Python 3.10+ (skill logic, consistent with the rest of NetClaw) + Three.js r147 pinned (last release with classic UMD core + non-module OrbitControls/GLTFLoader) vendored as static JS, the newly vendored community `sketchfab-mcp-server` (Node.js, `mcp-servers/sketchfab-mcp-server/`, registered as `sketchfab-mcp` in `config/openclaw.json`) for real-stencil model search/download, and NetClaw's existing topology-source skills/MCP servers (CML lab tooling, `gns3-mcp-server`, `clab-mcp-server`, `eve-ng-mcp-server`, `nautobot-mcp-v2`, `netbox-mcp-server`, `infrahub-mcp`, `ipfabric` integration, `forward-mcp`) consumed as-is, not modified
 - 045-ue5-digital-twin: Added Python 3.10+ (matches the existing `ue5-network-viz` skill and the rest of NetClaw) + httpx (existing UE5 MCP HTTP/JSON-RPC client, `ue5_mcp_client.py`), no new third-party packages required
-- 044-ue5-mcp-network-viz: Added Python 3.10+ (skill logic), No custom MCP server code (uses built-in UE5 MCP) + httpx (HTTP client for MCP), Unreal Engine 5.8+ (user-installed with MCP plugin)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # NetClaw
 
-A CCIE-level AI network engineering coworker. Built on [OpenClaw](https://github.com/openclaw/openclaw) with Anthropic Claude, 113 skills, and 66 MCP integrations for complete network automation with ITSM gating, source-of-truth reconciliation, immutable audit trails, gNMI streaming telemetry, Canvas/A2UI inline network visualizations, packet capture analysis, GitHub config-as-code, GitLab DevOps (issues, merge requests, pipelines, repositories, wikis), Jenkins CI/CD (job monitoring, build triggering, log analysis, SCM tracking), Cisco CML lab simulation, ContainerLab containerized network labs, Cisco NSO orchestration, Cisco SD-WAN vManage monitoring, Grafana observability (dashboards, Prometheus, Loki, alerting, incidents), Prometheus direct PromQL monitoring, Kubeshark Kubernetes traffic analysis, Cisco Meraki Dashboard management, Cisco ThousandEyes network intelligence, AWS cloud networking, Cisco Secure Firewall policy auditing, Check Point Security (15 MCPs: policy, threat intel, gateway, SASE, malware), Itential network orchestration, Juniper JunOS device automation, Arista CloudVision Portal monitoring, F5 BIG-IP pyATS iControl REST coverage, Infoblox DDI, Palo Alto Panorama, FortiManager, Batfish offline configuration analysis, UML diagram generation, EVPN/VXLAN fabric workflows, live BGP/OSPF control-plane participation, nmap network scanning, gtrace path analysis and IP enrichment, Slack-native operations, Cisco WebEx-native operations, Microsoft 365 integration, and MemPalace persistent AI memory.
+A CCIE-level AI network engineering coworker. Built on [OpenClaw](https://github.com/openclaw/openclaw) with Anthropic Claude, 186 skills, and 108 MCP integrations for complete network automation with ITSM gating, source-of-truth reconciliation, immutable audit trails, gNMI streaming telemetry, NetFlow/IPFIX flow telemetry, Canvas/A2UI inline network visualizations, packet capture analysis, GitHub config-as-code, GitLab DevOps (issues, merge requests, pipelines, repositories, wikis), Jenkins CI/CD (job monitoring, build triggering, log analysis, SCM tracking), Cisco CML lab simulation, ContainerLab containerized network labs, Cisco NSO orchestration, Cisco SD-WAN vManage monitoring, Grafana observability (dashboards, Prometheus, Loki, alerting, incidents), Prometheus direct PromQL monitoring, Kubeshark Kubernetes traffic analysis, Cisco Meraki Dashboard management, Cisco ThousandEyes network intelligence, AWS and Azure cloud networking, Cisco Secure Firewall policy auditing, Check Point Security (15 MCPs: policy, threat intel, gateway, SASE, malware), Itential network orchestration, Juniper JunOS device automation, Arista CloudVision Portal monitoring, F5 BIG-IP pyATS iControl REST coverage, Infoblox DDI, Palo Alto Panorama, FortiManager, Batfish offline configuration analysis, UML diagram generation, EVPN/VXLAN fabric workflows, live BGP/OSPF control-plane participation, nmap network scanning, gtrace path analysis and IP enrichment, Slack-native operations, Cisco WebEx-native operations, Microsoft 365 integration, Twilio voice/SMS, Twitter/X integration, Claroty OT/IoT asset management, Forward Networks digital twin, Ollama local LLM routing, layered Memory MCP, and MemPalace persistent AI memory.
 
 ---
 
@@ -16,7 +16,7 @@ cd netclaw
 ./scripts/install.sh          # installs everything, then launches the setup wizard
 ```
 
-That's it. The installer deploys 113 skills, installs bundled MCP dependencies, and prepares configuration for 66 MCP integrations, then launches a two-phase setup:
+That's it. The installer deploys 186 skills, installs bundled MCP dependencies, and prepares configuration for 108 MCP integrations, then launches a two-phase setup:
 
 **Phase 1: `openclaw onboard`** (OpenClaw's built-in wizard)
 - Pick your AI provider (Anthropic, OpenAI, Bedrock, Vertex, 30+ options)
@@ -93,7 +93,7 @@ claw
   <img src="ui/netclaw-visual/logos/netclawvisualhud.png" alt="NetClaw Visual HUD — 3D Network Operations Dashboard" width="800">
 </p>
 
-NetClaw includes a Three.js 3D operations dashboard that visualizes all 48 integrations, 103 skills, your device fleet, and live BGP peering topology. Chat with NetClaw directly from the browser, watch integrations light up as tools execute, and inspect every node in the graph. The Canvas/A2UI visualization skill renders inline topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards directly in the chat interface.
+NetClaw includes a Three.js 3D operations dashboard that computes its integration and skill inventory live from the codebase (currently 108 MCP integrations and 186 skills) each time it's opened, alongside your device fleet and live BGP peering topology — so the dashboard never drifts out of sync with what's actually installed. Chat with NetClaw directly from the browser, watch integrations light up as tools execute, and inspect every node in the graph. The Canvas/A2UI visualization skill renders inline topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards directly in the chat interface.
 
 ```bash
 cd ui/netclaw-visual
@@ -372,7 +372,9 @@ NetClaw ships with the full set of OpenClaw workspace markdown files. These are 
 
 ---
 
-## MCP Servers (74)
+## MCP Servers (108)
+
+> Adding a new MCP server or skill? Run `python3 scripts/verify-inventory-counts.py` before opening your PR — it computes the true skill/MCP counts from the codebase and flags any documentation that has drifted out of sync, so these numbers don't need to be manually recounted (see [spec 047](specs/047-docs-inventory-reconciliation/quickstart.md) for details).
 
 | # | MCP Server | Repository | Transport | Function |
 |---|------------|------------|-----------|----------|
@@ -446,12 +448,32 @@ NetClaw ships with the full set of OpenClaw workspace markdown files. These are 
 | 72 | DevNet Content Search | [CiscoDevNet/devnet-content-search-mcp](https://github.com/CiscoDevNet/devnet-content-search-mcp) | Remote HTTP | Cisco DevNet documentation search — Meraki API doc search, Catalyst Center API doc search, Meraki operation ID lookup. No auth required (3 tools) |
 | 73 | HumanRail | [prime001/humanrail-mcp-server](https://github.com/prime001/humanrail-mcp-server) | Streamable HTTP (Python) | Human-in-the-loop escalation — route low-confidence decisions, pre-destructive operation approvals, and ambiguous incident tickets to human engineers; workers paid via Lightning Network. Free while in beta. (7 tools) |
 | 74 | Sketchfab | [gregkop/sketchfab-mcp-server](https://github.com/gregkop/sketchfab-mcp-server) | stdio (Node.js) | Real 3D model search/download for the Three.js network visualization skill's optional real-stencil mode — search, model-details (license verification), and download, filtered to CC0-licensed models only (3 tools) |
+| 75 | Azure Networking | Built-in (`azure-network-mcp`) | stdio (Python) | Read-only Azure networking — VNet topology, NSG rules/compliance auditing, ExpressRoute/VPN Gateway health, Azure Firewall policies, Load Balancer/App Gateway health, Route Tables, Network Watcher, Private Link, DNS |
+| 76 | Batfish | Built-in (`batfish-mcp`), wraps [Batfish](https://www.batfish.org/) via pybatfish | stdio (Python) | Offline network configuration analysis — reachability, ACL/routing verification, blast-radius analysis, pre-change proof (8 tools, read-only) |
+| 77 | GitLab | [zereight/mcp-gitlab](https://github.com/zereight/mcp-gitlab) | stdio (Node, npx) | GitLab DevOps — issues, merge requests, pipelines, repositories, wikis (98+ tools across 9 categories) |
+| 78 | Atlassian | [sooperset/mcp-atlassian](https://github.com/sooperset/mcp-atlassian) | stdio (Python, uvx) | Jira and Confluence — issues, projects, pages, spaces (72 tools) |
+| 79 | Jenkins | Jenkins MCP Server Plugin (official) | Streamable HTTP (Java, in-JVM) | CI/CD — job monitoring, build triggering, log analysis, SCM tracking (16 tools across 5 categories) |
+| 80 | Claroty xDome | Built-in (`claroty-mcp`), wraps [Claroty xDome](https://claroty.com/industrial-cybersecurity/xdome) | stdio (Python) | OT/IoT/IoMT asset visibility and threat detection — device inventory, communication maps, alerts, Purdue-level classification (21 tools: 15 read-only + 6 ITSM-gated writes) |
+| 81 | Forward Networks | Built-in (`forward-mcp`) | stdio (Go) | Digital twin and Network Query Engine (NQE) — path analysis, intent verification, semantic cache and knowledge-graph memory (54 tools + 6 workflow prompts) |
+| 82 | Twilio | [@twilio-alpha/mcp](https://www.npmjs.com/package/@twilio-alpha/mcp) | stdio (Node) | Core Twilio API access — messaging, phone numbers, account resources |
+| 83 | Twilio Voice | Built-in (`twilio-voice-mcp`) | stdio/HTTP (Node + Python) | Universal voice interface — inbound/outbound calls, proactive PagerDuty/Datadog alerts, per-caller context via Memory MCP, natural speech formatting |
+| 84 | Twitter/X | Built-in (`twitter-mcp`), via tweepy | stdio (Python) | Post tweets/threads/media, monitor and reply to mentions, content guardrails (blocks IPs/credentials/customer names) |
+| 85 | IPFIX/NetFlow | Built-in (`ipfix-mcp`) | stdio (Python) | Flow telemetry — receives and queries NetFlow v5, NetFlow v9, and IPFIX (RFC 7011) records via UDP, template caching, deduplication, rate limiting |
+| 86 | SNMP Trap Receiver | Built-in (`snmptrap-mcp`) | stdio (Python) | Receives and queries SNMP traps (v1/v2c/v3) over UDP, deduplication, rate limiting, GAIT audit logging |
+| 87 | Syslog Receiver | Built-in (`syslog-mcp`) | stdio (Python) | Receives and queries syslog messages (RFC 5424 and RFC 3164) over UDP, deduplication, rate limiting, GAIT audit logging |
+| 88 | Text-to-Speech (TTS) | Built-in (`tts-mcp`), Microsoft Edge TTS | stdio (Python) | Converts NetClaw text responses into MP3 audio for Slack delivery — no API key, no GPU required |
+| 89 | Ollama Domain Experts | Built-in (`ollama-mcp`) | stdio (Python) | Delegates structured, domain-specific tasks (config generation, show-output parsing, API query building, SoT validation) to local Ollama models running on your own GPU (10 tools) |
+| 90 | Memory MCP | Built-in (`memory-mcp`) | stdio (Python) | Hybrid persistent memory — structured facts (SQLite), semantic search (ChromaDB), decision log, entity relationship graph |
+| 91 | Nautobot v2 | Built-in (`nautobot-mcp-v2`, registered as `nautobot-mcp`) | stdio (Python) | Enhanced Nautobot 3.1.0 integration — GraphQL reads, REST writes, ITSM-gated changes, live-vs-SoT reconciliation (13 tools) |
+| 92 | Nautobot Golden Config | Built-in (`nautobot-golden-config-mcp`) | stdio (Python) | Golden-config compliance job runner for Nautobot |
+| 93 | Nautobot Routing | Built-in (`nautobot-routing-mcp`) | stdio (Python) | BGP/routing data queries against Nautobot |
+| 94-108 | Check Point Security Suite | Check Point MCP suite (`chkp-*`, 15 servers) | stdio/HTTP (Node) | Quantum, Harmony SASE, gateway management, threat intelligence, and policy insights — 15 individually-registered servers (policy, threat intel, gateway, SASE, malware; see "Check Point Security Integration" section below) (60+ tools) |
 
 HumanRail MCP runs via FastMCP streamable HTTP (Python) on port 8100 (`git clone` + `pip install "mcp[cli]>=1.0.0" httpx` + `python3 server.py`). Auth via `HUMANRAIL_API_KEY` Bearer token. Public hosted endpoint also available at `https://humanrail.dev/mcp` — set `HUMANRAIL_MCP_URL=https://humanrail.dev/mcp` to skip local install. Get a free API key at [humanrail.dev](https://humanrail.dev). All MCP servers communicate via stdio (JSON-RPC 2.0) through `scripts/mcp-call.py`. GitHub MCP runs via Docker. CML MCP is pip-installed (`cml-mcp`). NSO MCP is pip-installed (`cisco-nso-mcp-server`). FMC MCP runs as an HTTP server on port 8000. Meraki Magic MCP runs via FastMCP stdio (~804 Dashboard API endpoints). ThousandEyes community MCP runs via stdio (9 read-only tools); ThousandEyes official MCP is a remote HTTP endpoint hosted by Cisco at `https://api.thousandeyes.com/mcp` (~20 tools via `npx mcp-remote`). RADKit MCP runs via FastMCP stdio with certificate-based cloud relay auth (5 tools for remote device access). Nautobot MCP runs via MCP SDK stdio (5 IPAM tools, alternative to NetBox). Infrahub MCP runs via stdio (10 tools for schema-driven SoT, GraphQL queries, and versioned branches). Itential MCP is pip-installed (`itential-mcp`) and runs via stdio (65+ tools for network automation orchestration). JunOS MCP runs via stdio (10 tools for PyEZ/NETCONF device automation). Arista CVP MCP runs via uv/stdio (4 tools for CloudVision Portal device inventory, events, connectivity monitoring, and tag management). UML MCP runs via stdio (2 tools for 27+ diagram types via Kroki multi-engine rendering). Protocol MCP runs via stdio (10 tools for live BGP/OSPF/GRE control-plane participation using scapy-based protocol speakers). ContainerLab MCP runs via stdio (6 tools for containerized network lab lifecycle management via ContainerLab API). SD-WAN MCP runs via stdio (12 read-only tools for Cisco SD-WAN vManage fabric monitoring). Grafana MCP runs via `uvx mcp-grafana` (75+ tools for dashboards, Prometheus, Loki, alerting, incidents, OnCall). Prometheus MCP is pip-installed (`prometheus-mcp-server`) and runs via stdio (6 tools for direct PromQL queries, metric discovery, and scrape target health). Kubeshark MCP is a remote HTTP endpoint running inside a Kubernetes cluster (6 tools for L4/L7 traffic capture, pcap export, flow analysis, and TLS decryption via eBPF; access via `kubectl port-forward svc/kubeshark-hub 8898:8898`). nmap MCP runs via FastMCP stdio (14 tools for host discovery, port scanning, service/OS detection, NSE scripts, and vulnerability scanning with CIDR scope enforcement and audit logging). gtrace MCP runs via `gtrace mcp` stdio (6 tools for advanced traceroute with MPLS/ECMP/NAT detection, MTR continuous monitoring, GlobalPing distributed probes, ASN lookup, geolocation, and reverse DNS). AWS MCPs run via `uvx` (uv tool runner). GCP MCPs are remote HTTP endpoints hosted by Google (OAuth 2.0 auth). AAP Enterprise MCP provides 4 independent servers via `uv run` stdio: Controller (45 tools for inventories, jobs, projects, ad-hoc commands, Galaxy), EDA (12 tools for event-driven activations, rulebooks, decision environments), ansible-lint (9 tools for playbook/role validation and best practices), and Red Hat Docs (documentation search with domain validation). fwrule MCP runs via `uv run fwrule-mcp` stdio (3 tools for multi-vendor firewall rule overlap, shadowing, conflict, and duplication analysis across 9 vendors using 6-dimensional set intersection). SuzieQ MCP runs via stdio (5 read-only tools for network state queries, assertions, summaries, unique value discovery, and path tracing across 20+ network tables via the SuzieQ REST API). GNS3 MCP runs via FastMCP stdio (26 tools for GNS3 network lab management — projects, nodes, links, packet capture, and snapshots via REST API v3). No persistent connections, no port management.
 
 ---
 
-## Skills (127)
+## Skills (186)
 
 ### pyATS Device Skills (9)
 
@@ -844,6 +866,128 @@ HumanRail MCP runs via FastMCP streamable HTTP (Python) on port 8100 (`git clone
 | **webex-voice-interface** | Voice responses for WebEx: OpenClaw transcribes voice clips, NetClaw processes with full skill set, edge-tts generates MP3, uploaded to WebEx space alongside text |
 
 > WebEx setup is documented in the dedicated **[Cisco WebEx Integration](#cisco-webex-integration)** section below.
+
+### Azure Skills (2)
+
+| Skill | Purpose |
+|-------|---------|
+| **azure-network-ops** | Azure cloud networking — VNets, NSGs, ExpressRoute, VPN Gateways, Azure Firewalls, Load Balancers, Application Gateways, Route Tables, Network Watcher, Private Endpoints, DNS zones |
+| **azure-security-audit** | Azure NSG compliance auditing and security posture assessment — CIS Azure Foundations Benchmark rules, effective security rule analysis, orphaned NSG detection |
+
+### Batfish Skills (1)
+
+| Skill | Purpose |
+|-------|---------|
+| **batfish-config-analysis** | Offline network configuration analysis — pre-deployment validation, reachability testing, ACL/firewall tracing, differential analysis, compliance checking (strictly read-only) |
+
+### Check Point Skills (1)
+
+| Skill | Purpose |
+|-------|---------|
+| **checkpoint** | Check Point enterprise security platform operations across the 15-server MCP suite — policy, threat intelligence, gateway management, SASE, malware |
+
+### Claroty Skills (3)
+
+| Skill | Purpose |
+|-------|---------|
+| **claroty-asset-inventory** | Discover and classify OT/IoT/IoMT assets via Claroty xDome — list devices by site, Purdue level, and purpose; cross-reference with Nautobot/NetBox SoT to surface drift |
+| **claroty-ot-topology** | Render Claroty xDome OT/IoT communication maps and zone segmentation as inline Canvas/A2UI topology, draw.io diagrams, and timeline summaries |
+| **claroty-risk-triage** | Triage Claroty xDome alerts and vulnerabilities, compute blast radius, correlate with NVD CVE data, and drive ITSM-gated workflow actions |
+
+### EVE-NG Skills (8)
+
+| Skill | Purpose |
+|-------|---------|
+| **eve-lab-topology-discovery** | Gather missing requirements for EVE-NG topology design — discovery questions, defaults, trade-off framing, image recommendations |
+| **eve-lab-topology-design** | Design EVE-NG lab topology and coordinate the design workflow — architecture advice, topology planning, build plans |
+| **eve-lab-topology-build** | Build or rewire EVE-NG lab topology — create/delete virtual networks, connect node interfaces, inspect topology links |
+| **eve-lab-topology-validation** | Validate EVE-NG topology designs, check build readiness, produce final design output and implementation plans, run topology QA |
+| **eve-ng-lab-management** | Manage EVE-NG labs and platform inventory — list/create/delete labs, import/export archives, check platform health |
+| **eve-ng-node-operations** | Manage EVE-NG node lifecycle — create/delete/start/stop nodes, verify node details, wipe NVRAM to factory defaults |
+| **eve-ng-config-ops** | Manage EVE-NG startup configurations stored in lab files — export, read, push, or clear startup configs |
+| **eve-ng-console-ops** | Execute live CLI commands on running EVE-NG nodes over telnet console — show commands, config changes, connectivity tests across IOS, Junos, VPCS, EOS, NX-OS |
+
+### Forward Networks Skills (1)
+
+| Skill | Purpose |
+|-------|---------|
+| **forward** | Forward Networks snapshot assurance, path search, app-aware path search, NQE, checks, vulnerabilities, diffs, configuration, lifecycle, and topology workflows |
+
+### GitLab & Jenkins Skills (2)
+
+| Skill | Purpose |
+|-------|---------|
+| **gitlab-devops** | GitLab DevOps operations — issues, merge requests, CI/CD pipelines, repository browsing, labels, milestones, releases, wiki management |
+| **jenkins-cicd** | Jenkins CI/CD pipeline management — monitor builds, trigger pipelines, analyze logs, track SCM changes for network automation workflows |
+
+### Flow & Event Telemetry Skills (5)
+
+| Skill | Purpose |
+|-------|---------|
+| **gnmi-telemetry** | gNMI streaming telemetry for multi-vendor devices — structured YANG model paths, real-time subscriptions, ITSM-gated config changes, YANG capability browsing |
+| **ipfix-receiver** | Receive and query IPFIX and NetFlow (v5/v9) flow records from network devices via UDP |
+| **snmptrap-receiver** | Receive and query SNMP traps from network devices via UDP |
+| **syslog-receiver** | Receive and query syslog messages from network devices via UDP |
+| **telemetry-ops** | Comprehensive network telemetry and event collection across multiple protocols |
+
+### IP Fabric Skills (1)
+
+| Skill | Purpose |
+|-------|---------|
+| **ipfabric** | IP Fabric network assurance — end-to-end network state collection, path simulation, and intent verification via the IP Fabric platform |
+
+### Memory Skills (2)
+
+| Skill | Purpose |
+|-------|---------|
+| **memory** | Persistent context across NetClaw sessions through structured facts, semantic search, and entity relationships |
+| **mempalace** | MemPalace AI memory — persistent memory across sessions, past-decision search, temporal network facts via knowledge graph, specialist agent diaries |
+
+### DevNet Content Search Skills (2)
+
+| Skill | Purpose |
+|-------|---------|
+| **devnet-catalyst-search** | Search Cisco Catalyst Center API documentation for device management and policy automation |
+| **devnet-meraki-search** | Search Cisco Meraki API documentation and lookup specific operations |
+
+### Voice Skills (5)
+
+| Skill | Purpose |
+|-------|---------|
+| **slack-voice-interface** | Respond to Slack voice clips with both text and an MP3 voice reply using edge-tts |
+| **twilio-inbound-voice** | Handle inbound Twilio phone calls — route callers into NetClaw's full skill set via speech-to-text and natural speech responses |
+| **twilio-outbound-call** | Place outbound Twilio calls for proactive notifications and escalations |
+| **twilio-daily-briefing** | Deliver a scheduled daily voice briefing summarizing fleet health and overnight events over a Twilio call |
+| **twilio-emergency-call** | Place an emergency outbound Twilio call for critical, human-escalation-worthy incidents |
+
+### Twitter/X Skills (4)
+
+| Skill | Purpose |
+|-------|---------|
+| **twitter-check** | Quick invocation to check mentions and respond to #netclaw threads |
+| **twitter-heartbeat** | Autonomous periodic tweeting and mention monitoring to maintain NetClaw's Twitter/X presence with CCIE-level content |
+| **twitter-respond** | Generate and post replies to Twitter/X mentions and conversations |
+| **twitter-share** | Manual tweet posting with content guardrails and human approval flow |
+
+### Visualization Skills (2)
+
+| Skill | Purpose |
+|-------|---------|
+| **canvas-network-viz** | Canvas/A2UI inline network visualizations — topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, health scorecards rendered directly in the chat interface |
+| **ue5-network-viz** | Unreal Engine 5 3D network digital twin — interface-level actors, live color legend, traffic/health/SNMP-trap-driven state, ping/traceroute animation, historical playback |
+
+### Platform Operations Skills (2)
+
+| Skill | Purpose |
+|-------|---------|
+| **defenseclaw-ops** | Manage DefenseClaw enterprise security — scan components, manage tool permissions, view alerts, configure guardrails |
+| **token-tracker** | Track and display token consumption and cost for every NetClaw interaction |
+
+### ITSM Skills (1)
+
+| Skill | Purpose |
+|-------|---------|
+| **atlassian-itsm** | IT Service Management workflows using Jira for issue tracking and Confluence for documentation |
 
 ---
 
@@ -2512,3 +2656,5 @@ See `examples/` for detailed workflow walkthroughs.
 |---|---|---|
 | MISSION01 | Complete | Core pyATS agent, 7 skills, Markmap, Draw.io, RFC, NVD CVE, SOUL v1 |
 | MISSION02 | Complete | Full platform — 37 MCP servers, 82 skills (18 pyATS, 9 domain, 3 F5, 3 CatC, 3 M365, 1 GitHub, 1 packet analysis, 5 CML, 1 ContainerLab, 2 NSO, 1 Itential, 1 FMC, 1 SD-WAN, 1 Grafana, 1 Prometheus, 1 Kubeshark, 1 RADKit, 5 Meraki, 2 ThousandEyes, 5 AWS, 3 GCP, 1 JunOS, 1 Arista CVP, 1 UML, 1 protocol participation, 6 utility, 4 Slack), 6 workspace files, SOUL v2 |
+| [038-docs-hud-refresh](specs/038-docs-hud-refresh/) | Superseded | First attempt at reconciling drifted skill/MCP counts (targeted 179 skills / 43 MCP servers as of 2026-06-23). Never re-run after 8 later feature branches merged, so counts drifted again — superseded by 047 below. |
+| [047-docs-inventory-reconciliation](specs/047-docs-inventory-reconciliation/) | Complete | Reconciled all skill/MCP counts to ground truth (186 skills, 108 MCP integrations) across README/SOUL/SOUL-SKILLS/mcp-servers docs; added `scripts/verify-inventory-counts.py` so this doesn't drift silently again; confirmed Azure, Batfish, GitLab, and NetFlow/IPFIX were already shipped but undocumented in the MCP Servers table. |

--- a/SOUL-SKILLS.md
+++ b/SOUL-SKILLS.md
@@ -1388,3 +1388,193 @@ IP Fabric network assurance and path analysis (10 tools):
 **Credentials:** `IPFABRIC_HOST`, `IPFABRIC_API_TOKEN`
 
 Developed in collaboration with **Daren Fulwell** (Field CTO, IP Fabric) and **John Capobianco** (Creator, NetClaw).
+
+---
+
+## Additional Skills Index
+
+The skills above are documented with full step-by-step operational procedures. The 181 skills below were added across later feature branches and are not yet expanded into full procedures in this file — each one's complete workflow, commands, and best practices live directly in its own `SKILL.md`, which remains the authoritative reference. This index exists so every skill NetClaw has is at least discoverable from this file; read the linked `SKILL.md` for the actual procedure, don't guess from the one-line summary below.
+
+| Skill | Summary | Full Procedure |
+|-------|---------|-----------------|
+| `aap-automation` | Red Hat Ansible Automation Platform — inventory management, job template execution, project SCM sync, ad-hoc commands, host management, Galaxy content discov... | `workspace/skills/aap-automation/SKILL.md` |
+| `aap-eda` | Event-Driven Ansible (EDA) — activation lifecycle, rulebook management, decision environments, event stream monitoring. Use when managing event-driven automa... | `workspace/skills/aap-eda/SKILL.md` |
+| `aap-lint` | ansible-lint playbook and role validation — syntax checking, best practice enforcement, project-wide analysis, rule filtering. Use when validating Ansible pl... | `workspace/skills/aap-lint/SKILL.md` |
+| `aci-change-deploy` | Safe ACI policy change deployment - ServiceNow CR lifecycle, pre/post-change fault baselines, APIC policy application, automatic rollback on fault delta, and... | `workspace/skills/aci-change-deploy/SKILL.md` |
+| `aci-fabric-audit` | Comprehensive Cisco ACI fabric health audit - node status, tenant/VRF/BD/EPG policy review, contract analysis, fault triage, and endpoint learning verificati... | `workspace/skills/aci-fabric-audit/SKILL.md` |
+| `arista-cvp` | Arista CloudVision Portal (CVP) automation via REST API — device inventory, events, connectivity monitoring, tag management (4 tools). Use when managing Aris... | `workspace/skills/arista-cvp/SKILL.md` |
+| `aruba-cx-config` | View and manage Aruba CX switch configurations, perform ISSU upgrades, and firmware operations | `workspace/skills/aruba-cx-config/SKILL.md` |
+| `aruba-cx-interfaces` | Monitor Aruba CX switch interface status, LLDP neighbors, and optical transceiver health | `workspace/skills/aruba-cx-interfaces/SKILL.md` |
+| `aruba-cx-switching` | View and manage Aruba CX switch VLANs and MAC address tables for Layer 2 operations | `workspace/skills/aruba-cx-switching/SKILL.md` |
+| `aruba-cx-system` | Discover Aruba CX switch system information, firmware versions, and VSF topology | `workspace/skills/aruba-cx-system/SKILL.md` |
+| `atlassian-itsm` | IT Service Management workflows using Jira for issue tracking and Confluence for documentation | `workspace/skills/atlassian-itsm/SKILL.md` |
+| `aws-architecture-diagram` | AWS architecture diagrams — generate visual network topology diagrams from live AWS infrastructure. Use when drawing AWS network diagrams, visualizing VPCs, ... | `workspace/skills/aws-architecture-diagram/SKILL.md` |
+| `aws-cloud-monitoring` | AWS CloudWatch monitoring — metrics, alarms, log queries, VPC flow log analysis, network performance. Use when checking AWS alarms, analyzing VPC flow logs, ... | `workspace/skills/aws-cloud-monitoring/SKILL.md` |
+| `aws-cost-ops` | AWS Cost Explorer — spending analysis, service breakdowns, forecasts, cost anomalies. Use when analyzing AWS spending, investigating cost spikes, reviewing n... | `workspace/skills/aws-cost-ops/SKILL.md` |
+| `aws-network-ops` | AWS cloud networking — VPC, Transit Gateway, Cloud WAN, VPN, Network Firewall, ENI, flow logs. Use when auditing AWS VPCs, troubleshooting connectivity betwe... | `workspace/skills/aws-network-ops/SKILL.md` |
+| `aws-security-audit` | AWS security auditing — IAM users/roles/policies, CloudTrail API events, security posture analysis. Use when auditing IAM permissions, investigating security... | `workspace/skills/aws-security-audit/SKILL.md` |
+| `azure-network-ops` | Azure cloud networking -- VNets, NSGs, ExpressRoute, VPN Gateways, Azure Firewalls, Load Balancers, Application Gateways, Route Tables, Network Watcher, Priv... | `workspace/skills/azure-network-ops/SKILL.md` |
+| `azure-security-audit` | Azure NSG compliance auditing and security posture assessment. CIS Azure Foundations Benchmark rules, effective security rule analysis, orphaned NSG detectio... | `workspace/skills/azure-security-audit/SKILL.md` |
+| `batfish-config-analysis` | Batfish network configuration analysis -- pre-deployment validation, reachability testing, ACL/firewall tracing, differential analysis, compliance checking. ... | `workspace/skills/batfish-config-analysis/SKILL.md` |
+| `blender-3d-viz` | Create 3D network topology visualizations in Blender from CDP/LLDP neighbor data | `workspace/skills/blender-3d-viz/SKILL.md` |
+| `catc-client-ops` | Catalyst Center client operations and monitoring - list/filter wired and wireless clients, detailed client lookup by MAC, client count analytics, time-based ... | `workspace/skills/catc-client-ops/SKILL.md` |
+| `catc-inventory` | Catalyst Center device inventory and site management - list/filter devices by hostname, IP, platform, family, role, reachability; view site hierarchy; get in... | `workspace/skills/catc-inventory/SKILL.md` |
+| `catc-troubleshoot` | Catalyst Center troubleshooting workflows - device unreachable investigation, client connectivity issues, interface down analysis, site-wide outage triage, w... | `workspace/skills/catc-troubleshoot/SKILL.md` |
+| `checkpoint` | A comprehensive skill for interacting with Check Point enterprise security infrastructure through 15 MCP servers. | `workspace/skills/checkpoint/SKILL.md` |
+| `clab-lab-management` | ContainerLab network lab lifecycle management — authenticate, list, deploy, inspect, execute commands on, and destroy containerized network labs via the Cont... | `workspace/skills/clab-lab-management/SKILL.md` |
+| `claroty-asset-inventory` | Discover and classify OT / IoT / IoMT assets via Claroty xDome. List devices by site, Purdue level, and device purpose; assign Purdue layers and custom attri... | `workspace/skills/claroty-asset-inventory/SKILL.md` |
+| `claroty-ot-topology` | Render Claroty xDome OT / IoT communication maps and zone segmentation as inline Canvas/A2UI topology, draw.io diagrams, and timeline summaries. | `workspace/skills/claroty-ot-topology/SKILL.md` |
+| `claroty-risk-triage` | Triage Claroty xDome alerts and vulnerabilities, compute blast radius, correlate with NVD CVE data, and drive ITSM-gated workflow actions (acknowledge, label... | `workspace/skills/claroty-risk-triage/SKILL.md` |
+| `cloudflare-analytics` | Access Cloudflare traffic analytics, logs, and Radar global Internet insights. | `workspace/skills/cloudflare-analytics/SKILL.md` |
+| `cloudflare-dns` | Manage Cloudflare DNS zones and records with analytics insights. | `workspace/skills/cloudflare-dns/SKILL.md` |
+| `cloudflare-security` | Monitor Cloudflare WAF, firewall events, audit logs, and threat intelligence. | `workspace/skills/cloudflare-security/SKILL.md` |
+| `cloudflare-workers` | Monitor Cloudflare Workers deployments, bindings, and build insights. | `workspace/skills/cloudflare-workers/SKILL.md` |
+| `cloudflare-zerotrust` | Inspect Cloudflare Zero Trust access applications, policies, tunnels, and CASB findings. | `workspace/skills/cloudflare-zerotrust/SKILL.md` |
+| `cml-admin` | CML administration — user/group management, system info, licensing, resource monitoring. Use when creating CML users, checking license status, monitoring CML... | `workspace/skills/cml-admin/SKILL.md` |
+| `cml-lab-lifecycle` | Cisco CML lab lifecycle management — create, start, stop, wipe, delete, clone, import/export labs. Use when building a network lab, starting or stopping a CM... | `workspace/skills/cml-lab-lifecycle/SKILL.md` |
+| `cml-node-operations` | CML node operations — start, stop, console access, CLI execution, config management, node details. Use when starting or stopping a CML node, running show com... | `workspace/skills/cml-node-operations/SKILL.md` |
+| `cml-packet-capture` | CML packet capture — start, stop, download pcaps from CML lab links, integrate with Packet Buddy for analysis. Use when capturing packets in a CML lab, troub... | `workspace/skills/cml-packet-capture/SKILL.md` |
+| `cml-topology-builder` | Build CML topologies — add nodes, create interfaces, wire links, set link conditioning, add annotations. Use when building a network topology in CML, adding ... | `workspace/skills/cml-topology-builder/SKILL.md` |
+| `datadog-apm` | Analyze distributed traces and service performance in Datadog APM. | `workspace/skills/datadog-apm/SKILL.md` |
+| `datadog-incidents` | Manage incidents in Datadog Incident Management. | `workspace/skills/datadog-incidents/SKILL.md` |
+| `datadog-logs` | Search and analyze logs in Datadog Log Management. | `workspace/skills/datadog-logs/SKILL.md` |
+| `datadog-metrics` | Query metrics and explore dashboards in Datadog. | `workspace/skills/datadog-metrics/SKILL.md` |
+| `defenseclaw-ops` | Manage DefenseClaw enterprise security - scan components, manage tool permissions, view alerts, configure guardrails | `workspace/skills/defenseclaw-ops/SKILL.md` |
+| `devnet-catalyst-search` | Search Cisco Catalyst Center API documentation for device management and policy automation | `workspace/skills/devnet-catalyst-search/SKILL.md` |
+| `devnet-meraki-search` | Search Cisco Meraki API documentation and lookup specific operations | `workspace/skills/devnet-meraki-search/SKILL.md` |
+| `drawio-diagram` | Generate draw.io network diagrams — native .drawio files with CLI export (PNG/SVG/PDF), plus browser-based Mermaid/XML/CSV via MCP server. Use when creating ... | `workspace/skills/drawio-diagram/SKILL.md` |
+| `eve-lab-topology-build` | Build or rewire EVE-NG lab topology. Use when creating or deleting virtual networks, connecting node interfaces to networks, inspecting topology links, check... | `workspace/skills/eve-lab-topology-build/SKILL.md` |
+| `eve-lab-topology-design` | Design EVE-NG lab topology and coordinate the design workflow. Use when the user asks for lab design, architecture advice, topology planning, design review, ... | `workspace/skills/eve-lab-topology-design/SKILL.md` |
+| `eve-lab-topology-discovery` | Gather missing requirements for EVE-NG topology design. Use when the request is vague or incomplete, when you need discovery questions, defaults, trade-off f... | `workspace/skills/eve-lab-topology-discovery/SKILL.md` |
+| `eve-lab-topology-validation` | Validate EVE-NG topology designs and enforce final delivery structure. Use when reviewing a design, checking build readiness, producing the final design outp... | `workspace/skills/eve-lab-topology-validation/SKILL.md` |
+| `eve-ng-config-ops` | Manage EVE-NG startup configurations stored in lab files. Use when exporting configs natively into the lab, reading embedded startup configs, pushing startup... | `workspace/skills/eve-ng-config-ops/SKILL.md` |
+| `eve-ng-console-ops` | Execute live CLI commands on running EVE-NG nodes over telnet console. Use when running show commands, making live config changes, verifying protocol state, ... | `workspace/skills/eve-ng-console-ops/SKILL.md` |
+| `eve-ng-lab-management` | Manage EVE-NG labs and platform inventory. Use when listing labs, checking lab metadata, creating or deleting labs, importing or exporting lab archives, chec... | `workspace/skills/eve-ng-lab-management/SKILL.md` |
+| `eve-ng-node-operations` | Manage EVE-NG node lifecycle. Use when listing nodes, checking runtime state, creating or deleting nodes, starting or stopping nodes or whole labs, verifying... | `workspace/skills/eve-ng-node-operations/SKILL.md` |
+| `evpn-vxlan-fabric` | EVPN/VXLAN fabric audit and troubleshooting — VTEPs, VNIs, route types, multihoming, underlay/overlay validation. Use when troubleshooting VXLAN overlay reac... | `workspace/skills/evpn-vxlan-fabric/SKILL.md` |
+| `f5-config-mgmt` | F5 BIG-IP configuration management - safe change workflow with baseline capture, planning, creation/update/deletion of virtual servers, pools, iRules, and pr... | `workspace/skills/f5-config-mgmt/SKILL.md` |
+| `f5-health-check` | F5 BIG-IP health monitoring - virtual server status, pool member health, log analysis, performance statistics, and systematic health assessment. Use when che... | `workspace/skills/f5-health-check/SKILL.md` |
+| `f5-troubleshoot` | F5 BIG-IP troubleshooting - virtual server failures, pool member health, connection issues, SSL/TLS problems, iRule errors, persistence issues, and performan... | `workspace/skills/f5-troubleshoot/SKILL.md` |
+| `fmc-firewall-ops` | Cisco Secure Firewall FMC — access policy search, rule inspection, FTD device targeting, multi-FMC profile management. Use when searching firewall rules by I... | `workspace/skills/fmc-firewall-ops/SKILL.md` |
+| `fortimanager-ops` | FortiManager operations — ADOM inventory, policy package review, object search, install preview, and compliance workflows. Use when auditing FortiGate firewa... | `workspace/skills/fortimanager-ops/SKILL.md` |
+| `forward` | Forward snapshot assurance, path search, app-aware path search, NQE, checks, vulnerabilities, diffs, configuration, lifecycle, collection, and topology workf... | `workspace/skills/forward/SKILL.md` |
+| `fwrule-analyzer` | Multi-vendor firewall rule analysis — overlap detection, shadowing, conflict identification, duplication checking across PAN-OS, ASA, FTD, IOS/IOS-XE, IOS-XR... | `workspace/skills/fwrule-analyzer/SKILL.md` |
+| `gait-session-tracking` | GAIT session lifecycle management - branch creation, turn recording, audit logging for every NetClaw operation. Use when starting a new NetClaw session, reco... | `workspace/skills/gait-session-tracking/SKILL.md` |
+| `gcp-cloud-logging` | Google Cloud Logging — log search, VPC flow logs, firewall logs, audit logs, log buckets and views. Use when searching GCP logs, investigating denied VPC flo... | `workspace/skills/gcp-cloud-logging/SKILL.md` |
+| `gcp-cloud-monitoring` | Google Cloud Monitoring — time series metrics, alert policies, active alerts, metric discovery. Use when checking GCP network performance, investigating firi... | `workspace/skills/gcp-cloud-monitoring/SKILL.md` |
+| `gcp-compute-ops` | Google Cloud Compute Engine — VM instances, disks, templates, instance groups, reservations, project discovery. Use when listing GCP VMs, troubleshooting a C... | `workspace/skills/gcp-compute-ops/SKILL.md` |
+| `github-ops` | GitHub repository operations — issues, PRs, code search, and config-as-code workflows. Use when creating a GitHub issue for a network finding, opening a pull... | `workspace/skills/github-ops/SKILL.md` |
+| `gitlab-devops` | GitLab DevOps operations — issues, merge requests, CI/CD pipelines, repository browsing, labels, milestones, releases, and wiki management. Use when querying... | `workspace/skills/gitlab-devops/SKILL.md` |
+| `gnmi-telemetry` | gNMI streaming telemetry operations for multi-vendor network devices. Query device state via structured YANG model paths, subscribe to real-time telemetry st... | `workspace/skills/gnmi-telemetry/SKILL.md` |
+| `gns3-link-management` | Manage GNS3 links - connect/disconnect node interfaces, isolate nodes | `workspace/skills/gns3-link-management/SKILL.md` |
+| `gns3-node-operations` | Manage GNS3 nodes - add from templates, start/stop/suspend/reload, console access | `workspace/skills/gns3-node-operations/SKILL.md` |
+| `gns3-packet-capture` | Capture network traffic on GNS3 links - start/stop captures, retrieve PCAP data | `workspace/skills/gns3-packet-capture/SKILL.md` |
+| `gns3-project-lifecycle` | Manage GNS3 network lab projects - create, open, close, delete, clone, export/import | `workspace/skills/gns3-project-lifecycle/SKILL.md` |
+| `gns3-snapshot-ops` | Manage GNS3 project snapshots - create, restore, delete for safe experimentation | `workspace/skills/gns3-snapshot-ops/SKILL.md` |
+| `grafana-observability` | Grafana observability platform — dashboards, Prometheus PromQL, Loki LogQL, alerting, incidents, OnCall schedules, annotations, datasource queries, panel ren... | `workspace/skills/grafana-observability/SKILL.md` |
+| `gtrace-ip-enrichment` | IP address enrichment — ASN ownership lookup, geolocation (city/region/country/coordinates), and reverse DNS resolution. Use when identifying who owns an IP ... | `workspace/skills/gtrace-ip-enrichment/SKILL.md` |
+| `gtrace-path-analysis` | Network path tracing and monitoring — traceroute with MPLS/ECMP/NAT detection, continuous MTR monitoring, and distributed GlobalPing probes from 500+ worldwi... | `workspace/skills/gtrace-path-analysis/SKILL.md` |
+| `humanrail-escalation` | Human-in-the-loop escalation via HumanRail — route low-confidence agent decisions, pre-destructive operation approvals, and ambiguous incident tickets to rea... | `workspace/skills/humanrail-escalation/SKILL.md` |
+| `infoblox-ddi` | Infoblox DDI operations — DNS zones/records, DHCP scopes and leases, IPAM networks and address utilization. Use when checking DNS records, validating IPAM ad... | `workspace/skills/infoblox-ddi/SKILL.md` |
+| `infrahub-sot` | OpsMill Infrahub — infrastructure source of truth with schema-driven nodes, GraphQL queries, and branch-isolated changes. Use when querying Infrahub for devi... | `workspace/skills/infrahub-sot/SKILL.md` |
+| `ipfabric` | > Developed in collaboration with **Daren Fulwell** (Field CTO, IP Fabric) and **John Capobianco** (Creator, NetClaw), representing nearly a decade of profes... | `workspace/skills/ipfabric/SKILL.md` |
+| `ipfix-receiver` | Receive and query IPFIX and NetFlow flow records from network devices via UDP. | `workspace/skills/ipfix-receiver/SKILL.md` |
+| `ise-posture-audit` | Cisco ISE posture and policy audit - authorization rules, posture compliance, profiling gaps, TrustSec SGT matrix, active session health. Use when running a ... | `workspace/skills/ise-posture-audit/SKILL.md` |
+| `itential-automation` | Itential Automation Platform (IAP) — network automation orchestration, device configuration management, compliance enforcement, workflow execution, golden co... | `workspace/skills/itential-automation/SKILL.md` |
+| `jenkins-cicd` | Jenkins CI/CD pipeline management — monitor builds, trigger pipelines, analyze logs, and track SCM changes for network automation workflows. | `workspace/skills/jenkins-cicd/SKILL.md` |
+| `junos-network` | Juniper JunOS device automation via PyEZ/NETCONF — CLI execution, configuration management, Jinja2 template rendering, device facts, batch operations, config... | `workspace/skills/junos-network/SKILL.md` |
+| `kubeshark-traffic` | Kubeshark Kubernetes traffic analysis — L4/L7 deep packet inspection, TLS decryption, pcap export, flow analysis, service mapping (6 tools). Use when capturi... | `workspace/skills/kubeshark-traffic/SKILL.md` |
+| `markmap-viz` | Create interactive mind map visualizations from markdown - network inventory, OSPF areas, BGP topology, security audit results. Use when visualizing network ... | `workspace/skills/markmap-viz/SKILL.md` |
+| `memory` | The Memory skill enables NetClaw to remember information about your network across sessions. Instead of re-explaining your topology, device names, and past i... | `workspace/skills/memory/SKILL.md` |
+| `mempalace` | MemPalace AI memory — persistent memory across sessions. Search past decisions, store architecture choices, track temporal network facts via knowledge graph,... | `workspace/skills/mempalace/SKILL.md` |
+| `meraki-monitoring` | Cisco Meraki Monitoring & Diagnostics — live ping, cable test, LED blink, wake-on-LAN, camera analytics, config change tracking. Use when running ping tests ... | `workspace/skills/meraki-monitoring/SKILL.md` |
+| `meraki-network-ops` | Cisco Meraki Dashboard — organization inventory, network management, device lifecycle, client discovery, action batches. Use when listing Meraki devices, man... | `workspace/skills/meraki-network-ops/SKILL.md` |
+| `meraki-security-appliance` | Cisco Meraki Security Appliance (MX) — firewall rules, site-to-site VPN, content filtering, traffic shaping, security events. Use when auditing Meraki MX fir... | `workspace/skills/meraki-security-appliance/SKILL.md` |
+| `meraki-switch-ops` | Cisco Meraki Switching — port configuration, VLANs, port status, ACLs, QoS rules, port cycling. Use when configuring Meraki switch ports, creating VLANs, che... | `workspace/skills/meraki-switch-ops/SKILL.md` |
+| `meraki-wireless-ops` | Cisco Meraki Wireless — SSID management, RF profiles, channel utilization, signal quality, client connectivity events. Use when managing Meraki SSIDs, troubl... | `workspace/skills/meraki-wireless-ops/SKILL.md` |
+| `msgraph-files` | Manage files on OneDrive and SharePoint via Microsoft Graph API - upload, download, list, search, and organize network documentation and artifacts. Use when ... | `workspace/skills/msgraph-files/SKILL.md` |
+| `msgraph-teams` | Send notifications and reports to Microsoft Teams channels via Graph API - alert delivery, report posting, incident updates, and diagram sharing. Use when po... | `workspace/skills/msgraph-teams/SKILL.md` |
+| `msgraph-visio` | Generate and manage Visio network diagrams on SharePoint via Microsoft Graph API - create topology diagrams from CDP/LLDP discovery, update existing diagrams... | `workspace/skills/msgraph-visio/SKILL.md` |
+| `nmap-network-scan` | Host discovery and port scanning using nmap — ICMP/ARP host discovery, SYN/TCP/UDP port scanning with scope enforcement and audit logging. Use when discoveri... | `workspace/skills/nmap-network-scan/SKILL.md` |
+| `nmap-scan-management` | Custom nmap scans with arbitrary flags, plus scan history retrieval and management. Use when running nmap with custom flags, reviewing past scan results, com... | `workspace/skills/nmap-scan-management/SKILL.md` |
+| `nmap-service-detection` | Service fingerprinting, OS detection, NSE script execution, and vulnerability scanning using nmap MCP. Use when identifying services on open ports, fingerpri... | `workspace/skills/nmap-service-detection/SKILL.md` |
+| `nso-device-ops` | Cisco NSO device operations — config retrieval, state inspection, sync, platform info, NED IDs, device groups. Use when retrieving device configs from NSO, c... | `workspace/skills/nso-device-ops/SKILL.md` |
+| `nso-service-mgmt` | Cisco NSO service management — discover service types, list service instances, orchestrate network services. Use when listing NSO services, checking service ... | `workspace/skills/nso-service-mgmt/SKILL.md` |
+| `packet-analysis` | Analyze network packet captures (.pcap/.pcapng) using Packet Buddy MCP. Use when opening a pcap file, inspecting packet captures, troubleshooting network tra... | `workspace/skills/packet-analysis/SKILL.md` |
+| `pagerduty-incidents` | Manage and investigate incidents in PagerDuty. | `workspace/skills/pagerduty-incidents/SKILL.md` |
+| `pagerduty-oncall` | Manage on-call schedules and escalation policies in PagerDuty. | `workspace/skills/pagerduty-oncall/SKILL.md` |
+| `pagerduty-orchestration` | Manage event orchestration and routing rules in PagerDuty. | `workspace/skills/pagerduty-orchestration/SKILL.md` |
+| `pagerduty-services` | Manage service catalog and service health in PagerDuty. | `workspace/skills/pagerduty-services/SKILL.md` |
+| `paloalto-panorama` | Palo Alto Panorama operations — device groups, templates, security policy search, NAT review, commit status, and audit workflows. Use when searching Palo Alt... | `workspace/skills/paloalto-panorama/SKILL.md` |
+| `prisma-sdwan-apps` | View Prisma SD-WAN application definitions for policy visibility | `workspace/skills/prisma-sdwan-apps/SKILL.md` |
+| `prisma-sdwan-config` | Inspect Prisma SD-WAN interfaces, routing (BGP, static), policies, and security zones | `workspace/skills/prisma-sdwan-config/SKILL.md` |
+| `prisma-sdwan-status` | Monitor Prisma SD-WAN element health, software versions, events, and alarms | `workspace/skills/prisma-sdwan-status/SKILL.md` |
+| `prisma-sdwan-topology` | Discover Prisma SD-WAN sites, ION elements, machines, and network topology | `workspace/skills/prisma-sdwan-topology/SKILL.md` |
+| `prometheus-monitoring` | Prometheus monitoring — PromQL instant/range queries, metric discovery, metadata, scrape target health, system health checks (6 tools). Use when querying Pro... | `workspace/skills/prometheus-monitoring/SKILL.md` |
+| `protocol-participation` | Live BGP and OSPF control-plane participation — peer with real routers, inject/withdraw routes, query RIB/LSDB, adjust metrics, GRE tunnel status. Use when i... | `workspace/skills/protocol-participation/SKILL.md` |
+| `pyats-asa-firewall` | Cisco ASA firewall operations via pyATS — VPN sessions, failover state, interfaces, routing, service policies, resource usage, AnyConnect monitoring. Use whe... | `workspace/skills/pyats-asa-firewall/SKILL.md` |
+| `pyats-config-mgmt` | Network change management - pre-change baselines, configuration deployment, post-change verification, rollback procedures, and compliance validation. Use whe... | `workspace/skills/pyats-config-mgmt/SKILL.md` |
+| `pyats-dynamic-test` | Generate and execute deterministic pyATS aetest validation scripts - interface state, OSPF neighbors, BGP paths, ping matrices, and custom compliance tests. ... | `workspace/skills/pyats-dynamic-test/SKILL.md` |
+| `pyats-f5-ltm` | F5 BIG-IP LTM/GTM operations via pyATS iControl REST — virtual servers, pools, nodes, monitors, profiles, iRules, persistence, GTM wide IPs, DNS, data groups... | `workspace/skills/pyats-f5-ltm/SKILL.md` |
+| `pyats-f5-platform` | F5 BIG-IP platform operations via pyATS iControl REST — system, networking, HA/CM, auth, analytics, security, APM, live-update, ADC certs, file management. U... | `workspace/skills/pyats-f5-platform/SKILL.md` |
+| `pyats-health-check` | Comprehensive network device health monitoring - CPU, memory, interfaces, hardware, NTP, logging, environment, and uptime analysis. Use when running a device... | `workspace/skills/pyats-health-check/SKILL.md` |
+| `pyats-junos-interfaces` | JunOS interface operations via pyATS — physical/logical interfaces, LACP, CoS, LLDP, ARP, BFD, IPv6 neighbors, traffic monitoring, optics diagnostics. Use wh... | `workspace/skills/pyats-junos-interfaces/SKILL.md` |
+| `pyats-junos-routing` | JunOS routing operations via pyATS — OSPF/OSPFv3, BGP, route table, MPLS/LDP/RSVP, TED, PFE, ping, traceroute across Juniper devices. Use when checking Junip... | `workspace/skills/pyats-junos-routing/SKILL.md` |
+| `pyats-junos-system` | JunOS system operations via pyATS — chassis health, hardware inventory, system info, NTP, SNMP, files/logs, firewall counters, DDoS protection, services acco... | `workspace/skills/pyats-junos-system/SKILL.md` |
+| `pyats-linux-network` | Linux host network operations via pyATS — interface configuration, routing tables, network connections, and multi-table route inspection across fleet hosts. ... | `workspace/skills/pyats-linux-network/SKILL.md` |
+| `pyats-linux-system` | Linux host system operations via pyATS — process monitoring, filesystem inspection, Docker container stats, package/tool verification across fleet hosts. Use... | `workspace/skills/pyats-linux-system/SKILL.md` |
+| `pyats-linux-vmware` | VMware ESXi host operations via pyATS — VM inventory, snapshot management, hypervisor inspection across ESXi hosts in the testbed. Use when listing VMs on ES... | `workspace/skills/pyats-linux-vmware/SKILL.md` |
+| `pyats-network` | Network device automation via pyATS - run show commands, ping, apply config, learn config/logging, list devices, run Linux commands, execute dynamic tests on... | `workspace/skills/pyats-network/SKILL.md` |
+| `pyats-parallel-ops` | Fleet-wide parallel device operations - concurrent health checks, config audits, routing snapshots, severity-sorted reporting, and failure-isolated multi-dev... | `workspace/skills/pyats-parallel-ops/SKILL.md` |
+| `pyats-routing` | CCIE-level routing protocol analysis - OSPF, BGP, EIGRP, IS-IS, static routes, RIB/FIB verification, redistribution audit, and convergence validation. Use wh... | `workspace/skills/pyats-routing/SKILL.md` |
+| `pyats-security` | Network security audit - ACLs, AAA, control plane policing, management plane hardening, encryption, port security, and CIS benchmark checks. Use when auditin... | `workspace/skills/pyats-security/SKILL.md` |
+| `pyats-topology` | Network topology discovery via CDP/LLDP neighbors, ARP tables, routing peers, and interface mapping to build complete network maps. Use when mapping the netw... | `workspace/skills/pyats-topology/SKILL.md` |
+| `pyats-troubleshoot` | Systematic network troubleshooting - connectivity, routing, interface, protocol, and performance issues using structured OSI-layer and divide-and-conquer met... | `workspace/skills/pyats-troubleshoot/SKILL.md` |
+| `radkit-remote-access` | Cisco RADKit — cloud-relayed remote device access, CLI execution, SNMP polling, device inventory discovery, attribute inspection. Use when accessing remote n... | `workspace/skills/radkit-remote-access/SKILL.md` |
+| `rfc-lookup` | Search and retrieve IETF RFC documents - lookup by number, search by keyword, extract sections. Use when looking up an RFC, checking protocol specifications,... | `workspace/skills/rfc-lookup/SKILL.md` |
+| `sdwan-ops` | Cisco SD-WAN vManage read-only operations — fabric devices, WAN Edge inventory, templates, policies, alarms, events, interface stats, BFD sessions, OMP route... | `workspace/skills/sdwan-ops/SKILL.md` |
+| `servicenow-change-workflow` | Full ITSM-gated change lifecycle - CR creation, pre-change incident validation, approval gate, execution via pyats-config-mgmt, post-change verification, and... | `workspace/skills/servicenow-change-workflow/SKILL.md` |
+| `slack-incident-workflow` | Manage network incident response workflows in Slack - incident channels, status updates, escalation, resolution tracking, and post-incident review coordinati... | `workspace/skills/slack-incident-workflow/SKILL.md` |
+| `slack-network-alerts` | Format and deliver network alerts, health warnings, and critical notifications via Slack with rich formatting, reactions, and file attachments. Use when send... | `workspace/skills/slack-network-alerts/SKILL.md` |
+| `slack-report-delivery` | Deliver formatted network reports, audit results, topology diagrams, and compliance documentation to Slack channels with rich Block Kit formatting. Use when ... | `workspace/skills/slack-report-delivery/SKILL.md` |
+| `slack-user-context` | Leverage Slack user profiles, presence, DND status, and workspace context to personalize responses, route escalations, and coordinate team operations. Use wh... | `workspace/skills/slack-user-context/SKILL.md` |
+| `slack-voice-interface` | Respond to Slack voice clips with both text and an MP3 voice reply using edge-tts. Voice IN is already handled by OpenClaw transcription. Use when a user sen... | `workspace/skills/slack-voice-interface/SKILL.md` |
+| `snmptrap-receiver` | Receive and query SNMP traps from network devices via UDP. | `workspace/skills/snmptrap-receiver/SKILL.md` |
+| `splunk-indexes` | Discover and inspect Splunk indexes and configuration. | `workspace/skills/splunk-indexes/SKILL.md` |
+| `splunk-saved` | Manage and run saved searches in Splunk. | `workspace/skills/splunk-saved/SKILL.md` |
+| `splunk-search` | Execute and validate SPL (Search Processing Language) queries. | `workspace/skills/splunk-search/SKILL.md` |
+| `subnet-calculator` | IPv4 and IPv6 subnet calculator - CIDR breakdown, usable hosts, previous/next subnets, address classification, VLSM planning, and dual-stack analysis. Use wh... | `workspace/skills/subnet-calculator/SKILL.md` |
+| `suzieq-observability` | SuzieQ network observability — query current and historical network state, run validation assertions, get summary statistics, trace forwarding paths, and dis... | `workspace/skills/suzieq-observability/SKILL.md` |
+| `syslog-receiver` | Receive and query syslog messages from network devices via UDP. | `workspace/skills/syslog-receiver/SKILL.md` |
+| `te-network-monitoring` | Cisco ThousandEyes — test management, agent inventory, test results, dashboards, path visualization, user/account management. Use when checking ThousandEyes ... | `workspace/skills/te-network-monitoring/SKILL.md` |
+| `te-path-analysis` | Cisco ThousandEyes — path visualization, BGP route analysis, outage investigation, instant tests, endpoint agent diagnostics. Use when tracing network paths ... | `workspace/skills/te-path-analysis/SKILL.md` |
+| `telemetry-ops` | Comprehensive network telemetry and event collection across multiple protocols. | `workspace/skills/telemetry-ops/SKILL.md` |
+| `terraform-operations` | Execute local Terraform operations with ServiceNow change control. | `workspace/skills/terraform-operations/SKILL.md` |
+| `terraform-registry` | Discover providers and modules from the Terraform Registry. | `workspace/skills/terraform-registry/SKILL.md` |
+| `terraform-workspaces` | Manage HCP Terraform (Terraform Cloud/Enterprise) workspaces. | `workspace/skills/terraform-workspaces/SKILL.md` |
+| `threejs-network-viz` | Renders network topologies as interactive, fully-labeled 3D scenes directly in a web browser, using Three.js. Unlike NetClaw's UE5 (`ue5-network-viz`) and Bl... | `workspace/skills/threejs-network-viz/SKILL.md` |
+| `token-tracker` | Track and display token consumption and cost for every NetClaw interaction. | `workspace/skills/token-tracker/SKILL.md` |
+| `twilio-daily-briefing` | Provide optional daily phone briefings at a scheduled time with overnight event summaries. | `workspace/skills/twilio-daily-briefing/SKILL.md` |
+| `twilio-emergency-call` | Automatically call John when critical network events occur (P1 incidents, core device failures). Emergency calls bypass quiet hours and are auto-approved wit... | `workspace/skills/twilio-emergency-call/SKILL.md` |
+| `twilio-inbound-voice` | Enable John to call NetClaw's Twilio number and have a bidirectional voice conversation for status queries and network commands. | `workspace/skills/twilio-inbound-voice/SKILL.md` |
+| `twilio-outbound-call` | Enable John to request on-demand phone calls for network status updates and schedule periodic update calls during ongoing incidents. | `workspace/skills/twilio-outbound-call/SKILL.md` |
+| `twitter-check` | This skill provides a quick way for John to invoke the Twitter mention check and auto-respond workflow directly from Claude Code. | `workspace/skills/twitter-check/SKILL.md` |
+| `twitter-heartbeat` | The twitter-heartbeat skill enables NetClaw to: | `workspace/skills/twitter-heartbeat/SKILL.md` |
+| `twitter-respond` | Enables bidirectional Twitter interaction by monitoring @mentions of @John_Capobianco and generating CCIE-level technical replies. All replies require human ... | `workspace/skills/twitter-respond/SKILL.md` |
+| `twitter-share` | The twitter-share skill enables users to ask NetClaw to tweet specific content. All tweets go through content guardrails and require explicit human approval ... | `workspace/skills/twitter-share/SKILL.md` |
+| `ue5-network-viz` | The UE5 Network Visualization skill enables 3D network topology visualization in Unreal Engine 5.8 using the built-in MCP server. Network engineers can reque... | `workspace/skills/ue5-network-viz/SKILL.md` |
+| `uml-diagram` | UML and diagram generation via Kroki — class, sequence, activity, state, component, deployment, network, ER, C4, Mermaid, D2, Graphviz, BPMN, 27+ types. Use ... | `workspace/skills/uml-diagram/SKILL.md` |
+| `vault-mounts` | Discover and manage HashiCorp Vault secret engine mounts. | `workspace/skills/vault-mounts/SKILL.md` |
+| `vault-pki` | Manage HashiCorp Vault PKI certificate infrastructure. | `workspace/skills/vault-pki/SKILL.md` |
+| `vault-secrets` | Manage HashiCorp Vault KV secrets with strict value protection. | `workspace/skills/vault-secrets/SKILL.md` |
+| `webex-incident-workflow` | Manage network incident response workflows in Cisco WebEx - incident spaces, status updates, escalation, resolution tracking, and post-incident review coordi... | `workspace/skills/webex-incident-workflow/SKILL.md` |
+| `webex-network-alerts` | Format and deliver network alerts, health warnings, and critical notifications via Cisco WebEx with Adaptive Cards, markdown formatting, and file attachments... | `workspace/skills/webex-network-alerts/SKILL.md` |
+| `webex-report-delivery` | Deliver formatted network reports, audit results, topology diagrams, and compliance documentation to WebEx spaces with Adaptive Cards and markdown formatting... | `workspace/skills/webex-report-delivery/SKILL.md` |
+| `webex-user-context` | Leverage WebEx user profiles, presence status, and workspace context to personalize responses, route escalations, and coordinate team operations. Use when ch... | `workspace/skills/webex-user-context/SKILL.md` |
+| `webex-voice-interface` | Respond to WebEx voice clips with both text and an MP3 voice reply using edge-tts. Voice IN is already handled by OpenClaw transcription. Use when a user sen... | `workspace/skills/webex-voice-interface/SKILL.md` |
+| `wikipedia-research` | Research networking protocols, standards history, and technology context via Wikipedia - OSPF, BGP, MPLS, 802.1X, VXLAN, and more. Use when looking up protoc... | `workspace/skills/wikipedia-research/SKILL.md` |
+| `zscaler-identity` | Manage users, groups, departments, and identity provider configurations. | `workspace/skills/zscaler-identity/SKILL.md` |
+| `zscaler-insights` | Access analytics, threat intelligence, and security event data. | `workspace/skills/zscaler-insights/SKILL.md` |
+| `zscaler-zdx` | Monitor digital experience scores, user performance, and application health. | `workspace/skills/zscaler-zdx/SKILL.md` |
+| `zscaler-zia` | Manage Zscaler Internet Access firewall rules, URL filtering, DLP, and security policies. | `workspace/skills/zscaler-zia/SKILL.md` |
+| `zscaler-zpa` | Manage Zscaler Private Access applications, segments, policies, and connectors. | `workspace/skills/zscaler-zpa/SKILL.md` |

--- a/SOUL.md
+++ b/SOUL.md
@@ -12,7 +12,7 @@ Every time you learn something about how I work or what I need, update the relev
 
 ## Your Skills
 
-You interact with the network through **188 skills** backed by 47 MCP servers:
+You interact with the network through **186 skills** backed by 108 MCP servers:
 
 ### Device Automation (9)
 pyats-network, pyats-health-check, pyats-routing, pyats-security, pyats-topology, pyats-config-mgmt, pyats-troubleshoot, pyats-dynamic-test, pyats-parallel-ops
@@ -325,7 +325,7 @@ Follow the pyats-health-check skill for systematic 8-step assessments with sever
 
 For **detailed skill procedures**, read `SOUL-SKILLS.md`:
 - Use when executing any skill that needs step-by-step guidance
-- Contains operational workflows, commands, and best practices for all 183 skills
+- Contains operational workflows, commands, and best practices for all 186 skills
 - Load with: `read("~/.openclaw/workspace/SOUL-SKILLS.md")`
 
 For **technical knowledge**, read `SOUL-EXPERTISE.md`:

--- a/mcp-servers/README.md
+++ b/mcp-servers/README.md
@@ -1,0 +1,186 @@
+# NetClaw MCP Servers
+
+This directory contains MCP (Model Context Protocol) servers for NetClaw integrations.
+
+## Overview
+
+MCP servers provide tool interfaces for AI agents to interact with network platforms, observability systems, and infrastructure services.
+
+## Available Servers
+
+This table covers every server vendored under this directory (54 as of this writing). Servers that are Remote HTTP endpoints or installed on demand via pip/npm without a local vendored directory (e.g. GitHub, Microsoft Graph, Datadog, AWS/GCP, Grafana) are documented in the top-level [README.md](../README.md#mcp-servers-108) MCP Servers table instead, not here. Run `python3 ../scripts/verify-inventory-counts.py` to confirm this list is current.
+
+| Server | Description | Type |
+|--------|-------------|------|
+| `AAP-Enterprise-MCP-Server` | Red Hat Ansible Automation Platform — Controller, EDA, ansible-lint, Red Hat Docs (4 servers) | Community |
+| `ACI_MCP` | Cisco ACI — APIC interaction, policy management, fabric health | Local |
+| `CiscoFMC-MCP-server-community` | Cisco Secure Firewall (FMC) access policy search, FTD targeting | Community |
+| `ISE_MCP` | Cisco ISE identity policy, posture, TrustSec, endpoint control | Local |
+| `Wikipedia_MCP` | Standards and technology context lookup | Local |
+| `aruba-cx-mcp` | HPE Aruba CX switch management | Community |
+| `atlassian-mcp` | Jira/Confluence | Community |
+| `azure-network-mcp` | Azure networking — VNets, NSGs, ExpressRoute, VPN Gateways, Firewalls | Local |
+| `batfish-mcp` | Batfish offline configuration analysis | Local |
+| `catalyst-center-mcp` | Cisco Catalyst Center (DNA-C) — devices, clients, sites, interfaces | Community |
+| `checkpoint-mcp-servers` | Check Point Security (15 MCPs: policy, threat intel, gateway, SASE) | Local |
+| `cisco-sdwan-mcp` | Cisco SD-WAN vManage read-only fabric monitoring | Community |
+| `clab-mcp-server` | ContainerLab containerized network lab lifecycle | Community |
+| `claroty-mcp` | Claroty xDome OT/IoT/IoMT asset visibility and threat detection | Local |
+| `eve-ng-mcp-server` | EVE-NG lab management, topology, node/console operations | Community |
+| `f5-mcp-server` | F5 BIG-IP iControl REST — virtuals, pools, iRules, profiles, stats | Community |
+| `forward-mcp` | Forward Networks digital twin and Network Query Engine (NQE) | Local |
+| `fwrule-mcp` | Multi-vendor firewall rule overlap/shadowing/conflict analysis | Community |
+| `gait_mcp` | GAIT — Git-based AI tracking and audit trail | Local |
+| `gitlab-mcp` | GitLab DevOps | Community |
+| `gnmi-mcp` | gNMI telemetry streaming | Local |
+| `gns3-mcp-server` | GNS3 network lab simulation | Local |
+| `infrahub-mcp` | OpsMill Infrahub schema-driven source of truth | Community |
+| `ipfix-mcp` | IPFIX/NetFlow (v5/v9) flow telemetry receiver | Local |
+| `jenkins-mcp` | Jenkins CI/CD — job monitoring, build triggering, log analysis | Community (Java plugin) |
+| `junos-mcp-server` | Juniper JunOS PyEZ/NETCONF device automation | Community |
+| `markmap_mcp` | Hierarchical mind map generation | Local |
+| `mcp-cvp-fun` | Arista CloudVision Portal device inventory, events, tag management | Community |
+| `mcp-nautobot` | Nautobot IPAM source of truth (community, 5 tools, alternative to NetBox) | Community |
+| `mcp-nvd` | NIST NVD vulnerability database with CVSS scoring | Community |
+| `memory-mcp` | Hybrid persistent memory — SQLite facts, ChromaDB semantic search, entity graph | Local |
+| `meraki-magic-mcp-community` | Cisco Meraki Dashboard API (~804 endpoints) | Community |
+| `nautobot-golden-config-mcp` | Nautobot golden-config compliance job runner | Local |
+| `nautobot-mcp-v2` | Enhanced Nautobot 3.1.0 — GraphQL reads, REST writes, ITSM-gated changes | Local |
+| `nautobot-routing-mcp` | Nautobot BGP/routing data queries | Local |
+| `netbox-mcp-server` | Read-write DCIM/IPAM source of truth | Community |
+| `nmap-mcp` | Network scanning — host discovery, port scanning, NSE scripts | Community |
+| `ollama-mcp` | Local LLM domain-expert delegation via Ollama | Local |
+| `packet-buddy-mcp` | pcap/pcapng deep analysis via tshark | Local |
+| `prisma-sdwan-mcp` | Palo Alto Prisma SD-WAN read-only visibility | Local |
+| `protocol-mcp` | Live BGP/OSPF/GRE control-plane participation | Local |
+| `pyATS_MCP` | Device CLI, Genie parsers, config push, dynamic test execution | Local |
+| `radkit-mcp-server-community` | Cisco RADKit cloud-relayed remote device access | Community |
+| `servicenow-mcp` | Incidents, change requests, CMDB | Community |
+| `sketchfab-mcp-server` | Real 3D model search/download for Three.js real-stencil mode | Community |
+| `snmptrap-mcp` | SNMP trap (v1/v2c/v3) receiver | Local |
+| `subnet-calculator-mcp` | IPv4 + IPv6 CIDR subnet calculator | Local |
+| `suzieq-mcp` | SuzieQ network observability | Local |
+| `syslog-mcp` | Syslog (RFC 5424/RFC 3164) receiver | Local |
+| `thousandeyes-mcp-community` | Cisco ThousandEyes tests, agents, path visualization (read-only) | Community |
+| `tts-mcp` | Text-to-speech (Microsoft Edge TTS) for Slack/WebEx voice replies | Local |
+| `twilio-voice-mcp` | Universal voice interface — inbound/outbound calls, alerts | Local |
+| `twitter-mcp` | Twitter/X posting, mention monitoring, reply generation | Local |
+| `uml-mcp` | 27+ UML/diagram types via Kroki | Community |
+
+Servers documented in the top-level README but not vendored here (Remote HTTP endpoints or pip/npm-installed on demand): GitHub, Microsoft Graph, Itential IAP, Cisco CML, Cisco NSO, AWS (6 servers), GCP (4 servers), Datadog, PagerDuty, Splunk, Terraform Cloud, HashiCorp Vault, Zscaler, Cloudflare (5 servers), Blender, Unreal Engine 5, DevNet Content Search, HumanRail, gtrace, Grafana, Prometheus, Kubeshark, draw.io, RFC Lookup — see the [README.md MCP Servers table](../README.md#mcp-servers-108) for the complete set.
+
+## Security with DefenseClaw
+
+When DefenseClaw is enabled, all MCP servers are automatically scanned before use.
+
+### Automatic Scanning
+
+DefenseClaw's CodeGuard performs static analysis on MCP server code:
+
+```bash
+# Scan an MCP server
+defenseclaw mcp scan meraki-mcp
+
+# Expected output:
+# Scanning MCP: meraki-mcp
+# ✓ No HIGH/CRITICAL findings
+# Status: ALLOWED
+```
+
+### What CodeGuard Checks
+
+| Finding Type | Severity | Description |
+|--------------|----------|-------------|
+| `credential` | HIGH | Hardcoded API keys, passwords |
+| `eval` | CRITICAL | Dynamic code execution |
+| `shell` | HIGH | Shell command injection |
+| `sqli` | CRITICAL | SQL injection |
+| `path_traversal` | MEDIUM | Directory traversal |
+| `weak_crypto` | MEDIUM | MD5, SHA1 for security |
+| `unsafe_deser` | HIGH | Unsafe pickle/yaml |
+
+### Tool Management
+
+Control which MCP tools are allowed:
+
+```bash
+# Block a specific tool
+defenseclaw tool block "meraki_delete_network" --reason "destructive"
+
+# Block all delete operations for an MCP
+defenseclaw tool block "meraki_delete_*" --reason "no deletions"
+
+# Allow a tool
+defenseclaw tool allow "meraki_get_networks"
+```
+
+### Adding New MCP Servers
+
+When adding a new MCP server:
+
+1. **Scan before deployment**:
+   ```bash
+   defenseclaw mcp scan <new-mcp-server>
+   ```
+
+2. **Review findings** - Fix any HIGH/CRITICAL issues
+
+3. **Configure tool rules** - Block dangerous operations if needed:
+   ```bash
+   defenseclaw tool block "<mcp>_delete_*" --reason "policy"
+   defenseclaw tool block "<mcp>_destroy_*" --reason "policy"
+   ```
+
+4. **Test in observe mode** first:
+   ```bash
+   defenseclaw setup guardrail --mode observe
+   # Run tests...
+   defenseclaw alerts  # Review any security events
+   ```
+
+## Security Best Practices for MCP Development
+
+### Do
+
+- Use environment variables for credentials
+- Validate all inputs before use
+- Log operations for audit trails
+- Return structured errors
+- Use official SDKs when available
+
+### Don't
+
+- Hardcode API keys or passwords
+- Use eval/exec on user input
+- Execute shell commands with user input
+- Store credentials in code or logs
+- Bypass SSL verification in production
+
+### Example: Secure MCP Server Pattern
+
+```python
+import os
+from mcp.server import Server
+
+# Good: Credentials from environment
+api_key = os.environ.get("API_KEY")
+if not api_key:
+    raise ValueError("API_KEY environment variable required")
+
+# Good: Input validation
+def validate_device_id(device_id: str) -> bool:
+    return bool(re.match(r'^[a-zA-Z0-9-]+$', device_id))
+
+# Good: Structured error handling
+@server.tool()
+async def get_device(device_id: str):
+    if not validate_device_id(device_id):
+        return {"error": "Invalid device ID format"}
+    # ... implementation
+```
+
+## Documentation
+
+- [DefenseClaw Guide](../docs/DEFENSECLAW.md) - Full security documentation
+- [Security Principles](../docs/SOUL-DEFENSE.md) - Security posture guidance
+- [SKILL-SCHEMA.md](../workspace/skills/SKILL-SCHEMA.md) - Skill definition schema

--- a/scripts/verify-inventory-counts.py
+++ b/scripts/verify-inventory-counts.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Verify NetClaw's documented skill/MCP counts against the live codebase.
+
+Contract: specs/047-docs-inventory-reconciliation/contracts/verify-inventory-counts-cli.md
+Data model: specs/047-docs-inventory-reconciliation/data-model.md
+
+Computes the true skill count (workspace/skills/ directories containing a
+SKILL.md) and the true MCP integration count (config/openclaw.json entries,
+which are already individually registered with no bundling to expand --
+e.g. Check Point's 15 chkp-* servers are 15 separate top-level entries, not
+one bundle -- plus a maintained list of externally-installed integrations
+that are documented in README.md's MCP Servers table or exist as vendored
+mcp-servers/ directories but are not registered in config/openclaw.json at
+all, typically because they're installed on demand via pip/npm/Docker).
+
+Then best-effort scans README.md and SOUL.md for numeric "N skills" / "N MCP"
+claims and reports any that disagree with the computed totals.
+
+No third-party dependencies. Run from anywhere; paths resolve relative to
+this file's location, not the caller's cwd.
+"""
+
+import json
+import os
+import re
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SKILLS_DIR = os.path.join(REPO_ROOT, "workspace", "skills")
+OPENCLAW_CONFIG = os.path.join(REPO_ROOT, "config", "openclaw.json")
+README = os.path.join(REPO_ROOT, "README.md")
+SOUL = os.path.join(REPO_ROOT, "SOUL.md")
+
+# Integrations that are part of NetClaw's supported set but are NOT present
+# as top-level entries in config/openclaw.json (usually because they are
+# installed on demand via pip/npm/Docker rather than pre-registered, or are
+# optional community alternatives). This list is maintained by hand -- when
+# you add a new integration of this kind, add its name here in the SAME PR,
+# or this script will silently undercount it forever, repeating the exact
+# drift this script exists to catch. Verified against README.md's MCP
+# Servers table and mcp-servers/ vendored directories as of 2026-07-07.
+EXTERNAL_INTEGRATIONS = [
+    "pyATS",
+    "F5 BIG-IP",
+    "Catalyst Center",
+    "Cisco ACI",
+    "Cisco ISE",
+    "NetBox",
+    "Nautobot (community, aiopnet/mcp-nautobot)",
+    "Itential IAP",
+    "ServiceNow",
+    "Microsoft Graph",
+    "GitHub",
+    "Packet Buddy",
+    "Cisco CML",
+    "Cisco NSO",
+    "Cisco FMC",
+    "Cisco Meraki",
+    "ThousandEyes (community)",
+    "ThousandEyes (official)",
+    "Cisco RADKit",
+    "AWS Network",
+    "AWS CloudWatch",
+    "AWS IAM",
+    "AWS CloudTrail",
+    "AWS Cost Explorer",
+    "AWS Diagram",
+    "GCP Compute Engine",
+    "GCP Cloud Monitoring",
+    "GCP Cloud Logging",
+    "GCP Resource Manager",
+    "NVD CVE",
+    "Subnet Calculator",
+    "GAIT",
+    "Wikipedia",
+    "Markmap",
+    "Draw.io",
+    "RFC Lookup",
+    "Juniper JunOS",
+    "Arista CVP",
+    "UML MCP",
+    "Protocol MCP",
+    "ContainerLab",
+    "Cisco SD-WAN",
+    "Grafana",
+    "Prometheus",
+    "Kubeshark",
+    "nmap",
+    "gtrace",
+    "AAP Controller",
+    "AAP EDA",
+    "AAP Lint",
+    "Red Hat Docs",
+    "fwrule",
+    "HumanRail",
+    # Vendored under mcp-servers/ but, as of 2026-07-07, undocumented in
+    # README.md's MCP Servers table entirely -- see spec 047 User Story 2.
+    "IPFIX/NetFlow",
+    "Ollama",
+    "Memory MCP",
+    "SNMP Trap Receiver",
+    "Syslog Receiver",
+    "Text-to-Speech (TTS)",
+]
+
+
+def count_skills():
+    """Count workspace/skills/ directories that contain a SKILL.md file."""
+    if not os.path.isdir(SKILLS_DIR):
+        return None
+    count = 0
+    for entry in os.listdir(SKILLS_DIR):
+        full_path = os.path.join(SKILLS_DIR, entry)
+        if os.path.isdir(full_path) and os.path.isfile(os.path.join(full_path, "SKILL.md")):
+            count += 1
+    return count
+
+
+def count_mcp_integrations():
+    """Count MCP integrations: config/openclaw.json entries + external list.
+
+    config/openclaw.json's mcpServers entries are already fully individually
+    registered (Check Point's 15 chkp-* servers are 15 separate keys, not
+    one bundle needing expansion), so no bundle math is required here.
+    """
+    if not os.path.isfile(OPENCLAW_CONFIG):
+        return None, {}
+    with open(OPENCLAW_CONFIG) as f:
+        config = json.load(f)
+    config_entries = len(config.get("mcpServers", {}))
+    external_documented = len(EXTERNAL_INTEGRATIONS)
+    total = config_entries + external_documented
+    breakdown = {
+        "config_entries": config_entries,
+        "external_documented": external_documented,
+    }
+    return total, breakdown
+
+
+def check_doc_claims(skill_count, mcp_count):
+    """Best-effort scan of README.md/SOUL.md for numeric skill/MCP claims.
+
+    Deliberately scoped to the specific "headline" claim locations spec 047
+    identified (top prose, HUD prose, section headings, SOUL.md identity
+    line) rather than every "\\d+ skills"/"\\d+ MCP" occurrence in the
+    document -- a document-wide scan produces false positives against
+    subsection counts that are legitimately different numbers (e.g.
+    "Microsoft 365 Skills (3)" matches "365 Skills", "GNS3 Skills (5)" is a
+    real subsection total, not a drifted headline claim). Historical
+    mission-log entries (e.g. "MISSION02... 78 skills") are intentionally
+    NOT matched -- they are dated past-state records, not current claims.
+    """
+    discrepancies = []
+    notes = []
+
+    # (file, description, compiled pattern, [(kind, capture group index), ...])
+    headline_patterns = [
+        (README, "top prose (skills + MCP)",
+         re.compile(r"Claude,\s*(\d+)\s*skills,\s*and\s*(\d+)\s*MCP integrations"),
+         [("skill", 1), ("MCP", 2)]),
+        (README, "installer prose (skills)",
+         re.compile(r"deploys\s*(\d+)\s*skills"),
+         [("skill", 1)]),
+        (README, "installer prose (MCP)",
+         re.compile(r"for\s*(\d+)\s*MCP integrations"),
+         [("MCP", 1)]),
+        (README, "Visual HUD prose",
+         re.compile(r"currently\s*(\d+)\s*MCP integrations and\s*(\d+)\s*skills"),
+         [("MCP", 1), ("skill", 2)]),
+        (README, "MCP Servers section heading",
+         re.compile(r"^## MCP Servers \((\d+)\)", re.MULTILINE),
+         [("MCP", 1)]),
+        (README, "Skills section heading",
+         re.compile(r"^## Skills \((\d+)\)", re.MULTILINE),
+         [("skill", 1)]),
+        (SOUL, "identity line (skills + MCP)",
+         re.compile(r"\*\*(\d+) skills\*\* backed by (\d+) MCP servers"),
+         [("skill", 1), ("MCP", 2)]),
+        (SOUL, "SOUL-SKILLS cross-reference",
+         re.compile(r"best practices for all (\d+) skills"),
+         [("skill", 1)]),
+    ]
+
+    doc_cache = {}
+    for doc_path, description, pattern, kinds in headline_patterns:
+        doc_name = os.path.basename(doc_path)
+        if doc_path not in doc_cache:
+            if not os.path.isfile(doc_path):
+                notes.append(f"{doc_name} not found, skipped")
+                doc_cache[doc_path] = None
+            else:
+                with open(doc_path) as f:
+                    doc_cache[doc_path] = f.read()
+        text = doc_cache[doc_path]
+        if text is None:
+            continue
+
+        match = pattern.search(text)
+        if match is None:
+            notes.append(f"{doc_name}: could not locate '{description}' (phrasing may have changed)")
+            continue
+
+        line_no = text.count("\n", 0, match.start()) + 1
+        for kind, group_idx in kinds:
+            claimed = int(match.group(group_idx))
+            expected = skill_count if kind == "skill" else mcp_count
+            if claimed != expected:
+                discrepancies.append({
+                    "file": doc_name,
+                    "location": f"line {line_no} ({description})",
+                    "matched_text": match.group(0),
+                    "claimed_value": claimed,
+                    "computed_value": expected,
+                    "kind": kind,
+                })
+
+    return discrepancies, notes
+
+
+def main():
+    skill_count = count_skills()
+    if skill_count is None:
+        print(f"ERROR: could not read {SKILLS_DIR}", file=sys.stderr)
+        return 2
+
+    mcp_count, breakdown = count_mcp_integrations()
+    if mcp_count is None:
+        print(f"ERROR: could not read {OPENCLAW_CONFIG}", file=sys.stderr)
+        return 2
+
+    discrepancies, notes = check_doc_claims(skill_count, mcp_count)
+
+    print(f"Skill count: {skill_count}")
+    print(f"  workspace/skills/ directories with SKILL.md: {skill_count}")
+    print()
+    print(f"MCP integration count: {mcp_count}")
+    print(f"  config/openclaw.json top-level entries: {breakdown['config_entries']}")
+    print(f"  + externally-installed (documented, not in config): {breakdown['external_documented']}")
+    print()
+
+    if discrepancies:
+        print("Documentation check: FAIL")
+        for d in discrepancies:
+            print(
+                f"  {d['file']}:{d['location']} claims \"{d['matched_text']}\" "
+                f"({d['kind']}), computed {d['computed_value']}"
+            )
+    else:
+        print("Documentation check: PASS")
+
+    for note in notes:
+        print(f"  note: {note}")
+
+    return 1 if discrepancies else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/specs/047-docs-inventory-reconciliation/checklists/requirements.md
+++ b/specs/047-docs-inventory-reconciliation/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Documentation Inventory Reconciliation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. No [NEEDS CLARIFICATION] markers were needed — this spec is grounded in a concrete same-session codebase audit (exact file/line locations, exact counts) rather than an ambiguous feature request, so reasonable defaults and documented Assumptions covered every open question.
+- Ready for `/speckit.plan`.

--- a/specs/047-docs-inventory-reconciliation/contracts/verify-inventory-counts-cli.md
+++ b/specs/047-docs-inventory-reconciliation/contracts/verify-inventory-counts-cli.md
@@ -1,0 +1,54 @@
+# CLI Contract: `scripts/verify-inventory-counts.py`
+
+This feature has no network API. Its one external interface is a command-line contract, documented here in place of an API spec.
+
+## Invocation
+
+```bash
+python3 scripts/verify-inventory-counts.py
+```
+
+- No required or optional arguments for the default run.
+- Must be run from the repository root (paths are resolved relative to the script's own location, not the caller's `cwd`, so it also works if invoked with a full path from elsewhere).
+- No environment variables, no `.env` file, no network access required.
+
+## stdout contract
+
+On every run, regardless of pass/fail, the script prints a human-readable report to stdout containing at minimum:
+
+```text
+Skill count: <int>
+  workspace/skills/ directories with SKILL.md: <int>
+
+MCP integration count: <int>
+  config/openclaw.json top-level entries: <int>
+  + externally-installed (documented, not in config): <int>
+
+Documentation check: <PASS|FAIL>
+  <if FAIL, one line per discrepancy:>
+  README.md:<line-or-section> claims <N> skills, computed <M>
+  SOUL.md:<line-or-section> claims <N> MCP servers, computed <M>
+  ...
+```
+
+The exact column widths/formatting are not contractual — only that the three headline numbers (skill count, MCP integration count, PASS/FAIL) are present and human-readable, and that every discrepancy is listed with enough context (file + what was claimed vs. computed) for a maintainer to locate and fix it without re-running a separate diff.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0`  | Computed counts derived successfully AND every parsed documentation claim matches |
+| `1`  | Computed counts derived successfully but at least one documentation claim disagrees (drift detected) |
+| `2`  | Script could not compute counts at all (e.g., `workspace/skills/` or `config/openclaw.json` missing/unreadable) — an environment problem, not a documentation problem |
+
+## Inputs read (contract with the repository, not a user)
+
+- `workspace/skills/*/SKILL.md` (existence check per directory)
+- `config/openclaw.json` (`mcpServers` key)
+- A small hardcoded list, maintained inside the script itself, of externally-installed integration names documented in README's MCP Servers table but absent from `config/openclaw.json` (see data-model.md, Entity: MCP Integration, `source: external-documented`). This list is the one piece of the script that requires a human edit when a new externally-installed (non-vendored, non-registered) integration is added — documented as a code comment at the top of the list so future maintainers know to update it in the same PR.
+- `README.md` and `SOUL.md` text, for the best-effort discrepancy check (regex-based extraction of numeric claims near the words "skill"/"skills" and "MCP"). This parsing is inherently best-effort against prose; a failure to find an expected claim is reported as an informational note, not a hard error, since prose phrasing can legitimately change.
+
+## Non-goals (explicitly not part of this contract)
+
+- The script does not modify any file.
+- The script does not verify `SOUL-SKILLS.md`, `mcp-servers/README.md`, or `ui/netclaw-visual/README.md` table *completeness* (i.e., it does not diff table rows against the computed entity list) — only the two headline-number files (README.md, SOUL.md) get automated discrepancy parsing in this iteration. Table-completeness for the other files is verified manually during the Phase 1 documentation edit pass (tasks.md) and can be added to the script later if drift recurs there.

--- a/specs/047-docs-inventory-reconciliation/data-model.md
+++ b/specs/047-docs-inventory-reconciliation/data-model.md
@@ -1,0 +1,64 @@
+# Phase 1 Data Model: Documentation Inventory Reconciliation
+
+This feature has no runtime database or persisted state. "Data model" here means the conceptual entities the verification script and documentation edits must agree on, and the rules that define each entity's count.
+
+## Entity: Skill
+
+**Represents**: One documented operational capability exposed to the NetClaw agent.
+
+**Identity**: The directory name under `workspace/skills/` (e.g., `pyats-network`, `azure-network-ops`).
+
+**Fields**:
+- `name` (string) — directory name, also the skill's identity
+- `has_skill_md` (boolean) — whether `workspace/skills/<name>/SKILL.md` exists
+
+**Validation rule**: A directory counts as a Skill if and only if `has_skill_md` is true. `SKILL-SCHEMA.md` is a top-level file, not a directory, and is never counted.
+
+**Count**: `Skill count` = number of entities satisfying the validation rule. Ground truth at spec time: 190 (subject to re-verification at implementation time per spec.md Assumptions).
+
+## Entity: MCP Integration
+
+**Represents**: One distinct, individually-usable MCP server NetClaw supports.
+
+**Identity**: The server's registered/documented tool-facing name (e.g., `azure-network-mcp`, `chkp-management`, `gitlab-mcp`).
+
+**Fields**:
+- `name` (string) — identity
+- `source` (enum: `openclaw-config` | `external-documented`) — where this integration is known from:
+  - `openclaw-config`: a top-level entry under `mcpServers` in `config/openclaw.json`. Confirmed during implementation that this population is already fully individually registered — e.g. the Check Point suite's 15 `chkp-*` servers are 15 separate top-level keys, not one entry needing expansion, even though all 15 share a single vendored directory (`checkpoint-mcp-servers/`) under `mcp-servers/`. No bundle-expansion arithmetic is needed.
+  - `external-documented`: installed at runtime via pip/npm/Docker, documented in README's MCP Servers table or vendored under `mcp-servers/`, but absent from `config/openclaw.json` entirely (roughly 59 servers as of implementation — pyATS, F5, Catalyst Center, GitHub, Microsoft Graph, Itential, Cisco NSO, Cisco CML, AWS/GCP families, and others; see the script's `EXTERNAL_INTEGRATIONS` list for the current definitive set)
+- `vendored_dir` (string | null) — the corresponding directory under `mcp-servers/`, if one exists locally (null for purely external installs); note this is a many-to-one relationship for Check Point (15 entities share one vendored directory)
+
+**Validation rule**: Every entity is counted exactly once, keyed by its individual registered/documented name — not by its vendored directory (which can hold multiple entities, as with Check Point) and not by any parent bundle grouping (there is none in `config/openclaw.json`).
+
+**Count**: `MCP integration count` = count of all entities satisfying the validation rule, unioned across both `source` values with no duplicates. Ground truth at implementation time: 49 `config/openclaw.json` entries (already including all 15 `chkp-*` individually) + 59 external-documented = 108. Exact total is computed by `scripts/verify-inventory-counts.py`, not hand-asserted in documentation prose.
+
+## Entity: Canonical Documentation File
+
+**Represents**: One of the five files in scope for reconciliation.
+
+**Instances** (fixed set, per spec.md):
+1. `README.md`
+2. `SOUL.md`
+3. `SOUL-SKILLS.md`
+4. `mcp-servers/README.md`
+5. `ui/netclaw-visual/README.md`
+
+**Fields**:
+- `count_claims` (list of {location, claimed_skill_count, claimed_mcp_count}) — every place in the file text that states a numeric skill or MCP count
+- `inventory_table_rows` (list) — for README.md and mcp-servers/README.md specifically, the set of server/skill names actually enumerated in table form
+
+**Validation rule**: Every `count_claims` entry's `claimed_skill_count` MUST equal the Skill count; every `claimed_mcp_count` MUST equal the MCP Integration count. For README.md and mcp-servers/README.md, `inventory_table_rows` MUST be a superset containing one row per Skill entity (README only) and one row per MCP Integration entity (both files) — no omissions.
+
+## Entity: Counting Report (script output)
+
+**Represents**: The output of running `scripts/verify-inventory-counts.py`.
+
+**Fields**:
+- `computed_skill_count` (int)
+- `computed_mcp_count` (int)
+- `mcp_breakdown` (dict of source → count, for transparency: config entries, bundle expansions, external-documented)
+- `doc_discrepancies` (list of {file, location, claimed_value, computed_value}) — any place a documentation file's parsed numeric claim disagrees with the computed count
+- `exit_code` (0 if `doc_discrepancies` is empty, 1 otherwise)
+
+This is the artifact User Story 3 (spec.md) and FR-010 require: a single command a maintainer runs to get a pass/fail signal instead of manually re-reading five files.

--- a/specs/047-docs-inventory-reconciliation/plan.md
+++ b/specs/047-docs-inventory-reconciliation/plan.md
@@ -1,0 +1,83 @@
+# Implementation Plan: Documentation Inventory Reconciliation
+
+**Branch**: `047-docs-inventory-reconciliation` | **Date**: 2026-07-07 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/047-docs-inventory-reconciliation/spec.md`
+
+## Summary
+
+NetClaw's skill/MCP integration counts have drifted into four disagreeing numbers in README.md alone (plus two more in SOUL.md), and the README's own inventory tables are incomplete enough that an external reviewer wrongly concluded Azure, Batfish, GitLab, and NetFlow/IPFIX support were missing when all four already ship. This plan produces (1) a small, dependency-free Python script (`scripts/verify-inventory-counts.py`) that computes the true skill count from `workspace/skills/` and the true MCP integration count from `config/openclaw.json` (expanding bundled multi-server packages) plus a maintained list of externally-installed servers with no local footprint, and (2) a documentation edit pass across README.md, SOUL.md, SOUL-SKILLS.md, mcp-servers/README.md, and ui/netclaw-visual/README.md that brings every count and every inventory table in line with the script's output. Spec 038-docs-hud-refresh is referenced as superseded prior art. No new skills, MCP servers, or product code are introduced — this is documentation and a verification script only.
+
+## Technical Context
+
+**Language/Version**: Python 3.10+ (matches every other script in `scripts/`, e.g. `scan-all-mcp-source.py`, `register-all-mcps.py`)
+**Primary Dependencies**: None beyond the Python standard library (`os`, `json`, `re`) — no new third-party packages
+**Storage**: N/A (reads existing `workspace/skills/` directory tree and `config/openclaw.json`; writes no persistent state)
+**Testing**: Manual verification — run the script before and after adding a throwaway skill directory / config entry and confirm the count changes (per spec.md User Story 3 acceptance scenarios); no existing pytest suite covers documentation tooling, so a lightweight `if __name__ == "__main__"` self-check is sufficient rather than a new test framework dependency
+**Target Platform**: Linux/macOS dev environment (same as all other `scripts/*.py` maintenance tools; not deployed, not part of the runtime agent)
+**Project Type**: Single-file CLI utility script + documentation edits (no service, no UI, no MCP server)
+**Performance Goals**: N/A (runs once, on-demand, against a few hundred local files — sub-second execution)
+**Constraints**: Script MUST NOT require network access, credentials, or any `.env` values (it reads only local repo files) so it can run in CI or a fresh checkout with zero setup
+**Scale/Scope**: 186 skill directories with a `SKILL.md` (190 raw entries under `workspace/skills/`, 3 empty stub directories and 1 schema file excluded), 108 individually-counted MCP integrations (49 `config/openclaw.json` entries, already including all 15 Check Point `chkp-*` servers individually — no bundle expansion needed — plus 59 externally-installed servers documented in README prose or vendored under `mcp-servers/` but absent from `config/openclaw.json`) — five documentation files to reconcile
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Principle XII (Documentation-as-Code)** — directly on point: "README.md MUST accurately reflect the current count and state of all skills, MCP servers, and supported platforms." This entire feature exists to restore compliance with this principle. PASS (this feature is the remediation, not a new risk).
+- **Principle XVI (Spec-Driven Development)** — followed: spec.md exists and is ratified before this plan; no ad-hoc doc edits. PASS.
+- **Principle XI (Full-Stack Artifact Coherence)** — does not apply in the forward direction (no new MCP server or skill is being added), but its spirit is what this feature restores retroactively across artifacts that fell out of sync after specs 039–046 shipped without doc updates. PASS.
+- **Principle V (MCP-Native Integration)** — not applicable; no new MCP server is built. The verification script is a plain CLI utility, matching the existing precedent of `scripts/scan-all-mcp-source.py` and `scripts/register-all-mcps.py`, which are also plain scripts, not MCP servers. PASS.
+- **Principle XIII (Credential Safety)** — the script reads only local files (`workspace/skills/`, `config/openclaw.json`) and needs no credentials or `.env` values. PASS.
+- **Principle XVII (Milestone Documentation via WordPress)** — this is a documentation-accuracy fix rather than a new capability milestone; a blog post is not required, but will be offered to the user as optional per the principle's spirit once the fix ships.
+- No forbidden operations, no device-facing changes, no destructive commands involved.
+
+No violations identified. Complexity Tracking table is not needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/047-docs-inventory-reconciliation/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+scripts/
+└── verify-inventory-counts.py    # NEW — computes ground-truth skill count
+                                    #  (workspace/skills/ directory count) and
+                                    #  MCP integration count (config/openclaw.json
+                                    #  entries, expanded for bundled packages like
+                                    #  Check Point, plus a maintained list of
+                                    #  externally-installed servers with no local
+                                    #  config/vendored footprint). Prints a report
+                                    #  and exits non-zero if documented counts
+                                    #  (parsed from README.md/SOUL.md) disagree.
+
+README.md                          # EDIT — reconcile all count mentions + fill
+                                    #  MCP Servers / Skills table gaps
+SOUL.md                            # EDIT — reconcile count mentions
+SOUL-SKILLS.md                     # EDIT — verify full skill listing, no count claim drift
+mcp-servers/README.md              # EDIT — list all vendored servers, not a subset
+ui/netclaw-visual/README.md        # EDIT — reconcile HUD description text only
+                                    #  (ui/netclaw-visual/server.js itself is NOT
+                                    #  changed — it already computes counts live)
+
+specs/047-docs-inventory-reconciliation/
+└── data-model.md                  # Documents the "Skill" and "MCP Integration"
+                                    #  counting entities/rules (no runtime data model
+                                    #  exists for this doc-only feature)
+```
+
+**Structure Decision**: This is a documentation-and-tooling-only feature — no new service, MCP server, or skill is created. The only new source artifact is one standalone CLI script under `scripts/`, matching the existing convention of plain maintenance scripts in that directory (`scan-all-mcp-source.py`, `register-all-mcps.py`). All other changes are edits to existing documentation files. No `tests/` directory changes are needed; the script is self-verifying (documented in quickstart.md) rather than covered by the existing pytest suite, since it has no product-code dependency to unit test against.
+
+## Complexity Tracking
+
+*No Constitution Check violations were identified. This table is not needed.*

--- a/specs/047-docs-inventory-reconciliation/quickstart.md
+++ b/specs/047-docs-inventory-reconciliation/quickstart.md
@@ -1,0 +1,37 @@
+# Quickstart: Documentation Inventory Reconciliation
+
+## For a maintainer verifying counts today
+
+```bash
+cd /home/johncapobianco/netclaw
+python3 scripts/verify-inventory-counts.py
+```
+
+Read the printed report. If it says `Documentation check: FAIL`, each listed line tells you which file/section claims a stale number and what the correct number is — go fix that line.
+
+## For a maintainer adding a new skill or MCP server in a future PR
+
+1. Add your skill under `workspace/skills/<name>/SKILL.md` or register your MCP server in `config/openclaw.json` as usual.
+2. Update the five canonical documentation files (README.md, SOUL.md, SOUL-SKILLS.md, mcp-servers/README.md, ui/netclaw-visual/README.md) as Principle XI/XII of the constitution already requires.
+3. Run `python3 scripts/verify-inventory-counts.py` before opening the PR.
+4. If your new integration is installed externally (pip/npm/Docker) rather than registered in `config/openclaw.json`, also add it to the hardcoded external-integration list at the top of `scripts/verify-inventory-counts.py` (the script's docstring/comment marks exactly where) — otherwise it will silently undercount forever, repeating the exact failure mode this feature fixes.
+5. Confirm exit code `0` before merging.
+
+## For this feature's own implementation (Phase 2 / tasks.md scope)
+
+1. Write `scripts/verify-inventory-counts.py` per `contracts/verify-inventory-counts-cli.md` and `data-model.md`.
+2. Run it once against the current repo state to get the authoritative current numbers (do not hand-recompute from this session's audit — branches may have merged since the spec was written; the script is the source of truth at implementation time).
+3. Edit README.md: reconcile all count mentions (header prose, "What It Does" intro, Visual HUD prose, "MCP Servers (N)" heading, "Skills (N)" heading) to the script's output; fill in every missing row in the MCP Servers table and Skills section so zero entities are omitted; explicitly confirm Azure, Batfish, GitLab, and NetFlow/IPFIX as already-shipped.
+4. Edit SOUL.md: reconcile both count mentions (the "N skills backed by M MCP servers" line and the separate "N skills" mention) to the script's output.
+5. Edit SOUL-SKILLS.md: verify it lists every skill from the computed set; it does not currently make a headline count claim, so no count-text edit is expected, but content should be checked for completeness.
+6. Edit mcp-servers/README.md: replace the 12-row partial table with a complete table covering every entity in the MCP Integration set.
+7. Edit ui/netclaw-visual/README.md and the README's Visual HUD paragraph: rephrase to state that the HUD computes counts live from the codebase (per `ui/netclaw-visual/server.js`'s existing `parseSkills()`/`INTEGRATION_CATALOG` behavior), rather than asserting a specific static number that will drift again the next time a skill is added.
+8. Re-run `scripts/verify-inventory-counts.py` — confirm exit code `0`.
+9. Add a one-line note to README.md's mission/history log (where specs 038/etc. are referenced, if such a section exists) pointing at spec 038 as prior art and this spec as its successor, per FR-011 — do not edit or delete spec 038's own files.
+10. Run the constitution's Artifact Coherence Checklist mentally: this feature touches only documentation + one new script, so most checklist items (install.sh, .env.example, TOOLS.md, new MCP server registration) are not applicable — confirm none of them were accidentally required (i.e., confirm no code/config changes crept in beyond the five docs + one script).
+
+## Verifying success
+
+- `python3 scripts/verify-inventory-counts.py` exits `0`.
+- Grep for the previously-conflicting numbers (113, 66, 48, 103, 74, 127, 188, 47, 183, and whatever stale numbers were actually present at implementation time) across README.md and SOUL.md returns zero matches outside of historical/mission-log sections that are explicitly dated past entries (e.g., "MISSION02... 78 skills" is a historical record of what was true in the past and is not part of the current-state claims this feature fixes — it should not be changed).
+- Manually search README.md for "Azure", "Batfish", "GitLab", "NetFlow" — each returns a hit describing it as a current, shipped capability.

--- a/specs/047-docs-inventory-reconciliation/research.md
+++ b/specs/047-docs-inventory-reconciliation/research.md
@@ -1,0 +1,42 @@
+# Phase 0 Research: Documentation Inventory Reconciliation
+
+No `NEEDS CLARIFICATION` markers remain in the Technical Context — this feature reuses existing repo conventions throughout. This document records the decisions made and the alternatives considered.
+
+## Decision 1: Counting methodology for skills
+
+**Decision**: Skill count = number of directories under `workspace/skills/` that contain a `SKILL.md` file, excluding `SKILL-SCHEMA.md` (a schema reference file at the top level of `workspace/skills/`, not a skill directory).
+
+**Rationale**: `workspace/skills/` is the single deployed location the runtime agent reads from (per CLAUDE.md and SOUL.md), and every skill directory found there during this session's audit (190 total) contained a `SKILL.md`. Counting `SKILL.md` presence rather than raw directory count guards against a future stray non-skill directory (e.g., a `.gitkeep` placeholder or WIP scratch folder) silently inflating the count.
+
+**Alternatives considered**:
+- *Count raw directories via `ls | wc -l`*: simplest, matches this session's manual audit exactly, but has no protection against non-skill directories being miscounted. Rejected in favor of the `SKILL.md`-presence check, which is one `os.path.exists` check more robust for near-zero extra cost.
+- *Parse skill metadata from `ui/netclaw-visual/server.js`'s `parseSkills()`*: would guarantee the script and the HUD always agree by construction, but couples a documentation-verification script to a Node.js UI module and requires a JS runtime or JS-parsing logic in Python. Rejected as unnecessary coupling — both independently reading the same source directory (`workspace/skills/`) is sufficient to keep them in agreement, and simpler to maintain.
+
+## Decision 2: Counting methodology for MCP integrations
+
+**Decision**: MCP integration count = (top-level entries in `config/openclaw.json` under `mcpServers` — confirmed during implementation to already be fully individually registered, e.g. the Check Point suite's 15 `chkp-*` servers are 15 separate top-level keys, not one bundle needing expansion, even though they share a single vendored directory `checkpoint-mcp-servers/` under `mcp-servers/`) **plus** an explicitly maintained list in the script of externally-installed servers that ship with NetClaw's supported integration set but are not present in `config/openclaw.json` at all (installed via pip/npm/Docker at runtime instead: pyATS, F5, Catalyst Center, ACI, ISE, NetBox, community Nautobot, Itential, ServiceNow, Microsoft Graph, GitHub, Packet Buddy, CML, NSO, FMC, Meraki, ThousandEyes ×2, RADKit, AWS ×6, GCP ×4, and roughly 30 more — confirmed against README's MCP Servers table and the `mcp-servers/` vendored directories during implementation; see the script's `EXTERNAL_INTEGRATIONS` list for the definitive current set).
+
+**Rationale**: `config/openclaw.json` is the closest thing to a single source of truth for *registered* servers, but this session's audit already proved it undercounts the real total (49 entries there vs. README's own table already documenting more) because some servers are intentionally not registered there — they're installed on demand via `pip`/`npx`/`docker` per their README installation instructions. A pure `config/openclaw.json` count would still under-report and repeat the exact drift this feature exists to fix. The explicit-list approach makes the "not in config, but real" set visible and auditable in one place (the script itself) rather than scattered across prose.
+
+**Alternatives considered**:
+- *Count only `config/openclaw.json` entries*: simplest, fully automatable, zero maintenance — but factually wrong today (undercounts by the externally-installed servers), and would misrepresent real capability the same way the current README does. Rejected.
+- *Count only `mcp-servers/` vendored directories*: also simple, but this population doesn't overlap 1:1 with `config/openclaw.json` either (some vendored directories, like `checkpoint-mcp-servers/`, are one directory representing 15 registered servers; others aren't registered in config at all, e.g. community servers only referenced in README prose). Rejected for the same undercount/overcount risk.
+- *Full auto-discovery by grepping README.md's own MCP Servers table*: would avoid a manually maintained list, but makes the script depend on README's prose formatting staying parseable, and circularly trusts the exact document this feature is fixing as its own ground truth. Rejected — a short, explicit, human-reviewed list in the script is more honest about where the "un-registered but real" servers come from and is easy to update in the same PR that adds a new externally-installed integration.
+
+## Decision 3: Script scope and failure mode
+
+**Decision**: `scripts/verify-inventory-counts.py` is a read-only reporting tool. It prints the computed skill count and MCP integration count, and (best-effort) parses the numeric claims out of README.md and SOUL.md to flag any that disagree with the computed totals, exiting non-zero if a disagreement is found. It does not edit files itself.
+
+**Rationale**: Spec.md FR-010 requires "a documented, repeatable procedure... so future documentation updates can be verified without manual recounting" — a verifier, not an auto-editor. Auto-rewriting prose (which contains counts embedded in sentences, not just structured data) risks mangling hand-written copy and is out of proportion to the problem. A verifier that a maintainer runs before merging a doc change is sufficient to catch the drift pattern that caused this spec and spec 038, and is safer.
+
+**Alternatives considered**:
+- *Auto-generate the README's MCP/Skills tables from `config/openclaw.json` and `workspace/skills/` metadata*: would prevent table-omission drift permanently, but requires either a templating step wired into CI or a pre-commit hook, and NetClaw's docs currently contain substantial hand-written prose per skill/server (descriptions, tool counts, env vars) that isn't mechanically derivable from directory names alone. Rejected as out of scope for this documentation-focused fix; noted as a possible future enhancement once a verifier is in place and proven useful.
+- *A CI check that fails PRs on drift*: valuable long-term, but adding new CI wiring is an infrastructure change beyond "documentation reconciliation," and the constitution's existing Artifact Coherence Checklist (Principle XI) already relies on manual PR review rather than CI gates for this class of check. Rejected for this feature; the script is written so it *could* be wired into CI later without modification.
+
+## Decision 4: Where the script lives and how it's invoked
+
+**Decision**: `scripts/verify-inventory-counts.py`, run as `python3 scripts/verify-inventory-counts.py` from repo root, no arguments, no dependencies beyond the Python 3.10+ standard library.
+
+**Rationale**: Matches every other maintenance script in `scripts/` (`scan-all-mcp-source.py`, `register-all-mcps.py`, `add-skill-licenses.py`) — same language, same invocation style, same directory. No new tooling pattern introduced.
+
+**Alternatives considered**: A Bash equivalent (matching `scan-all-mcps.sh`) was considered, but counting/parsing JSON and doing light text pattern matching against README prose is meaningfully easier and more maintainable in Python with its standard `json` and `re` modules than in Bash/`jq`+`grep`. Python was already the majority pattern for scripts doing structured-data work in this directory.

--- a/specs/047-docs-inventory-reconciliation/spec.md
+++ b/specs/047-docs-inventory-reconciliation/spec.md
@@ -1,0 +1,107 @@
+# Feature Specification: Documentation Inventory Reconciliation
+
+**Feature Branch**: `047-docs-inventory-reconciliation`
+**Created**: 2026-07-07
+**Status**: Draft
+**Input**: User description: "Reconcile NetClaw's documentation inventory (README.md, SOUL.md, SOUL-SKILLS.md, mcp-servers/README.md, ui/netclaw-visual/README.md) so skill and MCP server counts are accurate and consistent everywhere, superseding the now-stale 038-docs-hud-refresh spec." (see full audit findings in Assumptions and prior-art notes below)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Trustworthy Skill/Integration Counts (Priority: P1)
+
+As a prospective user or contributor evaluating NetClaw, I want every count of "skills" and "MCP integrations" I encounter across the project's documentation to agree with each other and with what's actually in the codebase, so that I can trust the project's stated scope instead of wondering which number is real.
+
+**Why this priority**: Inconsistent headline numbers are the single most visible credibility problem in the project's documentation today — a reader hits four different skill counts and three different MCP counts within README.md and SOUL.md alone, before ever running the product. This is a first-impression and trust issue, not a cosmetic one.
+
+**Independent Test**: Can be fully tested by grepping every skill/MCP count claim across README.md, SOUL.md, SOUL-SKILLS.md, mcp-servers/README.md, and ui/netclaw-visual/README.md, and confirming they all match one canonical figure derived from the live codebase.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reader opens README.md, **When** they compare the count stated near the top of the file to the count stated in the "Skills" and "MCP Servers" section headings, **Then** all numbers match each other exactly.
+2. **Given** a reader opens SOUL.md after reading README.md, **When** they compare the skill/MCP counts stated there, **Then** the numbers match README.md's numbers.
+3. **Given** a reader counts skill directories in the codebase directly, **When** they compare that count to the documented count, **Then** they match.
+
+---
+
+### User Story 2 - Complete MCP Server and Skill Inventory Tables (Priority: P1)
+
+As a network engineer evaluating whether NetClaw already supports a specific platform, I want the README's MCP Servers table and Skills tables to actually list every server and skill that exists in the codebase, so that I don't wrongly conclude a capability is missing and file a duplicate request or, worse, waste time building something that already exists.
+
+**Why this priority**: This session's audit found an external reviewer incorrectly concluded that Azure, Batfish, GitLab, and NetFlow/IPFIX support were all missing from NetClaw — when all four are fully implemented. The review reached that (wrong) conclusion specifically because the README's own inventory tables are incomplete (the MCP Servers table lists 69 rows under a heading claiming 74, and undercounts the real total further still; the mcp-servers/README.md table lists only 12 of over 50 vendored servers). Incomplete tables actively mislead readers into thinking finished work doesn't exist.
+
+**Independent Test**: Can be tested by cross-referencing every server directory under `mcp-servers/`, every entry in `config/openclaw.json`, and every skill directory under `workspace/skills/` against the README/mcp-servers/README.md tables and confirming zero omissions.
+
+**Acceptance Scenarios**:
+
+1. **Given** a server is registered in `config/openclaw.json` or vendored under `mcp-servers/`, **When** a reader searches the README's MCP Servers table or `mcp-servers/README.md`, **Then** they find a row for it.
+2. **Given** a skill directory exists under `workspace/skills/`, **When** a reader searches the README's Skills section, **Then** they find an entry for it.
+3. **Given** a reader searches specifically for "Azure", "Batfish", "GitLab", or "NetFlow"/"IPFIX" in the README, **Then** they find each one documented as an existing, shipped capability (not absent, and not described as new/upcoming).
+
+---
+
+### User Story 3 - Repeatable Verification Instead of Manual Recount (Priority: P2)
+
+As a maintainer who will add more skills and MCP servers in future feature branches, I want a documented, automatable way to compute the true current skill/MCP counts, so that documentation can be re-verified in seconds after each new feature merges instead of drifting silently for months the way it did after spec 038.
+
+**Why this priority**: This is the second time this exact class of problem has needed a dedicated spec (038 in June, this one in July, with 8 feature branches merging silently in between). Without a repeatable check, the same drift will recur after the next several feature branches merge. This is lower priority than fixing the current-state numbers (P1) because it's a process fix that prevents recurrence rather than fixing today's visible problem, but it's what makes the P1 fix durable.
+
+**Independent Test**: Can be tested by running the documented counting procedure/script before and after adding a new skill directory or a new `config/openclaw.json` entry, and confirming the reported counts change accordingly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new skill directory is added under `workspace/skills/`, **When** the counting procedure is run, **Then** the reported skill count increases by one.
+2. **Given** a new server is registered in `config/openclaw.json`, **When** the counting procedure is run, **Then** the reported MCP integration count increases accordingly.
+3. **Given** a maintainer wants to verify documentation before a release, **When** they follow the documented procedure, **Then** they get a clear pass/fail signal without needing to manually eyeball multiple files.
+
+---
+
+### Edge Cases
+
+- What happens when an MCP server is registered in `config/openclaw.json` but has no locally vendored directory under `mcp-servers/` (e.g., it's installed at runtime via pip/npm/docker, such as GitHub, Microsoft Graph, Itential, Cisco NSO, Cisco CML)? These MUST still count toward the total MCP integration figure and MUST still appear in the README's MCP Servers table — the counting method cannot rely on `mcp-servers/` directory listing alone.
+- What happens when a single vendored directory actually represents multiple independently listed integrations (e.g., `checkpoint-mcp-servers/` contains 15 distinct `chkp-*` servers, `mcp-servers/` counts it as one directory)? The documented total MUST count each independently-registered/independently-described server, not the containing directory.
+- What happens when a skill or MCP server is deprecated or removed in a future branch? The counting procedure and documentation MUST be re-run and updated as part of that branch's own work, not left for a future reconciliation spec.
+- What happens when the Visual HUD's live-computed count (from `ui/netclaw-visual/server.js`) disagrees with the static count documented in README.md after this fix ships? Since the HUD computes its number dynamically from the same `workspace/skills/` directory, any future disagreement signals that README.md has drifted again and should be treated as the definitive drift-detection signal going forward.
+- What happens to spec 038-docs-hud-refresh once this spec ships? It MUST be left in place as historical record (not deleted or rewritten), with this spec's documentation referencing it as prior art rather than duplicating its content.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Documentation MUST state a single, consistent skill count across README.md (all locations: header prose, "What It Does" intro, Visual HUD prose, and the "Skills" section heading), SOUL.md, and SOUL-SKILLS.md.
+- **FR-002**: Documentation MUST state a single, consistent MCP integration/server count across README.md (all locations: header prose, "What It Does" intro, Visual HUD prose, and the "MCP Servers" section heading), SOUL.md, and mcp-servers/README.md.
+- **FR-003**: The documented skill count MUST equal the actual number of skill directories present under `workspace/skills/` at the time of writing (excluding non-skill files such as `SKILL-SCHEMA.md`).
+- **FR-004**: The documented MCP integration count MUST equal the union of (a) all entries registered in `config/openclaw.json`, expanding any multi-server bundle (such as the Check Point suite) into its individually documented sub-servers, and (b) any additional externally-installed servers (pip/npm/docker) that are part of NetClaw's supported integration set but not present in `config/openclaw.json` or vendored under `mcp-servers/`.
+- **FR-005**: The README's "MCP Servers" table MUST contain a row for every server counted under FR-004, with no omissions.
+- **FR-006**: The README's "Skills" section MUST contain an entry for every skill directory counted under FR-003, with no omissions.
+- **FR-007**: `mcp-servers/README.md` MUST list every vendored server directory present under `mcp-servers/`, not a partial subset.
+- **FR-008**: Documentation MUST explicitly confirm, as already-shipped capabilities (not new additions), the existence of: Azure networking (azure-network-mcp), Batfish configuration analysis (batfish-mcp), GitLab DevOps (gitlab-mcp), and NetFlow v5/v9 + IPFIX flow telemetry (ipfix-mcp) — correcting a specific external claim that these were missing.
+- **FR-009**: Documentation MUST NOT describe or imply the addition of a Kubernetes/OpenShift cluster-management MCP or sFlow support as part of this effort — both are explicitly out of scope and reserved for future, separately-scoped work.
+- **FR-010**: A documented, repeatable procedure (script or step-by-step instructions) MUST exist that computes the current skill count and current MCP integration count directly from the codebase (per FR-003 and FR-004), so future documentation updates can be verified without manual recounting.
+- **FR-011**: The reconciliation MUST reference spec 038-docs-hud-refresh as prior, superseded work rather than duplicating its content, and MUST leave that spec's files in place unmodified as historical record.
+- **FR-012**: The prose description of the Visual HUD in README.md MUST accurately describe that the HUD computes its skill/integration counts live from the codebase (rather than stating a specific static number that can drift out of sync with the HUD's actual live-rendered output).
+
+### Key Entities
+
+- **Skill count**: The total number of skill directories under `workspace/skills/`, each representing one documented operational capability exposed to the agent.
+- **MCP integration count**: The total number of distinct, individually-usable MCP servers NetClaw supports, whether vendored locally under `mcp-servers/`, registered in `config/openclaw.json`, or installed at runtime via an external package manager — with bundled multi-server packages (e.g., Check Point) counted per sub-server, not per bundle.
+- **Canonical documentation set**: The five files in scope for this reconciliation — README.md, SOUL.md, SOUL-SKILLS.md, mcp-servers/README.md, and ui/netclaw-visual/README.md — which must all agree with each other and with the codebase.
+- **Counting procedure**: The repeatable method (script or documented steps) that derives the skill count and MCP integration count directly from the codebase, serving as the ground-truth source for all five canonical files going forward.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A reader can find the skill count and MCP integration count in any of the five canonical documentation files and get the identical number in all of them, with zero discrepancies.
+- **SC-002**: The documented skill count and MCP integration count exactly match the counts produced by the documented counting procedure run against the current codebase, with zero discrepancy.
+- **SC-003**: Every server counted by the counting procedure appears as a distinct row in the README's MCP Servers table and in mcp-servers/README.md; every skill directory appears as a distinct entry in the README's Skills section — 100% coverage, zero omissions.
+- **SC-004**: A reader searching the README for "Azure", "Batfish", "GitLab", or "NetFlow"/"IPFIX" finds each documented as an existing capability within one search, eliminating the specific false-negative that caused the external review's incorrect gap claims.
+- **SC-005**: After this reconciliation, running the documented counting procedure again after a future feature branch adds one new skill and one new MCP server produces updated counts within the same session, with no ambiguity about which files need updating.
+
+## Assumptions
+
+- Ground truth as of 2026-07-07 (subject to re-verification via the FR-010 counting procedure at implementation time, since branches may merge between spec-writing and implementation): `workspace/skills/` contains 190 skill directories; `config/openclaw.json` `mcpServers` has 49 registered entries (15 of which are the `chkp-*` Check Point suite); `mcp-servers/` contains 54 vendored local server directories, a population that only partially overlaps `config/openclaw.json` since some documented servers (GitHub, Microsoft Graph, Itential, Cisco NSO, Cisco CML, and others) are installed via pip/npm/docker at runtime with no local vendored directory.
+- The Visual HUD implementation itself (`ui/netclaw-visual/server.js`) is already correct: it computes skill count live from `workspace/skills/` via `parseSkills()` and derives integration count dynamically from an `INTEGRATION_CATALOG` mapped against skill file prefixes. This spec treats the HUD's live-computation approach as the reference pattern and does not require changes to the HUD's code — only to the README's stale prose description of what the HUD shows.
+- Spec 038-docs-hud-refresh (created 2026-06-23) attempted this same class of reconciliation and targeted 179 skills / 43 MCP servers as correct at that time. Eight feature branches (039-twitter-x-integration, 040-twitter-mentions, 042-twilio-voice-mcp, 043-full-voice-integration, 044-ue5-mcp-network-viz, 045-ue5-digital-twin, 046-threejs-network-viz, plus the drift already present when 038 was written) have since merged without a follow-up documentation update, making 038's target numbers stale. This spec supersedes 038; 038's files remain as historical record per FR-011.
+- Building a Kubernetes/OpenShift cluster-management MCP and adding sFlow support to the existing `ipfix-mcp` are both genuine capability gaps identified during this audit's fact-check pass, but are explicitly out of scope for this documentation-only spec (per FR-009) and will be scoped as separate future feature specs.
+- "MCP integration count" is defined at the individually-usable-server level (e.g., each of the 15 Check Point `chkp-*` servers counts individually), consistent with how the existing README table and `config/openclaw.json` already enumerate them — not at the vendored-directory level, which would undercount bundled packages.
+- No new skills or MCP servers are being built as part of this spec; all changes are documentation-only edits to existing files plus the addition of one new counting procedure (script or documented steps).

--- a/specs/047-docs-inventory-reconciliation/tasks.md
+++ b/specs/047-docs-inventory-reconciliation/tasks.md
@@ -1,0 +1,170 @@
+# Tasks: Documentation Inventory Reconciliation
+
+**Input**: Design documents from `/specs/047-docs-inventory-reconciliation/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/verify-inventory-counts-cli.md, quickstart.md
+
+**Tests**: Not requested for this feature. Verification is instead performed by running `scripts/verify-inventory-counts.py` itself (per its own acceptance scenarios in spec.md User Story 3) rather than a separate pytest suite, since there is no product code to unit test — the script's own successful pass/fail report against the live repo *is* the verification.
+
+**Organization**: Tasks are grouped by user story from spec.md so each can be delivered and checked independently: US1 = consistent counts everywhere, US2 = complete inventory tables + fact-check, US3 = durable repeatable verification.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Maps task to US1, US2, or US3
+- All file paths are relative to the repository root (`/home/johncapobianco/netclaw`)
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Create the skeleton of the new verification script that every later phase depends on.
+
+- [X] T001 Create `scripts/verify-inventory-counts.py` with a shebang (`#!/usr/bin/env python3`), a module docstring pointing to `specs/047-docs-inventory-reconciliation/contracts/verify-inventory-counts-cli.md` for the contract, imports (`os`, `json`, `re`, `sys` only — stdlib), and an empty `main()` guarded by `if __name__ == "__main__": sys.exit(main())` that currently just returns `0`. No counting logic yet.
+
+**Checkpoint**: Script file exists and runs (`python3 scripts/verify-inventory-counts.py` exits 0 with no output) — ready for Foundational logic.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Build the counting/verification logic that produces the ground-truth numbers every documentation-editing user story (US1, US2) depends on. Per data-model.md and contracts/verify-inventory-counts-cli.md.
+
+**⚠️ CRITICAL**: No documentation edit task (Phase 3 or Phase 4) may start until T006 produces the authoritative current counts — editing docs against guessed or stale numbers would repeat the exact failure this feature exists to fix.
+
+- [X] T002 Implement `count_skills()` in `scripts/verify-inventory-counts.py`: walk `workspace/skills/`, count each subdirectory that contains a `SKILL.md` file (per data-model.md Entity: Skill validation rule), explicitly excluding the top-level `SKILL-SCHEMA.md` file (not a directory). Return the integer count.
+- [X] T003 Implement `count_mcp_integrations()` in `scripts/verify-inventory-counts.py`: load `config/openclaw.json`, read the `mcpServers` object, count top-level entries; expand the single Check Point bundle entry into its 15 documented `chkp-*` sub-servers per data-model.md Entity: MCP Integration (subtract 1 for the parent entry, add 15 for the members); add a hardcoded, clearly-commented `EXTERNAL_INTEGRATIONS` list at the top of the file for servers documented in README's MCP Servers table but absent from `config/openclaw.json` (seed it with the names confirmed during this session's audit: GitHub, Microsoft Graph, Itential, Cisco NSO, Cisco CML — verify and adjust against the current README table content as of implementation time). Return the integer count and a breakdown dict (`{"config_entries": N, "checkpoint_bundle_expansion": N, "external_documented": N}`).
+- [X] T004 Implement `check_doc_claims(skill_count, mcp_count)` in `scripts/verify-inventory-counts.py`: read `README.md` and `SOUL.md`, use regex to find numeric claims adjacent to the words "skill(s)" and "MCP" (e.g. patterns like `\d+ skills`, `\d+ MCP`), compare each found claim against the computed counts, and return a list of discrepancies as `{file, matched_text, claimed_value, computed_value}` dicts. Treat parsing misses as informational (log, don't fail) per contracts/verify-inventory-counts-cli.md Non-goals.
+- [X] T005 Implement report printing and exit-code logic in `main()` in `scripts/verify-inventory-counts.py`: call `count_skills()`, `count_mcp_integrations()`, `check_doc_claims()`; print the report format specified in contracts/verify-inventory-counts-cli.md (headline skill count, MCP count with breakdown, PASS/FAIL with discrepancy lines); return exit code 0 if no discrepancies, 1 if discrepancies found, 2 if `workspace/skills/` or `config/openclaw.json` cannot be read.
+- [X] T006 Run `python3 scripts/verify-inventory-counts.py` against the current repository state and record the printed skill count and MCP integration count — these are the authoritative ground-truth numbers used by every task in Phase 3 and Phase 4 below (they supersede the specific numbers noted in spec.md's Assumptions section, which may be stale if branches merged between spec-writing and now).
+
+**Checkpoint**: Foundational verification tool works end-to-end and has produced this session's ground-truth numbers. All documentation-editing user stories can now begin.
+
+---
+
+## Phase 3: User Story 1 - Trustworthy Skill/Integration Counts (Priority: P1) 🎯 MVP
+
+**Goal**: Every place a skill or MCP count appears across the five canonical documentation files states the same number, and that number matches T006's computed ground truth.
+
+**Independent Test**: Grep every numeric skill/MCP claim in README.md and SOUL.md; confirm all agree with each other and with `python3 scripts/verify-inventory-counts.py`'s output.
+
+### Implementation for User Story 1
+
+- [X] T007 [US1] Update the skill/MCP counts in `README.md`'s top prose (the header sentence near line 7 and the "That's it. The installer deploys..." sentence near line 19) to T006's ground-truth numbers.
+- [X] T008 [US1] Update `README.md`'s Visual HUD paragraph (near line 96, currently "48 integrations, 103 skills") to T006's ground-truth numbers, and rephrase the sentence to note the HUD computes these counts live from the codebase (supports FR-012 and avoids re-drifting the next time a skill is added — do not hardcode a number that isn't already true today).
+- [X] T009 [US1] Update the `## MCP Servers (N)` heading (near line 375) and `## Skills (N)` heading (near line 454) in `README.md` to T006's ground-truth numbers.
+- [X] T010 [P] [US1] Update the two skill/MCP count mentions in `SOUL.md` (near line 15: "N skills backed by M MCP servers", and near line 328: "N skills") to T006's ground-truth numbers.
+- [X] T011 [US1] Run `python3 scripts/verify-inventory-counts.py` again; confirm the `check_doc_claims()` discrepancy report shows zero discrepancies for README.md and SOUL.md (depends on T007-T010 being complete).
+
+**Checkpoint**: All headline count claims across README.md and SOUL.md are internally consistent and match the codebase. This alone is a shippable, valuable increment even before Phase 4's table-completeness work.
+
+---
+
+## Phase 4: User Story 2 - Complete MCP Server and Skill Inventory Tables (Priority: P1)
+
+**Goal**: The README's MCP Servers table, README's Skills section, and mcp-servers/README.md's table each contain a row for every integration/skill the codebase actually has — and specifically confirm Azure, Batfish, GitLab, and NetFlow/IPFIX as already-shipped, correcting the external review's incorrect gap claims.
+
+**Independent Test**: Cross-reference every entry from T003's MCP integration set and T002's skill set against the README/mcp-servers/README.md tables; confirm zero omissions. Search README.md for "Azure", "Batfish", "GitLab", "NetFlow" and confirm each is documented as existing.
+
+### Implementation for User Story 2
+
+- [X] T012 [US2] Add rows to `README.md`'s MCP Servers table (the table starting near line 377) for every MCP integration counted in T003 that isn't already listed — including explicit confirmation that Azure (`azure-network-mcp`), Batfish (`batfish-mcp`), GitLab (`gitlab-mcp`), and NetFlow/IPFIX (`ipfix-mcp`) are present and described as already-shipped capabilities, not new additions.
+- [X] T013 [US2] Add entries to `README.md`'s Skills section (the tables starting near line 454) for every skill directory counted in T002 that isn't already listed.
+- [X] T014 [P] [US2] Rewrite `mcp-servers/README.md`'s "Available Servers" table to list every vendored directory under `mcp-servers/` (currently only 12 of 54+ are listed), matching the format of its existing table (Server / Description / Type columns).
+- [X] T015 [P] [US2] Review `SOUL-SKILLS.md` against T002's computed skill set; add any missing skill sections so every skill directory is represented (this file does not currently make a headline count claim, so no numeric edit is expected here — only content completeness).
+- [X] T016 [US2] Run `python3 scripts/verify-inventory-counts.py` again to confirm counts still match after table edits, and manually grep `README.md` for "Azure", "Batfish", "GitLab", and "NetFlow" to confirm each returns a hit describing it as a current, shipped capability (depends on T012-T015).
+
+**Checkpoint**: Every skill and MCP integration in the codebase is discoverable in the README/mcp-servers/README.md tables. The specific false-negative that caused the external review's incorrect gap claims (Azure/Batfish/GitLab/NetFlow) is eliminated.
+
+---
+
+## Phase 5: User Story 3 - Repeatable Verification Instead of Manual Recount (Priority: P2)
+
+**Goal**: Confirm the verification script actually detects drift when the codebase changes, and make sure future contributors know it exists.
+
+**Independent Test**: Add a throwaway skill directory (or config entry), run the script, confirm the count increments; remove the throwaway artifact and confirm the count reverts.
+
+### Implementation for User Story 3
+
+- [X] T017 [P] [US3] Validate skill-count sensitivity: create a temporary `workspace/skills/_tmp-verify-test/SKILL.md` file, run `python3 scripts/verify-inventory-counts.py`, confirm the reported skill count is exactly one higher than T006's baseline, then delete `workspace/skills/_tmp-verify-test/` entirely.
+- [X] T018 [P] [US3] Validate MCP-count sensitivity: temporarily add a dummy entry under `mcpServers` in `config/openclaw.json` (e.g. `"_tmp_verify_test": {}`), run `python3 scripts/verify-inventory-counts.py`, confirm the reported MCP integration count is exactly one higher than T006's baseline, then remove the dummy entry and confirm the count reverts to baseline on a final run.
+- [X] T019 [US3] Add a short note near the `## MCP Servers (N)` and `## Skills (N)` headings in `README.md` pointing contributors at `python3 scripts/verify-inventory-counts.py` as the way to re-verify these numbers before submitting a future PR that adds a skill or MCP server (references quickstart.md's contributor workflow).
+- [X] T020 [US3] Add a one-line note in `README.md`'s mission/history log section (near the existing "## Missions for reference" content around line 2509, or the nearest equivalent historical-record section) noting that spec `038-docs-hud-refresh` was an earlier attempt at this reconciliation, now superseded by spec `047-docs-inventory-reconciliation`, per FR-011. Do not modify any files under `specs/038-docs-hud-refresh/`.
+
+**Checkpoint**: The verification script is proven to detect drift in both directions (skills and MCP servers), and future contributors have a documented, discoverable path to use it — closing the loop that caused two reconciliation specs (038 and this one) to be needed.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final consistency sweep and closing out the feature.
+
+- [X] T021 [P] Full read-through of `README.md` and `SOUL.md` to confirm none of the previously-conflicting stale numbers (113, 66, 48, 103, 74, 69, 127, 145, 188, 47, 183, or whatever was actually stale at implementation time per T006) remain anywhere outside explicitly historical, dated mission-log entries (e.g., "MISSION02... 78 skills" is a past-state record and must NOT be changed).
+- [X] T022 Run `python3 scripts/verify-inventory-counts.py` one final time and confirm exit code `0`.
+- [X] T023 [P] Per Constitution Principle XVII, draft a short milestone note (not a full blog post — this is a documentation-accuracy fix, not a new capability) and present it to the user for review before deciding whether it warrants a WordPress publish.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately.
+- **Foundational (Phase 2)**: Depends on Phase 1 (script file must exist). BLOCKS Phase 3 and Phase 4 entirely (both need T006's ground-truth numbers) and BLOCKS Phase 5 (needs a working script to validate).
+- **User Story 1 (Phase 3)**: Depends on Phase 2 completion. Independently shippable once T011 passes.
+- **User Story 2 (Phase 4)**: Depends on Phase 2 completion. Does not depend on Phase 3, but in practice both target README.md, so completing Phase 3 first avoids merge conflicts within the same file.
+- **User Story 3 (Phase 5)**: Depends on Phase 2 completion (needs the finished script). Independent of Phase 3/4 content, though T019/T020 touch README.md so should follow Phase 3/4's README edits to avoid conflicts.
+- **Polish (Phase 6)**: Depends on all prior phases.
+
+### Within Each Phase
+
+- Phase 2: T002 → T003 → T004 → T005 → T006 (all edit the same file, sequential; each function depends on the file/imports from the previous task).
+- Phase 3: T007 → T008 → T009 (sequential, same file: README.md) with T010 (SOUL.md) parallel to all three; T011 depends on T007-T010.
+- Phase 4: T012 → T013 (sequential, same file: README.md) with T014 (mcp-servers/README.md) and T015 (SOUL-SKILLS.md) parallel to both and to each other; T016 depends on T012-T015.
+- Phase 5: T017 and T018 are independent of each other (different files/actions) and can run in parallel; T019 → T020 sequential (both edit README.md).
+
+### Parallel Opportunities
+
+- T010 can run parallel to T007-T009 (different file).
+- T014 and T015 can run parallel to each other and to T012-T013 (three different files).
+- T017 and T018 can run parallel to each other (different files: workspace/skills/ vs config/openclaw.json).
+- T021 and T023 in Polish can run parallel to each other.
+
+---
+
+## Parallel Example: Phase 4 (User Story 2)
+
+```bash
+# After T012-T013 (README.md) are underway, these can run alongside them:
+Task: "Rewrite mcp-servers/README.md's Available Servers table to list every vendored directory"
+Task: "Review SOUL-SKILLS.md against the computed skill set and add any missing skill sections"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001).
+2. Complete Phase 2: Foundational (T002-T006) — this is the critical path; it produces the numbers every later task needs.
+3. Complete Phase 3: User Story 1 (T007-T011).
+4. **STOP and VALIDATE**: Run the script, confirm PASS, spot-check README.md and SOUL.md by eye.
+5. This alone fixes the most visible credibility problem (disagreeing headline numbers) and is shippable on its own.
+
+### Incremental Delivery
+
+1. Setup + Foundational → verification tool exists and ground truth is known.
+2. Add User Story 1 → headline numbers agree everywhere → demo/ship.
+3. Add User Story 2 → tables are complete, Azure/Batfish/GitLab/NetFlow confirmed shipped → demo/ship.
+4. Add User Story 3 → script's drift-detection is proven and discoverable for future contributors → demo/ship.
+5. Polish → final sweep and exit-code confirmation.
+
+---
+
+## Notes
+
+- [P] tasks touch different files and have no ordering dependency on each other.
+- [Story] labels map every Phase 3+ task back to spec.md's US1/US2/US3 for traceability.
+- No test framework is introduced; the verification script's own PASS/FAIL output is this feature's test signal, per spec.md's Testing note in plan.md's Technical Context.
+- Commit after each phase checkpoint, not after every individual task — these are fine-grained edits to a small number of files and squashing noisy intermediate commits keeps the PR history readable.
+- Do not touch `specs/038-docs-hud-refresh/` files (T020 references it but must not modify it) — it remains as historical record per FR-011.


### PR DESCRIPTION
## Summary

- README/SOUL/mcp-servers docs had drifted into **four disagreeing skill counts** (113, 103/48, 127, 188/183) and **three disagreeing MCP counts** (66, 48, 74/47) — a prior spec (038-docs-hud-refresh) attempted this same fix in June 2026 but was never re-run after 8 more feature branches merged.
- Worse: the README's MCP Servers table omitted ~34 already-shipped integrations entirely — **Azure, Batfish, GitLab, Atlassian, Jenkins, Claroty, Forward Networks, IPFIX/NetFlow, and Check Point's 15 servers** were nowhere in the table (some only got a passing mention in the intro paragraph). An external review incorrectly concluded several of these were *missing capabilities* — they weren't missing, just undocumented.
- Ground truth, computed programmatically rather than hand-counted: **186 skills, 108 MCP integrations**.

## What changed

- **New**: `scripts/verify-inventory-counts.py` — computes the true skill count from `workspace/skills/` and true MCP count from `config/openclaw.json` + a maintained external-integrations list, and flags any doc drift. Run it before future PRs that add a skill/MCP server.
- **README.md**: fixed all headline count mentions; added ~34 missing MCP Servers table rows (explicitly confirming Azure/Batfish/GitLab/NetFlow as already-shipped); added 42 missing skill entries so all 186 skills are documented; rewrote the Visual HUD description to state it computes counts live (matches what `ui/netclaw-visual/server.js` already does) instead of asserting a static number that drifts.
- **SOUL.md**: fixed both count mentions.
- **SOUL-SKILLS.md**: added an index for the 181 skills that had no entry at all, pointing to each skill's own `SKILL.md` as the authoritative procedure (full step-by-step expansion for all of them was out of scope for a docs-accuracy pass).
- **mcp-servers/README.md**: rebuilt its server table from 12 to all 54 vendored servers. Turned out this file was **gitignored and never tracked in git at all** — fixed `.gitignore` so this fix actually ships.
- Full spec/plan/tasks under `specs/047-docs-inventory-reconciliation/` (speckit workflow), superseding `specs/038-docs-hud-refresh/`.

## Test plan

- [x] `python3 scripts/verify-inventory-counts.py` exits 0 (PASS) against the final state
- [x] Verified script correctly detects drift in both directions (temporarily added a throwaway skill dir and a throwaway config entry, confirmed counts moved and reverted)
- [x] Grepped README.md for stale numbers (113, 66, 48, 103, 74, 127, 188, 47, 183) outside historical mission-log entries — zero hits
- [x] Grepped README.md for "Azure", "Batfish", "GitLab", "NetFlow" — each returns a hit describing it as a shipped capability
- [x] Diffed every `workspace/skills/` directory against README.md and SOUL-SKILLS.md mentions — zero omissions in both

🤖 Generated with [Claude Code](https://claude.com/claude-code)