### PR TITLE
feat(052): negotiate model + suggested timeout in n2n/hello handshake

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,6 +130,8 @@ NETCLAW_ENABLE_PASSWORD=changeme
 # N2N_TOOL_TIMEOUT_S=120                        # Remote tool invocation timeout (seconds)
 # N2N_SKILL_TIMEOUT_S=600                       # Delegated skill task timeout (seconds)
 # N2N_CHAT_IDLE_TIMEOUT_S=300                   # Chat session idle close (seconds)
+# N2N_MODEL=                                    # Model advertised in n2n/hello (default: NETCLAW_MODEL). Lets peers see what runs your claw.
+# N2N_SUGGESTED_TIMEOUT_S=                      # Timeout (seconds) peers should use when waiting on YOUR replies. Set high if your model is slow (e.g. Ollama Cloud). Default: N2N_CHAT_IDLE_TIMEOUT_S or 300. Peers honor it up to a 900s ceiling.
 
 # ContainerLab (containerized network labs via API)
 # CLAB_API_SERVER_URL=http://localhost:8080     # ContainerLab API server URL

--- a/mcp-servers/protocol-mcp/bgp-daemon-v2.py
+++ b/mcp-servers/protocol-mcp/bgp-daemon-v2.py
@@ -204,11 +204,16 @@ async def handle_n2n(method, path, body):
                 peers.append({
                     "identity": p["identity"], "display_name": p["display_name"],
                     "state": p["state"], "chat_enabled": bool(p["chat_enabled"]),
+                    "model": p.get("peer_model"),
+                    "suggested_timeout_s": p.get("peer_suggested_timeout_s"),
                     "inventory_version": (meta or {}).get("inventory", {}).get("version") if meta else None,
                     "inventory_received_at": (meta or {}).get("received_at") if meta else None,
                     "stale": (meta or {}).get("stale") if meta else None,
                 })
-            return 200, {"enabled": True, "identity": fed.local_identity, "peers": peers}
+            from bgp.federation.service import local_model, local_suggested_timeout_s
+            return 200, {"enabled": True, "identity": fed.local_identity,
+                         "model": local_model(), "suggested_timeout_s": local_suggested_timeout_s(),
+                         "peers": peers}
 
         if method == "POST" and path == "/n2n/consent":
             peer_as = body.get("as"); router_id = body.get("router_id")

--- a/mcp-servers/protocol-mcp/bgp/federation/chat.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/chat.py
@@ -77,6 +77,21 @@ class ChatManager:
 
     # ---- outbound: OUR operator chats with the PEER's agent -----------
 
+    def _peer_wait_timeout(self, ident: str) -> int:
+        """How long to wait for a peer's chat reply. Honor the timeout the peer
+        advertised in n2n/hello (its model may be slow), capped to a ceiling so
+        a bad value can't block us forever. Falls back to our local default."""
+        from .service import MAX_HONORED_TIMEOUT_S
+        default = int(os.environ.get("N2N_CHAT_IDLE_TIMEOUT_S", "300"))
+        row = self.manager.get_peer(ident)
+        advertised = row.get("peer_suggested_timeout_s") if row else None
+        if not advertised:
+            return default
+        try:
+            return max(default, min(int(advertised), MAX_HONORED_TIMEOUT_S))
+        except (TypeError, ValueError):
+            return default
+
     async def open_and_send(self, ident: str, text: str, session_id: str = None):
         ch = self.service.channels.get(ident)
         if not ch:
@@ -94,7 +109,7 @@ class ChatManager:
             self.manager._conn.commit()
         self._append(session_id, f"[{self.service.local_identity}] {text}")
         reply = await ch.call("n2n/chat/message", {"session_id": session_id, "text": text},
-                              timeout=int(os.environ.get("N2N_CHAT_IDLE_TIMEOUT_S", "300")))
+                              timeout=self._peer_wait_timeout(ident))
         self._append(session_id, f"[{ident}] {reply.get('text','')}")
         self._touch(session_id)
         self.audit.record(direction="outbound", peer_identity=ident, target_type="chat",

--- a/mcp-servers/protocol-mcp/bgp/federation/invocation.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/invocation.py
@@ -255,6 +255,20 @@ class Invoker:
                                timeout=self.tool_timeout + 5)
         return {"source": ident, "trust": "remote-untrusted", "result": result}
 
