### PR TITLE
docs(049): spec/plan/tasks for merging PR #96's modular installer with coverage parity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # netclaw Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-07-07
+Auto-generated from all feature plans. Last updated: 2026-07-08
 
 ## Active Technologies
 - N/A (stateless server; subscription state held in-memory during runtime) (003-gnmi-mcp-server)
@@ -63,6 +63,8 @@ Auto-generated from all feature plans. Last updated: 2026-07-07
 - N/A (reads existing `workspace/skills/` directory tree and `config/openclaw.json`; writes no persistent state) (047-docs-inventory-reconciliation)
 - Node.js 18+ (official `chrome-devtools-mcp` server — no NetClaw-authored server code); Bash (setup/enable script, consistent with `scripts/*-enable.sh` convention); Markdown (skill + MCP documentation) + `chrome-devtools-mcp` (npm package, official Chrome DevTools team release, MIT-style OSS), Node.js 18+, a locally installed Chrome/Chromium binary (stable channel by default) (048-chrome-devtools-browser-inspection)
 - N/A for NetClaw itself (stateless proxy to a local browser process). A persistent Chrome profile directory on disk (`~/.openclaw/chrome-devtools/profile` by default, overridable via `CHROME_DEVTOOLS_PROFILE_DIR`) holds cookies/session state for manually authenticated sites — this is Chrome's own state, not a NetClaw-managed database. (048-chrome-devtools-browser-inspection)
