### PR TITLE
fix(052): N2N follow-ups — precise secret guard, late-consent pull, MCP servers advertised by default

### DIFF
--- a/mcp-servers/protocol-mcp/bgp/federation/inventory.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/inventory.py
@@ -100,8 +100,12 @@ class InventoryBuilder:
             "SELECT visibility, peer_list FROM visibility_setting WHERE item_type=? AND item_name=?",
             (item_type, item_name)).fetchone()
         if row is None:
-            # Defaults (data-model.md): skills advertised, MCP servers hidden
-            return item_type == "skill"
+            # Default: advertise both skills and MCP servers to federated peers.
+            # Inventories carry only names/descriptions/tool-names — never
+            # credentials or secrets (FR-007 guard still applies) — so peers see
+            # each other's full capability surface by default. Operators can hide
+            # specific skills or servers with n2n_set_visibility.
+            return True
         vis = row["visibility"]
         if vis == "hidden":
             return False

--- a/specs/052-n2n-federation/data-model.md
+++ b/specs/052-n2n-federation/data-model.md
@@ -72,7 +72,7 @@ Active federation requires one unrevoked row in each direction.
 |---|---|---|
 | item_type | TEXT | `skill` \| `mcp_server` |
 | item_name | TEXT | |
-| visibility | TEXT | `all_federated` \| `selected_peers` \| `hidden` (default: `hidden` for MCP servers, `all_federated` for skill names — FR-006) |
+| visibility | TEXT | `all_federated` \| `selected_peers` \| `hidden` (default: `all_federated` for both skills and MCP servers — FR-006; operators hide specific items explicitly) |
 | peer_list | TEXT NULL | JSON array when `selected_peers` |
 
 ## Entity: InvocationGrant

--- a/tests/n2n/test_inventory.py
+++ b/tests/n2n/test_inventory.py
@@ -41,13 +41,15 @@ def test_build_includes_skills_and_badges(manager, tmp_path):
     inv = b.build("as65007-7.7.7.7")
     skill_names = {s["name"] for s in inv["skills"]}
     assert "cml-lab-lifecycle" in skill_names          # skills advertised by default
-    assert inv["mcp_servers"] == []                    # MCP servers hidden by default
-    # Skills carry no badges (badges derive from advertised servers); make a server visible:
-    manager._conn.execute("INSERT INTO visibility_setting VALUES ('mcp_server','cml-mcp','all_federated',NULL)")
+    # MCP servers advertised by default now — cml-mcp present, CML badge derived
+    assert any(s["name"] == "cml-mcp" for s in inv["mcp_servers"])
+    assert "CML" in inv["badges"]
+    # Hiding a server removes it (and its badge) from the payload
+    manager._conn.execute("INSERT INTO visibility_setting VALUES ('mcp_server','cml-mcp','hidden',NULL)")
     manager._conn.commit()
     inv2 = b.build("as65007-7.7.7.7")
-    assert any(s["name"] == "cml-mcp" for s in inv2["mcp_servers"])
-    assert "CML" in inv2["badges"]
+    assert not any(s["name"] == "cml-mcp" for s in inv2["mcp_servers"])
+    assert "CML" not in inv2["badges"]
 
 
 def test_hidden_item_absent_from_payload(manager, tmp_path):

--- a/workspace/skills/n2n-federation/SKILL.md
+++ b/workspace/skills/n2n-federation/SKILL.md
@@ -48,7 +48,7 @@ Both operators must consent before ANY capability information flows.
 - `n2n_set_visibility(item_type="mcp_server", item_name="cml-mcp", visibility="all_federated")`
   to advertise a server; `visibility="hidden"` removes it from the advertised
   inventory entirely; `visibility="selected_peers"` with `peers="as65007-7.7.7.7"`
-  limits it. Defaults: skills advertised, MCP servers hidden.
+  limits it. Defaults: both skills and MCP servers advertised to federated peers (names/tool-names only, never secrets); hide specific items with visibility=hidden.
 
 ### 4. Sever (kill switch)
 


### PR DESCRIPTION
Follow-up fixes to #102 (N2N Federation), found while bringing up the live three-claw mesh (John/Nick/Byrn).

## What & why

1. **Precise no-secrets guard** — the guard scanned *every* `.env` value ≥8 chars as a secret, so a benign value (hostname, path, URL, feature flag) colliding with legitimate inventory text aborted the whole advertisement. This silently blocked Byrn's inventory from ever exchanging while Nick's (no collision) worked. Now only values of secret-named keys (`PASSWORD`/`SECRET`/`TOKEN`/`KEY`/`AUTH`/…) are scanned — real credentials still caught, false positives gone.

2. **Late-consent inventory recovery** — consenting *after* the NCFED channel already opened didn't trigger inventory exchange (the one-shot advertise-on-federate had already passed). Added on-consent re-advertise, a `FederationService.refresh_from()` PULL, and a `POST /n2n/peers/<id>/refresh` route so a claw can actively fetch a federated peer's inventory instead of only waiting for a push.

3. **MCP servers advertised by default** — previously hidden-by-default, so peers saw each other's skills but not MCP servers/tools or capability badges (which derive from advertised servers). Flipped to advertise both by default; still names/tool-names only, never secrets; operators hide specific items with `n2n_set_visibility`.

## Tests
22 passing (`tests/n2n/`), including the updated inventory visibility test.

## Live validation
On the running mesh: Nick federated with 190 skills exchanged; the pull route recovered inventory after a raced push; the secret-guard fix unblocks Byrn once he pulls this branch and restarts his daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)