+    def _peer_skill_timeout(self, ident) -> int:
+        """Wait budget for a remote skill run. A delegated skill executes on the
+        peer's model, so honor the timeout it advertised in n2n/hello (capped),
+        falling back to our local skill timeout."""
+        from .service import MAX_HONORED_TIMEOUT_S
+        row = self.service.manager.get_peer(ident)
+        advertised = row.get("peer_suggested_timeout_s") if row else None
+        if advertised:
+            try:
+                return max(self.skill_timeout, min(int(advertised), MAX_HONORED_TIMEOUT_S))
+            except (TypeError, ValueError):
+                pass
+        return self.skill_timeout
+
     async def invoke_remote_skill(self, ident, skill, input_text):
         ch = self.service.channels.get(ident)
         if not ch:
@@ -264,5 +278,5 @@ class Invoker:
                           target_name=skill, request_id=req_id, decision="requested", outcome="pending")
         result = await ch.call("n2n/tasks/submit",
                                {"skill": skill, "input_text": input_text, "request_id": req_id},
-                               timeout=self.skill_timeout + 5)
+                               timeout=self._peer_skill_timeout(ident) + 5)
         return {"source": ident, "trust": "remote-untrusted", "result": result}

--- a/mcp-servers/protocol-mcp/bgp/federation/manager.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/manager.py
@@ -48,6 +48,8 @@ CREATE TABLE IF NOT EXISTS federation_peer (
     endpoint_port INTEGER,
     state         TEXT NOT NULL DEFAULT 'not_federated',
     chat_enabled  INTEGER NOT NULL DEFAULT 0,
+    peer_model    TEXT,
+    peer_suggested_timeout_s INTEGER,
     created_at    TEXT NOT NULL,
     updated_at    TEXT NOT NULL
 );
