### PR TITLE
feat(055): peering lifecycle + chat ergonomics for the netclaw command

### DIFF
--- a/scripts/lib/render_md.py
+++ b/scripts/lib/render_md.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Minimal, dependency-free markdown-to-ANSI renderer for the netclaw TUI.
+
+Handles just the subset that shows up in N2N chat replies: **bold**, `code`,
+#/## headings, "=== TITLE ===" section markers, --- rules, and pipe tables.
+Reads markdown-ish text on stdin, writes ANSI-formatted text to stdout.
+"""
+import re
+import sys
+
+BOLD = "\033[1m"
+DIM = "\033[2m"
+CYAN = "\033[38;5;45m"
+NC = "\033[0m"
+
+INLINE_BOLD = re.compile(r"\*\*(.+?)\*\*")
+INLINE_CODE = re.compile(r"`([^`]+)`")
+HEADING = re.compile(r"^(#{1,6})\s+(.*)$")
+SECTION = re.compile(r"^===+\s*(.*?)\s*===+$")
+RULE = re.compile(r"^[-_*]{3,}$")
+TABLE_ROW = re.compile(r"^\s*\|.*\|\s*$")
+SEP_CELL = re.compile(r"^:?-+:?$")
+
+
+def inline(text):
+    text = INLINE_BOLD.sub(lambda m: f"{BOLD}{m.group(1)}{NC}", text)
+    text = INLINE_CODE.sub(lambda m: f"{CYAN}{m.group(1)}{NC}", text)
+    return text
+
+
+def split_row(line):
+    line = line.strip()
+    if line.startswith("|"):
+        line = line[1:]
+    if line.endswith("|"):
+        line = line[:-1]
+    return [c.strip() for c in line.split("|")]
+
+
+def render_table(rows):
+    is_sep = lambda cells: cells and all(SEP_CELL.match(c or "-") for c in cells)
+    parsed = [split_row(r) for r in rows]
+    header = None
+    body = []
+    for cells in parsed:
+        if is_sep(cells):
+            continue
+        if header is None:
+            header = cells
+        else:
+            body.append(cells)
+    if header is None:
+        return "\n".join(rows)
+    ncols = len(header)
+    widths = [len(header[i]) if i < len(header) else 0 for i in range(ncols)]
+    for row in body:
+        for i in range(ncols):
+            cell = row[i] if i < len(row) else ""
+            widths[i] = max(widths[i], len(cell))
+    out = []
+
+    def fmt(cells, bold=False):
+        parts = []
+        for i in range(ncols):
+            cell = cells[i] if i < len(cells) else ""
+            pad = cell.ljust(widths[i])
+            parts.append(f"{BOLD}{pad}{NC}" if bold else pad)
+        return "  " + (f" {DIM}│{NC} ").join(parts)
+
+    out.append(fmt(header, bold=True))
+    out.append(f"  {DIM}" + "─┼─".join("─" * w for w in widths) + f"{NC}")
+    for row in body:
+        out.append(fmt(row))
+    return "\n".join(out)
+
+
+def render(text):
+    lines = text.splitlines()
+    out = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        m = SECTION.match(line.strip())
+        if m:
+            out.append(f"{BOLD}{CYAN}{line.strip()}{NC}")
+            i += 1
+            continue
+        m = HEADING.match(line)
+        if m:
+            out.append(f"{BOLD}{CYAN}{m.group(2)}{NC}")
+            i += 1
+            continue
+        if RULE.match(line.strip()):
+            out.append(f"{DIM}{'─' * 60}{NC}")
+            i += 1
+            continue
+        if TABLE_ROW.match(line):
+            block = []
+            while i < len(lines) and TABLE_ROW.match(lines[i]):
+                block.append(lines[i])
+                i += 1
+            out.append(render_table(block))
+            continue
+        out.append(inline(line))
+        i += 1
+    return "\n".join(out)
+
+
+if __name__ == "__main__":
+    sys.stdout.write(render(sys.stdin.read()))

--- a/scripts/netclaw
+++ b/scripts/netclaw
@@ -4,14 +4,21 @@
 #   netclaw                 interactive menu (TUI launcher, installer, peering)
 #   netclaw tui             open the NetClaw chat TUI (openclaw tui)
 #   netclaw install [...]   run the component installer (flags pass through)
-#   netclaw peering [status|bgp|n2n|ngrok]   protocol peering status (non-interactive)
-#   netclaw chats [id]      list N2N chat sessions, or tail one
+#   netclaw peering [status|bgp|n2n|ngrok]    protocol peering status (non-interactive)
+#   netclaw peering up|down                   start/stop daemon + ngrok together
+#   netclaw peering announce                  print an endpoint message to relay to peers
+#   netclaw chats [id]       list N2N chat sessions, or tail one
+#   netclaw chats --watch    live-watch for new sessions/lines (Ctrl+C to stop)
 #   netclaw link            (re)create the ~/.local/bin/netclaw symlink
 #
 # Reads peering state from the mesh daemon HTTP API (bgp-daemon-v2.py,
 # default http://127.0.0.1:8179) and N2N chat transcripts from
-# ~/.openclaw/n2n/chats/. Status is read-only: if the daemon is down this
-# tool reports it and points at scripts/peering-setup.sh start.
+# ~/.openclaw/n2n/chats/. `peering up`/`down` start/stop the daemon
+# (scripts/peering-setup.sh) and the ngrok tunnel together. `announce` does
+# NOT push over the wire — that already happens automatically every ~30s for
+# peers with a live channel (see bgp-daemon-v2.py's _endpoint_watcher). It
+# prints our current endpoint for you to relay out-of-band when the channel
+# is closed, which is the common case.
 set -euo pipefail
 
 SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
@@ -22,12 +29,137 @@ source "$NETCLAW_ROOT/scripts/lib/tui.sh"
 BGP_API="${NETCLAW_BGP_API:-http://127.0.0.1:8179}"
 NGROK_API="${NETCLAW_NGROK_API:-http://127.0.0.1:4040}"
 CHATS_DIR="${NETCLAW_N2N_CHATS:-$HOME/.openclaw/n2n/chats}"
+RENDER_MD="$NETCLAW_ROOT/scripts/lib/render_md.py"
 
-api_get() { curl -s --max-time 3 "$BGP_API$1" 2>/dev/null; }
+render_md() { python3 "$RENDER_MD"; }
 
-ngrok_get() { curl -s --max-time 3 "$NGROK_API$1" 2>/dev/null; }
+# `|| true`: a connection failure here (daemon/ngrok down) is an expected,
+# already-handled condition downstream — it must never trip `set -e` and
+# kill the whole TUI when called bare from a menu case (e.g. `peering_overview; pause`).
+api_get() { curl -s --max-time 3 "$BGP_API$1" 2>/dev/null || true; }
+
+ngrok_get() { curl -s --max-time 3 "$NGROK_API$1" 2>/dev/null || true; }
 
 daemon_up() { api_get /status | grep -q '"running"'; }
+
+env_get() { grep -m1 "^${1}=" "$HOME/.openclaw/.env" 2>/dev/null | cut -d= -f2-; }
+
+ngrok_up() { pgrep -f 'ngrok (tcp|start)' >/dev/null 2>&1; }
+
+ngrok_start() {
+    if ngrok_up; then
+        echo -e "  ${T_DIM}ngrok is already running.${T_NC}"
+        return 0
+    fi
+    local port
+    port="$(env_get BGP_LISTEN_PORT)"
+    if [ -z "$port" ]; then
+        echo -e "  ${T_YELLOW}BGP_LISTEN_PORT not set in ~/.openclaw/.env — run peering-setup.sh first.${T_NC}"
+        return 1
+    fi
+    echo -e "  ${T_DIM}starting ngrok tcp $port...${T_NC}"
+    setsid nohup ngrok tcp "$port" --log /tmp/ngrok-mesh.log --log-format json \
+        > /dev/null 2>&1 < /dev/null &
+    disown
+    local i
+    for i in 1 2 3 4 5 6 7 8 9 10; do
+        sleep 1
+        local url
+        url="$(ngrok_get /api/tunnels | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    tcp = [t for t in d.get("tunnels", []) if t.get("proto") == "tcp"]
+    print(tcp[0]["public_url"].replace("tcp://", "") if tcp else "")
+except Exception:
+    print("")
+' 2>/dev/null)"
+        if [ -n "$url" ]; then
+            echo -e "  ${T_CYAN}ngrok up${T_NC}  endpoint: ${T_BOLD}${url}${T_NC}"
+            return 0
+        fi
+    done
+    echo -e "  ${T_YELLOW}ngrok started but no tcp tunnel appeared after 10s — check /tmp/ngrok-mesh.log${T_NC}"
+    return 1
+}
+
+ngrok_stop() {
+    if ! ngrok_up; then
+        echo -e "  ${T_DIM}ngrok is not running.${T_NC}"
+        return 0
+    fi
+    pkill -f 'ngrok (tcp|start)' 2>/dev/null || true
+    sleep 1
+    if ngrok_up; then
+        echo -e "  ${T_YELLOW}ngrok did not stop — check for a stuck process.${T_NC}"
+        return 1
+    fi
+    echo -e "  ${T_CYAN}ngrok stopped.${T_NC}  peers can no longer reach this node."
+}
+
+peering_start_all() {
+    echo ""
+    echo -e "  ${T_BOLD}Starting peering (daemon + ngrok)${T_NC}"
+    echo ""
+    "$NETCLAW_ROOT/scripts/peering-setup.sh" start
+    ngrok_start
+}
+
+peering_stop_all() {
+    echo ""
+    echo -e "  ${T_BOLD}Stopping peering (ngrok + daemon)${T_NC}"
+    echo ""
+    ngrok_stop
+    "$NETCLAW_ROOT/scripts/peering-setup.sh" stop
+}
+
+# Not a live push (that already happens automatically every ~30s for peers
+# with an open channel — see bgp-daemon-v2.py's _endpoint_watcher). This is
+# for the common case: the channel is closed and a human has to relay our
+# current endpoint out-of-band (Slack, text, etc.) so the peer can redial.
+peer_announce() {
+    if ! ngrok_up; then
+        echo -e "  ${T_YELLOW}ngrok is not running — nothing to announce. Start it first.${T_NC}"
+        return 1
+    fi
+    local endpoint
+    endpoint="$(ngrok_get /api/tunnels | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    tcp = [t for t in d.get("tunnels", []) if t.get("proto") == "tcp"]
+    print(tcp[0]["public_url"].replace("tcp://", "") if tcp else "")
+except Exception:
+    print("")
+' 2>/dev/null)"
+    if [ -z "$endpoint" ]; then
+        echo -e "  ${T_YELLOW}Could not read the current ngrok endpoint.${T_NC}"
+        return 1
+    fi
+    local as router_id name
+    as="$(env_get NETCLAW_LOCAL_AS)"
+    router_id="$(env_get NETCLAW_ROUTER_ID)"
+    name="$(env_get N2N_DISPLAY_NAME)"
+    echo ""
+    echo -e "  ${T_BOLD}Endpoint to relay${T_NC}  ${T_DIM}(paste to your peer out-of-band — Slack, text, etc.)${T_NC}"
+    echo ""
+    echo -e "  ${T_CYAN}NetClaw AS${as} (${name:-unnamed}) — new peering endpoint: ${T_BOLD}${endpoint}${T_NC}"
+    echo -e "  ${T_CYAN}Router ID ${router_id}. Update your n2n_consent host/port to redial.${T_NC}"
+    echo ""
+    if daemon_up; then
+        local peers
+        peers="$(api_get /n2n/status | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+for p in d.get("peers", []):
+    print("%s (%s)" % (p.get("identity","?"), p.get("display_name") or "unnamed"))
+' 2>/dev/null)"
+        if [ -n "$peers" ]; then
+            echo -e "  ${T_DIM}Federated peers who may need this:${T_NC}"
+            echo "$peers" | sed 's/^/    /'
+        fi
+    fi
+}
 
 daemon_down_msg() {
     echo -e "  ${T_YELLOW}Mesh daemon is not running.${T_NC}"
@@ -185,21 +317,90 @@ chat_tail() {
     echo ""
     echo -e "  ${T_BOLD}$(basename "$f" .txt)${T_NC}  ${T_DIM}(live — Ctrl+C to go back)${T_NC}"
     echo ""
-    # keep Ctrl+C local to tail so the menu survives
-    trap ' ' INT
-    tail -n 40 -f "$f" || true
+    tail -n 40 "$f" | render_md
+    # poll (not `tail -f`) so new content lands in complete chunks —
+    # render_md needs whole blocks to detect multi-line markdown tables.
+    #
+    # `trap 'break' INT` alone is unreliable here: when SIGINT hits a foreground
+    # `sleep`, bash's non-interactive default kills the whole process before the
+    # trap can run. Backgrounding sleep and `wait`-ing on it makes the signal
+    # interrupt `wait` instead, so the trap fires and the flag check below
+    # actually gets to run.
+    local stop=0
+    trap 'stop=1' INT
+    local size
+    size="$(wc -c < "$f" 2>/dev/null || echo 0)"
+    while true; do
+        sleep 2 & wait $! || true
+        [ "$stop" -eq 1 ] && break
+        local cur
+        cur="$(wc -c < "$f" 2>/dev/null || echo 0)"
+        if [ "$cur" -gt "$size" ]; then
+            tail -c "+$((size + 1))" "$f" | render_md
+            size="$cur"
+        fi
+    done
     trap - INT
     echo ""
+}
+
+chats_watch() {
+    local interval="${1:-5}"
+    echo ""
+    echo -e "  ${T_BOLD}Watching for N2N chat activity${T_NC}  ${T_DIM}(new sessions + new lines, every ${interval}s — Ctrl+C to go back)${T_NC}"
+    echo ""
+    # `trap 'break' INT` alone is unreliable: SIGINT hitting a foreground
+    # `sleep` kills the whole process before the trap runs. Background sleep
+    # and `wait` on it so the signal interrupts `wait` instead, letting the
+    # trap set a flag the loop actually gets to check.
+    local stop=0
+    trap 'stop=1' INT
+    declare -A sizes
+    local f prev cur
+    if ls "$CHATS_DIR"/*.txt >/dev/null 2>&1; then
+        while IFS= read -r f; do sizes["$f"]="$(wc -c < "$f" 2>/dev/null || echo 0)"; done \
+            < <(ls -1 "$CHATS_DIR"/*.txt 2>/dev/null)
+    fi
+    while true; do
+        if ls "$CHATS_DIR"/*.txt >/dev/null 2>&1; then
+            while IFS= read -r f; do
+                prev="${sizes[$f]:-}"
+                cur="$(wc -c < "$f" 2>/dev/null || echo 0)"
+                if [ -z "$prev" ]; then
+                    echo -e "  ${T_CYAN}new session${T_NC}  $(basename "$f" .txt)"
+                    prev=0
+                fi
+                if [ "$cur" -gt "$prev" ]; then
+                    echo -e "  ${T_DIM}--- $(basename "$f" .txt) ---${T_NC}"
+                    tail -c "+$((prev + 1))" "$f" | render_md
+                fi
+                sizes["$f"]="$cur"
+            done < <(ls -1 "$CHATS_DIR"/*.txt 2>/dev/null)
+        fi
+        sleep "$interval" & wait $! || true
+        [ "$stop" -eq 1 ] && break
+    done
+    trap - INT
 }
 
 chats_menu() {
     while true; do
         clear
-        chats_list || { pause; return 0; }
-        local opts=("${CHAT_LABELS[@]}" "← Back")
+        local have_chats=0
+        chats_list || have_chats=1
+        local opts=("▶ Watch for new activity (live)")
+        [ "$have_chats" -eq 0 ] && opts+=("${CHAT_LABELS[@]}")
+        opts+=("← Back")
         tui_menu "N2N chat sessions (newest first)" "${opts[@]}" || return 0
-        [ "$TUI_CHOICE" -ge "${#CHAT_FILES[@]}" ] && return 0
-        chat_tail "${CHAT_FILES[$TUI_CHOICE]}"
+        if [ "$TUI_CHOICE" -eq 0 ]; then
+            chats_watch
+            continue
+        fi
+        local idx=$((TUI_CHOICE - 1))
+        if [ "$have_chats" -ne 0 ] || [ "$idx" -ge "${#CHAT_FILES[@]}" ]; then
+            return 0
+        fi
+        chat_tail "${CHAT_FILES[$idx]}"
     done
 }
 
@@ -213,6 +414,9 @@ peering_menu() {
             "N2N federation detail" \
             "Ngrok tunnel (mesh transport)" \
             "N2N chat logs" \
+            "▶ Start peering (daemon + ngrok)" \
+            "■ Stop peering (ngrok + daemon)" \
+            "Announce endpoint (relay message for peers)" \
             "← Back" || return 0
         case "$TUI_CHOICE" in
             0) peering_overview; pause ;;
@@ -220,7 +424,10 @@ peering_menu() {
             2) peering_n2n; pause ;;
             3) peering_ngrok; pause ;;
             4) chats_menu ;;
-            5) return 0 ;;
+            5) peering_start_all; pause ;;
+            6) peering_stop_all; pause ;;
+            7) peer_announce; pause ;;
+            8) return 0 ;;
         esac
     done
 }
@@ -261,14 +468,19 @@ case "${1:-}" in
     install)   shift; exec "$NETCLAW_ROOT/scripts/install.sh" "$@" ;;
     peering)
         case "${2:-status}" in
-            status) peering_overview ;;
-            bgp)    peering_bgp ;;
-            n2n)    peering_n2n ;;
-            ngrok)  peering_ngrok ;;
-            *)      echo "Usage: netclaw peering [status|bgp|n2n|ngrok]"; exit 1 ;;
+            status)   peering_overview ;;
+            bgp)      peering_bgp ;;
+            n2n)      peering_n2n ;;
+            ngrok)    peering_ngrok ;;
+            up)       peering_start_all ;;
+            down)     peering_stop_all ;;
+            announce) peer_announce ;;
+            *)        echo "Usage: netclaw peering [status|bgp|n2n|ngrok|up|down|announce]"; exit 1 ;;
         esac ;;
     chats)
-        if [ -n "${2:-}" ]; then
+        if [ "${2:-}" = "--watch" ] || [ "${2:-}" = "watch" ]; then
+            chats_watch "${3:-5}"
+        elif [ -n "${2:-}" ]; then
             f="$CHATS_DIR/$2.txt"
             [ -f "$f" ] || f="$(ls "$CHATS_DIR"/"$2"*.txt 2>/dev/null | head -1 || true)"
             [ -n "$f" ] && [ -f "$f" ] || { echo "No chat session matching '$2' in $CHATS_DIR"; exit 1; }
@@ -281,6 +493,6 @@ case "${1:-}" in
         fi ;;
     link)      do_link ;;
     help|-h|--help)
-        sed -n '2,9p' "$SCRIPT_PATH" | sed 's/^# \{0,3\}//' ;;
+        sed -n '2,12p' "$SCRIPT_PATH" | sed 's/^# \{0,3\}//' ;;
     *) echo "Unknown command: $1 (try: netclaw help)"; exit 1 ;;
 esac

--- a/scripts/peering-setup.sh
+++ b/scripts/peering-setup.sh
@@ -8,6 +8,7 @@
 #
 #   ./scripts/peering-setup.sh           # interactive configuration wizard
 #   ./scripts/peering-setup.sh start     # start (or restart) the mesh BGP daemon
+#   ./scripts/peering-setup.sh stop      # stop the mesh BGP daemon
 #   ./scripts/peering-setup.sh status    # show daemon, sessions, and RIB summary
 
 set -euo pipefail
@@ -75,7 +76,7 @@ daemon_start() {
     # Pull only the daemon's keys from .env — values may contain JSON, and
     # other .env lines have unquoted spaces that break plain `source`.
     log_info "Starting mesh BGP daemon..."
-    env $(grep -E "^(NETCLAW_ROUTER_ID|NETCLAW_LOCAL_AS|NETCLAW_LAB_MODE|NETCLAW_MESH_ENABLED|NETCLAW_MESH_OPEN|BGP_LISTEN_PORT|BGP_API_PORT)=" "$OPENCLAW_ENV") \
+    env $(grep -E "^(NETCLAW_ROUTER_ID|NETCLAW_LOCAL_AS|NETCLAW_LAB_MODE|NETCLAW_MESH_ENABLED|NETCLAW_MESH_OPEN|BGP_LISTEN_PORT|BGP_API_PORT|N2N_ENABLED|N2N_DISPLAY_NAME|N2N_RATE_PER_MIN|N2N_DAILY_REQUESTS|N2N_DAILY_TOKENS)=" "$OPENCLAW_ENV") \
         NETCLAW_BGP_PEERS="$(env_get NETCLAW_BGP_PEERS)" \
         nohup python3 "$BGP_DAEMON" >> "$DAEMON_OUT" 2>&1 &
     local pid=$!
@@ -117,11 +118,26 @@ for pfx, r in d.get("loc_rib", {}).items():
     echo "    curl -X POST $BGP_API/add_peer -d '{\"ip\":\"N.tcp.ngrok.io\",\"as\":65001,\"port\":NNNNN,\"hostname\":true}'"
 }
 
+daemon_stop() {
+    if ! daemon_running; then
+        log_info "Mesh daemon is not running."
+        return 0
+    fi
+    pkill -f "bgp-daemon-v2\.py" 2>/dev/null || true
+    sleep 1
+    if daemon_running; then
+        log_error "Daemon did not stop — check for a stuck process."
+        exit 1
+    fi
+    log_info "Mesh daemon stopped."
+}
+
 case "${1:-}" in
     start)  daemon_start;  exit 0 ;;
+    stop)   daemon_stop;   exit 0 ;;
     status) daemon_status; exit 0 ;;
     "") ;;
-    *) echo "Usage: $0 [start|status]"; exit 1 ;;
+    *) echo "Usage: $0 [start|stop|status]"; exit 1 ;;
 esac
 
 # ── configuration wizard ─────────────────────────────────────────


### PR DESCRIPTION
Follow-up to #115. Extends the top-level `netclaw` command with peering lifecycle management and N2N chat quality-of-life improvements.

## What's new

### `netclaw peering up | down`
Start/stop the mesh BGP daemon (`peering-setup.sh`) and the ngrok tunnel together. `up` waits up to 10s for the tcp tunnel to appear and prints the public endpoint; `down` stops both cleanly.

### `netclaw peering announce`
Prints the current public endpoint formatted as a message to relay to peers. This does **not** push over the wire — that already happens automatically every ~30s for peers with a live channel (`bgp-daemon-v2.py` `_endpoint_watcher`). It covers the common case where the channel is closed and the endpoint must be shared out-of-band.

### `netclaw chats --watch`
Live-watch mode for N2N chat sessions — picks up new sessions and new lines as they arrive (Ctrl+C to stop).

### Markdown-rendered chat transcripts
New `scripts/lib/render_md.py` (stdlib-only) renders N2N chat markdown for the terminal instead of dumping raw markup.

### `peering-setup.sh`
- New `stop` subcommand (mirrors `start`/`status`)
- Daemon environment now passes through `N2N_ENABLED`, `N2N_DISPLAY_NAME`, `N2N_RATE_PER_MIN`, `N2N_DAILY_REQUESTS`, `N2N_DAILY_TOKENS`

### Fix
`api_get`/`ngrok_get` now append `|| true` so a connection failure (daemon/ngrok down — an expected, handled condition) can't trip `set -euo pipefail` and kill the whole TUI when called from a menu case.

## Testing
- `bash -n` on `scripts/netclaw` and `scripts/peering-setup.sh`
- `py_compile` on `scripts/lib/render_md.py`
- Exercised live during the 2026-07-11 cross-claw N2N federation session (peering up/down, announce, chats --watch against a real peer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)