### PR TITLE
fix(052): gateway agent uses --session-id (cross-version); HUD status…

### DIFF
--- a/mcp-servers/protocol-mcp/bgp/federation/gateway.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/gateway.py
@@ -67,8 +67,11 @@ async def run_agent_turn(prompt: str, session_key: str = "n2n", timeout_s: int =
     Raises TimeoutError on timeout; on non-zero exit returns the stderr tail as
     the reply so the caller can surface a useful message rather than crashing.
     """
+    # Use --session-id (supported across OpenClaw CLI versions). Older/newer
+    # builds diverge on --session-key vs --session-id; --session-id is the
+    # common one (a peer on a build without --session-key errored otherwise).
     cmd = ["openclaw", "agent", "--agent", AGENT_ID,
-           "--session-key", session_key, "--json", "-m", prompt]
+           "--session-id", session_key, "--json", "-m", prompt]
     proc = await asyncio.create_subprocess_exec(
         *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT)
     try:

--- a/ui/netclaw-visual/server.js
+++ b/ui/netclaw-visual/server.js
@@ -948,7 +948,10 @@ app.post('/api/n2n/chat', async (req, res) => {
 app.get('/api/gateway/status', async (req, res) => {
   const gw = getGatewayConfig();
   try {
+    // The gateway's /v1 API requires the bearer token — without it we get 401
+    // and the HUD falsely shows "offline". Send the token like the chat call does.
     const health = await fetch(`http://127.0.0.1:${gw.port}/v1/models`, {
+      headers: gw.token ? { 'Authorization': `Bearer ${gw.token}` } : {},
       signal: AbortSignal.timeout(2000),
     });
     res.json({ online: health.ok, port: gw.port });


### PR DESCRIPTION
… sends auth token

- gateway.py: --session-key isn't in all OpenClaw CLI versions (a federated peer errored "unknown option --session-key, did you mean --session-id?"). Switch to --session-id, which both builds accept. This was the last blocker on the N2N chat/skill responder path — the request now reaches the peer, runs its agent turn, and replies.
- HUD /api/gateway/status: send the bearer token (the /v1 API requires auth); without it the probe got 401 and the HUD falsely showed "NetClaw terminal: offline" even though the gateway was up.