### PR TITLE
fix(052): n2n-mcp client timeout 120s→610s so federated replies reach the agent

### DIFF
--- a/mcp-servers/n2n-mcp/server.py
+++ b/mcp-servers/n2n-mcp/server.py
@@ -47,7 +47,12 @@ async def _get(path: str, params: Optional[dict] = None) -> dict:
 
 
 async def _post(path: str, body: Optional[dict] = None) -> dict:
-    async with httpx.AsyncClient(base_url=BGP_DAEMON_API, timeout=120) as c:
+    # Must outlast the daemon's own operation timeouts (chat 300s / skill 600s)
+    # so the client never gives up before the daemon returns a definitive result.
+    # A 120s client timeout was dropping federated chat/skill replies before they
+    # arrived — e.g. a peer's Nautobot/CML answer never reached the Slack agent.
+    # (Credit: Nick spotted the 120s<300s mismatch.)
+    async with httpx.AsyncClient(base_url=BGP_DAEMON_API, timeout=610) as c:
         r = await c.post(path, json=body or {})
         return r.json()
 


### PR DESCRIPTION
Final outstanding N2N runtime fix — the only commit on 052-n2n-fixes not yet in main.

## What
The n2n-mcp client's `_post` timed out at 120s, but the daemon's federated operations run to 300s (chat) / 600s (skill invoke). So a peer's answer (e.g. Byrn's Nautobot query) completed on the daemon but never reached the Slack/gateway agent, which had already given up. The client now waits 610s — always outlasting the daemon's own operation timeouts — so completed results are delivered instead of dropped. (Credit: Nick identified the 120s<300s mismatch live.)

Merging this keeps `main` current so feature branches (e.g. 053) don't silently revert the runtime timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)