@@ -129,8 +131,24 @@ class FederationManager:
         self._conn = sqlite3.connect(self.db_path, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(SCHEMA)
+        self._migrate()
         self._conn.commit()
         logger.info("FederationManager ready (db=%s)", self.db_path)
+
+    def _migrate(self):
+        """Idempotent column additions for DBs created before a column existed.
+
+        SQLite has no 'ADD COLUMN IF NOT EXISTS', so probe PRAGMA table_info
+        and add anything missing. Keeps pre-existing federation.db files working
+        without a manual drop (Constitution XV — backwards compatible)."""
+        cols = {r["name"] for r in self._conn.execute("PRAGMA table_info(federation_peer)")}
+        for col, ddl in (
+            ("peer_model", "ALTER TABLE federation_peer ADD COLUMN peer_model TEXT"),
+            ("peer_suggested_timeout_s",
+             "ALTER TABLE federation_peer ADD COLUMN peer_suggested_timeout_s INTEGER"),
+        ):
+            if col not in cols:
+                self._conn.execute(ddl)
 
     # ---- peer registry ------------------------------------------------
 
@@ -245,6 +263,31 @@ class FederationManager:
     def set_chat_enabled(self, ident: str, enabled: bool):
         self._conn.execute("UPDATE federation_peer SET chat_enabled=?, updated_at=? WHERE identity=?",
                            (1 if enabled else 0, _now(), ident))
+        self._conn.commit()
+
+    # ---- peer profile: advertised model + suggested wait timeout -------
+
+    def set_peer_profile(self, ident: str, model: Optional[str] = None,
+                         suggested_timeout_s: Optional[int] = None):
+        """Store what a peer advertised about itself in the n2n/hello exchange:
+        the model it runs and how long we should wait for its chat/skill replies
+        (a slow model on the far side asks us to be patient)."""
+        sets, vals = [], []
+        if model is not None:
+            sets.append("peer_model=?"); vals.append(str(model))
+        if suggested_timeout_s is not None:
+            try:
+                # Convert first — only record the column if the value is valid,
+                # so sets/vals never drift out of sync.
+                t = int(suggested_timeout_s)
+                sets.append("peer_suggested_timeout_s=?"); vals.append(t)
+            except (TypeError, ValueError):
+                pass
+        if not sets:
+            return
+        sets.append("updated_at=?"); vals.append(_now())
+        vals.append(ident)
+        self._conn.execute(f"UPDATE federation_peer SET {','.join(sets)} WHERE identity=?", vals)
         self._conn.commit()
 
     def close(self):

--- a/mcp-servers/protocol-mcp/bgp/federation/service.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/service.py
@@ -20,6 +20,32 @@ from .audit import Auditor
 logger = logging.getLogger("n2n.service")
 
 
+def local_model() -> str:
+    """The model this claw runs, advertised to peers in n2n/hello so they can
+    size their wait timeouts. Falls back through the common env vars."""
+    return (os.environ.get("N2N_MODEL")
+            or os.environ.get("NETCLAW_MODEL")
+            or os.environ.get("BEDROCK_MODEL_ID")
+            or "unknown")
+
+
+def local_suggested_timeout_s() -> int:
+    """How long a peer should wait for OUR chat/skill replies. A slow local
+    model (e.g. an Ollama Cloud model) advertises a larger value so the far
+    side doesn't give up mid-turn. Defaults to the chat idle timeout."""
+    try:
+        return int(os.environ.get("N2N_SUGGESTED_TIMEOUT_S")
+                   or os.environ.get("N2N_CHAT_IDLE_TIMEOUT_S")
+                   or "300")
+    except (TypeError, ValueError):
+        return 300
+
+
+# Upper bound applied to a peer-advertised timeout before we honor it, so a
+# misconfigured or hostile peer can't make us block indefinitely.
+MAX_HONORED_TIMEOUT_S = 900
+
+
 class FederationService:
     def __init__(self, *, local_as: int, router_id: str, display_name: str = "",
                  refresh_s: int = 21600, manager: Optional[FederationManager] = None):
@@ -73,10 +99,17 @@ class FederationService:
         channel.display_name = params.get("display_name")
         # Peer presence on the channel implies they consented to us.
         self.manager.remote_consent(channel.peer_as, channel.peer_router_id)
+        # Record the model + suggested wait timeout the peer advertised so our
+        # outbound chat/skill calls to them size their timeout correctly.
+        self.manager.set_peer_profile(channel.peer_identity,
+                                      model=params.get("model"),
+                                      suggested_timeout_s=params.get("suggested_timeout_s"))
         state = self.manager._recompute_state(channel.peer_identity)
         if state == PeerState.FEDERATED:
             asyncio.create_task(self._advertise_to(channel))
-        return {"identity": self.local_identity, "display_name": self.display_name, "version": "1.0"}
+        return {"identity": self.local_identity, "display_name": self.display_name,
+                "version": "1.0", "model": local_model(),
+                "suggested_timeout_s": local_suggested_timeout_s()}
 
     async def _on_consent_state(self, channel, params):
         return {"state": self.manager.get_peer(channel.peer_identity)["state"]}
@@ -198,8 +231,13 @@ class FederationService:
             self.channels[ident] = ch
             await ch.start()
             resp = await ch.call("n2n/hello", {"identity": self.local_identity,
-                                               "display_name": self.display_name, "versions": ["1.0"]})
+                                               "display_name": self.display_name, "versions": ["1.0"],
+                                               "model": local_model(),
+                                               "suggested_timeout_s": local_suggested_timeout_s()})
             ch.display_name = resp.get("display_name")
+            # Store the acceptor's advertised model + suggested wait timeout.
+            self.manager.set_peer_profile(ident, model=resp.get("model"),
+                                          suggested_timeout_s=resp.get("suggested_timeout_s"))
             self.manager.remote_consent(peer_as, router_id)
             if self.manager._recompute_state(ident) == PeerState.FEDERATED:
                 await self._advertise_to(ch)