+- Bash (matches every existing NetClaw install/enable script and PR #96's own implementation), Python 3.10+ (for the coverage-check script, extending the existing `scripts/verify-inventory-counts.py` pattern) + None beyond what's already vendored — PR #96's own `scripts/lib/*.sh`, the repo's existing Python stdlib-only tooling convention (049-merge-modular-installer)
+- N/A (installer logic + a plain-text component manifest at `~/.openclaw/netclaw-components.conf`, per PR #96's own design) (049-merge-modular-installer)
 
 - Python 3.10+ + FastMCP (MCP framework), grpcio + grpcio-tools (gRPC transport), pygnmi (gNMI client library), protobuf, cryptography (TLS handling) (003-gnmi-mcp-server)
 
@@ -82,9 +84,9 @@ cd src [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLO
 Python 3.10+: Follow standard conventions
 
 ## Recent Changes
+- 049-merge-modular-installer: Added Bash (matches every existing NetClaw install/enable script and PR #96's own implementation), Python 3.10+ (for the coverage-check script, extending the existing `scripts/verify-inventory-counts.py` pattern) + None beyond what's already vendored — PR #96's own `scripts/lib/*.sh`, the repo's existing Python stdlib-only tooling convention
 - 048-chrome-devtools-browser-inspection: Added Node.js 18+ (official `chrome-devtools-mcp` server — no NetClaw-authored server code); Bash (setup/enable script, consistent with `scripts/*-enable.sh` convention); Markdown (skill + MCP documentation) + `chrome-devtools-mcp` (npm package, official Chrome DevTools team release, MIT-style OSS), Node.js 18+, a locally installed Chrome/Chromium binary (stable channel by default)
 - 047-docs-inventory-reconciliation: Added Python 3.10+ (matches every other script in `scripts/`, e.g. `scan-all-mcp-source.py`, `register-all-mcps.py`) + None beyond the Python standard library (`os`, `json`, `re`) — no new third-party packages
-- 046-threejs-network-viz: Added Python 3.10+ (skill logic, consistent with the rest of NetClaw) + Three.js r147 pinned (last release with classic UMD core + non-module OrbitControls/GLTFLoader) vendored as static JS, the newly vendored community `sketchfab-mcp-server` (Node.js, `mcp-servers/sketchfab-mcp-server/`, registered as `sketchfab-mcp` in `config/openclaw.json`) for real-stencil model search/download, and NetClaw's existing topology-source skills/MCP servers (CML lab tooling, `gns3-mcp-server`, `clab-mcp-server`, `eve-ng-mcp-server`, `nautobot-mcp-v2`, `netbox-mcp-server`, `infrahub-mcp`, `ipfabric` integration, `forward-mcp`) consumed as-is, not modified
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/049-merge-modular-installer/checklists/requirements.md
+++ b/specs/049-merge-modular-installer/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Merge Modular TUI Installer with Full Component-Coverage Parity
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- File and function names (catalog, install functions, constitution) are named because they are literally the subject of this feature's requirements (which files must be updated), not incidental implementation detail leaking in.
+- No [NEEDS CLARIFICATION] markers were needed — the user's own PR notes plus direct investigation of the PR #96 branch (catalog.sh, install-steps.sh, install.sh) provided enough grounding to make informed defaults, documented in Assumptions.
+- All items pass on first pass; no iteration required.

--- a/specs/049-merge-modular-installer/contracts/catalog-entry-format.md
+++ b/specs/049-merge-modular-installer/contracts/catalog-entry-format.md
@@ -1,0 +1,62 @@
+# Contract: Catalog Entry & Install Function Format
+
+**Feature**: 049-merge-modular-installer
+**Date**: 2026-07-08
+
+This is the format contract every new/expanded catalog entry in this feature must follow — it is PR #96's own existing format, documented here so the 9 backfilled entries plus `chrome-devtools` are indistinguishable in style from the other 72.
+
+## Catalog line (`scripts/lib/catalog.sh`)
+
+```
+"<id>|<Category>|<Name>|<Description>"
+```
+
+- `<id>`: lowercase, hyphen-separated, unique. Becomes `component_install_<id_with_underscores>()`.
+- `<Category>`: one of the existing category headers (`Device Automation`, `Source of Truth`, `Fabric & Orchestration`, `Security`, `Cloud`, `Observability`, `Labs & Simulation`, `ITSM & DevOps`, `Analysis & Diagrams`, `Voice & Social`, `Platform Services`) unless no existing category fits.
+- `<Name>`: Title Case display name.
+- `<Description>`: one line, may parenthesize tool/server counts.
+
+Example (this feature adds):
+```
+"chrome-devtools|Analysis & Diagrams|Chrome DevTools|Browser automation/inspection — visualization QA, controller GUI gap-fill, API discovery, Watch Mode (2 servers)"
+```
+
+## Install function (`scripts/lib/install-steps.sh`)
+
+```bash
+component_install_<id>() {
+log_step "Configuring <Name>..."
+echo "  Source: <upstream link or Built-in>"
+echo "  Auth: <credential requirement, or 'None'>"
+echo "  Transport: <stdio/http/etc + how it's spawned>"
+
+# self-contained logic — no delegation to a separate *-enable.sh script
+# even if one exists for standalone use (see research.md R5)
+...
+
+echo ""
+}
+```
+
+- No leading indentation inside the function body (matches every existing function in the file — flat style, not 4-space indented).
+- Ends with a blank `echo ""` line (matches every existing function).
+- Must not require sudo directly; if a step genuinely needs elevation, use the installer's existing sudo-confirmation mechanism rather than calling `sudo` unconditionally.
+
+## Profile membership
+
+Adding an id to a `PROFILE_*` string is optional per entry — only add it where the new component clearly belongs in that curated profile's theme (e.g. `chrome-devtools` fits `recommended` given it now underpins visualization-QA workflows already in that profile; the telemetry receivers fit `observability`).
+
+## Coverage allow-list entry (`scripts/verify-catalog-coverage.py`)
+
+For any catalog id that intentionally covers more than one registered MCP server (a grouping, per R4/FR-010):
+
+```python
+GROUPED_COVERAGE = {
+    "chrome-devtools": ["chrome-devtools-mcp", "chrome-devtools-mcp-visible"],
+    "checkpoint": ["chkp-argos-erm", "chkp-cpinfo-analysis", ...],  # existing, documented here for completeness
+    "aws": ["aws-network", "aws-cloudwatch", ...],
+    ...
+}
+```
+
+Any registered server id not reachable via a direct `catalog_id == server_id` match, and not listed as a value somewhere in `GROUPED_COVERAGE`, is reported as a gap.

--- a/specs/049-merge-modular-installer/data-model.md
+++ b/specs/049-merge-modular-installer/data-model.md
@@ -1,0 +1,69 @@
+# Data Model: Merge Modular TUI Installer with Full Component-Coverage Parity
+
+**Feature**: 049-merge-modular-installer
+**Date**: 2026-07-08
+
+None of these are persisted by a database — they are plain-text/shell structures already defined by PR #96's own design. This document records their exact shape so new entries (the gap backfill + chrome-devtools) are added consistently, and so the coverage-check script has a precise contract to parse against.
+
+## Entities
+
+### CatalogEntry
+
+One line in `scripts/lib/catalog.sh`'s `CATALOG` array.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id | str | Unique identifier, lowercase, hyphen-separated (e.g. `chrome-devtools`). Maps 1:1 to an install function name via `component_install_<id with hyphens as underscores>()`. |
+| category | str | Display grouping in the TUI checklist (e.g. `Analysis & Diagrams`, `ITSM & DevOps`). New entries use an existing category where the component fits; a new category is only introduced if none fits. |
+| name | str | Human-readable display name shown in the TUI and `--list` output. |
+| description | str | One-line description, may note tool/server counts in parentheses (e.g. `(15 servers)`), matching existing entries' style. |
+
+**Validation rules**: `id` must be unique across `CATALOG` (enforced implicitly by `catalog_has()`/`catalog_field()`'s linear scan — first match wins, so a duplicate id would silently shadow). No entry may reference an `id` with no corresponding `component_install_<id>()` function, or `install.sh`'s component-selection flow fails at runtime for that entry.
+
+### InstallFunction
+
+The bash function `component_install_<id>()` in `scripts/lib/install-steps.sh` implementing one `CatalogEntry`.
+
+**Validation rules**: Self-contained (per R5) — does not shell out to a separate `*-enable.sh` script even if one exists for standalone use; may inline the same logic. Must not require sudo unless the installer's own sudo-confirmation flow is used (matches PR #96's stated "asks before each individual command that needs root" design).
+
+### ProfileDefinition
+
+A named, space-separated string of `CatalogEntry` ids (e.g. `PROFILE_RECOMMENDED`), registered in `profile_components()`'s case statement and `PROFILE_NAMES`.
+
+**Validation rules**: Every id listed must exist in `CATALOG` (the installer's own `catalog_has()` check enforces this at runtime for `--components`; profile strings are not currently validated the same way, so a typo here fails silently — the new coverage-check script also cross-checks profile membership against catalog ids as a side effect of R3's design).
+
+### CoverageReport
+
+The output of `scripts/verify-catalog-coverage.py` (R3) — not a persisted entity, a computed diff.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| registered_servers | set[str] | MCP server ids from `config/openclaw.json`'s `mcpServers` keys |
+| catalog_covered | set[str] | Server ids covered by a `CatalogEntry`, expanded through the intentional-grouping allow-list (e.g. `checkpoint` expands to all 15 `chkp-*` ids) |
+| gaps | set[str] | `registered_servers - catalog_covered` — anything left here is a real, unexplained gap |
+| exit_code | int | `0` if `gaps` is empty, non-zero otherwise (so this can gate a pre-merge check) |
+
+### ComponentManifest
+
+The per-host record at `~/.openclaw/netclaw-components.conf` (PR #96's own design, unchanged by this feature) — a newline-separated list of installed catalog entry ids, used to preselect the TUI checklist on re-run.
+
+**Validation rules** (new, per FR-009): if the manifest contains an id that no longer exists in `CATALOG` (e.g. a name that changed across this merge), the installer's re-run flow must surface that explicitly rather than silently dropping it from the preselection with no explanation.
+
+## Relationships
+
+```
+CatalogEntry --[implemented by exactly one]--> InstallFunction
+ProfileDefinition --[references many]--> CatalogEntry (by id)
+ComponentManifest --[records many installed]--> CatalogEntry (by id)
+CoverageReport --[computed from]--> CatalogEntry (all) + config/openclaw.json (all registered servers)
+```
+
+## State Transitions
+
+### Coverage status (per registered MCP server, as tracked by CoverageReport)
+
+```
+registered, no catalog coverage           → GAP (fails the check)
+registered, direct 1:1 catalog entry      → COVERED
+registered, covered via grouping allow-list → COVERED (documented exception)
+```

--- a/specs/049-merge-modular-installer/plan.md
+++ b/specs/049-merge-modular-installer/plan.md
@@ -1,0 +1,81 @@
+# Implementation Plan: Merge Modular TUI Installer with Full Component-Coverage Parity
+
+**Branch**: `049-merge-modular-installer` | **Date**: 2026-07-08 | **Spec**: `specs/049-merge-modular-installer/spec.md`
+**Input**: Feature specification from `/specs/049-merge-modular-installer/spec.md`
+
+## Summary
+
+Complete community PR #96 (`calcuttin:feat/installer-tui-refactor`) directly on the contributor's branch: resolve its merge conflict with main, backfill the ~9 confirmed component-catalog gaps (GNS3, DevNet content search, Three.js viz + Sketchfab, the UDP telemetry receiver trio, Ollama, Memory MCP, Nautobot Golden Config, Nautobot Routing, base Twilio vs. Twilio Voice), retrofit spec 048's chrome-devtools-mcp as a new catalog entry + install function, build a repeatable coverage-check script so this class of drift cannot recur silently, and amend Constitution Principle XI to describe the new `catalog.sh` + `install-steps.sh` pattern. Push the completed result back onto `calcuttin:feat/installer-tui-refactor` (maintainer edits are enabled on PR #96) so it merges under the contributor's own PR, preserving their authorship.
+
+## Technical Context
+
+**Language/Version**: Bash (matches every existing NetClaw install/enable script and PR #96's own implementation), Python 3.10+ (for the coverage-check script, extending the existing `scripts/verify-inventory-counts.py` pattern)
+**Primary Dependencies**: None beyond what's already vendored — PR #96's own `scripts/lib/*.sh`, the repo's existing Python stdlib-only tooling convention
+**Storage**: N/A (installer logic + a plain-text component manifest at `~/.openclaw/netclaw-components.conf`, per PR #96's own design)
+**Testing**: `bash -n` syntax checks on all modified/added shell files (matches PR #96's own stated test plan); the new coverage-check script itself is the functional test for FR-001/002/008; a dry-run install of the retrofitted chrome-devtools component
+**Target Platform**: Linux, macOS, WSL2 — same targets as PR #96 and spec 048
+**Project Type**: Installer/tooling merge — no application runtime code, single project
+**Performance Goals**: N/A (installer runs interactively or as a short scripted CLI invocation; no throughput/latency target applies)
+**Constraints**: Must not reduce installable coverage versus current main (FR-003); must preserve PR #96's own design decisions (TUI, profile system, catalog format) unchanged; chrome-devtools retrofit must preserve the no-sudo, explicit-binary-path behavior already validated in spec 048
+**Scale/Scope**: ~9 new/expanded catalog entries plus their install functions, one new coverage-check script, one constitution amendment, one git merge conflict resolution across `scripts/install.sh`, `README.md`
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Safety-First Operations | N/A | Installer/tooling change; no device interaction. |
+| II. Read-Before-Write | N/A | No device configuration involved. |
+| III. ITSM-Gated Changes | N/A | Not a production network change. |
+| IV. Immutable Audit Trail | N/A | Installer runs are local, operator-initiated, not GAIT-logged operations (consistent with every existing `*-enable.sh`/`install.sh` precedent). |
+| V. MCP-Native Integration | PASS | This feature touches how MCP servers get *registered by the installer*, not the MCP protocol itself; no new bespoke protocol introduced. |
+| VI. Multi-Vendor Neutrality | PASS | Catalog entries stay vendor-neutral in structure (id/category/name/description); no vendor logic added to shared installer code. |
+| VII. Skill Modularity | PASS | No skill content changes; this is purely installer/tooling plumbing. |
+| VIII. Verify After Every Change | PASS (adapted) | "Verify" here means the coverage-check script (FR-001/002/008) plus PR #96's own existing post-install component verification — the installer-appropriate analogue of this principle, not a device-config verify. |
+| IX. Security by Default | PASS | Preserves PR #96's own no-sudo-by-default posture and the chrome-devtools retrofit's existing no-credential design; adds no new elevated-privilege path. |
+| X. Observability as First-Class | N/A | No new monitored system; installer coverage is observable via the new coverage-check script's own output. |
+| XI. Full-Stack Artifact Coherence | PASS (this feature's core subject) | This feature *is* the update to what XI's checklist points at — the amendment itself is the artifact-coherence work for the installer's own structure. |
+| XII. Documentation-as-Code | PASS | README.md (already touched by PR #96) and the constitution both get updated in this same effort. |
+| XIII. Credential Safety | PASS | No new credential handling; the chrome-devtools retrofit continues to require zero credentials, matching spec 048. |
+| XIV. Human-in-the-Loop | PASS | Pushing to a third party's fork branch and closing/superseding a PR are both irreversible-ish, visible-to-others actions — confirmed explicitly with the operator before execution (already done in conversation). |
+| XV. Backwards Compatibility | PASS (this feature's core subject) | FR-003 *is* the backwards-compatibility requirement — no existing installable capability may be lost. |
+| XVI. Spec-Driven Development | PASS | Following full SDD workflow for this merge, per the operator's own request. |
+| XVII. Milestone Documentation | DEFERRED | Applies post-implementation (blog post already deferred pending the combined 048+049 post, per prior conversation). |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/049-merge-modular-installer/
+├── plan.md              # This file
+├── research.md          # Phase 0 output — the full catalog gap analysis
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output — catalog entry / install function format contract
+└── tasks.md             # Phase 2 output (/speckit.tasks — not created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+scripts/install.sh                    # PR #96's thin dispatcher (unchanged design, conflict-resolved)
+scripts/lib/common.sh                 # PR #96's shared helpers (unchanged)
+scripts/lib/tui.sh                    # PR #96's TUI (unchanged)
+scripts/lib/catalog.sh                # + ~9 new/expanded entries (gap backfill + chrome-devtools)
+scripts/lib/install-steps.sh          # + one component_install_<id>() per new/expanded entry
+scripts/lib/netclaw-logo.ans          # PR #96's asset (unchanged)
+scripts/lib/make-logo-art.py          # PR #96's generator (unchanged)
+scripts/setup.sh                      # PR #96's credential-prompt integration (unchanged design)
+scripts/verify-catalog-coverage.py    # NEW — coverage-check script (FR-001, FR-002, FR-008)
+scripts/chrome-devtools-enable.sh     # Existing (spec 048) — role decided in research.md, kept or absorbed
+.specify/memory/constitution.md       # Amended: Principle XI text + version bump + Sync Impact Report
+README.md                             # PR #96's rewritten Quick Start, reconciled with main's current content
+```
+
+**Structure Decision**: Work happens directly on top of PR #96's branch (fetched locally as `pr-96-review`, tracking `refs/pull/96/head`), not a from-scratch reimplementation. The only new file is `scripts/verify-catalog-coverage.py`; everything else is additive entries inside PR #96's own files, following its own established conventions exactly (catalog line format, `component_install_<id>()` function shape). The completed branch is pushed back to `calcuttin:feat/installer-tui-refactor` (maintainer edits confirmed enabled) so it lands as PR #96, preserving the contributor's authorship on their original commit.
+
+## Complexity Tracking
+
+> No constitution violations requiring justification. The one principle worth calling out explicitly: XIV (Human-in-the-Loop) — pushing to a third-party contributor's fork and any decision to close/supersede their PR are both actions visible to someone outside this session, and were explicitly discussed and confirmed with the operator before this plan was written, not assumed.

--- a/specs/049-merge-modular-installer/quickstart.md
+++ b/specs/049-merge-modular-installer/quickstart.md
@@ -1,0 +1,61 @@
+# Quickstart: Merge Modular TUI Installer with Full Component-Coverage Parity
+
+**Feature**: 049-merge-modular-installer
+**Date**: 2026-07-08
+
+## Prerequisites
+
+1. Local clone of `automateyournetwork/netclaw` with write access (already the case in this session)
+2. PR #96's branch fetched locally: `git fetch origin pull/96/head:pr-96-review` (already done)
+3. `gh` CLI authenticated with push access to the base repo (already confirmed — used to open/merge PR #97)
+
+## Workflow
+
+### 1. Bring PR #96 up to date with main
+
+```bash
+git checkout pr-96-review
+git merge main   # or rebase — resolve scripts/install.sh and README.md conflicts by
+                  # taking PR #96's version of both files wholesale (clean replacement,
+                  # not a line merge), then proceed to step 2
+```
+
+### 2. Backfill the 9 confirmed catalog gaps
+
+For each gap in `research.md` R2, add one `CatalogEntry` line to `scripts/lib/catalog.sh` and one `component_install_<id>()` function to `scripts/lib/install-steps.sh`, following `contracts/catalog-entry-format.md` exactly.
+
+### 3. Retrofit chrome-devtools
+
+Add the `chrome-devtools` catalog entry and its install function per `research.md` R4/R5 — self-contained (browser resolution/provisioning + both MCP registrations inlined), `scripts/chrome-devtools-enable.sh` untouched and still documented as the standalone tool.
+
+### 4. Build the coverage-check script
+
+`scripts/verify-catalog-coverage.py` per `research.md` R3 and the `GROUPED_COVERAGE` allow-list in `contracts/catalog-entry-format.md`. Run it — it must report zero gaps before proceeding.
+
+### 5. Amend the constitution
+
+Per `research.md` R6 — update Principle XI's checklist line and body text, add a Sync Impact Report block, bump to the next MINOR version.
+
+### 6. Validate
+
+```bash
+bash -n scripts/install.sh scripts/lib/*.sh scripts/chrome-devtools-enable.sh
+python3 scripts/verify-catalog-coverage.py
+./scripts/install.sh --list   # confirm every new entry appears, no shell errors
+```
+
+### 7. Push to the contributor's branch
+
+```bash
+git push git@github.com:calcuttin/netclaw.git pr-96-review:feat/installer-tui-refactor
+```
+
+(Confirmed viable: `maintainerCanModify: true` on PR #96.) This updates PR #96 in place. Post an explanatory, appreciative comment on the PR per the conversation with the operator, then let PR #96 merge normally (still crediting the original contributor).
+
+## Verification
+
+1. `scripts/verify-catalog-coverage.py` exits 0.
+2. `./scripts/install.sh --list` shows all ~81 components (72 original + 9 backfilled/retrofitted), grouped correctly.
+3. `./scripts/install.sh --components chrome-devtools` completes without sudo and without any credential prompt.
+4. PR #96 shows `mergeable: MERGEABLE` (not `CONFLICTING`) after the push.
+5. The constitution file's Sync Impact Report and version number reflect the amendment.

--- a/specs/049-merge-modular-installer/research.md
+++ b/specs/049-merge-modular-installer/research.md
@@ -1,0 +1,75 @@
+# Research: Merge Modular TUI Installer with Full Component-Coverage Parity
+
+**Feature**: 049-merge-modular-installer
+**Date**: 2026-07-08
+
+## R1: Why the PR Is Reported as CONFLICTING
+
+**Finding**: PR #96 (`ae0afd6`) branches from `97a0e8b` ("045 ue5 digital twin"). Main has since advanced through specs 046 (Three.js viz + sketchfab-mcp-server), 047 (docs inventory reconciliation), and 048 (chrome-devtools-mcp), each of which added steps to the old monolithic `scripts/install.sh` — the exact file PR #96 deletes wholesale (3,391 of its 3,472 total deletions) and replaces with a 360-line dispatcher. Git cannot 3-way-merge "delete this whole file" against "three independent sets of edits to lines inside it," hence `mergeStateStatus: DIRTY`.
+
+**Decision**: Resolve by rebasing/merging main's current state into a working copy of PR #96's branch, taking PR #96's new `scripts/install.sh` + `scripts/lib/*` wholesale (no textual line-merge needed there — it's a clean replacement), then manually re-adding installer support for everything main gained since branch point as new catalog entries + install functions (this is the real work, not a git mechanics problem).
+
+## R2: Actual Catalog Coverage Gap (Manual Audit)
+
+**Method**: Compared PR #96's `scripts/lib/catalog.sh` (72 entries) against `config/openclaw.json`'s 51 registered MCP servers on current main plus README.md's full 110-row MCP Servers table (the authoritative human-curated inventory, since 59 of the 110 are "externally documented" integrations not captured as static JSON — built-in plugins, remote OAuth services, etc.).
+
+**Confirmed gaps** (catalog entries to add or expand):
+
+| Gap | Existing on main since | Notes |
+|-----|------------------------|-------|
+| GNS3 | spec 012 (predates PR #96 branch point — a **pre-existing** gap PR #96 inherited, not one it introduced) | `gns3-mcp` registered; no catalog entry at all |
+| DevNet Content Search | spec 026 (pre-existing gap) | `devnet-content-search` registered; no catalog entry |
+| Memory MCP | spec 033 (pre-existing gap) | Distinct from `mempalace` (which IS in the catalog) — `memory-mcp` has no entry |
+| Ollama Domain Experts | spec 037 (pre-existing gap) | No catalog entry at all |
+| Telemetry receivers (SNMP trap, syslog, IPFIX/NetFlow) | spec 010 (pre-existing gap, oldest one found) | Three related UDP receivers, registered as `snmptrap-mcp`/`syslog-mcp`/`ipfix-mcp`; no catalog entry |
+| Nautobot Golden Config | spec 028 (pre-existing gap) | `nautobot-golden-config-mcp` registered; catalog's single `nautobot` entry doesn't cover it |
+| Nautobot Routing | spec 030 (pre-existing gap) | `nautobot-routing-mcp` registered; same issue |
+| Base Twilio (core API/messaging) | spec 039-ish era (pre-existing gap) | `twilio-mcp` (core `@twilio-alpha/mcp`) registered separately from `twilio-voice-mcp`; catalog's `twilio` entry describes only the voice one |
+| Three.js Network Viz + Sketchfab | spec 046 (post-branch-point — genuinely introduced by the conflict window) | `threejs-network-viz` skill + optional vendored `sketchfab-mcp`; no catalog entry |
+| Chrome DevTools (headless + Watch Mode) | spec 048 (post-branch-point) | This feature's specific retrofit target (see R4) |
+
+**Not a gap**: `scripts/verify-inventory-counts.py` and other spec-047 maintenance tooling — these are repo-maintenance scripts with nothing to "install," correctly out of scope per the spec's Assumptions.
+
+**Decision**: Treat the pre-existing gaps (present even at PR #96's own branch point) and the post-branch-point gaps (046/047/048) with the same bar — FR-002/FR-003 require full parity with *current* main regardless of when a given gap was introduced. Nine new/expanded catalog entries in total close this list. This is a bounded, enumerable list — not an open-ended audit — which keeps this feature's scope tractable.
+
+**Important caveat**: This is a manual, one-time pass. Per FR-008, the actual authority going forward is the coverage-check script (R3) — if this manual pass missed anything, the script will catch it, and that's the point of building it.
+
+## R3: Coverage-Check Script Design
+
+**Decision**: Add `scripts/verify-catalog-coverage.py`, modeled directly on the existing `scripts/verify-inventory-counts.py` (same language, same "enumerate ground truth, enumerate the artifact, diff, exit non-zero on unexplained gap" shape, same repo convention of a small stdlib-only script). It:
+
+1. Enumerates `config/openclaw.json`'s `mcpServers` keys (ground truth for registered servers).
+2. Enumerates `scripts/lib/catalog.sh`'s catalog ids (parsed the same simple `|`-delimited way `catalog.sh` itself parses).
+3. Loads a small, explicit allow-list of intentional groupings/exclusions (e.g., `checkpoint` → covers all 15 `chkp-*` servers; `aws` → covers 6 AWS servers; maintenance scripts with no install step) — this is the mechanism that satisfies the spec's Edge Case about distinguishing real gaps from documented intentional exclusions (FR-010).
+4. Reports any registered server that isn't covered by a catalog id (directly or via the allow-list) as a gap, with a non-zero exit code.
+5. Does the same comparison for `workspace/skills/` against catalog coverage, for skills that have their own MCP dependency (a skill with no MCP server of its own, calling only already-covered servers, doesn't need a separate catalog entry — also encoded in the allow-list).
+
+**Rationale**: A script that can be re-run on every future feature branch (not just this one) is what actually satisfies FR-008 ("repeatable... not a one-time manual audit"). Reusing the existing script's shape keeps it consistent with repo convention rather than inventing a new style.
+
+**Alternatives considered**: A pure documentation checklist (rejected — exactly the failure mode that created this gap in the first place, since PR #96's own stated test plan was manual/eyeball); folding this into `verify-inventory-counts.py` itself (rejected — that script's job is skill/MCP *count* reconciliation across docs, a different concern from catalog *coverage*; keeping them separate, single-purpose scripts is more consistent with the repo's existing one-script-per-concern pattern).
+
+## R4: Chrome DevTools Retrofit — One Catalog Entry, Both Registrations
+
+**Decision**: Add a single catalog entry, `chrome-devtools`, whose `component_install_chrome_devtools()` function registers *both* `chrome-devtools-mcp` (headless) and `chrome-devtools-mcp-visible` (Watch Mode) and provisions/resolves the Chrome binary — mirroring the precedent already set by `checkpoint` (one entry, 15 servers) and `aws` (one entry, 6 servers). An operator selects "Chrome DevTools" once; both registrations and the browser resolution happen together, since they're one capability from a user's point of view.
+
+**Rationale**: The spec's FR-010 explicitly permits this style of grouping when it matches existing precedent, and splitting headless/Watch Mode into two separately-selectable catalog entries would be user-hostile — nobody wants "headless Chrome DevTools" without also being able to ask for Watch Mode, they're two modes of one thing.
+
+## R5: Fate of `scripts/chrome-devtools-enable.sh` (resolves FR-006)
+
+**Decision**: **Keep it standalone**, and additionally inline equivalent logic into `component_install_chrome_devtools()`. Do not delete it, do not have the new install function shell out to it.
+
+**Rationale — direct precedent found in PR #96's own tree**: `scripts/forward-enable.sh`, `scripts/memory-enable.sh`, and `scripts/defenseclaw-enable.sh` all still exist standalone in PR #96's branch, untouched, *alongside* their own inlined `component_install_forward()` / equivalent functions. Inspecting `component_install_forward()` directly confirms it reimplements Forward's clone/build/env-setup logic inline rather than calling `forward-enable.sh`. This is the new architecture's actual, observed convention: the TUI-driven install function is self-contained (so `install.sh` never has to shell out to N different scripts with N different flag conventions), while the standalone `*-enable.sh` script remains available for direct, non-TUI use (re-running just that one piece, CI, documentation examples that predate the TUI, etc.). Chrome DevTools already has extensive documentation (`mcp-servers/chrome-devtools-mcp/README.md`, `quickstart.md`, both `SKILL.md` files) pointing at `chrome-devtools-enable.sh` by name — keeping it avoids a documentation-wide rename for no functional benefit, while still giving the TUI its own self-contained function per the architecture's convention.
+
+**Alternatives considered**: Deleting the standalone script and having the install function be the only entry point — rejected, breaks existing documentation for no gain and contradicts the pattern set by three other existing components in the same PR. Having `component_install_chrome_devtools()` call `bash scripts/chrome-devtools-enable.sh` — rejected, doesn't match how `forward`/`memory`/`defenseclaw` do it (they inline, not delegate), and PR #96's own components generally avoid shelling out to other scripts within an install function.
+
+## R6: Constitution Amendment Scope
+
+**Decision**: Amend Principle XI ("Full-Stack Artifact Coherence") and the associated Artifact Coherence Checklist, replacing the line `scripts/install.sh — installation steps for new dependencies` with language describing the catalog-entry-plus-install-function pattern (naming both `scripts/lib/catalog.sh` and `scripts/lib/install-steps.sh` explicitly), and adding a note that the new coverage-check script (R3) is how compliance gets verified rather than manual review alone. Version bump: MINOR (clarifying/extending existing principle text to match reality, not redefining or removing a principle), per the constitution's own semantic-versioning rule in its Governance section. A Sync Impact Report comment block is added at the top of the file, matching the style already used for the 1.0.0 → 1.1.0 bump.
+
+**Alternatives considered**: A MAJOR bump — rejected, this doesn't redefine what artifact coherence *means*, only updates which concrete files satisfy it, which is exactly the kind of change the constitution's own versioning rule reserves for MINOR.
+
+## R7: Attribution / Merge Mechanics
+
+**Decision**: Complete this work directly on `pr-96-review` (local branch tracking `refs/pull/96/head`), then push the result to `calcuttin:feat/installer-tui-refactor`. Confirmed via `gh pr view 96` that `maintainerCanModify: true` — the contributor explicitly enabled maintainer edits, so this is both technically possible and clearly welcomed by them. This updates PR #96 in place rather than opening a new, competing PR, preserving the contributor's own commit and its authorship in the final history regardless of who pushes follow-up commits after it.
+
+**Fallback** (only if the push is rejected for a reason not visible from `maintainerCanModify`, e.g. branch protection on their fork): open a new PR that includes their original commit (via merge, not squash-and-reattribute) with an explicit comment on PR #96 crediting them and linking to the superseding PR, then close #96. Discussed and pre-approved by the operator; not expected to be needed.

--- a/specs/049-merge-modular-installer/spec.md
+++ b/specs/049-merge-modular-installer/spec.md
@@ -1,0 +1,105 @@
+# Feature Specification: Merge Modular TUI Installer with Full Component-Coverage Parity
+
+**Feature Branch**: `049-merge-modular-installer`
+**Created**: 2026-07-08
+**Status**: Draft
+**Input**: User description: "Merge the community-contributed modular TUI installer (PR #96, branch feat/installer-tui-refactor, from fork calcuttin) into main, with full component-coverage parity, plus retrofit the chrome-devtools-mcp integration (spec 048) into the new architecture, plus amend the project constitution to reflect the new installer structure. PR #96 replaces the ~3,700-line monolithic scripts/install.sh (45 hardcoded, all-or-nothing steps) with a modular, selection-driven installer... GitHub reports the PR as CONFLICTING against main... the new catalog.sh is missing installer coverage for MCP servers/skills that exist on main today... A merge that silently drops installer support for any already-shipped, still-registered MCP server or skill is a regression, not just a conflict to paper over."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - No Regression: Every Installable Capability Survives the Merge (Priority: P1)
+
+An operator installing NetClaw fresh, or re-running the installer on an existing install, must be able to install (or continue to have installed) every MCP server and skill that the project currently ships — regardless of whether that capability existed when the community contributor started their installer rewrite. Today, the contributed installer's component catalog was built against an older snapshot of the project and is missing entries for capabilities that have shipped since (confirmed gaps include GNS3, the standalone memory MCP, Ollama local LLM routing, the UDP telemetry receivers, DevNet content search, and everything from the three most recent feature branches). Merging as-is would silently make those capabilities uninstallable through the new installer.
+
+**Why this priority**: This is the difference between "adopt a great contribution" and "ship a regression that quietly deletes existing functionality." It must be resolved before anything else in this effort has value — a great TUI that can't install everything the project already does is not yet mergeable.
+
+**Independent Test**: Run an automated coverage check that compares the merged installer's component catalog against the live registered MCP servers and workspace skills; the check reports zero unexplained gaps.
+
+**Acceptance Scenarios**:
+
+1. **Given** the full list of MCP servers currently registered in NetClaw's reference configuration, **When** the coverage check runs against the merged installer's catalog, **Then** every one of those servers is represented by a catalog entry (either one-to-one, or as part of a deliberately documented group, such as the existing consolidation of the 15 Check Point servers into one entry).
+2. **Given** the full list of skills in the workspace that require an installable setup step (a dependency to fetch, a credential prompt, an MCP registration), **When** the coverage check runs, **Then** every one of those skills is represented by a catalog entry and install function.
+3. **Given** a host that was previously fully set up using the old monolithic installer, **When** an operator re-runs the merged installer, **Then** the components that host already has installed are recognized and preselected, not dropped or presented as if never installed.
+4. **Given** the coverage check finds a capability intentionally excluded from the catalog (for example, a repo-maintenance script with nothing to "install"), **When** the check runs, **Then** it distinguishes that documented, intentional exclusion from a real gap, rather than reporting it as a failure forever.
+
+---
+
+### User Story 2 - Chrome DevTools Is a First-Class Component in the New Installer (Priority: P2)
+
+The Chrome DevTools browser-automation capability (spec 048) — its two MCP registrations (headless and headed "Watch Mode") and its two skills — needs to be selectable the same way every other component is in the new installer: shown in the catalog, included in whichever profile(s) make sense, and installed via a proper install function, not left behind as an artifact of the old monolithic script the contributed installer deletes.
+
+**Why this priority**: Directly follows from User Story 1 (it's one of the confirmed coverage gaps) but is called out on its own because it has specific behavior — provisioning a browser binary without elevated privileges, and pinning an explicit binary path rather than relying on a default lookup — that must be preserved exactly, not just "have some install function that sort of works."
+
+**Independent Test**: Select the Chrome DevTools component (individually or via a profile that includes it) through the new installer and confirm both MCP registrations end up configured with a working, explicit browser binary reference, with no elevated-privilege step required and no credential ever requested.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator selects the Chrome DevTools component through the new installer (TUI or scripted flag), **When** installation runs, **Then** a usable Chrome/Chromium binary is located or provisioned without requiring sudo, and both the headless and Watch Mode registrations are configured with an explicit reference to that binary.
+2. **Given** the component is already installed and the operator re-runs the installer, **When** they leave the component selected, **Then** re-installation is idempotent (no duplicate registrations, no broken state).
+3. **Given** a maintainer wants to know whether the previously-standalone browser-provisioning helper still exists as its own script or was absorbed into the installer, **When** they read the relevant project documentation, **Then** the answer is stated explicitly, and it matches the pattern used by comparable existing components (so a future contributor doesn't have to guess which style to follow).
+
+---
+
+### User Story 3 - The Constitution Reflects How Installer Support Is Actually Added Now (Priority: P3)
+
+A future contributor adding a new MCP server or skill needs to know, from the project's own governing document, that "update the installer" now means adding a catalog entry and an install function in two specific files — not adding a numbered step to a single large script that no longer exists in that form.
+
+**Why this priority**: Lower urgency than the first two (the merge can technically happen without this), but leaving the constitution describing a script structure that no longer exists would make every future feature's artifact-coherence checklist wrong on day one after this merge.
+
+**Independent Test**: Read the constitution's artifact-coherence requirements after this change and confirm they describe the current, real installer structure — a person unfamiliar with the installer's history can follow them correctly on the first try.
+
+**Acceptance Scenarios**:
+
+1. **Given** the constitution's artifact-coherence checklist, **When** it is read after this change, **Then** it names the catalog and install-function files (not a single monolithic install script) as the required touchpoint for new capabilities.
+2. **Given** the constitution defines its own amendment process (documented rationale, impact review, version bump), **When** this change is made, **Then** that process is followed and recorded the same way prior amendments were.
+
+---
+
+### Edge Cases
+
+- What happens when an old install step doesn't map cleanly to one new catalog entry (e.g., it installed two related things at once)? The coverage check and catalog MUST account for legitimate one-to-many or many-to-one groupings, not force an artificial one-to-one mapping.
+- What happens when a component's install behavior depends on something the new installer's own safety rules restrict (for example, refusing to run under sudo) — does that ever conflict with a component's own no-sudo design? These MUST be complementary, not contradictory (a component that already avoids sudo should not be blocked by a general anti-sudo safeguard).
+- What happens if the coverage check itself becomes stale the same way the original catalog did? It MUST be a repeatable, re-runnable check (not a one-time manual pass) so this specific failure mode cannot recur silently.
+- What happens to a host's existing component manifest (the record of what's installed) if it references something that no longer exists in the merged catalog under the same name? The re-run experience MUST surface this clearly rather than silently dropping or silently mismapping it.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a repeatable way to verify that every MCP server currently registered in NetClaw's reference configuration has a corresponding entry in the merged installer's component catalog.
+- **FR-002**: System MUST provide a repeatable way to verify that every skill in the workspace that requires an installable setup step has a corresponding catalog entry and install function, or is explicitly documented as intentionally excluded (with a stated reason).
+- **FR-003**: The merged installer MUST NOT remove the ability to install any MCP server or skill that was installable through the pre-merge installer.
+- **FR-004**: The merged installer MUST include the Chrome DevTools integration — both MCP registrations and both associated skills — as catalog entries with working install functions.
+- **FR-005**: The Chrome DevTools install function(s) MUST preserve existing behavior: locate or provision a Chrome/Chromium binary without requiring elevated privileges, and register both MCP servers with an explicit binary-path reference rather than relying on a default channel-based lookup.
+- **FR-006**: Project documentation MUST state explicitly whether the standalone Chrome DevTools browser-provisioning helper remains an independently invokable script or is absorbed into the installer's own component logic, and that choice MUST be consistent with how comparable existing components handle non-trivial setup logic in the new architecture.
+- **FR-007**: The project constitution MUST be amended, following its own documented amendment process, so its artifact-coherence requirements describe the current catalog-and-install-function pattern rather than a single monolithic install script.
+- **FR-008**: The coverage-verification method (FR-001, FR-002) MUST be runnable repeatedly as part of normal development, not only as a one-time manual audit performed for this merge.
+- **FR-009**: Re-running the merged installer on a host previously set up with the old monolithic installer MUST recognize and preselect components that host already has, rather than presenting a blank or incorrect starting state.
+- **FR-010**: A component MAY be represented in the catalog as a deliberate group (matching existing precedent, such as the consolidation of the Check Point server suite into a single entry) rather than strictly one-to-one with every underlying MCP server, provided the coverage check accounts for that grouping explicitly.
+- **FR-011**: The resulting change MUST be mergeable into the current state of the main branch with no unresolved conflicts, while preserving the original contributor's authorship on their work.
+
+### Key Entities
+
+- **Catalog Entry**: An installable unit an operator can select — an identifier, category, display name, and description — mapped to exactly one install function.
+- **Install Profile**: A named, curated set of catalog entry identifiers representing a common use case (e.g., a Cisco-focused install, a security-focused install).
+- **Install Function**: The executable logic that installs and configures one catalog entry, including any prerequisite resolution specific to that component.
+- **Coverage Report**: The computed comparison between what is actually registered/present today (live configuration and workspace skills) and what the catalog covers, distinguishing real gaps from documented, intentional exclusions.
+- **Component Manifest**: The per-host record of which catalog entries have already been installed, used to preselect on a re-run.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The coverage-verification check reports zero unexplained gaps between what's live/registered today and what the merged installer's catalog covers.
+- **SC-002**: An operator who previously installed every component available under the old installer sees 100% of those components represented and preselected when they re-run the new installer.
+- **SC-003**: An operator can install the Chrome DevTools capability through the new installer (via profile or explicit selection) and end up with the same working, no-sudo, explicit-binary-path behavior previously validated for that capability.
+- **SC-004**: The resulting pull request is reported as cleanly mergeable against main, with zero manual conflict markers remaining.
+- **SC-005**: A contributor unfamiliar with the installer's history can read the constitution and correctly identify which files to update to add installer support for a new capability, without reading install script history first.
+
+## Assumptions
+
+- The contributed installer's overall design — the TUI, the profile system, the catalog file format — is accepted as the target architecture for this project going forward; this effort extends its coverage and resolves its conflict with main, and does not redesign those decisions.
+- "Installable setup steps" excludes skills that are pure documentation/workflow skills requiring no dependency fetch, credential, or MCP registration of their own (they call existing, already-installed MCP servers) — these do not need a catalog entry.
+- The project's existing inventory-verification tooling (built for a prior documentation-reconciliation effort) is a reasonable starting point to extend for the new catalog-coverage check, since it already knows how to enumerate the live configuration and workspace skills.
+- The constitution amendment described here is a clarifying/extending change to existing principle text (not a redefinition or removal of a principle), consistent with a minor version bump under the constitution's own semantic-versioning rule.
+- The external contributor is not expected to make further changes themselves; this effort completes the coverage-parity and retrofit work directly on top of their contributed branch, preserving their authorship, before merging.

--- a/specs/049-merge-modular-installer/tasks.md
+++ b/specs/049-merge-modular-installer/tasks.md
@@ -19,8 +19,8 @@
 
 **Purpose**: Get PR #96's branch conflict-free against current main before any new content is added
 
-- [ ] T001 On `pr-96-review`, merge current `main` into the branch; resolve the `scripts/install.sh` and `README.md` conflicts by taking PR #96's version of both wholesale (a clean file replacement, not a line-by-line merge — see research.md R1)
-- [ ] T002 [P] Run `bash -n` on `scripts/install.sh` and every file under `scripts/lib/` post-merge to confirm the baseline (before any new entries) is syntactically valid
+- [X] T001 On `pr-96-review`, merge current `main` into the branch; resolve the `scripts/install.sh` and `README.md` conflicts by taking PR #96's version of both wholesale (a clean file replacement, not a line-by-line merge — see research.md R1)
+- [X] T002 [P] Run `bash -n` on `scripts/install.sh` and every file under `scripts/lib/` post-merge to confirm the baseline (before any new entries) is syntactically valid
 
 ---
 
@@ -30,8 +30,8 @@
 
 **CRITICAL**: No user story work can be marked done until this phase's script exists and runs (even reporting known gaps) — it's the acceptance mechanism for US1
 
-- [ ] T003 Create `scripts/verify-catalog-coverage.py`: enumerate `config/openclaw.json`'s `mcpServers` keys, enumerate `scripts/lib/catalog.sh`'s catalog ids, apply the `GROUPED_COVERAGE` allow-list (per contracts/catalog-entry-format.md) for existing intentional groupings (`checkpoint` → 15 `chkp-*` servers, `aws` → its 6 servers, `gcp` → its 4, `aap` → its 4), report any registered server not reachable via a direct or grouped match as a gap, and exit non-zero if any gap is unexplained
-- [ ] T004 [P] Run `scripts/verify-catalog-coverage.py` against the post-merge, pre-backfill state and confirm it correctly reports the 9 known gaps from research.md R2 (proves the script itself works before it's used to prove the backfill worked)
+- [X] T003 Create `scripts/verify-catalog-coverage.py`: enumerate `config/openclaw.json`'s `mcpServers` keys, enumerate `scripts/lib/catalog.sh`'s catalog ids, apply the `GROUPED_COVERAGE` allow-list (per contracts/catalog-entry-format.md) for existing intentional groupings (`checkpoint` → 15 `chkp-*` servers, `aws` → its 6 servers, `gcp` → its 4, `aap` → its 4), report any registered server not reachable via a direct or grouped match as a gap, and exit non-zero if any gap is unexplained
+- [X] T004 [P] Run `scripts/verify-catalog-coverage.py` against the post-merge, pre-backfill state and confirm it correctly reports the 9 known gaps from research.md R2 (proves the script itself works before it's used to prove the backfill worked)
 
 **Checkpoint**: Coverage-check tool exists and correctly identifies the known gaps. Backfill work (US1) can now proceed and be verified.
 
@@ -45,17 +45,17 @@
 
 ### Implementation for User Story 1
 
-- [ ] T005 [P] [US1] Add `gns3` catalog entry to `scripts/lib/catalog.sh` (category: Labs & Simulation) and `component_install_gns3()` to `scripts/lib/install-steps.sh`, per contracts/catalog-entry-format.md
-- [ ] T006 [P] [US1] Add `devnet-search` catalog entry (category: ITSM & DevOps or Analysis & Diagrams, whichever existing category fits DevNet Content Search's remote-HTTP no-auth nature) and `component_install_devnet_search()`
-- [ ] T007 [P] [US1] Add `memory-mcp` catalog entry (category: Platform Services, alongside `mempalace`) and `component_install_memory_mcp()`, clearly distinguishing its description from `mempalace`'s
-- [ ] T008 [P] [US1] Add `ollama` catalog entry (category: Platform Services) and `component_install_ollama()`
-- [ ] T009 [P] [US1] Add `telemetry-receivers` catalog entry (category: Observability) covering SNMP trap, syslog, and IPFIX/NetFlow together, and `component_install_telemetry_receivers()` registering all three (`snmptrap-mcp`, `syslog-mcp`, `ipfix-mcp`)
-- [ ] T010 [P] [US1] Add `nautobot-golden-config` catalog entry (category: Source of Truth) and `component_install_nautobot_golden_config()`
-- [ ] T011 [P] [US1] Add `nautobot-routing` catalog entry (category: Source of Truth) and `component_install_nautobot_routing()`
-- [ ] T012 [P] [US1] Expand catalog coverage for base Twilio: either broaden the existing `twilio` entry's description/install function to also register `twilio-mcp` alongside `twilio-voice-mcp`, or add a distinct `twilio-core` entry — whichever keeps the description accurate; update `component_install_twilio()` accordingly
-- [ ] T013 [P] [US1] Add `threejs-viz` catalog entry (category: Analysis & Diagrams, alongside `blender`/`ue5`) and `component_install_threejs_viz()` covering `threejs-network-viz` plus the optional vendored `sketchfab-mcp` real-stencil mode
-- [ ] T014 [US1] Update `GROUPED_COVERAGE` in `scripts/verify-catalog-coverage.py` for any of T005-T013 that cover more than one registered server (at minimum `telemetry-receivers` and the Twilio entry from T012)
-- [ ] T015 [US1] Run `scripts/verify-catalog-coverage.py` and confirm zero unexplained gaps remain for every registered server that existed prior to spec 048 (chrome-devtools itself is still an expected, separate gap at this point — closed in Phase 4)
+- [X] T005 [P] [US1] Add `gns3` catalog entry to `scripts/lib/catalog.sh` (category: Labs & Simulation) and `component_install_gns3()` to `scripts/lib/install-steps.sh`, per contracts/catalog-entry-format.md
+- [X] T006 [P] [US1] Add `devnet-search` catalog entry (category: ITSM & DevOps or Analysis & Diagrams, whichever existing category fits DevNet Content Search's remote-HTTP no-auth nature) and `component_install_devnet_search()`
+- [X] T007 [P] [US1] Add `memory-mcp` catalog entry (category: Platform Services, alongside `mempalace`) and `component_install_memory_mcp()`, clearly distinguishing its description from `mempalace`'s
+- [X] T008 [P] [US1] Add `ollama` catalog entry (category: Platform Services) and `component_install_ollama()`
+- [X] T009 [P] [US1] Add `telemetry-receivers` catalog entry (category: Observability) covering SNMP trap, syslog, and IPFIX/NetFlow together, and `component_install_telemetry_receivers()` registering all three (`snmptrap-mcp`, `syslog-mcp`, `ipfix-mcp`)
+- [X] T010 [P] [US1] Add `nautobot-golden-config` catalog entry (category: Source of Truth) and `component_install_nautobot_golden_config()`
+- [X] T011 [P] [US1] Add `nautobot-routing` catalog entry (category: Source of Truth) and `component_install_nautobot_routing()`
+- [X] T012 [P] [US1] Expand catalog coverage for base Twilio: either broaden the existing `twilio` entry's description/install function to also register `twilio-mcp` alongside `twilio-voice-mcp`, or add a distinct `twilio-core` entry — whichever keeps the description accurate; update `component_install_twilio()` accordingly
+- [X] T013 [P] [US1] Add `threejs-viz` catalog entry (category: Analysis & Diagrams, alongside `blender`/`ue5`) and `component_install_threejs_viz()` covering `threejs-network-viz` plus the optional vendored `sketchfab-mcp` real-stencil mode
+- [X] T014 [US1] Update `GROUPED_COVERAGE` in `scripts/verify-catalog-coverage.py` for any of T005-T013 that cover more than one registered server (at minimum `telemetry-receivers` and the Twilio entry from T012)
+- [X] T015 [US1] Run `scripts/verify-catalog-coverage.py` and confirm zero unexplained gaps remain for every registered server that existed prior to spec 048 (chrome-devtools itself is still an expected, separate gap at this point — closed in Phase 4)
 
 **Checkpoint**: Every pre-048 capability on main is installable through the new installer. This alone is mergeable as a non-regressive improvement over PR #96's original submission.
 
@@ -69,12 +69,12 @@
 
 ### Implementation for User Story 2
 
-- [ ] T016 [US2] Add `chrome-devtools` catalog entry to `scripts/lib/catalog.sh` (category: Analysis & Diagrams, per research.md R4 — one entry covering both registrations) per contracts/catalog-entry-format.md
-- [ ] T017 [US2] Write `component_install_chrome_devtools()` in `scripts/lib/install-steps.sh`, self-contained (per research.md R5 — inline, not delegating to `scripts/chrome-devtools-enable.sh`): find a system Chrome/Chromium binary or provision one via `npx @puppeteer/browsers install chrome@stable`, then register both `chrome-devtools-mcp` (`--headless=true`) and `chrome-devtools-mcp-visible` (`--headless=false`) with the resolved `--executablePath`
-- [ ] T018 [US2] Add `chrome-devtools` to the `recommended` profile in `scripts/lib/catalog.sh` (it now underpins visualization-QA workflows already represented in that profile)
-- [ ] T019 [US2] Update `GROUPED_COVERAGE` in `scripts/verify-catalog-coverage.py`: `"chrome-devtools": ["chrome-devtools-mcp", "chrome-devtools-mcp-visible"]`
-- [ ] T020 [US2] Update `mcp-servers/chrome-devtools-mcp/README.md`, `quickstart.md` (spec 048), and both `SKILL.md` files with a short note that the component is now also installable via `./scripts/install.sh --components chrome-devtools` (in addition to the standalone `scripts/chrome-devtools-enable.sh`, which remains supported per research.md R5)
-- [ ] T021 [US2] Run `scripts/verify-catalog-coverage.py` and confirm zero unexplained gaps remain for chrome-devtools-mcp and chrome-devtools-mcp-visible
+- [X] T016 [US2] Add `chrome-devtools` catalog entry to `scripts/lib/catalog.sh` (category: Analysis & Diagrams, per research.md R4 — one entry covering both registrations) per contracts/catalog-entry-format.md
+- [X] T017 [US2] Write `component_install_chrome_devtools()` in `scripts/lib/install-steps.sh`, self-contained (per research.md R5 — inline, not delegating to `scripts/chrome-devtools-enable.sh`): find a system Chrome/Chromium binary or provision one via `npx @puppeteer/browsers install chrome@stable`, then register both `chrome-devtools-mcp` (`--headless=true`) and `chrome-devtools-mcp-visible` (`--headless=false`) with the resolved `--executablePath`
+- [X] T018 [US2] Add `chrome-devtools` to the `recommended` profile in `scripts/lib/catalog.sh` (it now underpins visualization-QA workflows already represented in that profile)
+- [X] T019 [US2] Update `GROUPED_COVERAGE` in `scripts/verify-catalog-coverage.py`: `"chrome-devtools": ["chrome-devtools-mcp", "chrome-devtools-mcp-visible"]`
+- [X] T020 [US2] Update `mcp-servers/chrome-devtools-mcp/README.md`, `quickstart.md` (spec 048), and both `SKILL.md` files with a short note that the component is now also installable via `./scripts/install.sh --components chrome-devtools` (in addition to the standalone `scripts/chrome-devtools-enable.sh`, which remains supported per research.md R5)
+- [X] T021 [US2] Run `scripts/verify-catalog-coverage.py` and confirm zero unexplained gaps remain for chrome-devtools-mcp and chrome-devtools-mcp-visible
 
 **Checkpoint**: Chrome DevTools is fully represented in the new installer with no behavior regression from spec 048's validated design.
 
@@ -88,8 +88,8 @@
 
 ### Implementation for User Story 3
 
-- [ ] T022 [US3] In `.specify/memory/constitution.md`, update Principle XI's body text and the Artifact Coherence Checklist line that currently reads `scripts/install.sh — installation steps for new dependencies` to instead describe adding a `CatalogEntry` to `scripts/lib/catalog.sh` and a `component_install_<id>()` function to `scripts/lib/install-steps.sh`, and note that `scripts/verify-catalog-coverage.py` is how compliance is verified
-- [ ] T023 [US3] Add a Sync Impact Report comment block at the top of `.specify/memory/constitution.md` (matching the existing 1.0.0→1.1.0 style) documenting this amendment, and bump the version per its MINOR-bump rule (clarifying/extending existing principle text, not redefining a principle)
+- [X] T022 [US3] In `.specify/memory/constitution.md`, update Principle XI's body text and the Artifact Coherence Checklist line that currently reads `scripts/install.sh — installation steps for new dependencies` to instead describe adding a `CatalogEntry` to `scripts/lib/catalog.sh` and a `component_install_<id>()` function to `scripts/lib/install-steps.sh`, and note that `scripts/verify-catalog-coverage.py` is how compliance is verified
+- [X] T023 [US3] Add a Sync Impact Report comment block at the top of `.specify/memory/constitution.md` (matching the existing 1.0.0→1.1.0 style) documenting this amendment, and bump the version per its MINOR-bump rule (clarifying/extending existing principle text, not redefining a principle)
 
 **Checkpoint**: Constitution accurately describes the merged installer's real structure.
 
@@ -99,12 +99,12 @@
 
 **Purpose**: Final validation and landing the work under the contributor's own PR
 
-- [ ] T024 [P] Run `bash -n` on every modified/added file: `scripts/install.sh`, all of `scripts/lib/*.sh`, `scripts/chrome-devtools-enable.sh`, `scripts/setup.sh`
-- [ ] T025 [P] Run `./scripts/install.sh --list` and visually confirm all ~81 components appear, correctly grouped, with no shell errors
-- [ ] T026 Reconcile `README.md`'s installer section (PR #96's rewrite) with any current-main content it doesn't yet account for (e.g. mentions of newly-backfilled components in the Quick Start narrative, if warranted)
-- [ ] T027 Push the completed branch to the contributor's fork: `git push git@github.com:calcuttin/netclaw.git pr-96-review:feat/installer-tui-refactor` (confirmed viable — `maintainerCanModify: true`)
-- [ ] T028 Post a comment on PR #96 explaining what changed (conflict resolution + 9 coverage-gap backfills + chrome-devtools retrofit + constitution amendment) and crediting the contributor's original work, per the conversation with the operator
-- [ ] T029 Confirm via `gh pr view 96` that `mergeable` now reports `MERGEABLE`, not `CONFLICTING`
+- [X] T024 [P] Run `bash -n` on every modified/added file: `scripts/install.sh`, all of `scripts/lib/*.sh`, `scripts/chrome-devtools-enable.sh`, `scripts/setup.sh`
+- [X] T025 [P] Run `./scripts/install.sh --list` and visually confirm all ~81 components appear, correctly grouped, with no shell errors
+- [X] T026 Reconcile `README.md`'s installer section (PR #96's rewrite) with any current-main content it doesn't yet account for (e.g. mentions of newly-backfilled components in the Quick Start narrative, if warranted)
+- [X] T027 Push the completed branch to the contributor's fork: `git push git@github.com:calcuttin/netclaw.git pr-96-review:feat/installer-tui-refactor` (confirmed viable — `maintainerCanModify: true`)
+- [X] T028 Post a comment on PR #96 explaining what changed (conflict resolution + 9 coverage-gap backfills + chrome-devtools retrofit + constitution amendment) and crediting the contributor's original work, per the conversation with the operator
+- [X] T029 Confirm via `gh pr view 96` that `mergeable` now reports `MERGEABLE`, not `CONFLICTING`
 
 ---
 
@@ -164,3 +164,9 @@ User Story 1 is the MVP — it's the one that turns "a great PR that would silen
 - This is a merge-and-extend effort on top of a community contribution, not new application code — no new runtime dependency is introduced beyond what PR #96 and spec 048 already established
 - The coverage-check script (T003) is itself a durable project asset — it should keep working after this feature ships, catching the next contributor's version of this same drift
 - Every new catalog entry and install function must match `contracts/catalog-entry-format.md` exactly, since the whole point of this exercise is that the merged installer reads as one coherent system, not "PR #96's style" plus "NetClaw's bolted-on style"
+
+## Completion Record
+
+All 29 tasks completed 2026-07-08. The actual `scripts/lib/catalog.sh` / `scripts/lib/install-steps.sh` / `scripts/verify-catalog-coverage.py` / constitution changes were implemented directly on a local copy of PR #96's branch (`refs/pull/96/head`) and pushed to `calcuttin:feat/installer-tui-refactor` to preserve contributor attribution — see PR #96 for that diff and its own commit history. PR #96 went from `mergeStateStatus: DIRTY` / `mergeable: CONFLICTING` to `CLEAN` / `MERGEABLE` as a direct result. An explanatory comment was posted on PR #96 crediting the original contribution. This branch's job was the spec/plan/tasks record of that work, not the implementation itself.
+
+One unrelated, pre-existing bug was found and fixed along the way (separate commit on `main`, `dc5e411`): `.gitignore`'s `mcp-servers/*` rule had no exception for `atlassian-mcp/` or `chrome-devtools-mcp/`, so both directories' READMEs were silently never committed despite being referenced throughout the docs. Restored.

--- a/specs/049-merge-modular-installer/tasks.md
+++ b/specs/049-merge-modular-installer/tasks.md
@@ -1,0 +1,166 @@
+# Tasks: Merge Modular TUI Installer with Full Component-Coverage Parity
+
+**Input**: Design documents from `/specs/049-merge-modular-installer/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/catalog-entry-format.md, quickstart.md
+
+**Tests**: Not explicitly requested beyond `bash -n` syntax checks (matches PR #96's own stated test plan) and the coverage-check script itself, which functions as the acceptance test for User Story 1.
+
+**Organization**: Work happens directly on `pr-96-review` (local branch tracking PR #96's `refs/pull/96/head`), not a fresh reimplementation. Tasks are grouped by user story per spec.md's priorities.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Get PR #96's branch conflict-free against current main before any new content is added
+
+- [ ] T001 On `pr-96-review`, merge current `main` into the branch; resolve the `scripts/install.sh` and `README.md` conflicts by taking PR #96's version of both wholesale (a clean file replacement, not a line-by-line merge — see research.md R1)
+- [ ] T002 [P] Run `bash -n` on `scripts/install.sh` and every file under `scripts/lib/` post-merge to confirm the baseline (before any new entries) is syntactically valid
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The coverage-check tool that both validates the backfill work (US1) and prevents this exact drift from recurring (FR-008)
+
+**CRITICAL**: No user story work can be marked done until this phase's script exists and runs (even reporting known gaps) — it's the acceptance mechanism for US1
+
+- [ ] T003 Create `scripts/verify-catalog-coverage.py`: enumerate `config/openclaw.json`'s `mcpServers` keys, enumerate `scripts/lib/catalog.sh`'s catalog ids, apply the `GROUPED_COVERAGE` allow-list (per contracts/catalog-entry-format.md) for existing intentional groupings (`checkpoint` → 15 `chkp-*` servers, `aws` → its 6 servers, `gcp` → its 4, `aap` → its 4), report any registered server not reachable via a direct or grouped match as a gap, and exit non-zero if any gap is unexplained
+- [ ] T004 [P] Run `scripts/verify-catalog-coverage.py` against the post-merge, pre-backfill state and confirm it correctly reports the 9 known gaps from research.md R2 (proves the script itself works before it's used to prove the backfill worked)
+
+**Checkpoint**: Coverage-check tool exists and correctly identifies the known gaps. Backfill work (US1) can now proceed and be verified.
+
+---
+
+## Phase 3: User Story 1 — No Regression: Every Installable Capability Survives the Merge (Priority: P1) 🎯 MVP
+
+**Goal**: Close all 9 confirmed catalog gaps so the merged installer has zero regression versus current main.
+
+**Independent Test**: `scripts/verify-catalog-coverage.py` exits 0 with no unexplained gaps.
+
+### Implementation for User Story 1
+
+- [ ] T005 [P] [US1] Add `gns3` catalog entry to `scripts/lib/catalog.sh` (category: Labs & Simulation) and `component_install_gns3()` to `scripts/lib/install-steps.sh`, per contracts/catalog-entry-format.md
+- [ ] T006 [P] [US1] Add `devnet-search` catalog entry (category: ITSM & DevOps or Analysis & Diagrams, whichever existing category fits DevNet Content Search's remote-HTTP no-auth nature) and `component_install_devnet_search()`
+- [ ] T007 [P] [US1] Add `memory-mcp` catalog entry (category: Platform Services, alongside `mempalace`) and `component_install_memory_mcp()`, clearly distinguishing its description from `mempalace`'s
+- [ ] T008 [P] [US1] Add `ollama` catalog entry (category: Platform Services) and `component_install_ollama()`
+- [ ] T009 [P] [US1] Add `telemetry-receivers` catalog entry (category: Observability) covering SNMP trap, syslog, and IPFIX/NetFlow together, and `component_install_telemetry_receivers()` registering all three (`snmptrap-mcp`, `syslog-mcp`, `ipfix-mcp`)
+- [ ] T010 [P] [US1] Add `nautobot-golden-config` catalog entry (category: Source of Truth) and `component_install_nautobot_golden_config()`
+- [ ] T011 [P] [US1] Add `nautobot-routing` catalog entry (category: Source of Truth) and `component_install_nautobot_routing()`
+- [ ] T012 [P] [US1] Expand catalog coverage for base Twilio: either broaden the existing `twilio` entry's description/install function to also register `twilio-mcp` alongside `twilio-voice-mcp`, or add a distinct `twilio-core` entry — whichever keeps the description accurate; update `component_install_twilio()` accordingly
+- [ ] T013 [P] [US1] Add `threejs-viz` catalog entry (category: Analysis & Diagrams, alongside `blender`/`ue5`) and `component_install_threejs_viz()` covering `threejs-network-viz` plus the optional vendored `sketchfab-mcp` real-stencil mode
+- [ ] T014 [US1] Update `GROUPED_COVERAGE` in `scripts/verify-catalog-coverage.py` for any of T005-T013 that cover more than one registered server (at minimum `telemetry-receivers` and the Twilio entry from T012)
+- [ ] T015 [US1] Run `scripts/verify-catalog-coverage.py` and confirm zero unexplained gaps remain for every registered server that existed prior to spec 048 (chrome-devtools itself is still an expected, separate gap at this point — closed in Phase 4)
+
+**Checkpoint**: Every pre-048 capability on main is installable through the new installer. This alone is mergeable as a non-regressive improvement over PR #96's original submission.
+
+---
+
+## Phase 4: User Story 2 — Chrome DevTools Is a First-Class Component (Priority: P2)
+
+**Goal**: Add spec 048's chrome-devtools-mcp integration as a proper catalog entry + install function, replacing the deleted monolithic Step 52b.
+
+**Independent Test**: Selecting the Chrome DevTools component through the new installer (TUI or `--components chrome-devtools`) results in both MCP registrations configured with a working, explicit browser-binary reference, no sudo required, no credential requested.
+
+### Implementation for User Story 2
+
+- [ ] T016 [US2] Add `chrome-devtools` catalog entry to `scripts/lib/catalog.sh` (category: Analysis & Diagrams, per research.md R4 — one entry covering both registrations) per contracts/catalog-entry-format.md
+- [ ] T017 [US2] Write `component_install_chrome_devtools()` in `scripts/lib/install-steps.sh`, self-contained (per research.md R5 — inline, not delegating to `scripts/chrome-devtools-enable.sh`): find a system Chrome/Chromium binary or provision one via `npx @puppeteer/browsers install chrome@stable`, then register both `chrome-devtools-mcp` (`--headless=true`) and `chrome-devtools-mcp-visible` (`--headless=false`) with the resolved `--executablePath`
+- [ ] T018 [US2] Add `chrome-devtools` to the `recommended` profile in `scripts/lib/catalog.sh` (it now underpins visualization-QA workflows already represented in that profile)
+- [ ] T019 [US2] Update `GROUPED_COVERAGE` in `scripts/verify-catalog-coverage.py`: `"chrome-devtools": ["chrome-devtools-mcp", "chrome-devtools-mcp-visible"]`
+- [ ] T020 [US2] Update `mcp-servers/chrome-devtools-mcp/README.md`, `quickstart.md` (spec 048), and both `SKILL.md` files with a short note that the component is now also installable via `./scripts/install.sh --components chrome-devtools` (in addition to the standalone `scripts/chrome-devtools-enable.sh`, which remains supported per research.md R5)
+- [ ] T021 [US2] Run `scripts/verify-catalog-coverage.py` and confirm zero unexplained gaps remain for chrome-devtools-mcp and chrome-devtools-mcp-visible
+
+**Checkpoint**: Chrome DevTools is fully represented in the new installer with no behavior regression from spec 048's validated design.
+
+---
+
+## Phase 5: User Story 3 — The Constitution Reflects Reality (Priority: P3)
+
+**Goal**: Amend Constitution Principle XI so future contributors know the real artifact-coherence touchpoint for installer support.
+
+**Independent Test**: A person unfamiliar with the installer's history reads the amended constitution and correctly identifies `scripts/lib/catalog.sh` and `scripts/lib/install-steps.sh` (not `scripts/install.sh` directly) as the files to touch.
+
+### Implementation for User Story 3
+
+- [ ] T022 [US3] In `.specify/memory/constitution.md`, update Principle XI's body text and the Artifact Coherence Checklist line that currently reads `scripts/install.sh — installation steps for new dependencies` to instead describe adding a `CatalogEntry` to `scripts/lib/catalog.sh` and a `component_install_<id>()` function to `scripts/lib/install-steps.sh`, and note that `scripts/verify-catalog-coverage.py` is how compliance is verified
+- [ ] T023 [US3] Add a Sync Impact Report comment block at the top of `.specify/memory/constitution.md` (matching the existing 1.0.0→1.1.0 style) documenting this amendment, and bump the version per its MINOR-bump rule (clarifying/extending existing principle text, not redefining a principle)
+
+**Checkpoint**: Constitution accurately describes the merged installer's real structure.
+
+---
+
+## Phase 6: Polish & Merge
+
+**Purpose**: Final validation and landing the work under the contributor's own PR
+
+- [ ] T024 [P] Run `bash -n` on every modified/added file: `scripts/install.sh`, all of `scripts/lib/*.sh`, `scripts/chrome-devtools-enable.sh`, `scripts/setup.sh`
+- [ ] T025 [P] Run `./scripts/install.sh --list` and visually confirm all ~81 components appear, correctly grouped, with no shell errors
+- [ ] T026 Reconcile `README.md`'s installer section (PR #96's rewrite) with any current-main content it doesn't yet account for (e.g. mentions of newly-backfilled components in the Quick Start narrative, if warranted)
+- [ ] T027 Push the completed branch to the contributor's fork: `git push git@github.com:calcuttin/netclaw.git pr-96-review:feat/installer-tui-refactor` (confirmed viable — `maintainerCanModify: true`)
+- [ ] T028 Post a comment on PR #96 explaining what changed (conflict resolution + 9 coverage-gap backfills + chrome-devtools retrofit + constitution amendment) and crediting the contributor's original work, per the conversation with the operator
+- [ ] T029 Confirm via `gh pr view 96` that `mergeable` now reports `MERGEABLE`, not `CONFLICTING`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — must complete first (nothing else can be verified against a still-conflicting branch)
+- **Foundational (Phase 2)**: Depends on Setup — BLOCKS all user stories (US1's acceptance test doesn't exist without it)
+- **User Stories (Phases 3-5)**: All depend on Foundational
+  - US1 (Phase 3): No dependencies on US2/US3 — MVP target
+  - US2 (Phase 4): Independent of US1's specific entries, but conventionally done after US1 closes the bulk of the gap list
+  - US3 (Phase 5): Fully independent of US1/US2 — could be done in parallel by a different contributor
+- **Polish (Phase 6)**: Depends on all three user stories being complete (the push in T027 should carry the whole, complete result)
+
+### Within Each User Story
+
+- Each catalog-entry-plus-install-function pair (T005-T013, T016-T017) is a self-contained unit — implement, then move to the next
+- Coverage-check re-runs (T015, T021) happen after their story's entries are all in place, not after each individual one
+
+### Parallel Opportunities
+
+- T005 through T013 (all nine US1 backfill entries) touch the same two files (`catalog.sh`, `install-steps.sh`) but are logically independent — implement sequentially within one working session to avoid edit conflicts on the same files, even though they're marked [P] for conceptual independence
+- T022 and T023 (US3) can proceed in parallel with Phase 3/4 work, since the constitution file is untouched by either
+- T024 and T025 (Phase 6) can run in parallel — different concerns, no shared state
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001-T002)
+2. Complete Phase 2: Foundational (T003-T004)
+3. Complete Phase 3: User Story 1 (T005-T015)
+4. **STOP and VALIDATE**: `scripts/verify-catalog-coverage.py` reports zero gaps for everything that predates spec 048
+5. This alone is already a strictly better, mergeable state than PR #96's original submission — it fixes the regression risk even before chrome-devtools or the constitution are touched
+
+### Incremental Delivery
+
+1. Setup + Foundational → coverage tool exists, ready to measure progress
+2. Add US1 (9-gap backfill) → verify → no-regression baseline established
+3. Add US2 (chrome-devtools retrofit) → verify → spec 048 fully represented in the new installer
+4. Add US3 (constitution amendment) → future contributors have accurate guidance
+5. Phase 6 (Polish + Push) → PR #96 becomes mergeable, contributor gets full credit
+
+### Suggested MVP Scope
+
+User Story 1 is the MVP — it's the one that turns "a great PR that would silently regress the installer" into "a great PR that's actually safe to merge." US2 and US3 are important but the project would not be worse off shipping US1 alone first if time were constrained.
+
+---
+
+## Notes
+
+- [P] tasks = different files, or independent conceptual units within the same two files (see Parallel Opportunities caveat above)
+- [Story] label maps task to specific user story for traceability
+- This is a merge-and-extend effort on top of a community contribution, not new application code — no new runtime dependency is introduced beyond what PR #96 and spec 048 already established
+- The coverage-check script (T003) is itself a durable project asset — it should keep working after this feature ships, catching the next contributor's version of this same drift
+- Every new catalog entry and install function must match `contracts/catalog-entry-format.md` exactly, since the whole point of this exercise is that the merged installer reads as one coherent system, not "PR #96's style" plus "NetClaw's bolted-on style"


### PR DESCRIPTION
## Summary
- Documents the SDD process behind completing community PR #96 (modular TUI installer): resolving its merge conflict with `main`, backfilling 9 confirmed component-catalog gaps, retrofitting spec 048's Chrome DevTools integration, adding a repeatable coverage-check script, and amending Constitution Principle XI.
- The actual implementation lives in **PR #96** (pushed to `calcuttin:feat/installer-tui-refactor` to preserve contributor attribution) — this PR is the spec/plan/tasks record of why and how, not the diff itself.
- One unrelated bug found and already fixed on `main` directly (commit `dc5e411`): a `.gitignore` gap silently excluding `mcp-servers/atlassian-mcp/README.md` and `mcp-servers/chrome-devtools-mcp/README.md` from ever being committed.

## Test plan
- [x] Spec/plan/tasks/checklists generated via the Speckit workflow — checklist passes 16/16
- [x] `scripts/verify-catalog-coverage.py` (new, built as part of this effort) reports zero unexplained gaps across all 81 installer components
- [x] `bash -n` passes on every modified/added installer script
- [x] Live end-to-end test: selected the Chrome DevTools component through the real installer — no sudo, no credential prompt, live gateway stayed healthy
- [x] PR #96 confirmed `mergeable: MERGEABLE` / `mergeStateStatus: CLEAN` after the push (was `CONFLICTING` / `DIRTY`)
- [x] Constitution amended (1.1.0 → 1.2.0) with a proper Sync Impact Report

🤖 Generated with [Claude Code](https://claude.com/claude-code)