### PR TITLE
fix(052): clean N2N replies — parse finalAssistantVisibleText across OpenClaw builds

### DIFF
--- a/mcp-servers/protocol-mcp/bgp/federation/gateway.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/gateway.py
@@ -36,15 +36,35 @@ def _extract_reply(stdout: str):
         # No JSON — return raw trailing text so the caller still gets something.
         return stdout.strip()[-2000:], 0
 
-    # Reply text: result.payloads[*].text (concatenated)
-    texts = []
+    # Reply text. OpenClaw builds differ: some put the clean answer in
+    # finalAssistantVisibleText, others in result.payloads[*].text. Prefer the
+    # visible-text field (recursively, since nesting varies), then fall back.
+    def _find(o, keys):
+        if isinstance(o, dict):
+            for k in keys:
+                v = o.get(k)
+                if isinstance(v, str) and v.strip():
+                    return v
+            for v in o.values():
+                r = _find(v, keys)
+                if r:
+                    return r
+        elif isinstance(o, list):
+            for v in o:
+                r = _find(v, keys)
+                if r:
+                    return r
+        return None
+
+    reply = _find(obj, ("finalAssistantVisibleText", "finalAssistantRawText"))
     result = obj.get("result", obj)
-    for p in (result.get("payloads") or []):
-        if isinstance(p, dict) and isinstance(p.get("text"), str):
-            texts.append(p["text"])
-    reply = "\n".join(t for t in texts if t.strip())
     if not reply:
-        # Fallbacks across possible shapes
+        # result.payloads[*].text (concatenated), skipping obvious tool-schema dumps
+        texts = [p["text"] for p in (result.get("payloads") or [])
+                 if isinstance(p, dict) and isinstance(p.get("text"), str)
+                 and '"schemaHash"' not in p["text"]]
+        reply = "\n".join(t for t in texts if t.strip())
+    if not reply:
         for key in ("reply", "text", "message", "output", "response"):
             v = result.get(key)
             if isinstance(v, str) and v.strip():


### PR DESCRIPTION
Follow-up to the merged N2N fixes. One commit that landed after the last merge.

## What
Federated chat/skill replies came back wrapped in the responder's full agent-run envelope (tool-call summaries, provider/model, schema hashes, run IDs) instead of just the answer — because different OpenClaw builds put the clean answer in different places:
- some builds → `result.payloads[*].text`
- others (e.g. gpt-5.5/openai, embedded runner — Nick's build) → `finalAssistantVisibleText`, with `payloads` carrying tool-schema dumps

`gateway.py::_extract_reply` now prefers `finalAssistantVisibleText`/`finalAssistantRawText` (searched recursively, since nesting varies), and skips `schemaHash` dumps in the `payloads` fallback.

## Verified
Live: John's claw pulled Nick's CML lab list over N2N (`NetClaw OSPF 2R`, 2 nodes, started). Unit-checked `_extract_reply` against Nick's gpt-5.5 envelope shape — extracts the clean answer, drops the trace.

## Peer action to get clean replies
This runs on the **responder** side, so a peer's replies come back clean once **that peer** pulls latest `052-n2n-fixes`/`main` and restarts their mesh daemon. The federation and data already work regardless (the answer arrives, just verbose, until they refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)