--- a/specs/052-n2n-federation/contracts/n2n-wire-protocol.md
+++ b/specs/052-n2n-federation/contracts/n2n-wire-protocol.md
@@ -41,11 +41,20 @@ correlation (FR-015).
 
 | Method | Direction | Params | Result |
 |---|---|---|---|
-| `n2n/hello` | both, on channel open | `{identity, display_name, versions: ["1.0"]}` | `{identity, display_name, version: "1.0"}` |
+| `n2n/hello` | both, on channel open | `{identity, display_name, versions: ["1.0"], model?, suggested_timeout_s?}` | `{identity, display_name, version: "1.0", model?, suggested_timeout_s?}` |
 | `n2n/consent_state` | both | `{state}` | `{state}` — used to surface pending/severed transitions |
 | `n2n/sever` | either | `{}` | `{acked: true}` — kill switch notification; receiver marks peer severed and closes channel (FR-004) |
 
-### Capability exchange (A2A AgentCard-inspired)
+#### Model + timeout negotiation (in `n2n/hello`)
+
+Each side optionally advertises `model` (the LLM running its gateway agent) and
+`suggested_timeout_s` (how long the peer should wait for its chat/skill replies).
+A claw on a slow model (e.g. an Ollama Cloud model that takes 1–3 min/turn)
+advertises a larger `suggested_timeout_s` so the requesting side does not give
+up mid-turn. Receivers store the peer's values and use `suggested_timeout_s`
+(clamped to `[local_default, 900]`) as the wait on outbound `n2n/chat/message`
+and `n2n/tasks/submit`. Both fields are optional and backwards compatible — a
+peer that omits them (older build) falls back to local defaults.
 
 | Method | Direction | Params | Result |
 |---|---|---|---|

--- a/tests/n2n/test_model_timeout.py
+++ b/tests/n2n/test_model_timeout.py
@@ -1,0 +1,114 @@
+"""Model + suggested-timeout negotiation in the n2n/hello handshake.
+
+A claw advertises the model it runs and how long peers should wait for its
+replies. The requesting side stores those and sizes its outbound chat/skill
+timeout to the peer's advertised value (clamped), so a slow far-side model
+doesn't cause a premature client-side timeout.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+from bgp.federation.manager import FederationManager, peer_identity
+from bgp.federation import service as svc
+
+
+def _mgr():
+    return FederationManager(base_dir=tempfile.mkdtemp())
+
+
+def test_local_profile_from_env(monkeypatch):
+    monkeypatch.delenv("N2N_MODEL", raising=False)
+    monkeypatch.setenv("NETCLAW_MODEL", "glm-5.2:cloud")
+    monkeypatch.delenv("N2N_SUGGESTED_TIMEOUT_S", raising=False)
+    monkeypatch.delenv("N2N_CHAT_IDLE_TIMEOUT_S", raising=False)
+    assert svc.local_model() == "glm-5.2:cloud"
+    assert svc.local_suggested_timeout_s() == 300  # default
+
+    monkeypatch.setenv("N2N_MODEL", "claude-sonnet-4")
+    monkeypatch.setenv("N2N_SUGGESTED_TIMEOUT_S", "45")
+    assert svc.local_model() == "claude-sonnet-4"        # N2N_MODEL wins
+    assert svc.local_suggested_timeout_s() == 45
+
+
+def test_set_and_get_peer_profile():
+    m = _mgr()
+    m.upsert_peer(65001, "4.4.4.4", "John")
+    ident = peer_identity(65001, "4.4.4.4")
+    m.set_peer_profile(ident, model="qwen3:480b-cloud", suggested_timeout_s=200)
+    p = m.get_peer(ident)
+    assert p["peer_model"] == "qwen3:480b-cloud"
+    assert p["peer_suggested_timeout_s"] == 200
+
+
+def test_set_peer_profile_partial_and_bad_values():
+    m = _mgr()
+    m.upsert_peer(65007, "7.7.7.7")
+    ident = peer_identity(65007, "7.7.7.7")
+    # Only model, no timeout
+    m.set_peer_profile(ident, model="llama3")
+    assert m.get_peer(ident)["peer_model"] == "llama3"
+    assert m.get_peer(ident)["peer_suggested_timeout_s"] is None
+    # Bad timeout value is ignored, doesn't crash
+    m.set_peer_profile(ident, suggested_timeout_s="not-a-number")
+    assert m.get_peer(ident)["peer_suggested_timeout_s"] is None
+
+
+def test_migration_adds_columns_to_legacy_db():
+    """A federation.db created before these columns existed gets them added."""
+    import sqlite3
+    base = tempfile.mkdtemp()
+    db = os.path.join(base, "federation.db")
+    # Simulate a legacy table without the new columns
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE federation_peer (identity TEXT PRIMARY KEY, peer_as INTEGER, "
+        "router_id TEXT, display_name TEXT, endpoint_host TEXT, endpoint_port INTEGER, "
+        "state TEXT, chat_enabled INTEGER, created_at TEXT, updated_at TEXT)")
+    conn.execute(
+        "INSERT INTO federation_peer VALUES ('as65001-4.4.4.4',65001,'4.4.4.4','John',"
+        "NULL,NULL,'federated',1,'2026-01-01T00:00:00Z','2026-01-01T00:00:00Z')")
+    conn.commit()
+    conn.close()
+
+    # Opening via the manager should migrate in the missing columns
+    m = FederationManager(db_path=db, base_dir=base)
+    p = m.get_peer("as65001-4.4.4.4")
+    assert p is not None
+    assert p["peer_model"] is None
+    assert p["peer_suggested_timeout_s"] is None
+    # And the setter now works on the migrated row
+    m.set_peer_profile("as65001-4.4.4.4", model="claude", suggested_timeout_s=60)
+    assert m.get_peer("as65001-4.4.4.4")["peer_model"] == "claude"
+
+
+def test_chat_honors_peer_timeout_clamped(monkeypatch):
+    """ChatManager._peer_wait_timeout clamps the peer value to [default, 900]."""
+    from bgp.federation.chat import ChatManager
+
+    monkeypatch.setenv("N2N_CHAT_IDLE_TIMEOUT_S", "300")
+    m = _mgr()
+    ident = peer_identity(65001, "4.4.4.4")
+    m.upsert_peer(65001, "4.4.4.4", "John")
+
+    class _FakeService:
+        def __init__(self, manager):
+            self.manager = manager
+            self.authz = None
+            self.audit = None
+    cm = ChatManager.__new__(ChatManager)
+    cm.manager = m
+
+    # No advertised value -> local default
+    assert cm._peer_wait_timeout(ident) == 300
+    # Advertised below default -> raised to default (never wait less than ours)
+    m.set_peer_profile(ident, suggested_timeout_s=45)
+    assert cm._peer_wait_timeout(ident) == 300
+    # Advertised above default -> honored
+    m.set_peer_profile(ident, suggested_timeout_s=600)
+    assert cm._peer_wait_timeout(ident) == 600
+    # Advertised above the ceiling -> clamped to 900
+    m.set_peer_profile(ident, suggested_timeout_s=99999)
+    assert cm._peer_wait_timeout(ident) == 900


### PR DESCRIPTION
Federated claws now advertise the LLM they run and how long peers should wait for their chat/skill replies. A claw on a slow model (e.g. Ollama Cloud at 2-3 min/turn) advertises a larger suggested_timeout_s so the requesting side doesn't give up mid-turn — the root cause of 'chat-open timed out' reports when the responder is actually completing successfully.

- n2n/hello params + result gain optional model, suggested_timeout_s
- FederationManager: peer_model/peer_suggested_timeout_s columns with idempotent PRAGMA-probed migration for existing federation.db files
- open_channel + _on_hello store the peer's advertised profile both ways
- outbound chat (open_and_send) and skill (invoke_remote_skill) size their wait to the peer's suggested_timeout_s, clamped to [local_default, 900]
- /n2n/status surfaces local + per-peer model and suggested_timeout_s
- env: N2N_MODEL, N2N_SUGGESTED_TIMEOUT_S
- wire-protocol contract updated; 5 new tests (27 total pass)

Backwards compatible: peers omitting the fields (older builds) fall back to local defaults; the daemon behaves identically with N2N disabled.