### PR TITLE
feat(056): iN2N — a "risk" of NetClaws (internal federation), live-proven

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,6 +136,15 @@ NETCLAW_ENABLE_PASSWORD=changeme
 # N2N_RECONNECT_BACKOFF_MIN_S=5                 # Channel auto-reconnect backoff floor (seconds)
 # N2N_RECONNECT_BACKOFF_MAX_S=60                # Channel auto-reconnect backoff cap (seconds)
 # N2N_RECONNECT_UNREACHABLE_AFTER=5             # Consecutive reconnect failures before "unreachable" display
+# iN2N — Internal NetClaw Federation (feature 056): a "risk" of focused claws
+# behind one Border. Members dial the Border outbound; no ngrok, no public mesh.
+# N2N_ROLE=standalone                           # standalone | border | member (default standalone = risk of one)
+# N2N_RISK_NAME=                                # the risk's name (border/member roles)
+# N2N_RISK_DESCRIPTION=                         # the risk's description
+# N2N_ENABLED_STACKS=en2n                       # border only: en2n | in2n | both
+# N2N_IN2N_PORT=                                # border only: optional dedicated iN2N listener port
+# N2N_BORDER_ENDPOINT=                          # member only: host:port to dial the Border outbound
+# N2N_QUARANTINE_THRESHOLD=5                    # consecutive member auth/health failures before auto-quarantine
 
 # ContainerLab (containerized network labs via API)
 # CLAB_API_SERVER_URL=http://localhost:8080     # ContainerLab API server URL

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,10 @@ yarn-error.log*
 # OpenClaw
 .openclaw/
 
+# iN2N keys/certs (feature 056) — runtime-generated self-signed keys, never committed.
+# Live path is ~/.openclaw/n2n/keys/ (already covered by .openclaw/); guard repo-local copies.
+**/n2n/keys/
+
 # Local agent state and audit harnesses
 .gait/
 memory/
@@ -95,3 +99,6 @@ config/twilio-voice.json
 # Generated topology visualizations and downloaded/cached 3D assets (spec 046)
 # — regenerated on demand by output.py/assets.py, never checked in.
 workspace/output/
+
+# iN2N migration scaffold (contains per-member .env slices — never commit)
+migration-staging/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # netclaw Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-07-11
+Auto-generated from all feature plans. Last updated: 2026-07-12
 
 ## Active Technologies
 - N/A (stateless server; subscription state held in-memory during runtime) (003-gnmi-mcp-server)
@@ -71,6 +71,8 @@ Auto-generated from all feature plans. Last updated: 2026-07-11
 - SQLite at `~/.openclaw/n2n/federation.db` (consent records, grants, (052-n2n-federation)
 - Python 3.10+ (daemon federation layer + n2n-mcp, matching + Existing `bgp-daemon-v2.py` + `bgp/federation/*` (053-n2n-ergonomics)
 - Extend the existing SQLite at `~/.openclaw/n2n/federation.db` with (053-n2n-ergonomics)
+- Python 3.10+ (daemon federation layer + `n2n-mcp`, matching 052/053), Node.js 18+/ES2022 (HUD), Bash (installer), no new languages + Existing `bgp-daemon-v2.py` + `bgp/federation/*` (manager, channel, service, inventory, authorization, invocation, chat, gateway, negotiate, tasks, audit), FastMCP (`n2n-mcp`), Python stdlib `json`/`sqlite3`/`asyncio`/`ssl`/`socket`; `cryptography` (already a repo dependency, spec 003) for self-signed key generation and pinned-key verification. No new third-party packages. (056-in2n-internal-federation)
+- Extend the existing SQLite at `~/.openclaw/n2n/federation.db` with iN2N tables: `risk` (name/description/role/enabled-stacks), `member` (risk-local id, pinned key, transport binding, scope, health, state), `enrollment_token` (single-use). Reuse `delegated_task` for internal delegation; internal delegations are recorded in the existing `remote_invocation_record` audit table with a `channel_kind` discriminator. Pinned keys and the risk's own key stored under `~/.openclaw/n2n/keys/`. (056-in2n-internal-federation)
 
 - Python 3.10+ + FastMCP (MCP framework), grpcio + grpcio-tools (gRPC transport), pygnmi (gNMI client library), protobuf, cryptography (TLS handling) (003-gnmi-mcp-server)
 
@@ -90,9 +92,9 @@ cd src [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLO
 Python 3.10+: Follow standard conventions
 
 ## Recent Changes
+- 056-in2n-internal-federation: Added Python 3.10+ (daemon federation layer + `n2n-mcp`, matching 052/053), Node.js 18+/ES2022 (HUD), Bash (installer), no new languages + Existing `bgp-daemon-v2.py` + `bgp/federation/*` (manager, channel, service, inventory, authorization, invocation, chat, gateway, negotiate, tasks, audit), FastMCP (`n2n-mcp`), Python stdlib `json`/`sqlite3`/`asyncio`/`ssl`/`socket`; `cryptography` (already a repo dependency, spec 003) for self-signed key generation and pinned-key verification. No new third-party packages.
 - 053-n2n-ergonomics: Added Python 3.10+ (daemon federation layer + n2n-mcp, matching + Existing `bgp-daemon-v2.py` + `bgp/federation/*`
 - 052-n2n-federation: Added Python 3.10+ (daemon federation layer + n2n-mcp, matching + Existing `bgp-daemon-v2.py` (listener, protocol
-- 050-computer-use-desktop: Added Bash (install function, matching every existing `scripts/lib/install-steps.sh` entry), Markdown (skill documentation) + OpenClaw's ClawHub `computer-use` skill (consumed as-is, no fork); apt packages `xvfb`, `xfce4`, `xfce4-terminal`, `xdotool`, `scrot`, `imagemagick`, `dbus-x11`, `x11vnc`, `novnc`, `websockify` (all confirmed present in this host's apt repositories; `dbus-x11`, `imagemagick`, `scrot`, `xvfb` already installed)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/N2N-PEERING-NETCLAWS.md
+++ b/N2N-PEERING-NETCLAWS.md
@@ -3,7 +3,10 @@
 **NetClaw-to-NetClaw (N2N) Federation** turns a set of independently-operated
 NetClaw instances into a federated mesh of AI network engineers that can
 discover, use, and converse with one another — safely, and only between
-operators who both opt in.
+operators who both opt in. This document covers **eN2N** (external federation
+between different operators). For **iN2N** — one operator's own group of focused
+claws behind a Border Claw ("a risk of NetClaws") — see
+[docs/N2N-RISK.md](docs/N2N-RISK.md) and the [eN2N vs iN2N](#en2n-vs-in2n--external-federation-vs-a-risk-of-netclaws) summary below.
 
 > **Is N2N a new protocol?** Yes. **NCFED** is a new application-layer protocol
 > introduced by NetClaw. It is *not* BGP and not a reuse of an existing wire
@@ -183,9 +186,36 @@ Full spec: [`specs/053-n2n-ergonomics/`](specs/053-n2n-ergonomics/).
 
 ---
 
+## eN2N vs iN2N — external federation vs "a risk of NetClaws"
+
+Everything above is **eN2N**: federation between **different operators'** claws
+over the NCFED mesh, gated by mutual consent. Feature 056 adds **iN2N**, the
+*internal* counterpart: **one operator** running a group of focused claws — a
+**risk** — coordinated by a single **Border Claw**.
+
+| | eN2N (this document) | iN2N ([docs/N2N-RISK.md](docs/N2N-RISK.md)) |
+|---|---|---|
+| Between | different operators | one operator's own claws |
+| Trust | mutual consent per peer | pinned key + single-use token (one owner) |
+| Transport | NCFED over the BGP mesh (ngrok) | members dial the Border outbound (loopback/VPN) |
+| Topology | peer-to-peer between Borders | hub-and-spoke (Border ↔ members) — no mesh |
+| Identity | each claw's BGP identity | one identity per risk (the Border) |
+
+**How they compose:** a *risk* federates externally through its **Border only** —
+Border-to-Border. To a peer, a risk is one identity; member claws and internal
+topology are never exposed. The Border advertises the **aggregate** of its
+members' capabilities under the risk identity, so a peer can still ask "does that
+risk have CML?" and the Border routes it internally. The eN2N wire format,
+consent, and safety model in this document are **unchanged** by iN2N.
+
+Already federated with a peer who is adopting the risk model? See
+[docs/N2N-RISK-MIGRATION-FOR-PEERS.md](docs/N2N-RISK-MIGRATION-FOR-PEERS.md).
+
 ## Reference
 
+- **A risk of NetClaws (iN2N):** [`docs/N2N-RISK.md`](docs/N2N-RISK.md)
+- **For federated peers (migration readout):** [`docs/N2N-RISK-MIGRATION-FOR-PEERS.md`](docs/N2N-RISK-MIGRATION-FOR-PEERS.md)
 - Skill: [`workspace/skills/n2n-federation/SKILL.md`](workspace/skills/n2n-federation/SKILL.md)
 - MCP server: [`mcp-servers/n2n-mcp/README.md`](mcp-servers/n2n-mcp/README.md)
-- Spec / plan / contracts: [`specs/052-n2n-federation/`](specs/052-n2n-federation/)
+- Spec / plan / contracts: [`specs/052-n2n-federation/`](specs/052-n2n-federation/) (eN2N) · [`specs/056-in2n-internal-federation/`](specs/056-in2n-internal-federation/) (iN2N)
 - Mesh bring-up (BGP layer): [`PEERINGEXAMPLE.md`](PEERINGEXAMPLE.md)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,30 @@ Scripted / non-interactive installs:
 ./scripts/install.sh --list                       # see all components & profiles
 ```
 
+## A Risk of NetClaws (iN2N)
+
+A **risk** is the (real) collective noun for a group of lobsters — and NetClaw is
+a lobster. You can now run **a risk of NetClaws**: instead of one monolith
+carrying every skill, run a group of **focused, specialized claws** coordinated by
+a single **Border Claw**. You talk only to the Border; it routes each request to
+the member that owns the capability (a CML claw, a pyATS claw, an Azure claw…) and
+returns the result.
+
+- **Focus & token economy** — each member carries a handful of skills, not 190.
+- **Least privilege** — each member gets *only* its integration's secrets.
+- **One door** — the Border is the single interface, single external identity, and
+  single audit trail; members dial it outbound (no ngrok, no mesh, no inbound
+  ports — co-located or across clouds). Any provider/model per claw (incl. local
+  Ollama). Cold/on-demand members spin up on first use.
+
+At install you pick **standalone**, **Border**, or **Member**. This is the
+*internal* counterpart to N2N federation between different operators (eN2N). A
+classic standalone NetClaw is just "a risk of one, its own Border."
+
+**→ Full guide: [docs/N2N-RISK.md](docs/N2N-RISK.md)** · external peering:
+[N2N-PEERING-NETCLAWS.md](N2N-PEERING-NETCLAWS.md) · already federated with a peer?
+[docs/N2N-RISK-MIGRATION-FOR-PEERS.md](docs/N2N-RISK-MIGRATION-FOR-PEERS.md)
+
 Whatever you pick, the installer then runs a two-phase setup:
 
 **Phase 1: `openclaw onboard`** (OpenClaw's built-in wizard)
@@ -500,7 +524,7 @@ NetClaw ships with the full set of OpenClaw workspace markdown files. These are 
 | 109 | Chrome DevTools | [ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp) | stdio (Node, npx) | Controlled browser automation/inspection — visualization render QA (screenshot + console check), controller GUI gap-filling, undocumented vendor API discovery via network-request capture, general web-GUI automation. No credentials; auth via one-time manual sign-in into a persistent Chrome profile (~20 tools used across 2 skills) |
 | 110 | Chrome DevTools (Watch Mode) | [ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp) | stdio (Node, npx) | Same server, headed (`--headless=false`) instead of headless — a real Chrome window opens wherever NetClaw runs, so an operator can watch it navigate/click/read live (e.g. via Slack: "watch it log into the NetBox demo and create a site"). Works on any host with a display (Mac, Linux desktop, WSL2 with WSLg); no OS-specific code |
 | 111 | Computer Use | OpenClaw ClawHub skill (`computer-use`, installed via `openclaw skills install`, not `config/openclaw.json`) | Script-based (bash + xdotool, `DISPLAY=:99`) | Full-desktop automation for legacy tools with no browser or API path — virtual Xvfb+XFCE desktop, 17 mouse/keyboard/screenshot actions, VNC/noVNC live-viewing (loopback-only) for Watch Mode. No credentials (used by 1 skill) |
-| 112 | N2N Federation | Built-in (`n2n-mcp`) | stdio (Python) | NetClaw-to-NetClaw federation over the BGP mesh via the new **NCFED** protocol (JSON-RPC 2.0, MCP + A2A semantics) — mutual-consent capability exchange, default-deny remote tool/skill invocation with approvals/budgets/audit, claw-to-claw chat, plus **async task delegation, channel auto-reconnect, endpoint auto-re-announce, and version negotiation** for self-healing reliability (23 tools). See [N2N-PEERING-NETCLAWS.md](N2N-PEERING-NETCLAWS.md) |
+| 112 | N2N Federation | Built-in (`n2n-mcp`) | stdio (Python) | NetClaw-to-NetClaw federation over the BGP mesh via the new **NCFED** protocol (JSON-RPC 2.0, MCP + A2A semantics) — mutual-consent capability exchange, default-deny remote tool/skill invocation with approvals/budgets/audit, claw-to-claw chat, plus **async task delegation, channel auto-reconnect, endpoint auto-re-announce, and version negotiation** for self-healing reliability. Plus **iN2N — "a risk of NetClaws"**: one operator's group of focused member claws behind a single Border Claw (routing, least-privilege per-member secrets, cold/on-demand members, any provider/model incl. local Ollama) (30 tools). See [N2N-PEERING-NETCLAWS.md](N2N-PEERING-NETCLAWS.md) (external) and [docs/N2N-RISK.md](docs/N2N-RISK.md) (internal/risk) |
 
 ### Additional Server Notes
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -94,6 +94,12 @@ arista-cvp
 
 ### Protocol Participation Skills (2)
 protocol-participation, n2n-federation
+<!-- n2n-federation covers both eN2N (federate with other operators' claws over
+the NCFED mesh) and iN2N (feature 056): one operator's own "risk" of focused
+member claws behind a single Border Claw, which routes work to the right
+specialist. Roles: standalone | border | member. See workspace/skills/
+n2n-federation/SKILL.md. -->
+
 
 ### Cisco FMC Skills (1)
 fmc-firewall-ops

--- a/docs/N2N-RISK-MIGRATION-FOR-PEERS.md
+++ b/docs/N2N-RISK-MIGRATION-FOR-PEERS.md
@@ -1,0 +1,79 @@
+# N2N Risk model — technical readout for federated peers (Nick, Byrn)
+
+**TL;DR:** Feature 056 (iN2N / "a risk of NetClaws") is an **internal** federation
+layer. **eN2N — the NCFED mesh you federate with John over — is frozen and
+unchanged.** Your federation keeps working with **no re-consent**. There is one
+brief mesh blip when John restarts his daemon to become a Border, and after that
+John's claw advertises *more* capabilities (the aggregate of his internal
+members) under the same identity you already trust.
+
+---
+
+## What changed
+
+- **New: iN2N (internal federation).** One operator can now split their monolithic
+  NetClaw into a **risk** — a group of focused member claws behind one **Border
+  Claw**. John is decomposing his ~190-skill monolith into a Border + ~27 scoped
+  members (CML claw, pyATS claw, Azure claw, …). See [N2N-RISK.md](N2N-RISK.md).
+- **Frozen: eN2N (the NCFED mesh).** The wire framing, `n2n/hello` handshake,
+  mutual consent, default-deny invocation, budgets, kill switch, and the
+  no-secrets guard are **byte-for-byte unchanged** and regression-tested (the
+  full eN2N test suite still passes). Nothing you rely on moved.
+- **Members are invisible to you.** A risk presents **one identity** externally
+  (the Border). You will **never** see member IDs, endpoints, or internal
+  topology (design guarantee FR-016).
+
+## What this means for your federation with John
+
+- **John's Border keeps his existing BGP identity — AS 65001 / router-id
+  4.4.4.4.** So your consent, grants, and cached state for `as65001-4.4.4.4` stay
+  valid. **No re-consent, no re-grant.**
+- **One brief blip:** promoting the monolith to a Border requires a daemon
+  restart. Your NCFED channel to John drops for <60s and **auto-reconnects** (the
+  053 reconnect supervisor). If John's ngrok endpoint rolls on that restart,
+  endpoint auto-re-announce redials you; if you're on a pre-053 build, redial
+  once with his new `host:port`.
+- **You'll see MORE of John's capabilities, not fewer.** John's Border now
+  advertises the **union** of his members' specialties under `as65001-4.4.4.4`.
+  So `n2n_peer_capabilities(peer="as65001-4.4.4.4")` will list cml, pyats, azure,
+  ise, forward, ipfabric, … as risk-level capabilities (tagged as aggregate),
+  with no member breakdown. Asking John's claw to run one of those still works
+  exactly as before — the Border routes it internally to the right member.
+
+## What YOU need to do
+
+**To keep federating with John: essentially nothing.** Concretely:
+
+1. `git pull` your netclaw repo to pick up 056 (safe — eN2N is frozen; your
+   `N2N_ROLE` defaults to `standalone`, so your behavior does not change).
+2. Restart your mesh daemon at your convenience (or don't — you'll re-federate
+   with John's Border automatically after his restart regardless).
+3. Confirm: `n2n_status` → `as65001-4.4.4.4` shows `federated`. Optionally
+   `n2n_peer_capabilities(peer="as65001-4.4.4.4")` to see John's new aggregate
+   capability set.
+
+That's it. No config changes are required on your side.
+
+## Optional — adopt the Risk model yourself
+
+If you want the same focus / token-economy / least-privilege benefits, you can
+turn your own claw into a risk. It's the same tooling:
+
+1. Read [N2N-RISK.md](N2N-RISK.md).
+2. See what members your box could run: `python3 scripts/in2n-profiles.py list`
+   (env-gated to your configured backends).
+3. Generate a **parallel-cutover** plan (generate-only, touches nothing):
+   `python3 scripts/in2n-migrate.py --risk <your-risk> --border-endpoint <host:port>`
+   then read `migration-staging/RUNBOOK.md`.
+4. Your Border keeps your existing AS/router-id, so **John's** federation with
+   **you** likewise continues uninterrupted. Members can be co-located or spread
+   across your own hosts/clouds (they dial your Border outbound — no mesh, no
+   inbound ports). Pick any provider/model per member, including local/Ollama.
+
+## Interop notes
+
+- eN2N stays **Border-to-Border** between risks. A member of one risk never talks
+  to another operator's risk directly.
+- Different OpenClaw builds/models keep interoperating via the 053 capability
+  negotiation — unchanged.
+- Questions or anything odd during John's cutover: ping the Slack thread.

--- a/docs/N2N-RISK.md
+++ b/docs/N2N-RISK.md
@@ -142,6 +142,34 @@ See `.env.example` (`N2N_ROLE`, `N2N_RISK_NAME`, `N2N_ENABLED_STACKS`,
 vars `N2N_MEMBER_ID` / `N2N_MEMBER_MODEL` / `N2N_MEMBER_SCOPE` /
 `N2N_ENROLLMENT_TOKEN` / `N2N_IDLE_EXIT_S`).
 
+## Proven live — the full recipe (and gotchas)
+
+Decomposing a real monolith into a risk surfaced details worth writing down:
+
+- **A member runtime** = a *scoped OpenClaw home* (`scripts/in2n-member-home.py`):
+  filtered `mcp.servers`, **comms plugins stripped** (slack/webex crash
+  `openclaw agent --local`), a **direct model provider registered at the member's
+  tier** (and whitelisted in `agents.defaults.models`), workspace shared. The
+  member process is `scripts/in2n-member.py` (dial + enroll + execute; `--idle-exit`
+  for cold/on-demand), launched **detached** (`setsid`) so it survives.
+- **Slimming a Border is TWO things, not one:** (1) trim its `mcp.servers` to the
+  broker set, AND (2) give it its **own workspace + Border persona**
+  (`scripts/in2n-border-workspace.py`) — broker skills only + a SOUL that says
+  "I'm the Border, I DELEGATE domain work to members via `n2n_route`." Without (2)
+  the Border still carries ~190 skill files and answers like the monolith instead
+  of routing. Point `agents.defaults.workspace` at the Border workspace + restart
+  the gateway.
+- **Models:** each claw registers a **direct provider** (any: Anthropic / OpenAI /
+  local Ollama) at its tier — Border=Opus, heavy members=Sonnet, trivial=Haiku.
+  If your model routes through a proxy (e.g. a DefenseClaw LLM gateway) make sure
+  it's running, or register a direct provider so a claw isn't blocked by a down
+  proxy. `agents.defaults.model.primary` needs a matching `models.providers[...]`.
+- **Deploy the `n2n-federation` skill** to a Border's workspace — without it the
+  Border's agent doesn't know the `n2n_*` routing tools exist.
+- **On-demand cold-start** requires members to be *routable while `provisioned`*
+  (the router treats provisioned members as candidates → `ensure_member_up`
+  spawns them on first route).
+
 ## See also
 
 - [N2N-PEERING-NETCLAWS.md](../N2N-PEERING-NETCLAWS.md) — eN2N (external peering)

--- a/docs/N2N-RISK.md
+++ b/docs/N2N-RISK.md
@@ -1,0 +1,151 @@
+# A Risk of NetClaws — Internal Federation (iN2N)
+
+> A **risk** is the (real) collective noun for a group of lobsters. NetClaw is a
+> lobster. So a coordinated group of NetClaws is **a risk of NetClaws** — and,
+> for a security-adjacent product, the pun is intentional.
+
+iN2N (internal NetClaw-to-NetClaw federation) lets **one operator** run a group
+of **focused, specialized NetClaws** — a *risk* — coordinated by a single
+**Border Claw**. You only ever talk to the Border; it routes each request to the
+member claw that owns the capability and returns the result. It is the internal
+counterpart to **eN2N** (external federation between *different* operators over
+the NCFED mesh — see [N2N-PEERING-NETCLAWS.md](../N2N-PEERING-NETCLAWS.md)).
+
+## Why
+
+One monolithic NetClaw carrying 190+ skills is expensive (huge context per turn)
+and blast-radius-wide (every credential in one process). A risk splits that into
+small specialists:
+
+- **Focus & token economy** — a CML claw carries ~5 skills, not 190; a pyATS
+  claw carries only pyATS. Each member's context stays small and cheap.
+- **Least privilege** — each member gets *only* its integration's secrets. A
+  compromised CML claw literally has no path to your Azure or firewall creds.
+- **One door, one audit trail** — the Border is the single interface, the single
+  external identity, and the single place every action is logged.
+
+## The model
+
+```
+                    (you talk only to the Border)
+                              │
+                    ┌─────────▼─────────┐        eN2N (NCFED mesh)
+   external ◄───────┤    BORDER CLAW    ├───────► other operators' risks
+   peer risks       │  gateway · comms  │         (Border-to-Border only)
+                    │  routing · audit  │
+                    └───┬───┬───┬───┬───┘
+                iN2N (internal transport — members dial OUT)
+                    │   │   │   │
+                  ┌─▼┐┌─▼┐┌─▼┐┌─▼┐   ... each a focused, scoped member claw
+                  │cml││pyats││azure││ise│   (CML claw, pyATS claw, Azure claw, …)
+                  └──┘└────┘└─────┘└───┘
+```
+
+- **Standalone** — a classic NetClaw is simply "a risk of one, its own Border".
+- **Border Claw** — the only claw with the gateway and comms (Slack/Discord/
+  Webex/Twilio/Twitter/PagerDuty/ServiceNow), routing, audit/GAIT, memory, and
+  humanrail. Deliberately carries **no** domain skills — its job is to broker.
+  Exactly one per risk. It also runs eN2N (external federation) if enabled.
+- **Member Claw** — a tightly-scoped specialist (one vendor/tool per claw). Dials
+  the Border, runs delegated tasks over only its scoped MCPs, never talks to the
+  outside world. Base floor on every member: iN2N runtime + self-status + memory
+  + GAIT + humanrail escalation.
+
+## Key properties
+
+- **Hub-and-spoke, no mesh.** Members **dial outbound** to the Border's one
+  reachable endpoint — loopback when co-located, or a private-network / overlay-
+  VPN / tunnel address when distributed across hosts/clouds/datacenters. No
+  inbound ports on members, no ngrok, **no iBGP/mesh** — the Border is the hub.
+- **Trust = pinned key, not consent.** A member enrolls once with a single-use
+  token and its own runtime-generated self-signed key, which the Border pins
+  (trust-on-first-use). No CA. eN2N's mutual-consent model applies only *between*
+  risks, at the Border boundary.
+- **One external identity.** To a peer risk, the whole risk appears as one
+  identity (the Border). Member identities/endpoints/topology never leak. The
+  Border advertises the **aggregate** of member capabilities under the risk (so a
+  peer learns "this risk can do CML, pyATS, Azure…") without exposing structure.
+- **Any provider/model per claw.** Each member is its own OpenClaw *embedded*
+  agent (`openclaw agent --local --model <provider/model>`) — Anthropic, OpenAI,
+  Google, or **local/Ollama**, mixed freely. The Border can reason on a flagship
+  model while members run cheaper/faster ones.
+- **Hybrid runtime (cold/on-demand).** A hot set stays always-on; other members
+  idle-exit when quiet and the Border **cold-starts** them on the next route
+  (spawns, waits for enrollment, delegates). Big resource/token savings.
+- **Security posture is a risk mode.** `N2N_RISK_MODE=testing` (fast iteration,
+  no guards) vs `production` (DefenseClaw + OpenShell sandbox enforced — members
+  run sandboxed under [OpenShell](DEFENSECLAW.md)).
+- **Enforced scope.** A member refuses out-of-scope work even from its Border.
+
+## Roles at install
+
+The installer asks: **standalone**, **Border**, or **Member**. A Border chooses
+`eN2N` / `iN2N` / `both`. A Member points at its Border and enrolls. This is the
+**primary** path — a fresh install stands up a risk directly; an existing
+monolith can also be *migrated* into one (below).
+
+## Profiles (env-gated, one claw per vendor/tool)
+
+Member profiles are **derived from your installed skill catalog** and **gated on
+their backend being configured** — you are never offered a member you can't run.
+
+```bash
+python3 scripts/in2n-profiles.py list          # members you can run right now
+python3 scripts/in2n-profiles.py list --all     # + dormant (skills present, no backend)
+python3 scripts/in2n-profiles.py show cml        # skills in the cml member
+```
+
+Granularity is per vendor/tool: `cml`, `containerlab`, `pyats`, `ipfabric`,
+`suzieq`, `batfish`, `forward`, `gtrace`, `packet`, `itential`, `aap`, `nso`,
+`aci`, `catalyst-center`, `f5`, `meraki`, `sdwan`, `ise`, `asa`, `checkpoint`,
+`paloalto`, `fortimanager`, `zscaler`, `claroty`, `nmap`, `nvd`, `fwrule`, `aws`,
+`azure`, `gcp`, `netbox`, `nautobot`, `infrahub`, `infoblox`, `github`. Utilities
+like visualization (`viz`) stay grouped. DefenseClaw + OpenShell are the
+production-mode security layer.
+
+## Operating a risk
+
+On the Border (MCP tools, or `netclaw risk …` / the `netclaw` TUI):
+
+| Action | Tool / command |
+|--------|----------------|
+| Risk status (role, stacks, members) | `n2n_risk_status` · `netclaw risk status` |
+| List members (scope, state, live) | `n2n_member_list` · `netclaw risk members` |
+| Member health / quarantine alerts | `n2n_member_health` · `netclaw risk health` |
+| Provision a member (+ token) | `n2n_member_add` · `netclaw risk add <profile> <name>` |
+| Issue an enrollment token | `n2n_enroll_token` · `netclaw risk token` |
+| Route a request to a member | `n2n_route` · `netclaw risk route "<request>"` |
+| Remove a member (unpin) | `n2n_member_remove` · `netclaw risk remove <id>` |
+
+Members run the lightweight launcher `scripts/in2n-member.py` (dial + enroll +
+execute; `--idle-exit N` for cold/on-demand).
+
+## Migrating a monolith into a risk
+
+`scripts/in2n-migrate.py` is **generate-only** — it never stops/starts/removes
+anything. It reads your existing `~/.openclaw/.env` and produces, in a
+gitignored `migration-staging/`, a **least-privilege `.env` slice** + launcher
+per member, a `border.env.additions`, and a step-by-step **`RUNBOOK.md`** for a
+**parallel cutover** (backup → promote to Border alongside the running monolith →
+bring up members one at a time → move comms to the Border last → decommission the
+monolith last, with a rollback path).
+
+```bash
+python3 scripts/in2n-migrate.py --risk my-risk --border-endpoint 127.0.0.1:11790
+# review migration-staging/RUNBOOK.md — then run it by hand
+```
+
+## Environment
+
+See `.env.example` (`N2N_ROLE`, `N2N_RISK_NAME`, `N2N_ENABLED_STACKS`,
+`N2N_IN2N_PORT`, `N2N_BORDER_ENDPOINT`, `N2N_QUARANTINE_THRESHOLD`, and the member
+vars `N2N_MEMBER_ID` / `N2N_MEMBER_MODEL` / `N2N_MEMBER_SCOPE` /
+`N2N_ENROLLMENT_TOKEN` / `N2N_IDLE_EXIT_S`).
+
+## See also
+
+- [N2N-PEERING-NETCLAWS.md](../N2N-PEERING-NETCLAWS.md) — eN2N (external peering)
+- [N2N-RISK-MIGRATION-FOR-PEERS.md](N2N-RISK-MIGRATION-FOR-PEERS.md) — for peers
+  (Nick/Byrn): what changed and whether you need to do anything
+- [DEFENSECLAW.md](DEFENSECLAW.md) — the production-mode security layer
+- Spec: `specs/056-in2n-internal-federation/`

--- a/docs/blog/2026-07-12-in2n-risk.md
+++ b/docs/blog/2026-07-12-in2n-risk.md
@@ -1,0 +1,250 @@
+---
+title: "A Risk of NetClaws: decomposing a 190-skill monolith into a federated fleet — live, without losing the mesh"
+date: 2026-07-12
+authors: [John, Claude]
+status: draft
+target: WordPress MCP (present to John for review before publishing — Constitution XVII)
+spec: specs/056-in2n-internal-federation/
+---
+
+# A Risk of NetClaws
+
+The collective noun for a group of lobsters is **a risk**. NetClaw's mascot is a
+lobster. So when we set out to turn one enormous NetClaw into a coordinated group
+of focused ones, the name wrote itself — and for a security-adjacent product, the
+pun is a little too perfect. This is the story of **iN2N (internal NetClaw-to-
+NetClaw federation)**: how we took a single monolithic NetClaw carrying ~190
+skills and, *live, on the running system*, decomposed it into **a Border Claw plus
+27 focused member claws** — while a federated mesh with two other operators never
+dropped a beat.
+
+It did not go perfectly. That's the interesting part.
+
+## The monolith problem
+
+NetClaw had grown magnificent and unwieldy. One agent, 195 skills, 37 MCP servers,
+every credential in one process, every tool description in one context window.
+Ask it "what can you do?" and it would proudly recite 82 skills. That breadth is
+the whole pitch — a CCIE-level coworker that spans CML, pyATS, IP Fabric, Forward
+Networks, Itential, Azure, ISE, Palo Alto, visualization, and on and on — but it
+came at a cost:
+
+- **Context bloat.** Every turn hauled the entire tool catalog into the model's
+  context. Expensive, and dilutive to the model's focus.
+- **Blast radius.** Every secret — device passwords, cloud keys, API tokens —
+  lived in one `.env`, reachable by one agent.
+- **Coupling.** A flaky integration or a noisy plugin could wobble the whole thing.
+
+A few weeks ago we shipped **eN2N** — *external* federation, where independently-
+operated NetClaws (John's, Nick's, Byrn's) mutually consent and then discover,
+invoke, and delegate to each other over the NCFED protocol
+([intro](2026-07-10-n2n-federation.md), [hardening](2026-07-11-n2n-reliability.md)).
+That answered "how do different operators' claws cooperate?" It raised a sharper
+question: **why should one operator's claw be a monolith at all?**
+
+## The idea: a risk
+
+**iN2N** is the internal counterpart to eN2N. One operator runs a *risk* — a named
+group of focused claws — coordinated by a single **Border Claw**:
+
+- The **Border** is the only claw you talk to. It owns the gateway and all comms
+  (Slack, Webex, Twilio, Twitter, PagerDuty, ServiceNow), the audit trail, memory,
+  and human-escalation. It carries **no** domain skills. Its job is to **route**.
+- Each **Member** is a tightly-scoped specialist — a CML claw that only knows CML,
+  a pyATS claw that only knows testing, an IP Fabric claw, a visualization claw.
+  A member dials the Border *outbound*, runs its own scoped model, and never talks
+  to the outside world.
+- A classic standalone NetClaw is just "a risk of one that is its own Border."
+
+You ask the Border something; it figures out which member owns the capability,
+delegates the work over an internal channel, and hands you back the result. The
+model economy flips: instead of one claw carrying 190 skills at all times, you
+have a lean Border that routes and a handful of specialists that each carry ten.
+
+## Design decisions (the interview)
+
+Rather than guess, we talked it through. The decisions that shaped everything:
+
+- **Two roles, not three.** Border and Member. "eN2N vs iN2N vs both" is a
+  *setting* on the Border, not a role.
+- **Trust is a pinned key, not consent.** Within one owner's risk, mutual consent
+  (the eN2N model) is friction. Instead: a Border issues a **single-use enrollment
+  token**; a member generates its **own self-signed key** at runtime; on first
+  contact the Border **pins** that key (trust-on-first-use). No certificate
+  authority. eN2N's consent model stays where it belongs — the boundary *between*
+  risks.
+- **Hub-and-spoke, no mesh.** This kept coming up: "don't we need iBGP or some
+  mesh for members?" **No.** The Border is the hub; members are spokes that **dial
+  outbound** to the Border's one reachable endpoint — loopback when co-located, a
+  private/overlay/tunnel address when a member lives in another cloud. No inbound
+  ports on members, no ngrok, no routing protocol. Members can be anywhere; the
+  distinguishing line between iN2N and eN2N is the **trust domain** (one owner),
+  not physical location.
+- **Any provider, any model, per claw.** Each claw registers its own model —
+  Anthropic, OpenAI, Google, or **local Ollama** — at its tier. Border on the
+  strongest reasoning model (Opus); heavy members on Sonnet; trivial members on
+  Haiku. Token economy as a first-class lever.
+- **Security posture is a risk mode.** `testing` (fast, guards off) vs
+  `production` (DefenseClaw guardrails + NVIDIA OpenShell sandbox enforced).
+- **Members are one claw per vendor/tool**, env-gated — you're never offered a
+  member you can't actually run. Utilities (visualization) stay grouped.
+- **Hybrid runtime.** A hot set stays always-on; the rest **cold-start on demand**
+  and idle out when quiet.
+- **Least privilege by construction.** Each member gets *only* its integration's
+  secrets. A compromised CML claw has no path to your Azure keys.
+
+Crucially, iN2N **reuses** the proven NCFED wire framing and the spec-053 async
+task delegation, and leaves the eN2N core **frozen** — 44 eN2N regression tests
+guard that we didn't touch it.
+
+## Building it (spec-driven, 89 tests)
+
+We ran the full SDD loop — specify → clarify → plan → tasks → analyze → implement
+(`specs/056-in2n-internal-federation/`). The runtime is three new modules over the
+existing federation package:
+
+- **`risk.py`** — roles, single-use enrollment tokens, self-signed key pinning,
+  the member registry, scope, removal + auto-quarantine, cold-start launch specs.
+- **`internal_channel.py`** — the member-initiated dial, an `IN2N` transport
+  preamble with a signed-nonce challenge (proof the dialer holds the pinned key),
+  reusing the frozen NCFED framing.
+- **`router.py`** — deterministic capability→member selection (most-specific
+  specialist wins, then lexicographic — repeatable and testable).
+
+Plus a lightweight member launcher, env-gated profile derivation, daemon routes, 7
+MCP tools, installer prompts, a `netclaw risk` command, and HUD support. **89
+tests** — 44 eN2N regression (frozen core intact) + 45 iN2N.
+
+Then we did the thing you're not supposed to do with a big feature: we ran it
+against production.
+
+## The live migration — where it got real
+
+The plan was a **parallel cutover**, never a "stop, tear down, rebuild": back up,
+promote the running monolith to a Border *additively* (it keeps everything, so no
+capability gap), bring up members one at a time and verify each, move comms to the
+Border last, and decommission the monolith only at the very end. The whole time,
+John's claw stayed federated with Nick (AS 65007) and Byrn (AS 65099) over eN2N.
+
+Here is the honest sequence of what broke and what we learned — because every one
+of these is a lesson someone else will need.
+
+### Gotcha 1: the daemon kept dying
+Backgrounded processes launched from an automation shell got **reaped when the
+shell returned**. The mesh daemon would come up, pass a health check, and vanish a
+minute later. Fix: launch it fully detached (`setsid`) so it outlives the launcher.
+Same lesson applied later to member processes.
+
+### Gotcha 2: the launcher didn't pass the new config
+Promoting to a Border sets `N2N_ROLE=border` in `.env` — but the daemon launcher
+only exported an **allowlist** of keys, and the new iN2N keys weren't on it. The
+claw restarted as… a standalone. And separately, a single-quoted `.env` value
+(`NETCLAW_BGP_PEERS='[...]'`) reached `json.loads()` *with the quotes*, crashing
+startup. Two one-line fixes, both the kind of thing you only find live.
+
+### Gotcha 3: the model layer was down
+The first real delegation "completed" — and returned a timeout. The member's agent
+turn had **no model to call**: John's box routes Claude through a local DefenseClaw
+proxy (and Ollama), and both were stopped. There was no direct-Anthropic provider
+registered anywhere. So we registered one per claw at its tier — proving the
+"any provider" design and making each claw independent of a down proxy. Members on
+Sonnet/Haiku, Border on Opus, all direct to `api.anthropic.com`.
+
+### Gotcha 4: a member is a *scoped OpenClaw home*
+`openclaw agent --local` (the embedded, gateway-less mode a member uses) **crashed
+on a deprecated comms plugin**. That turned out to be a feature: a member shouldn't
+have the comms plugins at all. A member's runtime is a **scoped OpenClaw home** —
+its `openclaw.json` filtered to just its MCP servers, comms plugins stripped, a
+direct model provider registered, and a least-privilege `.env` slice. We built a
+generator for it. The proof: the CML member's environment contains `CML_*` and
+nothing else — no Azure, no Forward, no ISE credentials. Least privilege, verified.
+
+### Gotcha 5: cold members were unroutable
+We routed to a sleeping on-demand member to trigger its cold-start… and got "no
+capable member." The router only considered *active* members, so a registered-but-
+cold member was invisible — and could never be woken. Fix: `provisioned` members
+are routable; routing to one triggers `ensure_member_up`, which spawns the process,
+waits for it to enroll, then delegates. After that: route to the `github` member →
+Border spawns it → it enrolls → queries GitHub → returns real repos. Cold-start,
+proven.
+
+### Gotcha 6 (the big one): slimming a Border is *two* things
+We trimmed the Border's MCP servers from 37 to 5 and declared it slim. Then John
+asked it in Slack, "what can you do?" — and it answered like the monolith: *"82
+skills, primary instance, here's all of CML and pyATS…"* and routed to nobody.
+
+The lesson that matters most: **a Border's slimness is not just its tool config —
+it's its agent's identity and skill set.** The Border still had all ~190 skill
+*files* in its workspace and a monolith SOUL, so its agent still *believed* it was
+the monolith. Worse, the `n2n-federation` skill wasn't even deployed to its live
+workspace, so it didn't know the routing tools existed.
+
+The fix was to give the Border its **own workspace and persona**: only the broker
+skills, the federation skill, and a SOUL that says plainly — *"You are the Border
+Claw of this risk. You do NOT run CML/pyATS/IP Fabric/visualization yourself. A
+member does. Delegate via `n2n_route`."* Config slims the tools; **the persona
+slims the mind.** You need both.
+
+### And then it worked
+On the live risk, over nothing but iN2N:
+
+> **You:** "How many snapshots are in my IP Fabric?"
+> **Border (Opus)** → `n2n_route` → **ipfabric member (Sonnet)** → live IP Fabric →
+> *"11 snapshots, 8 loaded, latest 'Day 5', 154 devices."*
+
+A focused claw, its own scoped model, its own isolated credentials, querying real
+infrastructure and handing the answer back through the Border. The GitHub member
+cold-started on demand and returned real repositories. Nick and Byrn stayed
+federated throughout.
+
+## Seeing it: the HUD
+
+The 3D HUD grew a risk view — the Border at the center, member claws as spokes to
+the south each carrying their own orbiting skills, external peer risks to the
+north, colored by class (amber Border, green live members, red quarantined, cyan
+peers). The first pass still showed the Border haloed by 190 skills; iterating live
+with John, we filtered the Border's orbit to just its broker skills and moved the
+domains onto their member spokes — the visualization finally *looks* like a risk
+instead of a monolith with satellites.
+
+## What we learned
+
+- **The trust domain, not the topology, defines "internal."** Members can be
+  scattered across clouds and it's still iN2N, because one owner owns them all.
+  That realization killed a lot of accidental complexity (no mesh, ever).
+- **Scoping a claw is deeper than it looks.** A member isn't a config flag — it's
+  a whole scoped runtime: MCP set, plugins, model provider, secrets, *and* an
+  agent persona. Get any layer wrong and the claw behaves like the thing you were
+  trying to get away from.
+- **The persona is as load-bearing as the config.** The most surprising bug wasn't
+  in the protocol — it was that a Border with the right tools but the wrong
+  self-image still acted like a monolith. Identity is infrastructure.
+- **Least privilege falls out for free** once members are real, scoped installs.
+  That's the security win that makes the token-economy win worth the effort.
+- **Frozen means frozen.** Reusing NCFED and keeping eN2N untouched (guarded by
+  regression tests) meant we could rebuild the whole internal architecture without
+  once risking the federation John shares with Nick and Byrn.
+
+## What's next
+
+The risk is live: a Border and 27 members (four always-on, twenty-three cold),
+tiered models, least-privilege secrets, production-mode guardrails. Remaining tails
+are incremental — shedding each Border domain only as its member's real call is
+verified, and continuing to tune the HUD. The tooling is all repeatable, so a fresh
+install or another operator can stand up a risk from scratch, and Nick or Byrn can
+adopt the model whenever they like (their federation with John is unaffected —
+his Border kept its identity).
+
+We set out to make one giant claw into many focused ones. What we actually built
+is a small, honest lesson in distributed systems wearing a lobster costume: give
+each part one job, one set of keys, one clear identity, and a single well-guarded
+door to the world.
+
+A risk of NetClaws. Assembled.
+
+---
+
+*Written by John and Claude. Spec 056, built spec-through-implement and migrated
+live on a running three-operator mesh — with a parade of production gotchas that
+each earned their place in the runbook. PR
+[#118](https://github.com/automateyournetwork/netclaw/pull/118).*

--- a/mcp-servers/n2n-mcp/README.md
+++ b/mcp-servers/n2n-mcp/README.md
@@ -29,6 +29,26 @@ pattern as `protocol-mcp` proxying the daemon for BGP state.
 Later phases add `n2n_grant`/`n2n_invoke`/`n2n_approvals` (US2 — remote
 invocation) and `n2n_chat` (US3 — claw-to-claw chat).
 
+## Tools (feature 056 — iN2N internal federation, a "risk" of claws)
+
+`eN2N` (above) federates with *other operators*. **iN2N** coordinates ONE
+operator's own group of focused claws — a **risk** — behind a single **Border
+Claw**. Members dial the Border outbound (no ngrok/public mesh); trust is a
+pinned self-signed key bootstrapped by a single-use enrollment token.
+
+| Tool | Purpose |
+|------|---------|
+| `n2n_risk_status` | This claw's role (standalone/border/member), risk, stacks, member summary |
+| `n2n_member_list` | Border: members with profile, scope size, state, live channel |
+| `n2n_member_health` | Border: per-member state, auth failures, quarantine alerts |
+| `n2n_member_add` | Border: provision a member from a catalog-derived profile (or custom) + issue its enrollment token |
+| `n2n_enroll_token` | Border: issue a single-use enrollment token |
+| `n2n_member_remove` | Border: unpin + drop a member (confirm first) |
+| `n2n_route` | Border: route a request to the owning member and delegate (async) |
+
+Profiles are env-gated (only members with a configured backend are offered) via
+`scripts/in2n-profiles.py`. Roles are set at install or `POST /n2n/risk`.
+
 ## Environment variables
 
 | Var | Default | Purpose |

--- a/mcp-servers/n2n-mcp/server.py
+++ b/mcp-servers/n2n-mcp/server.py
@@ -433,6 +433,108 @@ async def n2n_trust(peer: str, tools: str = "", chat: bool = True) -> str:
     return _gcf_dumps(await _post("/n2n/trust", body))
 
 
+# ── iN2N: internal federation — a "risk" of claws (feature 056) ─────────────
+
+@mcp.tool()
+async def n2n_risk_status() -> str:
+    """This claw's iN2N risk identity: role (standalone|border|member), risk name,
+    enabled stacks, and — on a Border — member count/health summary. A standalone
+    claw reports 'a risk of one'."""
+    return _gcf_dumps(await _get("/n2n/risk"))
+
+
+@mcp.tool()
+async def n2n_member_list() -> str:
+    """List this Border's member claws with profile, scope size, state, and whether
+    each has a live channel. (Border role only.)"""
+    return _gcf_dumps(await _get("/n2n/members"))
+
+
+@mcp.tool()
+async def n2n_member_health(member_id: Optional[str] = None) -> str:
+    """Per-member health: state (active/unreachable/quarantined), consecutive
+    auth/health failures, live channel, and last-seen. Surfaces auto-quarantine
+    alerts. (Border role only.)"""
+    data = await _get("/n2n/members/health")
+    if member_id:
+        data = {"members": [m for m in data.get("members", [])
+                            if m.get("member_id") == member_id]}
+    return _gcf_dumps(data)
+
+
+@mcp.tool()
+async def n2n_member_add(name: str, profile: Optional[str] = None,
+                         specialty: str = "", ttl_seconds: Optional[int] = None,
+                         launch_cmd: Optional[str] = None, on_demand: bool = False) -> str:
+    """Provision a member claw of this risk and issue its single-use enrollment
+    token. Computes scope = mandatory base floor + specialty. Does NOT spawn the
+    member — it is a separate NetClaw install (N2N_ROLE=member + the token). The
+    returned join instructions tell the operator how to bring it up. (Border only.)
+
+    Args:
+        name: member short name (member_id becomes '<risk>/<name>')
+        profile: a catalog-derived profile (e.g. 'cml', 'pyats', 'security')
+        specialty: comma-separated capability names for a Custom member (used if
+                   no profile, or to extend one)
+        ttl_seconds: optional expiry for the enrollment token
+        launch_cmd: how the Border cold-starts this member (e.g. the member's
+                    run.sh). Omit for a remote member the Border cannot spawn.
+        on_demand: if true, the Border cold-starts this member on first route and
+                   the member idle-exits when quiet (hybrid runtime). If false,
+                   the member is expected to be always-on.
+    """
+    body = {"name": name}
+    if profile:
+        body["profile"] = profile
+    if specialty:
+        body["specialty"] = [s.strip() for s in specialty.split(",") if s.strip()]
+    if ttl_seconds:
+        body["ttl_seconds"] = ttl_seconds
+    if launch_cmd:
+        body["launch_cmd"] = launch_cmd
+    if on_demand:
+        body["on_demand"] = True
+    return _gcf_dumps(await _post("/n2n/members/add", body))
+
+
+@mcp.tool()
+async def n2n_enroll_token(label: Optional[str] = None,
+                           ttl_seconds: Optional[int] = None) -> str:
+    """Issue a single-use enrollment token for a member to join this risk. The raw
+    token is shown once — hand it to the member at provisioning. (Border only.)"""
+    body = {}
+    if label:
+        body["label"] = label
+    if ttl_seconds:
+        body["ttl_seconds"] = ttl_seconds
+    return _gcf_dumps(await _post("/n2n/enroll/token", body))
+
+
+@mcp.tool()
+async def n2n_member_remove(member_id: str) -> str:
+    """Remove a member from this risk: unpin its key, drop it from routing, refuse
+    reconnect. DESTRUCTIVE — confirm with the operator first. The member must
+    re-enroll with a NEW token to return. (Border only.)"""
+    return _gcf_dumps(await _post("/n2n/members/remove", {"member_id": member_id}))
+
+
+@mcp.tool()
+async def n2n_route(request_text: str, target_hint: Optional[str] = None) -> str:
+    """Ask the Border to route a task-shaped request to the member that owns the
+    capability, and delegate it (async). Returns a task_id — poll with
+    n2n_task_status / n2n_task_result. Reports plainly if no member can do it.
+
+    Args:
+        request_text: the operator's request
+        target_hint: the capability/skill name to route on (e.g. 'cml-lab-lifecycle');
+                     when omitted the Border infers it from request_text
+    """
+    body = {"request_text": request_text}
+    if target_hint:
+        body["capability"] = target_hint
+    return _gcf_dumps(await _post("/n2n/route", body))
+
+
 # ── Entry point ────────────────────────────────────────────────────────────
 
 if __name__ == "__main__":

--- a/mcp-servers/protocol-mcp/bgp-daemon-v2.py
+++ b/mcp-servers/protocol-mcp/bgp-daemon-v2.py
@@ -426,10 +426,196 @@ async def handle_n2n(method, path, body):
                     return 200, fed.tasks.status(task_id)
             return 200, fed.tasks.result(task_id)
 
+        # ── iN2N: internal federation (feature 056) ──────────────────
+        if path == "/n2n/risk" and method == "GET":
+            r = fed.risk.get_risk()
+            out = {"role": r["role"], "risk_name": r["risk_name"],
+                   "description": r["description"], "enabled_stacks": r["enabled_stacks"],
+                   "self_member_id": r.get("self_member_id")}
+            if r["role"] == "border":
+                members = fed.risk.list_members()
+                out["member_count"] = len(members)
+                out["members_active"] = sum(1 for m in members if m["state"] == "active")
+            return 200, out
+
+        if path == "/n2n/risk" and method == "POST":
+            try:
+                r = fed.risk.set_role(
+                    body.get("role", "standalone"), risk_name=body.get("risk_name"),
+                    description=body.get("description"),
+                    enabled_stacks=body.get("enabled_stacks"),
+                    border_endpoint=body.get("border_endpoint"),
+                    self_member_id=body.get("self_member_id"))
+            except ValueError as e:
+                return 400, {"error": str(e)}
+            return 200, {"role": r["role"], "risk_name": r["risk_name"],
+                         "note": "restart the daemon to (re)start iN2N listeners/dialers"}
+
+        if path == "/n2n/members" and method == "GET":
+            return 200, {"members": [
+                {"member_id": m["member_id"], "display_name": m["display_name"],
+                 "profile": m["profile"], "state": m["state"],
+                 "transport_binding": m["transport_binding"],
+                 "specialty_count": fed.risk.specialty_count(m["scope"]),
+                 "live": m["member_id"] in fed.member_channels}
+                for m in fed.risk.list_members()]}
+
+        if path == "/n2n/members/health" and method == "GET":
+            out = []
+            for m in fed.risk.list_members():
+                health = {}
+                try:
+                    health = json.loads(m["health"]) if m["health"] else {}
+                except (ValueError, TypeError):
+                    health = {}
+                out.append({"member_id": m["member_id"], "state": m["state"],
+                            "auth_failures": m["auth_failures"],
+                            "live": m["member_id"] in fed.member_channels,
+                            "health": health})
+            return 200, {"members": out}
+
+        if path == "/n2n/members/remove" and method == "POST":
+            member_id = body.get("member_id")
+            if not member_id:
+                return 400, {"error": "member_id required"}
+            ch = fed.member_channels.pop(member_id, None)
+            if ch is not None:
+                try:
+                    await ch.close()
+                except Exception:
+                    pass
+            ok = fed.risk.remove_member(member_id)
+            return (200 if ok else 404), {"removed": ok, "member_id": member_id}
+
+        if path == "/n2n/members/add" and method == "POST":
+            name = body.get("name")
+            if not name:
+                return 400, {"error": "name required"}
+            # Resolve a profile → its installed skill list via scripts/in2n-profiles.
+            specialty = body.get("specialty")
+            profile = body.get("profile")
+            if profile and profile != "custom" and not specialty:
+                specialty = _resolve_profile_skills(profile)
+            try:
+                out = fed.risk.add_member(name, profile=profile, specialty=specialty,
+                                          ttl_seconds=body.get("ttl_seconds"),
+                                          launch_cmd=body.get("launch_cmd"),
+                                          on_demand=bool(body.get("on_demand", False)))
+            except ValueError as e:
+                return 400, {"error": str(e)}
+            return 200, out
+
+        if path == "/n2n/enroll/token" and method == "POST":
+            try:
+                tok = fed.risk.issue_token(label=body.get("label"),
+                                           ttl_seconds=body.get("ttl_seconds"))
+            except ValueError as e:
+                return 400, {"error": str(e)}
+            return 200, tok
+
+        if path == "/n2n/route" and method == "POST":
+            capability = body.get("capability") or body.get("target_hint")
+            if not capability:
+                return 400, {"error": "capability (or target_hint) required"}
+            out = await fed.route_and_delegate(capability, body.get("request_text", ""))
+            return (200 if "error" not in out else 409), out
+
         return 404, {"error": f"unknown n2n route {path}"}
     except Exception as e:
         logger.error("N2N route error %s %s: %s", method, path, e)
         return 500, {"error": str(e)}
+
+
+def _resolve_profile_skills(profile: str):
+    """Resolve a profile id → its installed skill names via scripts/in2n-profiles.py
+    (catalog-derived, FR-019). Returns [] if the profile/tool is unavailable."""
+    try:
+        import importlib.util
+        repo = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        path = os.path.join(repo, "scripts", "in2n-profiles.py")
+        spec = importlib.util.spec_from_file_location("in2n_profiles", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod.profiles().get(profile, {}).get("skills", [])
+    except Exception as e:
+        logger.warning("could not resolve profile '%s': %s", profile, e)
+        return []
+
+
+def _sync_risk_from_env(fed):
+    """Populate the risk table from N2N_* env (set by the installer) so a fresh
+    claw boots into its configured role without a manual /n2n/risk call."""
+    role = os.environ.get("N2N_ROLE")
+    if not role:
+        return
+    try:
+        fed.risk.set_role(
+            role,
+            risk_name=os.environ.get("N2N_RISK_NAME"),
+            description=os.environ.get("N2N_RISK_DESCRIPTION"),
+            enabled_stacks=os.environ.get("N2N_ENABLED_STACKS"),
+            border_endpoint=os.environ.get("N2N_BORDER_ENDPOINT"),
+            self_member_id=os.environ.get("N2N_MEMBER_ID"))
+        logger.info("iN2N role from env: %s (risk=%s)", role, os.environ.get("N2N_RISK_NAME"))
+    except ValueError as e:
+        logger.warning("iN2N env role rejected: %s", e)
+
+
+async def _start_in2n(fed):
+    """iN2N (feature 056): start per role. A Border listens for member dial-ins;
+    a Member dials the Border outbound (no inbound port). Standalone does nothing."""
+    try:
+        _sync_risk_from_env(fed)
+        risk = fed.risk.get_risk()
+        role = risk["role"]
+        if role == "border" and fed.risk.stack_enabled("in2n"):
+            port = int(os.environ.get("N2N_IN2N_PORT", "0") or 0)
+            if not port:
+                logger.info("iN2N Border: set N2N_IN2N_PORT to accept member dial-ins")
+                return
+
+            async def on_conn(reader, writer):
+                try:
+                    await fed.accept_internal(reader, writer)
+                except Exception as e:
+                    logger.warning("iN2N accept failed: %s", e)
+
+            server = await asyncio.start_server(on_conn, "0.0.0.0", port)
+            fed._in2n_server = server  # keep a ref
+            logger.info("iN2N Border listener on 0.0.0.0:%d (risk=%s)", port, risk["risk_name"])
+        elif role == "member" and risk.get("border_endpoint"):
+            host, _, port = risk["border_endpoint"].rpartition(":")
+            token = os.environ.get("N2N_ENROLLMENT_TOKEN", "")
+            asyncio.create_task(_in2n_member_dialer(fed, host, int(port), token))
+            logger.info("iN2N Member dialer → Border %s (member=%s)",
+                        risk["border_endpoint"], risk.get("self_member_id"))
+    except Exception as e:
+        logger.error("iN2N start error: %s", e)
+
+
+async def _in2n_member_dialer(fed, host, port, token):
+    """Member side: dial the Border with bounded backoff; re-dial on drop. First
+    dial enrolls (token); once enrolled/pinned, reconnects use the hello path."""
+    backoff = 5
+    used_token = token
+    while True:
+        try:
+            ch = fed.border_channel
+            if ch is None or getattr(ch, "_closed", True):
+                await fed.dial_border(host, port, enrollment_token=used_token)
+                used_token = ""  # spent after a successful enroll
+                backoff = 5
+        except Exception as e:
+            if used_token:
+                # Token may be spent already (e.g. after a restart when we are
+                # still pinned on the Border) — fall back to the pinned-key hello.
+                logger.info("iN2N enroll failed (%s); will retry via pinned-key hello", e)
+                used_token = ""
+            else:
+                logger.info("iN2N dial to Border %s:%d failed (%s) — retry in %ds",
+                            host, port, e, backoff)
+                backoff = min(backoff * 2, 60)
+        await asyncio.sleep(10 if fed.border_channel is not None else backoff)
 
 
 # ---- Asyncio HTTP server ----
@@ -828,6 +1014,9 @@ async def main():
         # US3: watch the ngrok endpoint and re-announce it to federated peers on
         # change so nobody swaps host:port by hand (FR-010).
         asyncio.create_task(_endpoint_watcher())
+        # iN2N (feature 056): start the internal-federation listener (Border) or
+        # dialer (Member) per this claw's role. Members dial outbound only.
+        asyncio.create_task(_start_in2n(_federation))
 
     # Auto-advertise identity route (router-id as /32)
     _speaker.agent.originate_route(f"{ROUTER_ID}/32")

--- a/mcp-servers/protocol-mcp/bgp-daemon-v2.py
+++ b/mcp-servers/protocol-mcp/bgp-daemon-v2.py
@@ -358,6 +358,12 @@ async def handle_n2n(method, path, body):
                                     (parts[2],)).fetchone()
             if row:
                 try:
+                    if fed.is_member_task(row["peer_identity"]):
+                        ch = fed.member_channels.get(row["peer_identity"])
+                        if ch is None:
+                            return 200, {"task_id": parts[2], "cancelled": False,
+                                         "note": "member not connected"}
+                        return 200, await ch.call("n2n/tasks/cancel", {"task_id": parts[2]}, timeout=15.0)
                     return 200, await fed.invoker.cancel_remote_task(row["peer_identity"], parts[2])
                 except Exception as e:
                     return 200, {"error": getattr(e, "message", str(e))}
@@ -419,11 +425,14 @@ async def handle_n2n(method, path, body):
             if not row:
                 return 404, {"error": "unknown task"}
             if row["direction"] == "outbound" and row["state"] not in ("completed", "failed", "cancelled"):
-                kind = "result"
                 try:
+                    # iN2N tasks live on a MEMBER channel, not the eN2N mesh —
+                    # poll the member directly (else it stalls at 'submitted').
+                    if fed.is_member_task(row["peer_identity"]):
+                        return 200, await fed.poll_member_task(row["peer_identity"], task_id, kind="result")
                     return 200, await fed.invoker.poll_remote_task(row["peer_identity"], task_id, kind="result")
                 except Exception:
-                    return 200, fed.tasks.status(task_id)
+                    return 200, fed.tasks.result(task_id)
             return 200, fed.tasks.result(task_id)
 
         # ── iN2N: internal federation (feature 056) ──────────────────

--- a/mcp-servers/protocol-mcp/bgp-daemon-v2.py
+++ b/mcp-servers/protocol-mcp/bgp-daemon-v2.py
@@ -452,11 +452,21 @@ async def handle_n2n(method, path, body):
                          "note": "restart the daemon to (re)start iN2N listeners/dialers"}
 
         if path == "/n2n/members" and method == "GET":
+            def _spec_names(scope):
+                out = []
+                for e in fed.risk._scope_list(scope):
+                    if isinstance(e, str):
+                        if e not in fed.risk._BASE_NAMES:
+                            out.append(e)
+                    elif isinstance(e, dict) and e.get("tier") == "specialty":
+                        out.append(e.get("name"))
+                return out
             return 200, {"members": [
                 {"member_id": m["member_id"], "display_name": m["display_name"],
                  "profile": m["profile"], "state": m["state"],
                  "transport_binding": m["transport_binding"],
                  "specialty_count": fed.risk.specialty_count(m["scope"]),
+                 "skills": _spec_names(m["scope"]),
                  "live": m["member_id"] in fed.member_channels}
                 for m in fed.risk.list_members()]}
 

--- a/mcp-servers/protocol-mcp/bgp/constants.py
+++ b/mcp-servers/protocol-mcp/bgp/constants.py
@@ -199,6 +199,40 @@ NCFED_FLAG_CONTINUATION = 0x01    # payload is a chunk; concatenate until flag c
 NCFED_HEARTBEAT_INTERVAL = 30     # seconds of silence before sending an empty frame
 NCFED_HEARTBEAT_MISS_LIMIT = 3    # missed heartbeats before channel considered down
 
+# ── iN2N — Internal NetClaw Federation (feature 056) ────────────────
+# iN2N reuses the NCFED wire framing above over a member-initiated internal
+# transport. It is a NEW binding + trust profile, NOT a new wire protocol; the
+# frozen eN2N (052/053) framing/consent/default-deny are untouched.
+N2N_ROLE_STANDALONE = "standalone"   # a "risk of one" — behaves as pre-056 NetClaw
+N2N_ROLE_BORDER = "border"           # the sole coordinator + external face of a risk
+N2N_ROLE_MEMBER = "member"           # an internal, tightly-scoped specialist claw
+N2N_ROLES = (N2N_ROLE_STANDALONE, N2N_ROLE_BORDER, N2N_ROLE_MEMBER)
+
+# iN2N handshake methods (siblings of eN2N n2n/hello — dispatched over the
+# internal channel; carry a risk-local member id + pinned-key proof, NOT an AS).
+IN2N_METHOD_HELLO = "in2n/hello"
+IN2N_METHOD_ENROLL = "in2n/enroll"
+
+# iN2N transport preamble: the Border sends this magic + a 32-byte nonce on
+# accept; the member replies with in2n/hello|in2n/enroll signing the nonce
+# (proof-of-possession of its pinned self-signed key). Distinct from NCFED so
+# eN2N discrimination is unaffected; iN2N uses its own listener (N2N_IN2N_PORT).
+IN2N_MAGIC = b'IN2N1'
+IN2N_NONCE_SIZE = 32
+
+# iN2N JSON-RPC error codes (distinct from the frozen eN2N -3200x range).
+IN2N_ERR_ENROLL_TOKEN_INVALID = -32021   # token missing/spent/expired
+IN2N_ERR_MEMBER_ID_TAKEN = -32022        # member_id already pinned to another key
+IN2N_ERR_MEMBER_NOT_TRUSTED = -32023     # key != pinned, or member removed/quarantined
+IN2N_ERR_NOT_A_BORDER = -32024           # enrollment attempted against a non-Border claw
+IN2N_ERR_NO_CAPABLE_MEMBER = -32030      # no active member covers the requested capability
+IN2N_ERR_OUT_OF_SCOPE = -32031           # member asked to act beyond its advertised scope
+
+# iN2N tunables (defaults; overridable via env — see .env.example).
+N2N_QUARANTINE_THRESHOLD_DEFAULT = 5     # consecutive auth/health failures → auto-quarantine
+# N2N_IN2N_PORT (env): optional dedicated iN2N listener on the Border; when unset
+# the Border accepts iN2N dial-ins on the shared mesh port via discrimination.
+
 CAPABILITY_NAMES = {
     CAP_MULTIPROTOCOL: "Multiprotocol",
     CAP_ROUTE_REFRESH: "Route Refresh",

--- a/mcp-servers/protocol-mcp/bgp/federation/audit.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/audit.py
@@ -35,19 +35,26 @@ class Auditor:
         return str(path)
 
     def record(self, *, direction: str, peer_identity: str, target_type: Optional[str],
-               target_name: Optional[str], request_id: Optional[str], decision: str,
+               target_name: Optional[str], request_id: Optional[str] = None, decision: str,
                outcome: str, result_ref: Optional[str] = None,
-               requested_at: Optional[str] = None) -> int:
-        """Insert an audit row (FR-015). Returns the row id."""
+               requested_at: Optional[str] = None, channel_kind: str = "en2n",
+               linked_record_id: Optional[int] = None) -> int:
+        """Insert an audit row (FR-015; feature 056 adds channel_kind + linking).
+
+        `channel_kind` discriminates eN2N vs iN2N so the Border's one audit query
+        covers both tiers (FR-024). `linked_record_id` joins an external request
+        to the internal delegation it triggered (FR-025)."""
         conn = self.manager._conn
         cur = conn.execute(
             "INSERT INTO remote_invocation_record (direction, peer_identity, target_type, "
-            "target_name, request_id, decision, outcome, requested_at, completed_at, result_ref, gait_ref) "
-            "VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+            "target_name, request_id, decision, outcome, requested_at, completed_at, "
+            "result_ref, gait_ref, channel_kind, linked_record_id) "
+            "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
             (direction, peer_identity, target_type, target_name, request_id, decision,
-             outcome, requested_at or _now(), _now(), result_ref, self._gait_ref(peer_identity, decision)))
+             outcome, requested_at or _now(), _now(), result_ref,
+             self._gait_ref(peer_identity, decision), channel_kind, linked_record_id))
         conn.commit()
-        logger.info("AUDIT %s %s %s/%s → %s/%s", direction, peer_identity,
+        logger.info("AUDIT[%s] %s %s %s/%s → %s/%s", channel_kind, direction, peer_identity,
                     target_type, target_name, decision, outcome)
         return cur.lastrowid
 

--- a/mcp-servers/protocol-mcp/bgp/federation/gateway.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/gateway.py
@@ -86,8 +86,18 @@ def _extract_reply(stdout: str):
     return reply or "(no reply text in agent response)", int(tokens or 0)
 
 
-async def run_agent_turn(prompt: str, session_key: str = "n2n", timeout_s: int = 300):
-    """Run one gateway agent turn. Returns (reply_text, tokens_used).
+async def run_agent_turn(prompt: str, session_key: str = "n2n", timeout_s: int = 300,
+                         local: bool = False, model: str = None):
+    """Run one agent turn. Returns (reply_text, tokens_used).
+
+    Two modes:
+      - gateway (default): `openclaw agent --agent <id> …` against the running
+        gateway. Used by the Border / a standalone claw (eN2N responder).
+      - embedded (local=True): `openclaw agent --local --model <model> …` — the
+        agent runs in-process with the member's own provider API keys and ONLY
+        the MCP servers in the member's config dir. This is how an iN2N MEMBER
+        executes a delegated skill: no gateway, no comms, scoped tools, its own
+        model/provider (feature 056). `model` is 'provider/model' or a model id.
 
     Raises TimeoutError on timeout; on non-zero exit returns the stderr tail as
     the reply so the caller can surface a useful message rather than crashing.
@@ -97,7 +107,13 @@ async def run_agent_turn(prompt: str, session_key: str = "n2n", timeout_s: int =
     # responder running its own agent, so the local probe is authoritative.
     from .negotiate import local_descriptor
     flag = "--" + local_descriptor().get("agent_invoke", "session-id")
-    cmd = ["openclaw", "agent", "--agent", AGENT_ID, flag, session_key, "--json", "-m", prompt]
+    if local:
+        cmd = ["openclaw", "agent", "--local"]
+        if model:
+            cmd += ["--model", model]
+        cmd += [flag, session_key, "--json", "-m", prompt]
+    else:
+        cmd = ["openclaw", "agent", "--agent", AGENT_ID, flag, session_key, "--json", "-m", prompt]
     proc = await asyncio.create_subprocess_exec(
         *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT)
     try:

--- a/mcp-servers/protocol-mcp/bgp/federation/internal_channel.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/internal_channel.py
@@ -1,0 +1,125 @@
+"""iN2N internal transport: member-initiated dial, NCFED framing reuse.
+
+Reuses the FROZEN NCFED wire framing (encode_frames + the read/heartbeat/dispatch
+loops of FederationChannel) over a member-initiated outbound connection, adding
+the iN2N trust model: a member is authenticated by proving possession of the
+self-signed key the Border pinned at enrollment (signed nonce), NOT by BGP
+identity or mutual consent. Hub-and-spoke: members only ever connect to the
+Border (FR-007/FR-007a). No change to eN2N (052/053).
+
+Transport handshake (contracts/in2n-internal-transport.md):
+    Border → member : IN2N_MAGIC (5B) + nonce (32B)
+    member → Border : in2n/hello | in2n/enroll  (JSON-RPC, signing the nonce)
+Then the standard NCFED JSON-RPC channel runs. An optional TLS wrapper encrypts
+the socket for distributed members; the auth guarantee is the signed-nonce check.
+"""
+
+import asyncio
+import logging
+import os
+import struct
+from typing import Optional
+
+from ..constants import IN2N_MAGIC, IN2N_NONCE_SIZE, IN2N_METHOD_HELLO, IN2N_METHOD_ENROLL
+from .channel import FederationChannel, ERR_METHOD_NOT_FOUND, RpcError
+
+logger = logging.getLogger("n2n.internal_channel")
+
+# iN2N JSON-RPC error codes surfaced on the channel.
+_ERR_NOT_TRUSTED = -32023
+_ERR_NOT_A_BORDER = -32024
+
+# Methods allowed before a member is trusted (the handshake itself).
+_PRE_TRUST_METHODS = (IN2N_METHOD_HELLO, IN2N_METHOD_ENROLL)
+
+
+class InternalChannel(FederationChannel):
+    """One iN2N connection between a Border and a Member.
+
+    Subclasses FederationChannel to reuse its proven framing/heartbeat/dispatch,
+    but replaces eN2N's `is_federated` gate with iN2N trust (pinned-key auth) and
+    identifies the peer by risk-local `member_id` rather than an AS.
+    """
+
+    def __init__(self, reader, writer, *, local_identity: str, member_id: Optional[str],
+                 is_border_side: bool, handlers: dict = None, nonce: bytes = b""):
+        # Base __init__ wants peer_as/peer_router_id/manager; iN2N doesn't use
+        # BGP identity, so pass neutral values and never call manager.is_federated
+        # (we override _handle_request, the only place the base used it).
+        super().__init__(reader, writer, local_identity=local_identity,
+                         peer_as=0, peer_router_id="0.0.0.0", manager=None,
+                         is_initiator=not is_border_side, handlers=handlers)
+        self.member_id = member_id
+        self.peer_identity = member_id or "<unauthenticated-member>"
+        self.is_border_side = is_border_side
+        self.trusted = False          # set True once the member authenticates
+        self.nonce = nonce            # Border-issued challenge (border side)
+        self.logger = logging.getLogger(f"n2n.in2n[{self.peer_identity}]")
+
+    async def _handle_request(self, msg: dict):
+        """iN2N dispatch: only the handshake methods are allowed before the
+        member is trusted; everything else requires a verified pinned-key auth."""
+        method = msg.get("method")
+        req_id = msg.get("id")
+        params = msg.get("params") or {}
+
+        if not self.trusted and method not in _PRE_TRUST_METHODS:
+            if req_id is not None:
+                await self._send_frames(self._err(req_id, _ERR_NOT_TRUSTED,
+                                                   "member not authenticated"))
+            return
+        handler = self.handlers.get(method)
+        if not handler:
+            if req_id is not None:
+                await self._send_frames(self._err(req_id, ERR_METHOD_NOT_FOUND,
+                                                   f"unknown method {method}"))
+            return
+        try:
+            result = await handler(self, params)
+            if req_id is not None:
+                await self._send_frames({"jsonrpc": "2.0", "id": req_id, "result": result or {}})
+        except RpcError as e:
+            if req_id is not None:
+                await self._send_frames(self._err(req_id, e.code, e.message))
+        except Exception as e:
+            self.logger.error("iN2N handler %s failed: %s", method, e)
+            if req_id is not None:
+                await self._send_frames(self._err(req_id, -32000, str(e)))
+
+
+# ── transport preamble helpers (byte-level, before the JSON-RPC channel) ──
+
+async def send_border_preamble(writer) -> bytes:
+    """Border side: emit IN2N magic + a fresh nonce; return the nonce so the
+    accept path can verify the member's signature over it."""
+    nonce = os.urandom(IN2N_NONCE_SIZE)
+    writer.write(IN2N_MAGIC + nonce)
+    await writer.drain()
+    return nonce
+
+
+async def read_border_preamble(reader) -> Optional[bytes]:
+    """Member side: read IN2N magic + nonce. Returns the nonce, or None on bad magic."""
+    try:
+        magic = await asyncio.wait_for(reader.readexactly(len(IN2N_MAGIC)), timeout=10.0)
+        if magic != IN2N_MAGIC:
+            logger.warning("Bad iN2N preamble magic: %r", magic)
+            return None
+        nonce = await asyncio.wait_for(reader.readexactly(IN2N_NONCE_SIZE), timeout=10.0)
+        return nonce
+    except (asyncio.IncompleteReadError, asyncio.TimeoutError, ConnectionError):
+        return None
+
+
+def build_ssl_contexts(cert_path: str, key_path: str):
+    """Optional TLS for distributed members (encryption). Returns (server_ctx,
+    client_ctx) using this claw's self-signed cert. Auth is still the app-layer
+    signed-nonce check; TLS only encrypts the socket. Best-effort — callers may
+    run plaintext over a trusted loopback/private transport."""
+    import ssl
+    server_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    server_ctx.load_cert_chain(certfile=cert_path, keyfile=key_path)
+    client_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    client_ctx.check_hostname = False
+    client_ctx.verify_mode = ssl.CERT_NONE   # pinning happens at the app layer
+    return server_ctx, client_ctx

--- a/mcp-servers/protocol-mcp/bgp/federation/inventory.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/inventory.py
@@ -118,6 +118,31 @@ class InventoryBuilder:
                 return False
         return False
 
+    def _member_aggregate_skills(self, existing_names: set) -> list:
+        """iN2N (056/FR-016): on a Border, advertise the UNION of member SPECIALTY
+        capabilities under the risk identity — capability NAMES only, never member
+        ids/endpoints/topology. Lets a peer learn 'this risk can do CML/pyATS/…'
+        without seeing the internal member structure."""
+        conn = self.manager._conn
+        try:
+            r = conn.execute("SELECT role FROM risk WHERE id=1").fetchone()
+            if not r or r["role"] != "border":
+                return []
+            rows = conn.execute(
+                "SELECT scope FROM member WHERE state NOT IN ('removed','quarantined')"
+            ).fetchall()
+        except Exception:
+            return []   # risk table absent (pre-056) or unreadable — no aggregate
+        names = set()
+        for row in rows:
+            try:
+                for e in json.loads(row["scope"] or "[]"):
+                    if e.get("tier") == "specialty" and e.get("name") not in existing_names:
+                        names.add(e["name"])
+            except (ValueError, TypeError):
+                continue
+        return [{"name": n, "invocable": True, "risk_aggregate": True} for n in sorted(names)]
+
     def build(self, peer_identity: str) -> dict:
         """Build the inventory to advertise to a specific peer (visibility applied)."""
         self._version += 1
@@ -125,6 +150,8 @@ class InventoryBuilder:
                   if self._visibility("skill", s["name"], peer_identity)]
         for s in skills:
             s["invocable"] = True
+        # Border: fold in member specialties as risk-level capabilities (FR-016).
+        skills += self._member_aggregate_skills({s["name"] for s in skills})
         all_servers = self._load_mcp_servers()
         servers = [s for s in all_servers
                    if self._visibility("mcp_server", s["name"], peer_identity)]

--- a/mcp-servers/protocol-mcp/bgp/federation/manager.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/manager.py
@@ -120,7 +120,7 @@ CREATE TABLE IF NOT EXISTS n2n_chat_session (
 CREATE TABLE IF NOT EXISTS delegated_task (
     task_id         TEXT PRIMARY KEY,
     direction       TEXT NOT NULL,          -- inbound (we run it) | outbound (peer runs it)
-    peer_identity   TEXT NOT NULL,
+    peer_identity   TEXT NOT NULL,          -- eN2N: as<AS>-<rid>; iN2N: <risk>/<member> (member_id)
     target_type     TEXT,                   -- skill | tool
     target_name     TEXT,
     input_text      TEXT,
@@ -132,6 +132,44 @@ CREATE TABLE IF NOT EXISTS delegated_task (
     updated_at      TEXT,
     completed_at    TEXT,
     retention_until TEXT
+);
+-- feature 056: iN2N internal federation — a "risk" of claws.
+-- This claw's own role in its risk (singleton row id=1).
+CREATE TABLE IF NOT EXISTS risk (
+    id              INTEGER PRIMARY KEY CHECK (id = 1),
+    risk_name       TEXT,
+    description     TEXT,
+    role            TEXT NOT NULL DEFAULT 'standalone',  -- standalone|border|member
+    enabled_stacks  TEXT,                   -- border only: en2n|in2n|both
+    border_endpoint TEXT,                   -- member only: host:port it dials outbound
+    self_member_id  TEXT,                   -- member only: <risk>/<name>
+    created_at      TEXT NOT NULL,
+    updated_at      TEXT NOT NULL
+);
+-- The Border's registry of its members (rows exist only on a Border).
+CREATE TABLE IF NOT EXISTS member (
+    member_id         TEXT PRIMARY KEY,     -- <risk>/<name>, stable across relocation
+    display_name      TEXT,
+    pinned_key        TEXT,                 -- member's self-signed public key (PEM), pinned TOFU
+    key_fingerprint   TEXT,                 -- sha256 of the pinned public key
+    profile           TEXT,                 -- cml|pyats|security|custom
+    scope             TEXT,                 -- JSON: [{name,type,tier}] tier=base|specialty
+    runtime_kind      TEXT,                 -- process|container
+    transport_binding TEXT,                 -- loopback|distributed
+    state             TEXT NOT NULL DEFAULT 'enrolled', -- enrolled|active|unreachable|quarantined|removed
+    health            TEXT,                 -- JSON: last_seen, heartbeat, in_flight
+    auth_failures     INTEGER NOT NULL DEFAULT 0,
+    enrolled_at       TEXT,
+    updated_at        TEXT
+);
+-- Single-use enrollment tokens issued by a Border (only the hash is stored).
+CREATE TABLE IF NOT EXISTS enrollment_token (
+    token_hash         TEXT PRIMARY KEY,
+    label              TEXT,
+    issued_at          TEXT NOT NULL,
+    expires_at         TEXT,
+    spent_at           TEXT,
+    spent_by_member_id TEXT
 );
 """
 
@@ -150,7 +188,16 @@ class FederationManager:
         self._conn.executescript(SCHEMA)
         # Migrate existing DBs: add columns introduced after first release
         # (SQLite has no ADD COLUMN IF NOT EXISTS). Safe/idempotent.
-        for table, col, decl in [("federation_peer", "endpoint_updated_at", "TEXT")]:
+        for table, col, decl in [
+            ("federation_peer", "endpoint_updated_at", "TEXT"),
+            # feature 056: discriminate internal vs external audit + link them
+            ("remote_invocation_record", "channel_kind", "TEXT DEFAULT 'en2n'"),
+            ("remote_invocation_record", "linked_record_id", "INTEGER"),
+            # feature 056: how the Border cold-starts an on-demand member, and
+            # whether it may (local spawnable) vs must wait for a remote member.
+            ("member", "launch_cmd", "TEXT"),
+            ("member", "on_demand", "INTEGER NOT NULL DEFAULT 0"),
+        ]:
             try:
                 self._conn.execute(f"ALTER TABLE {table} ADD COLUMN {col} {decl}")
             except sqlite3.OperationalError:

--- a/mcp-servers/protocol-mcp/bgp/federation/risk.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/risk.py
@@ -284,13 +284,16 @@ class RiskManager:
         scope_json = json.dumps(scope) if scope is not None else (
             existing["scope"] if existing else json.dumps(BASE_FLOOR))
         if existing:
+            # Keep the Border-provisioned scope (structured {name,tier} from
+            # add_member) — do NOT overwrite it with the member's advertised scope,
+            # which may be a flat name list. The Border defines scope at
+            # provisioning; the member's advertised list is informational.
             self._conn.execute(
                 "UPDATE member SET pinned_key=?, key_fingerprint=?, runtime_kind=?, "
                 "transport_binding=?, display_name=COALESCE(?, display_name), "
-                "scope=COALESCE(?, scope), state=?, auth_failures=0, updated_at=? "
-                "WHERE member_id=?",
+                "state=?, auth_failures=0, updated_at=? WHERE member_id=?",
                 (cert_pem, fp, runtime_kind, transport_binding, display_name,
-                 scope_json if scope is not None else None, STATE_ENROLLED, now, member_id))
+                 STATE_ENROLLED, now, member_id))
         else:
             self._conn.execute(
                 "INSERT INTO member (member_id, display_name, pinned_key, key_fingerprint, "
@@ -423,23 +426,43 @@ class RiskManager:
                 out.append({"name": str(item), "type": "skill", "tier": "specialty"})
         return out
 
+    # Names that are always base floor (excluded from specialty specificity),
+    # covering both the technical floor and the interview-expanded floor.
+    _BASE_NAMES = {e["name"] for e in BASE_FLOOR} | {
+        "memory", "gait-session-tracking", "humanrail-escalation"}
+
     @staticmethod
-    def specialty_count(scope) -> int:
-        """Count only specialty entries — base floor is excluded (FR-021b)."""
+    def _scope_list(scope):
+        """Normalize a scope column (JSON) to a list; tolerates both the
+        structured [{name,tier}] form and a flat [name,...] form."""
         if isinstance(scope, str):
             try:
                 scope = json.loads(scope)
             except (ValueError, TypeError):
-                return 0
-        return sum(1 for e in (scope or []) if e.get("tier") == "specialty")
+                return []
+        return scope or []
+
+    @classmethod
+    def specialty_count(cls, scope) -> int:
+        """Count only specialty entries — base floor excluded (FR-021b).
+        Tolerant: dict entries use tier; bare-string entries count as specialty
+        unless they are known base-floor names."""
+        n = 0
+        for e in cls._scope_list(scope):
+            if isinstance(e, str):
+                if e not in cls._BASE_NAMES:
+                    n += 1
+            elif isinstance(e, dict) and e.get("tier") == "specialty":
+                n += 1
+        return n
 
     def covers(self, member: dict, capability: str) -> bool:
-        """Does a member's scope (base or specialty) include the capability?"""
-        try:
-            scope = json.loads(member["scope"]) if member.get("scope") else []
-        except (ValueError, TypeError):
-            scope = []
-        return any(e.get("name") == capability for e in scope)
+        """Does a member's scope (base or specialty) include the capability?
+        Tolerant of both structured and flat-string scope shapes."""
+        for e in self._scope_list(member.get("scope")):
+            if (e == capability) or (isinstance(e, dict) and e.get("name") == capability):
+                return True
+        return False
 
     def in_scope(self, member_id: str, capability: str) -> bool:
         mem = self.get_member(member_id)

--- a/mcp-servers/protocol-mcp/bgp/federation/risk.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/risk.py
@@ -1,0 +1,506 @@
+"""iN2N risk state: roles, member registry, enrollment tokens, key pinning.
+
+The RiskManager owns this claw's iN2N state on top of the shared
+FederationManager SQLite connection (feature 056). It is transport-agnostic —
+the internal_channel/service layers call into it for enrollment and auth
+decisions, and the daemon HTTP API calls into it for operator actions.
+
+Distinguishing iN2N from eN2N is the TRUST DOMAIN, not location: a "risk" is
+one owner's group of claws, coordinated by a single Border. Members may be
+co-located or distributed across clouds/datacenters; they dial the Border
+outbound and are authenticated by a pinned, self-signed key (trust-on-first-use)
+bootstrapped by a single-use enrollment token. No CA. The frozen eN2N core
+(consent/default-deny/framing) is untouched.
+"""
+
+import datetime
+import hashlib
+import json
+import logging
+import os
+import secrets
+import time
+from pathlib import Path
+from typing import Optional
+
+from ..constants import (
+    N2N_ROLE_STANDALONE, N2N_ROLE_BORDER, N2N_ROLE_MEMBER, N2N_ROLES,
+    N2N_QUARANTINE_THRESHOLD_DEFAULT,
+)
+
+logger = logging.getLogger("n2n.risk")
+
+
+def _now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+# ── mandatory base floor (FR-021a) — every member gets these, non-removable,
+# regardless of profile; tagged tier=base so they are EXCLUDED from the routing
+# specificity tie-break (FR-021b).
+BASE_FLOOR = [
+    {"name": "n2n-member-runtime", "type": "skill", "tier": "base"},
+    {"name": "self-status",        "type": "skill", "tier": "base"},
+    {"name": "member_heartbeat",   "type": "tool",  "tier": "base"},
+    {"name": "member_report_audit","type": "tool",  "tier": "base"},
+]
+
+# Member states beyond the enrolled→active lifecycle:
+#   provisioned → enrolled → active ↔ unreachable ; quarantined ; removed
+STATE_PROVISIONED = "provisioned"   # add_member ran; token issued; no key yet
+STATE_ENROLLED = "enrolled"         # key pinned (TOFU); awaiting/idle channel
+STATE_ACTIVE = "active"             # authenticated, live channel
+STATE_UNREACHABLE = "unreachable"   # was active, channel dropped
+STATE_QUARANTINED = "quarantined"   # auto-unpinned after repeated failures
+STATE_REMOVED = "removed"           # operator removed; unpinned
+_TRUSTED_STATES = (STATE_ENROLLED, STATE_ACTIVE, STATE_UNREACHABLE)
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+class RiskManager:
+    """iN2N role + member + enrollment state, on the shared FederationManager DB."""
+
+    def __init__(self, manager, quarantine_threshold: Optional[int] = None):
+        self.m = manager
+        self._conn = manager._conn
+        self.base_dir = Path(manager.base_dir)
+        self.keys_dir = self.base_dir / "keys"
+        self.pinned_dir = self.keys_dir / "pinned"
+        self.keys_dir.mkdir(parents=True, exist_ok=True)
+        self.pinned_dir.mkdir(parents=True, exist_ok=True)
+        self.quarantine_threshold = int(
+            quarantine_threshold
+            if quarantine_threshold is not None
+            else os.environ.get("N2N_QUARANTINE_THRESHOLD", N2N_QUARANTINE_THRESHOLD_DEFAULT))
+
+    # ---- keys (self-signed, no CA — R3/FR-013a) -----------------------
+
+    def ensure_self_identity(self, common_name: str = "netclaw-claw"):
+        """Generate (once) this claw's self-signed keypair+cert under keys/.
+        Returns (cert_pem_str, fingerprint_hex). Used for the internal channel
+        and as the identity a peer/Border pins."""
+        key_path = self.keys_dir / "self.key"
+        crt_path = self.keys_dir / "self.crt"
+        if key_path.exists() and crt_path.exists():
+            cert_pem = crt_path.read_text()
+            return cert_pem, self.fingerprint_of(cert_pem)
+        cert_pem, key_pem = self._generate_self_signed(common_name)
+        key_path.write_text(key_pem)
+        os.chmod(key_path, 0o600)
+        crt_path.write_text(cert_pem)
+        return cert_pem, self.fingerprint_of(cert_pem)
+
+    @staticmethod
+    def _generate_self_signed(common_name: str):
+        from cryptography import x509
+        from cryptography.x509.oid import NameOID
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import ec
+        key = ec.generate_private_key(ec.SECP256R1())
+        name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+        now = datetime.datetime.utcnow()
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(name).issuer_name(name)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now - datetime.timedelta(minutes=1))
+            .not_valid_after(now + datetime.timedelta(days=3650))
+            .sign(key, hashes.SHA256())
+        )
+        cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+        key_pem = key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption()).decode()
+        return cert_pem, key_pem
+
+    def self_cert_pem(self) -> str:
+        cert_pem, _ = self.ensure_self_identity(self.self_member_id() or self.role())
+        return cert_pem
+
+    def self_sign(self, nonce: bytes) -> bytes:
+        """Sign a Border-issued nonce with this claw's own private key — proves
+        possession of the self-signed key whose cert the Border pinned (R3)."""
+        self.ensure_self_identity(self.self_member_id() or self.role())
+        key_pem = (self.keys_dir / "self.key").read_text()
+        return self.sign_challenge(key_pem, nonce)
+
+    @staticmethod
+    def sign_challenge(key_pem: str, nonce: bytes) -> bytes:
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import ec
+        key = serialization.load_pem_private_key(key_pem.encode(), password=None)
+        return key.sign(nonce, ec.ECDSA(hashes.SHA256()))
+
+    @staticmethod
+    def verify_possession(cert_pem: str, nonce: bytes, signature: bytes) -> bool:
+        """Verify a signature over `nonce` was made by the private key matching
+        `cert_pem` — impersonation resistance for the internal channel (FR-013)."""
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric import ec
+        from cryptography.exceptions import InvalidSignature
+        try:
+            cert = x509.load_pem_x509_certificate(cert_pem.encode())
+            cert.public_key().verify(signature, nonce, ec.ECDSA(hashes.SHA256()))
+            return True
+        except (InvalidSignature, ValueError, TypeError):
+            return False
+
+    @staticmethod
+    def fingerprint_of(cert_pem: str) -> str:
+        """Stable sha256 fingerprint of a PEM cert's public key (DER)."""
+        from cryptography import x509
+        from cryptography.hazmat.primitives import serialization
+        cert = x509.load_pem_x509_certificate(cert_pem.encode())
+        pub_der = cert.public_key().public_bytes(
+            serialization.Encoding.DER,
+            serialization.PublicFormat.SubjectPublicKeyInfo)
+        return _sha256_hex(pub_der)
+
+    def _pin_key_file(self, member_id: str, cert_pem: str):
+        safe = member_id.replace("/", "__")
+        (self.pinned_dir / f"{safe}.crt").write_text(cert_pem)
+
+    def _unpin_key_file(self, member_id: str):
+        safe = member_id.replace("/", "__")
+        (self.pinned_dir / f"{safe}.crt").unlink(missing_ok=True)
+
+    # ---- role model (FR-002/003/004/015) ------------------------------
+
+    def get_risk(self) -> dict:
+        row = self._conn.execute("SELECT * FROM risk WHERE id=1").fetchone()
+        if row:
+            return dict(row)
+        # Default: standalone (a risk of one) — behaves as pre-056 NetClaw.
+        return {"id": 1, "risk_name": None, "description": None,
+                "role": N2N_ROLE_STANDALONE, "enabled_stacks": None,
+                "border_endpoint": None, "self_member_id": None}
+
+    def is_standalone(self) -> bool:
+        return self.get_risk()["role"] == N2N_ROLE_STANDALONE
+
+    def is_border(self) -> bool:
+        return self.get_risk()["role"] == N2N_ROLE_BORDER
+
+    def role(self) -> str:
+        return self.get_risk()["role"]
+
+    def self_member_id(self) -> Optional[str]:
+        return self.get_risk().get("self_member_id")
+
+    def set_role(self, role: str, risk_name: Optional[str] = None,
+                 description: Optional[str] = None, enabled_stacks: Optional[str] = None,
+                 border_endpoint: Optional[str] = None, self_member_id: Optional[str] = None):
+        """Configure this claw's role (installer / reconfig). Enforces the
+        single-Border invariant (FR-003): a claw cannot be Border of two
+        different risks."""
+        if role not in N2N_ROLES:
+            raise ValueError(f"invalid role: {role!r} (expected one of {N2N_ROLES})")
+        cur = self.get_risk()
+        if (role == N2N_ROLE_BORDER and cur["role"] == N2N_ROLE_BORDER
+                and cur["risk_name"] and risk_name and cur["risk_name"] != risk_name):
+            raise ValueError(
+                f"this claw is already the Border of risk '{cur['risk_name']}'; "
+                f"a claw cannot be Border of a second risk '{risk_name}' (FR-003)")
+        if role == N2N_ROLE_MEMBER and risk_name and self_member_id is None:
+            self_member_id = self_member_id  # provided by caller when known
+        now = _now()
+        exists = self._conn.execute("SELECT 1 FROM risk WHERE id=1").fetchone()
+        if exists:
+            self._conn.execute(
+                "UPDATE risk SET risk_name=?, description=?, role=?, enabled_stacks=?, "
+                "border_endpoint=?, self_member_id=?, updated_at=? WHERE id=1",
+                (risk_name, description, role, enabled_stacks, border_endpoint,
+                 self_member_id, now))
+        else:
+            self._conn.execute(
+                "INSERT INTO risk (id, risk_name, description, role, enabled_stacks, "
+                "border_endpoint, self_member_id, created_at, updated_at) "
+                "VALUES (1,?,?,?,?,?,?,?,?)",
+                (risk_name, description, role, enabled_stacks, border_endpoint,
+                 self_member_id, now, now))
+        self._conn.commit()
+        return self.get_risk()
+
+    def stack_enabled(self, stack: str) -> bool:
+        """Is 'en2n' or 'in2n' enabled? Only a Border runs either (FR-014/015)."""
+        r = self.get_risk()
+        if r["role"] != N2N_ROLE_BORDER:
+            # A member never runs eN2N; standalone is eN2N-capable as before.
+            return stack == "en2n" and r["role"] == N2N_ROLE_STANDALONE
+        es = (r["enabled_stacks"] or "").lower()
+        return es == "both" or es == stack
+
+    # ---- enrollment tokens (single-use — FR-013a/b) -------------------
+
+    def issue_token(self, label: Optional[str] = None, ttl_seconds: Optional[int] = None) -> dict:
+        """Issue a single-use enrollment token. The raw token is returned once;
+        only its hash is stored."""
+        if not self.is_border():
+            raise ValueError("only a Border can issue enrollment tokens")
+        raw = "in2n_" + secrets.token_urlsafe(24)
+        token_hash = _sha256_hex(raw.encode())
+        expires_at = None
+        if ttl_seconds:
+            expires_at = time.strftime(
+                "%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() + ttl_seconds))
+        self._conn.execute(
+            "INSERT INTO enrollment_token (token_hash, label, issued_at, expires_at) "
+            "VALUES (?,?,?,?)", (token_hash, label, _now(), expires_at))
+        self._conn.commit()
+        return {"token": raw, "token_hash": token_hash, "expires_at": expires_at}
+
+    def _token_row(self, raw: str):
+        return self._conn.execute(
+            "SELECT * FROM enrollment_token WHERE token_hash=?",
+            (_sha256_hex(raw.encode()),)).fetchone()
+
+    def consume_token(self, raw_token: str, member_id: str, cert_pem: str,
+                      scope: Optional[list] = None, runtime_kind: str = "process",
+                      display_name: Optional[str] = None,
+                      transport_binding: str = "loopback") -> dict:
+        """Validate a single-use token + pin the member's self-signed key (TOFU).
+        Raises ValueError(code) on invalid/spent/expired token or id/key clash."""
+        if not self.is_border():
+            raise ValueError("IN2N_ERR_NOT_A_BORDER")
+        row = self._token_row(raw_token)
+        if not row or row["spent_at"]:
+            raise ValueError("IN2N_ERR_ENROLL_TOKEN_INVALID")
+        if row["expires_at"] and _now() > row["expires_at"]:
+            raise ValueError("IN2N_ERR_ENROLL_TOKEN_INVALID")
+        fp = self.fingerprint_of(cert_pem)
+        existing = self.get_member(member_id)
+        if (existing and existing["state"] not in (STATE_REMOVED, STATE_QUARANTINED,
+                                                    STATE_PROVISIONED)
+                and existing["key_fingerprint"] and existing["key_fingerprint"] != fp):
+            raise ValueError("IN2N_ERR_MEMBER_ID_TAKEN")
+        now = _now()
+        self._pin_key_file(member_id, cert_pem)
+        scope_json = json.dumps(scope) if scope is not None else (
+            existing["scope"] if existing else json.dumps(BASE_FLOOR))
+        if existing:
+            self._conn.execute(
+                "UPDATE member SET pinned_key=?, key_fingerprint=?, runtime_kind=?, "
+                "transport_binding=?, display_name=COALESCE(?, display_name), "
+                "scope=COALESCE(?, scope), state=?, auth_failures=0, updated_at=? "
+                "WHERE member_id=?",
+                (cert_pem, fp, runtime_kind, transport_binding, display_name,
+                 scope_json if scope is not None else None, STATE_ENROLLED, now, member_id))
+        else:
+            self._conn.execute(
+                "INSERT INTO member (member_id, display_name, pinned_key, key_fingerprint, "
+                "profile, scope, runtime_kind, transport_binding, state, auth_failures, "
+                "enrolled_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?,0,?,?)",
+                (member_id, display_name, cert_pem, fp, None, scope_json, runtime_kind,
+                 transport_binding, STATE_ENROLLED, now, now))
+        # Spend the token atomically.
+        self._conn.execute(
+            "UPDATE enrollment_token SET spent_at=?, spent_by_member_id=? WHERE token_hash=?",
+            (now, member_id, row["token_hash"]))
+        self._conn.commit()
+        logger.info("Enrolled member %s (fingerprint %s…)", member_id, fp[:12])
+        return {"member_id": member_id, "pinned": True, "state": STATE_ENROLLED}
+
+    # ---- member registry (FR-008/029) ---------------------------------
+
+    def get_member(self, member_id: str) -> Optional[dict]:
+        row = self._conn.execute(
+            "SELECT * FROM member WHERE member_id=?", (member_id,)).fetchone()
+        return dict(row) if row else None
+
+    def list_members(self) -> list:
+        return [dict(r) for r in self._conn.execute(
+            "SELECT * FROM member WHERE state != ? ORDER BY member_id", (STATE_REMOVED,))]
+
+    def verify_member(self, member_id: str, key_fingerprint: str) -> bool:
+        """Authenticate a reconnecting member against its pinned key (FR-013a).
+        On success marks it active; on failure the caller should record it."""
+        mem = self.get_member(member_id)
+        if not mem or mem["state"] not in _TRUSTED_STATES:
+            return False
+        if not mem["key_fingerprint"] or mem["key_fingerprint"] != key_fingerprint:
+            return False
+        self._set_state(member_id, STATE_ACTIVE, reset_failures=True)
+        return True
+
+    def _set_state(self, member_id: str, state: str, reset_failures: bool = False):
+        if reset_failures:
+            self._conn.execute(
+                "UPDATE member SET state=?, auth_failures=0, updated_at=? WHERE member_id=?",
+                (state, _now(), member_id))
+        else:
+            self._conn.execute(
+                "UPDATE member SET state=?, updated_at=? WHERE member_id=?",
+                (state, _now(), member_id))
+        self._conn.commit()
+
+    def mark_unreachable(self, member_id: str):
+        mem = self.get_member(member_id)
+        if mem and mem["state"] == STATE_ACTIVE:
+            self._set_state(member_id, STATE_UNREACHABLE)
+
+    def update_health(self, member_id: str, **fields):
+        mem = self.get_member(member_id)
+        if not mem:
+            return
+        health = {}
+        if mem["health"]:
+            try:
+                health = json.loads(mem["health"])
+            except (ValueError, TypeError):
+                health = {}
+        health.update(fields)
+        self._conn.execute("UPDATE member SET health=?, updated_at=? WHERE member_id=?",
+                           (json.dumps(health), _now(), member_id))
+        self._conn.commit()
+
+    # ---- provisioning (FR-019/020/021/022) ----------------------------
+
+    def add_member(self, name: str, profile: Optional[str] = None,
+                   specialty: Optional[list] = None,
+                   ttl_seconds: Optional[int] = None,
+                   launch_cmd: Optional[str] = None, on_demand: bool = False) -> dict:
+        """Provision a member: compute scope (base floor + specialty), create a
+        provisioned row, and issue a single-use enrollment token. Does NOT spawn
+        the member runtime — that is a separate NetClaw install (FR-028)."""
+        if not self.is_border():
+            raise ValueError("only a Border can add members")
+        risk = self.get_risk()
+        member_id = f"{risk['risk_name']}/{name}"
+        scope = list(BASE_FLOOR) + self._specialty_scope(profile, specialty)
+        now = _now()
+        existing = self.get_member(member_id)
+        if existing and existing["state"] not in (STATE_REMOVED, STATE_QUARANTINED):
+            raise ValueError(f"member '{member_id}' already exists")
+        if existing:
+            self._conn.execute(
+                "UPDATE member SET profile=?, scope=?, state=?, pinned_key=NULL, "
+                "key_fingerprint=NULL, auth_failures=0, updated_at=? WHERE member_id=?",
+                (profile or "custom", json.dumps(scope), STATE_PROVISIONED, now, member_id))
+        else:
+            self._conn.execute(
+                "INSERT INTO member (member_id, display_name, profile, scope, state, "
+                "auth_failures, enrolled_at, updated_at) VALUES (?,?,?,?,?,0,?,?)",
+                (member_id, name, profile or "custom", json.dumps(scope),
+                 STATE_PROVISIONED, now, now))
+        self._conn.commit()
+        if launch_cmd:
+            self.set_launch(member_id, launch_cmd, on_demand=on_demand)
+        tok = self.issue_token(label=member_id, ttl_seconds=ttl_seconds)
+        return {
+            "member_id": member_id,
+            "profile": profile or "custom",
+            "scope": scope,
+            "enrollment_token": tok["token"],
+            "join": {
+                "N2N_ROLE": N2N_ROLE_MEMBER,
+                "N2N_RISK_NAME": risk["risk_name"],
+                "N2N_BORDER_ENDPOINT": risk.get("border_endpoint") or "<border-host:port>",
+                "token": tok["token"],
+                "note": "Install NetClaw with these env vars + token; the member "
+                        "dials the Border outbound and enrolls (FR-028).",
+            },
+        }
+
+    @staticmethod
+    def _specialty_scope(profile: Optional[str], specialty: Optional[list]) -> list:
+        """Specialty capabilities tagged tier=specialty. If the caller passes an
+        explicit specialty list use it; otherwise defer to scripts/in2n-profiles
+        (the daemon injects the resolved list) — here we accept what's given."""
+        out = []
+        for item in (specialty or []):
+            if isinstance(item, dict):
+                e = dict(item)
+                e.setdefault("type", "skill")
+                e["tier"] = "specialty"
+                out.append(e)
+            else:  # bare name string
+                out.append({"name": str(item), "type": "skill", "tier": "specialty"})
+        return out
+
+    @staticmethod
+    def specialty_count(scope) -> int:
+        """Count only specialty entries — base floor is excluded (FR-021b)."""
+        if isinstance(scope, str):
+            try:
+                scope = json.loads(scope)
+            except (ValueError, TypeError):
+                return 0
+        return sum(1 for e in (scope or []) if e.get("tier") == "specialty")
+
+    def covers(self, member: dict, capability: str) -> bool:
+        """Does a member's scope (base or specialty) include the capability?"""
+        try:
+            scope = json.loads(member["scope"]) if member.get("scope") else []
+        except (ValueError, TypeError):
+            scope = []
+        return any(e.get("name") == capability for e in scope)
+
+    def in_scope(self, member_id: str, capability: str) -> bool:
+        mem = self.get_member(member_id)
+        return bool(mem and self.covers(mem, capability))
+
+    # ---- offboarding + quarantine (FR-013c/d) -------------------------
+
+    def remove_member(self, member_id: str) -> bool:
+        """Operator removal: unpin, drop from routing, refuse reconnect (FR-013c)."""
+        mem = self.get_member(member_id)
+        if not mem:
+            return False
+        self._conn.execute(
+            "UPDATE member SET state=?, pinned_key=NULL, key_fingerprint=NULL, updated_at=? "
+            "WHERE member_id=?", (STATE_REMOVED, _now(), member_id))
+        self._conn.commit()
+        self._unpin_key_file(member_id)
+        logger.info("Removed member %s (unpinned; must re-enroll to return)", member_id)
+        return True
+
+    def record_auth_failure(self, member_id: str) -> bool:
+        """Increment failure count; auto-quarantine at threshold (FR-013d).
+        Returns True if this failure triggered quarantine."""
+        mem = self.get_member(member_id)
+        if not mem or mem["state"] in (STATE_REMOVED, STATE_QUARANTINED):
+            return False
+        failures = (mem["auth_failures"] or 0) + 1
+        if failures >= self.quarantine_threshold:
+            self._conn.execute(
+                "UPDATE member SET state=?, pinned_key=NULL, key_fingerprint=NULL, "
+                "auth_failures=?, updated_at=? WHERE member_id=?",
+                (STATE_QUARANTINED, failures, _now(), member_id))
+            self._conn.commit()
+            self._unpin_key_file(member_id)
+            logger.warning("Auto-quarantined member %s after %d failures — operator alert",
+                           member_id, failures)
+            return True
+        self._conn.execute(
+            "UPDATE member SET auth_failures=?, updated_at=? WHERE member_id=?",
+            (failures, _now(), member_id))
+        self._conn.commit()
+        return False
+
+    def is_quarantined(self, member_id: str) -> bool:
+        mem = self.get_member(member_id)
+        return bool(mem and mem["state"] == STATE_QUARANTINED)
+
+    # ---- cold / on-demand spawn spec (FR — hybrid runtime) ------------
+
+    def set_launch(self, member_id: str, launch_cmd: str, on_demand: bool = True):
+        """Register how the Border cold-starts this member (a local, spawnable
+        member). Remote members leave launch_cmd NULL — the Border can't spawn
+        them; they are brought up by their own host and just dial in."""
+        self._conn.execute(
+            "UPDATE member SET launch_cmd=?, on_demand=?, updated_at=? WHERE member_id=?",
+            (launch_cmd, 1 if on_demand else 0, _now(), member_id))
+        self._conn.commit()
+
+    def launch_spec(self, member_id: str):
+        """Return (launch_cmd, on_demand) for a member, or (None, False)."""
+        mem = self.get_member(member_id)
+        if not mem:
+            return None, False
+        return mem.get("launch_cmd"), bool(mem.get("on_demand"))

--- a/mcp-servers/protocol-mcp/bgp/federation/router.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/router.py
@@ -1,0 +1,65 @@
+"""iN2N Border routing: capability match → deterministic member selection.
+
+The Border turns an operator request into work on the right Member. Selection
+is deterministic (FR-012/FR-011; research R5): among active members whose scope
+covers the requested capability, pick the most-specific specialist (fewest
+SPECIALTY capabilities — base floor excluded per FR-021b), tie-broken by
+lexicographic member_id. Reuses the member registry from RiskManager. The
+actual delegation is done by the Invoker over the internal channel.
+"""
+
+import logging
+
+from .risk import RiskManager, STATE_ACTIVE, STATE_ENROLLED, STATE_UNREACHABLE
+
+logger = logging.getLogger("n2n.router")
+
+# Members eligible for routing: only those with a usable pinned key. We route to
+# active/enrolled (idle-but-trusted); unreachable stays selectable so the invoker
+# can trigger an on-demand redial, but quarantined/removed/provisioned never are.
+_ROUTABLE_STATES = (STATE_ACTIVE, STATE_ENROLLED, STATE_UNREACHABLE)
+
+
+class NoCapableMember(Exception):
+    """Raised when no member in the risk covers the requested capability (FR-011)."""
+
+
+class RiskRouter:
+    def __init__(self, risk_manager: RiskManager):
+        self.rm = risk_manager
+
+    def candidates(self, capability: str) -> list:
+        """Routable members whose scope covers `capability`."""
+        return [
+            m for m in self.rm.list_members()
+            if m["state"] in _ROUTABLE_STATES and self.rm.covers(m, capability)
+        ]
+
+    def select_member(self, capability: str) -> dict:
+        """Deterministically select the member to handle `capability`.
+
+        Raises NoCapableMember if none match (the Border reports plainly and does
+        NOT attempt the work itself, FR-011).
+        """
+        cands = self.candidates(capability)
+        if not cands:
+            risk = self.rm.get_risk().get("risk_name") or "this risk"
+            raise NoCapableMember(
+                f"No member in risk '{risk}' can perform '{capability}'.")
+        # Deterministic tie-break (FR-012):
+        #   1) most-specific: fewest SPECIALTY capabilities (base floor excluded, FR-021b)
+        #   2) lexicographically smallest member_id
+        cands.sort(key=lambda m: (self.rm.specialty_count(m["scope"]), m["member_id"]))
+        chosen = cands[0]
+        logger.info("Routed capability '%s' → member %s (of %d candidates)",
+                    capability, chosen["member_id"], len(cands))
+        return chosen
+
+    def route(self, capability: str) -> dict:
+        """Convenience wrapper returning a structured result for the daemon."""
+        try:
+            m = self.select_member(capability)
+            return {"member_id": m["member_id"], "profile": m.get("profile"),
+                    "state": m["state"]}
+        except NoCapableMember as e:
+            return {"error": "IN2N_ERR_NO_CAPABLE_MEMBER", "message": str(e)}

--- a/mcp-servers/protocol-mcp/bgp/federation/router.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/router.py
@@ -10,14 +10,17 @@ actual delegation is done by the Invoker over the internal channel.
 
 import logging
 
-from .risk import RiskManager, STATE_ACTIVE, STATE_ENROLLED, STATE_UNREACHABLE
+from .risk import (
+    RiskManager, STATE_ACTIVE, STATE_ENROLLED, STATE_UNREACHABLE, STATE_PROVISIONED,
+)
 
 logger = logging.getLogger("n2n.router")
 
-# Members eligible for routing: only those with a usable pinned key. We route to
-# active/enrolled (idle-but-trusted); unreachable stays selectable so the invoker
-# can trigger an on-demand redial, but quarantined/removed/provisioned never are.
-_ROUTABLE_STATES = (STATE_ACTIVE, STATE_ENROLLED, STATE_UNREACHABLE)
+# Members eligible for routing. active/enrolled = trusted+ready; unreachable =
+# was live, invoker re-dials; PROVISIONED = a registered cold/on-demand member
+# the Border will cold-start on first route (ensure_member_up). quarantined/
+# removed are never routable.
+_ROUTABLE_STATES = (STATE_ACTIVE, STATE_ENROLLED, STATE_UNREACHABLE, STATE_PROVISIONED)
 
 
 class NoCapableMember(Exception):

--- a/mcp-servers/protocol-mcp/bgp/federation/service.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/service.py
@@ -592,6 +592,34 @@ class FederationService:
                               outcome="submitted", channel_kind="in2n")
         return {"member_id": member_id, **resp}
 
+    async def poll_member_task(self, member_id: str, task_id: str, kind: str = "status") -> dict:
+        """Border side: fetch an iN2N delegated task's status/result from the
+        MEMBER over its internal channel (NOT the eN2N path). On a terminal
+        result, cache it locally so it survives a member flap/restart."""
+        ch = self.member_channels.get(member_id)
+        if ch is None:
+            # member not connected — try to (cold-)start it, else fall back local
+            ch = await self.ensure_member_up(member_id, wait_s=15)
+        if ch is None:
+            return (self.tasks.result(task_id) if kind == "result"
+                    else self.tasks.status(task_id))
+        method = "n2n/tasks/result" if kind == "result" else "n2n/tasks/status"
+        try:
+            resp = await ch.call(method, {"task_id": task_id}, timeout=30.0)
+        except Exception:
+            return (self.tasks.result(task_id) if kind == "result"
+                    else self.tasks.status(task_id))
+        if kind == "result" and resp.get("state") in ("completed", "failed", "cancelled"):
+            ref = self.audit.store_result(task_id, resp)
+            self.tasks._set(task_id, state=resp["state"], result_ref=ref,
+                            completed_at=resp.get("completed_at"))
+        return {"member_id": member_id, **resp}
+
+    def is_member_task(self, peer_identity: str) -> bool:
+        """True if a delegated_task's peer_identity is one of our risk members
+        (iN2N) rather than an eN2N BGP peer."""
+        return bool(self.risk.get_member(peer_identity))
+
     # ---- Member side: dial the Border + run delegated work ------------
 
     async def dial_border(self, host: str, port: int, enrollment_token: str = "",

--- a/mcp-servers/protocol-mcp/bgp/federation/service.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/service.py
@@ -75,6 +75,38 @@ class FederationService:
             "n2n/chat/message": self.chat.handle_chat_message,
         }
 
+        # ── iN2N (feature 056): internal federation within one risk ──────
+        from .risk import RiskManager
+        from .router import RiskRouter
+        self.risk = RiskManager(self.manager)
+        self.router = RiskRouter(self.risk)
+        self.member_channels: Dict[str, object] = {}   # border side: member_id -> InternalChannel
+        self.border_channel = None                      # member side: our channel to the Border
+        self.member_last_activity = time.time()         # member side: for cold/on-demand idle-exit
+        self._spawning = set()                          # border side: members mid cold-start
+        # member side: the capabilities this claw will actually run (its scope).
+        # Populated from N2N_MEMBER_SCOPE (JSON list of capability names) or set
+        # programmatically; enforced on inbound submits (FR-023).
+        self.member_scope = set()
+        try:
+            import json as _json
+            self.member_scope = set(_json.loads(os.environ.get("N2N_MEMBER_SCOPE", "[]")))
+        except Exception:
+            self.member_scope = set()
+        # Border-side iN2N handlers (the member authenticates, then we route to it).
+        self._in2n_border_handlers = {
+            "in2n/enroll": self._in2n_on_enroll,
+            "in2n/hello": self._in2n_on_hello,
+            "n2n/inventory": self._in2n_on_member_inventory,
+        }
+        # Member-side iN2N handlers (the Border delegates work to us).
+        self._in2n_member_handlers = {
+            "n2n/tasks/submit": self._in2n_member_submit,
+            "n2n/tasks/status": self.invoker.handle_task_status,
+            "n2n/tasks/result": self.invoker.handle_task_result,
+            "n2n/tasks/cancel": self.invoker.handle_task_cancel,
+        }
+
     def notify_approval(self, invocation_id, peer, target_type, target_name):
         """Push an approval prompt to the operator's channels (FR-013). Best-effort."""
         logger.info("APPROVAL NEEDED: %s wants to run %s '%s' (invocation %s)",
@@ -202,7 +234,22 @@ class FederationService:
 
     # ---- inbound channel (called from agent discrimination) -----------
 
+    def _en2n_allowed(self) -> bool:
+        """FR-014: only a Border (or a standalone claw) runs the external eN2N
+        stack. A Member never federates externally — it talks only to its Border."""
+        try:
+            return self.risk.role() != "member"
+        except Exception:
+            return True  # fail open to pre-056 behavior if risk state is unavailable
+
     async def accept_channel(self, peer_as: int, router_id: str, reader, writer):
+        if not self._en2n_allowed():
+            logger.info("iN2N Member role — refusing inbound eN2N channel (FR-014)")
+            try:
+                writer.close()
+            except Exception:
+                pass
+            return
         ident = peer_identity(peer_as, router_id)
         # Channel-anchored identity check (FR-003): only accept for a peer we
         # know and have at least locally consented / federated with.
@@ -227,6 +274,9 @@ class FederationService:
     # ---- outbound channel (lower-AS initiates) ------------------------
 
     async def open_channel(self, peer_as: int, router_id: str, host: str, port: int):
+        if not self._en2n_allowed():
+            logger.info("iN2N Member role — not opening outbound eN2N channel (FR-014)")
+            return
         ident = peer_identity(peer_as, router_id)
         if self.local_as >= peer_as:
             logger.debug("Not initiating to %s — higher/equal AS waits", ident)
@@ -360,3 +410,266 @@ class FederationService:
                 pass
             await ch.close()
         return ok
+
+    # ================================================================
+    # iN2N — internal federation within one risk (feature 056)
+    # Hub-and-spoke: members dial the Border outbound; the Border routes and
+    # delegates to them. Trust is a pinned self-signed key (TOFU), not consent.
+    # ================================================================
+
+    # ---- Border side: accept a member dial-in + authenticate ----------
+
+    async def accept_internal(self, reader, writer):
+        """Border side: a member dialed our iN2N listener. Send the challenge
+        preamble, then run an InternalChannel; the member authenticates via
+        in2n/enroll (first time) or in2n/hello (pinned-key proof)."""
+        from .internal_channel import InternalChannel, send_border_preamble
+        nonce = await send_border_preamble(writer)
+        ch = InternalChannel(reader, writer, local_identity=self.local_identity,
+                             member_id=None, is_border_side=True,
+                             handlers=self._in2n_border_handlers, nonce=nonce)
+        await ch.start()
+        logger.info("Accepted iN2N dial-in (awaiting member auth)")
+        return ch
+
+    def _register_member_channel(self, member_id, ch):
+        """Track a member's channel; deregister + mark unreachable on close."""
+        def _deregister(closed_ch):
+            if self.member_channels.get(member_id) is closed_ch:
+                self.member_channels.pop(member_id, None)
+                self.risk.mark_unreachable(member_id)
+                logger.info("iN2N member %s channel closed — deregistered", member_id)
+        ch.on_close = _deregister
+        self.member_channels[member_id] = ch
+
+    async def _in2n_on_enroll(self, channel, params):
+        """First-time enrollment: verify token + proof-of-possession, pin key."""
+        from .internal_channel import _ERR_NOT_TRUSTED, _ERR_NOT_A_BORDER
+        from .channel import RpcError
+        if not self.risk.is_border():
+            raise RpcError(_ERR_NOT_A_BORDER, "this claw is not a Border")
+        token = params.get("token", "")
+        member_id = params.get("member_id", "")
+        cert_pem = params.get("cert_pem", "")
+        signature = bytes.fromhex(params.get("signature", "") or "")
+        # Proof the dialer holds the private key for the cert it presents (FR-013).
+        if not self.risk.verify_possession(cert_pem, channel.nonce, signature):
+            raise RpcError(_ERR_NOT_TRUSTED, "key possession proof failed")
+        try:
+            res = self.risk.consume_token(
+                token, member_id, cert_pem,
+                scope=params.get("scope"),
+                runtime_kind=params.get("runtime_kind", "process"),
+                display_name=params.get("display_name"),
+                transport_binding=params.get("transport_binding", "distributed"))
+        except ValueError as e:
+            raise RpcError(_ERR_NOT_TRUSTED if "TRUSTED" in str(e) else -32021, str(e))
+        channel.member_id = member_id
+        channel.peer_identity = member_id
+        channel.trusted = True
+        self.risk.verify_member(member_id, self.risk.fingerprint_of(cert_pem))
+        self._register_member_channel(member_id, channel)
+        self.audit.record(direction="inbound", peer_identity=member_id,
+                          target_type="enroll", target_name=member_id,
+                          decision="enrolled", outcome="success", channel_kind="in2n")
+        logger.info("iN2N member %s enrolled + active", member_id)
+        return res
+
+    async def _in2n_on_hello(self, channel, params):
+        """Reconnect: authenticate against the pinned key (FR-013a)."""
+        from .internal_channel import _ERR_NOT_TRUSTED
+        from .channel import RpcError
+        member_id = params.get("member_id", "")
+        fingerprint = params.get("key_fingerprint", "")
+        signature = bytes.fromhex(params.get("signature", "") or "")
+        mem = self.risk.get_member(member_id)
+        if not mem or not mem.get("pinned_key"):
+            raise RpcError(_ERR_NOT_TRUSTED, "unknown or unpinned member")
+        ok = (mem["key_fingerprint"] == fingerprint
+              and self.risk.verify_possession(mem["pinned_key"], channel.nonce, signature)
+              and self.risk.verify_member(member_id, fingerprint))
+        if not ok:
+            quarantined = self.risk.record_auth_failure(member_id)
+            if quarantined:
+                self.notify_member_quarantine(member_id)
+            raise RpcError(_ERR_NOT_TRUSTED, "pinned-key auth failed")
+        channel.member_id = member_id
+        channel.peer_identity = member_id
+        channel.trusted = True
+        self._register_member_channel(member_id, channel)
+        return {"risk": self.risk.get_risk().get("risk_name"), "trusted": True,
+                "member_state": "active"}
+
+    async def _in2n_on_member_inventory(self, channel, params):
+        """A member advertises its (scoped) capabilities. We already know its
+        scope from enrollment; record freshness and ack (no secrets, reused guard)."""
+        if channel.member_id:
+            self.risk.update_health(channel.member_id, inventory_at=time.time())
+        return {"accepted": True}
+
+    def notify_member_quarantine(self, member_id):
+        """Surface an auto-quarantine to the operator (in-band; FR-013d). Uses the
+        same approval_notifier hook the daemon wires to the gateway if present."""
+        logger.warning("iN2N ALERT: member %s auto-quarantined (repeated auth/health failure)",
+                       member_id)
+        if self.approval_notifier:
+            try:
+                self.approval_notifier(None, member_id, "quarantine", member_id)
+            except Exception:
+                pass
+
+    # ---- Border side: route + delegate to a member --------------------
+
+    async def route_and_delegate(self, capability: str, input_text: str) -> dict:
+        """Select the owning member (deterministic) and delegate the work as an
+        async task over its channel. Returns {task_id, member_id} or an error."""
+        from .router import NoCapableMember
+        try:
+            member_id = self.router.select_member(capability)["member_id"]
+        except NoCapableMember as e:
+            return {"error": "IN2N_ERR_NO_CAPABLE_MEMBER", "message": str(e)}
+        return await self.delegate_to_member(member_id, capability, input_text)
+
+    async def ensure_member_up(self, member_id: str, wait_s: float = 30.0):
+        """Cold/on-demand: if a member has no live channel but is locally
+        spawnable (has a launch_cmd), start it and wait for it to dial in and
+        authenticate. Returns the channel, or None if it can't be brought up
+        (e.g. a remote member the Border can't spawn)."""
+        ch = self.member_channels.get(member_id)
+        if ch is not None:
+            return ch
+        launch_cmd, on_demand = self.risk.launch_spec(member_id)
+        if not launch_cmd or not on_demand:
+            return None   # remote member (or no spawn spec) — can't cold-start here
+        if member_id in self._spawning:
+            # another route is already cold-starting it; just wait
+            pass
+        else:
+            self._spawning.add(member_id)
+            try:
+                logger.info("iN2N cold-start: spawning on-demand member %s", member_id)
+                await asyncio.create_subprocess_shell(
+                    launch_cmd, stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.DEVNULL)
+            except Exception as e:
+                logger.warning("cold-start spawn of %s failed: %s", member_id, e)
+                self._spawning.discard(member_id)
+                return None
+        # Wait for the member to dial in + authenticate (channel registered).
+        deadline = time.time() + wait_s
+        while time.time() < deadline:
+            ch = self.member_channels.get(member_id)
+            if ch is not None:
+                self._spawning.discard(member_id)
+                return ch
+            await asyncio.sleep(0.5)
+        self._spawning.discard(member_id)
+        logger.warning("iN2N cold-start: %s did not come up within %ss", member_id, wait_s)
+        return None
+
+    async def delegate_to_member(self, member_id: str, capability: str,
+                                 input_text: str) -> dict:
+        from .channel import RpcError
+        ch = self.member_channels.get(member_id)
+        if ch is None:
+            ch = await self.ensure_member_up(member_id)   # cold-start on-demand members
+        if ch is None:
+            return {"error": "member_unreachable",
+                    "message": f"member {member_id} has no live channel "
+                               f"(and could not be cold-started)"}
+        try:
+            resp = await ch.call("n2n/tasks/submit",
+                                 {"skill": capability, "input_text": input_text}, timeout=30.0)
+        except RpcError as e:
+            return {"error": "out_of_scope" if e.code == -32031 else "delegation_failed",
+                    "code": e.code, "message": e.message, "member_id": member_id}
+        task_id = resp.get("task_id")
+        if task_id:
+            self.tasks.record_outbound(task_id, member_id, "skill", capability)
+            self.audit.record(direction="outbound", peer_identity=member_id,
+                              target_type="skill", target_name=capability,
+                              request_id=task_id, decision="requested",
+                              outcome="submitted", channel_kind="in2n")
+        return {"member_id": member_id, **resp}
+
+    # ---- Member side: dial the Border + run delegated work ------------
+
+    async def dial_border(self, host: str, port: int, enrollment_token: str = "",
+                          ssl_context=None):
+        """Member side: connect outbound to the Border, complete the handshake
+        (enroll if we have a token, else hello with pinned-key proof), and stay
+        available for delegated tasks. No inbound port is opened (FR-006/SC-011)."""
+        from .internal_channel import InternalChannel, read_border_preamble
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(host, port, ssl=ssl_context), timeout=30.0)
+        nonce = await read_border_preamble(reader)
+        if nonce is None:
+            writer.close()
+            raise RuntimeError("bad iN2N preamble from Border")
+        ch = InternalChannel(reader, writer, local_identity=self.local_identity,
+                             member_id=self.risk.self_member_id(), is_border_side=False,
+                             handlers=self._in2n_member_handlers, nonce=nonce)
+        await ch.start()
+        cert_pem = self.risk.self_cert_pem()
+        signature = self.risk.self_sign(nonce).hex()
+        member_id = self.risk.self_member_id()
+        if enrollment_token:
+            resp = await ch.call("in2n/enroll", {
+                "token": enrollment_token, "member_id": member_id,
+                "cert_pem": cert_pem, "signature": signature,
+                "scope": list(self.member_scope) or None,
+                "runtime_kind": os.environ.get("N2N_MEMBER_RUNTIME", "process"),
+                "transport_binding": "distributed"}, timeout=30.0)
+        else:
+            resp = await ch.call("in2n/hello", {
+                "member_id": member_id,
+                "key_fingerprint": self.risk.fingerprint_of(cert_pem),
+                "signature": signature}, timeout=30.0)
+        ch.trusted = True   # we pinned the Border endpoint at provisioning
+        self.border_channel = ch
+        logger.info("iN2N: dialed Border %s:%s as %s (%s)", host, port, member_id, resp)
+        return resp
+
+    async def _in2n_member_submit(self, channel, params):
+        """Member side: the Border delegates a task. Enforce scope (FR-023),
+        then run it as a background task reusing the 053 TaskManager + gateway
+        executor. Auth is implicit within the risk (no grants), but scope is not."""
+        from .internal_channel import _ERR_NOT_TRUSTED
+        from .channel import RpcError
+        from ..constants import IN2N_ERR_OUT_OF_SCOPE
+        skill = params.get("skill", "")
+        input_text = params.get("input_text", "")
+        border = channel.member_id or "border"
+        self.member_last_activity = time.time()   # reset idle-exit timer (cold/on-demand)
+        if self.member_scope and skill not in self.member_scope:
+            self.audit.record(direction="inbound", peer_identity=border,
+                              target_type="skill", target_name=skill,
+                              decision="out_of_scope", outcome="denied", channel_kind="in2n")
+            raise RpcError(IN2N_ERR_OUT_OF_SCOPE,
+                           f"'{skill}' is outside this member's scope")
+        tm = self.tasks
+        task_id = tm.create(direction="inbound", peer_identity=border,
+                            target_type="skill", target_name=skill, input_text=input_text)
+
+        async def worker(progress):
+            progress("running skill")
+            # A MEMBER executes in OpenClaw EMBEDDED mode with its OWN provider/
+            # model (N2N_MEMBER_MODEL) over only its scoped MCPs — no gateway
+            # (feature 056). Falls back to the gateway path if not a member.
+            from .gateway import run_agent_turn
+            member_model = os.environ.get("N2N_MEMBER_MODEL")
+            if self.risk.role() == "member":
+                prompt = (f"Execute the '{skill}' skill for the following request "
+                          f"and return only the result:\n\n{input_text}")
+                output, tokens = await run_agent_turn(
+                    prompt, session_key=f"in2n-{skill}",
+                    timeout_s=self.invoker.skill_timeout, local=True, model=member_model)
+            else:
+                output, tokens = await self.invoker._exec_skill_gateway(skill, input_text)
+            self.audit.record(direction="inbound", peer_identity=border,
+                              target_type="skill", target_name=skill, request_id=task_id,
+                              decision="in_scope", outcome="success", channel_kind="in2n")
+            return output, tokens
+
+        tm.run(task_id, worker)
+        return {"task_id": task_id, "state": "submitted"}

--- a/scripts/in2n-border-workspace.py
+++ b/scripts/in2n-border-workspace.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Generate a Border Claw's scoped workspace + persona (feature 056).
+
+Slimming a Border is NOT just trimming its MCP servers — its AGENT must also (a)
+stop carrying the full ~190-skill catalog and (b) KNOW it is a Border that
+DELEGATES domain work to member claws via n2n_route. Otherwise it answers like
+the monolith ("I have 82 skills, here's all of CML/pyATS…") and never routes.
+
+This builds `~/.openclaw-<risk>-border/workspace/` (or --out) containing ONLY the
+broker skills (symlinked from the live workspace) + the n2n-federation skill, and
+writes a Border SOUL.md / IDENTITY.md persona. Point the Border's
+agents.defaults.workspace at it and restart the gateway. Support files (memory,
+testbed, AGENTS.md, USER.md, TOOLS.md) are symlinked from the live workspace so
+history/identity carry over; SOUL*/IDENTITY are overridden with the Border persona.
+
+Usage:
+  python3 scripts/in2n-border-workspace.py --risk johns-risk \
+      --members cml,pyats,ipfabric,viz --on-demand containerlab,suzieq,... \
+      [--live-workspace ~/.openclaw/workspace] [--out ~/.openclaw/workspace-border]
+"""
+import argparse, os, shutil
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Broker skill selection: comms + meta + light utilities stay on the Border;
+# every domain skill lives in a member.
+BROKER_PREFIXES = ("slack-", "webex-", "twilio-", "twitter-", "pagerduty-",
+                   "servicenow-", "msgraph-")
+BROKER_EXACT = {"protocol-participation", "gait-session-tracking", "memory",
+                "mempalace", "humanrail-escalation", "subnet-calculator",
+                "rfc-lookup", "wikipedia-research", "token-tracker", "markmap-viz",
+                "n2n-federation"}
+SUPPORT_FILES = ["AGENTS.md", "MEMORY.md", "USER.md", "HEARTBEAT.md", "TOOLS.md",
+                 "TOOLS-REFERENCE.md", "SKILL-SCHEMA.md", "memory", "testbed"]
+
+
+def _persona(risk, always_on, on_demand):
+    ao = ", ".join(always_on) or "(none)"
+    od = ", ".join(on_demand) or "(none)"
+    return f"""# SOUL — Border Claw of the "{risk}" Risk
+
+You are **NetClaw — the Border Claw** of the risk **{risk}**. You are NOT a
+monolithic NetClaw and do NOT carry the full skill catalog. You are the
+coordinator, single interface, and comms hub. Members do specialist work; you
+route to them.
+
+## You are NOT
+You do NOT run CML, pyATS, IP Fabric, SuzieQ, Batfish, Forward, gTrace, packet
+capture, Itential, AAP, NSO, ACI, Catalyst Center, F5, SD-WAN, ISE, Palo Alto,
+FortiManager, nmap, NVD, firewall analysis, AWS/Azure/GCP, NetBox/Nautobot/
+Infrahub, Infoblox, GitHub, or visualization yourself. **A member does.**
+
+## Member claws (delegate via `n2n_route`)
+- Always-on: {ao}
+- On-demand (cold-start on first route): {od}
+
+## How you handle a request (ALWAYS)
+1. Comms / audit / memory / broker utility → handle yourself.
+2. Otherwise DELEGATE: pick the owning member (call `n2n_member_list` if unsure),
+   `n2n_route(request_text, target_hint=<capability>)`, poll `n2n_task_status` /
+   `n2n_task_result`, return the member's answer. Never claim to run a domain
+   skill directly, never list a flat 190-skill catalog — describe the members.
+
+## Your own skills (broker set only)
+Comms (Slack/Webex/Twilio/Twitter/PagerDuty/ServiceNow/MS Graph), memory +
+MemPalace, GAIT audit, humanrail, N2N federation control (`n2n_*`), protocol/mesh,
+and light utilities (subnet, RFC, Wikipedia, markmap, token-tracker).
+See workspace/skills/n2n-federation/SKILL.md.
+"""
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--risk", required=True)
+    ap.add_argument("--members", default="", help="always-on member names, comma-sep")
+    ap.add_argument("--on-demand", default="", help="on-demand member names, comma-sep")
+    ap.add_argument("--live-workspace", default="~/.openclaw/workspace")
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    ws = os.path.expanduser(args.live_workspace)
+    out = os.path.expanduser(args.out or f"~/.openclaw-{args.risk}-border/workspace")
+    always_on = [x.strip() for x in args.members.split(",") if x.strip()]
+    on_demand = [x.strip() for x in args.on_demand.split(",") if x.strip()]
+    os.makedirs(os.path.join(out, "skills"), exist_ok=True)
+
+    # broker skills (symlink from live) + n2n-federation (from repo if missing)
+    n = 0
+    skills_src = os.path.join(ws, "skills")
+    for name in (os.listdir(skills_src) if os.path.isdir(skills_src) else []):
+        if name.startswith(BROKER_PREFIXES) or name in BROKER_EXACT:
+            src = os.path.join(skills_src, name)
+            dst = os.path.join(out, "skills", name)
+            if not os.path.lexists(dst):
+                os.symlink(src, dst); n += 1
+    nf = os.path.join(out, "skills", "n2n-federation")
+    if not os.path.exists(nf):
+        repo_nf = os.path.join(REPO, "workspace", "skills", "n2n-federation")
+        if os.path.isdir(repo_nf):
+            shutil.copytree(repo_nf, nf); n += 1
+
+    # support/identity files symlinked; SOUL*/IDENTITY overridden with the persona
+    for f in SUPPORT_FILES:
+        src = os.path.join(ws, f)
+        dst = os.path.join(out, f)
+        if os.path.exists(src) and not os.path.lexists(dst):
+            os.symlink(src, dst)
+    with open(os.path.join(out, "SOUL.md"), "w") as fh:
+        fh.write(_persona(args.risk, always_on, on_demand))
+    with open(os.path.join(out, "IDENTITY.md"), "w") as fh:
+        fh.write(f"# Border Claw · risk {args.risk}\n\nSingle interface + comms + "
+                 f"router. Delegates all domain work to member claws via n2n_route. "
+                 f"See SOUL.md.\n")
+
+    print(f"Border workspace: {out}")
+    print(f"  broker skills: {n}  (+ support files symlinked, SOUL/IDENTITY = Border persona)")
+    print(f"  Point agents.defaults.workspace at it, then restart the gateway.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/in2n-member-home.py
+++ b/scripts/in2n-member-home.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Provision a member's scoped OpenClaw home (feature 056).
+
+Generalizes the recipe proven live for the ipfabric member: from the Border's
+~/.openclaw/openclaw.json, build ~/.openclaw-<risk>-<member>/openclaw.json that
+is SCOPED to one member:
+  - mcp.servers  → filtered to the member's servers (+ memory-mcp)
+  - plugins/channels → comms plugins stripped (they crash `openclaw agent --local`)
+  - models.providers.anthropic → a DIRECT Anthropic provider registered at the
+    member's tier model (so the member runs Claude without the DefenseClaw proxy)
+  - workspace → symlinked to the Border's (identity/skills); scope is enforced by
+    the member's declared N2N_MEMBER_SCOPE + the trimmed MCP set
+Sets nothing live — just writes the member home. The member launcher points at it
+via OPENCLAW_STATE_DIR / OPENCLAW_CONFIG_PATH.
+
+Usage: python3 scripts/in2n-member-home.py --risk johns-risk --member ipfabric \
+         [--model claude-sonnet-5] [--anthropic-key-from ~/.openclaw/.env]
+"""
+import argparse, copy, importlib.util, json, os, sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+HOME = os.path.expanduser("~")
+COMMS_PLUGINS = {"slack", "webex", "discord", "twilio", "twitter", "msteams"}
+
+
+def _profiles():
+    spec = importlib.util.spec_from_file_location(
+        "in2n_profiles", os.path.join(REPO, "scripts", "in2n-profiles.py"))
+    m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+    return m
+
+
+def _anthropic_key(env_path):
+    try:
+        for line in open(os.path.expanduser(env_path)):
+            if line.startswith("ANTHROPIC_API_KEY="):
+                return line.split("=", 1)[1].strip().strip('"').strip("'")
+    except OSError:
+        pass
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--risk", required=True)
+    ap.add_argument("--member", required=True, help="profile/member name, e.g. ipfabric")
+    ap.add_argument("--model", default=None, help="override model (default: profile tier)")
+    ap.add_argument("--anthropic-key-from", default="~/.openclaw/.env")
+    ap.add_argument("--border-config", default=f"{HOME}/.openclaw/openclaw.json")
+    args = ap.parse_args()
+
+    prof = _profiles()
+    name = args.member
+    model = args.model or prof.model_tier(name)
+    keep = set(prof.MCP_SERVERS.get(name, [])) | {"memory-mcp"}
+    border = json.load(open(args.border_config))
+    m = copy.deepcopy(border)
+
+    # 1. scope MCP servers
+    all_servers = border.get("mcp", {}).get("servers", {})
+    m.setdefault("mcp", {})["servers"] = {k: v for k, v in all_servers.items() if k in keep}
+
+    # 2. strip comms plugins/channels that break --local; keep defenseclaw (guardrails)
+    pl = m.get("plugins", {})
+    if isinstance(pl, dict):
+        for sub in ("entries", "load"):
+            if isinstance(pl.get(sub), dict):
+                pl[sub] = {k: v for k, v in pl[sub].items() if k not in COMMS_PLUGINS}
+        if isinstance(pl.get("allow"), list):
+            pl["allow"] = [x for x in pl["allow"]
+                           if not any(c in str(x).lower() for c in COMMS_PLUGINS)]
+    m["channels"] = {}
+
+    # 3. register a DIRECT Anthropic provider at the member's tier model, AND
+    #    whitelist that model for agent "main" (agents.defaults.models) — the
+    #    agent rejects a --model override that isn't in its allow-list.
+    key = _anthropic_key(args.anthropic_key_from)
+    m.setdefault("models", {}).setdefault("providers", {})["anthropic"] = {
+        "baseUrl": "https://api.anthropic.com", "apiKey": key, "api": "anthropic-messages",
+        "models": [{"id": model, "name": model, "reasoning": False,
+                    "input": ["text", "image"], "contextWindow": 200000, "maxTokens": 64000}],
+    }
+    allow = m.setdefault("agents", {}).setdefault("defaults", {}).setdefault("models", {})
+    allow.setdefault(f"anthropic/{model}", {"alias": "member"})
+
+    # 4. write the scoped home + share the workspace (identity/skills) via symlink
+    mh = f"{HOME}/.openclaw-{args.risk}-{name}"
+    os.makedirs(mh, exist_ok=True)
+    json.dump(m, open(f"{mh}/openclaw.json", "w"), indent=2)
+    os.chmod(f"{mh}/openclaw.json", 0o600)
+    ws = f"{mh}/workspace"
+    if not os.path.exists(ws):
+        os.symlink(f"{HOME}/.openclaw/workspace", ws)
+
+    print(f"scoped home: {mh}")
+    print(f"  mcp.servers: {list(m['mcp']['servers'].keys())}")
+    print(f"  model: {model}  (anthropic key: {'present' if key else 'MISSING'})")
+    print(f"  OPENCLAW_STATE_DIR={mh}")
+    print(f"  OPENCLAW_CONFIG_PATH={mh}/openclaw.json")
+    print(f"  N2N_MEMBER_MODEL={model}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/in2n-member.py
+++ b/scripts/in2n-member.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""iN2N member launcher — the lightweight member runtime (feature 056).
+
+A member claw is NOT a full OpenClaw + gateway. This launcher runs ONLY the iN2N
+client: it dials its Border, enrolls (first run, with a token) or re-authenticates
+against its pinned self-signed key, and on each delegated task executes the skill
+via `openclaw agent --local --model <member-model>` over the member's OWN scoped
+MCP config + provider/model. No BGP speaker, no gateway, no comms, no 195-skill
+catalog. Works for a FRESH member install and for a migrated member alike.
+
+Config (from the member's scoped .env / env):
+  N2N_ROLE=member
+  N2N_RISK_NAME=<risk>
+  N2N_MEMBER_ID=<risk>/<name>
+  N2N_BORDER_ENDPOINT=host:port          # loopback when co-located, or a reachable
+                                         # Border endpoint (VPN/overlay/ngrok) when remote
+  N2N_ENROLLMENT_TOKEN=<token>           # first run only (single-use); dropped after enroll
+  N2N_MEMBER_MODEL=<provider/model>      # this member's LLM (any provider incl local/Ollama)
+  N2N_MEMBER_SCOPE=<json list of capability names>   # what this member will run
+  N2N_MEMBER_BASE=<dir>                  # member's own ~/.openclaw-members/<name>/n2n
+
+Cold / on-demand:
+  --idle-exit <seconds>   exit cleanly after this long with no delegated task, so
+                          the Border can spin the member down and cold-start it
+                          again on the next route. Omit for an always-on member.
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                "..", "mcp-servers", "protocol-mcp"))
+
+from bgp.federation.service import FederationService          # noqa: E402
+from bgp.federation.manager import FederationManager          # noqa: E402
+
+logging.basicConfig(level=os.environ.get("N2N_LOG_LEVEL", "INFO"),
+                    format="%(asctime)s %(name)s %(levelname)s %(message)s")
+log = logging.getLogger("in2n-member")
+
+
+async def _dial_loop(svc, host, port, token):
+    """Dial the Border with bounded backoff; re-dial on drop. First dial enrolls
+    with the token; once pinned, reconnects use the pinned-key hello path."""
+    backoff, used_token = 5, token
+    while True:
+        ch = svc.border_channel
+        if ch is None or getattr(ch, "_closed", True):
+            try:
+                await svc.dial_border(host, port, enrollment_token=used_token)
+                used_token = ""          # token is single-use / spent after enroll
+                backoff = 5
+            except Exception as e:
+                if used_token:
+                    log.info("enroll failed (%s); retrying via pinned-key hello", e)
+                    used_token = ""
+                else:
+                    log.info("dial to Border %s:%d failed (%s) — retry in %ds",
+                             host, port, e, backoff)
+                    backoff = min(backoff * 2, 60)
+        await asyncio.sleep(10 if svc.border_channel is not None else backoff)
+
+
+async def _idle_watch(svc, idle_exit):
+    """Cold/on-demand: exit when idle past the threshold and no task is running."""
+    while True:
+        await asyncio.sleep(5)
+        in_flight = any(not t.done() for t in svc.tasks._workers.values())
+        idle = time.time() - svc.member_last_activity
+        if not in_flight and idle >= idle_exit:
+            log.info("idle %ds ≥ %ds and no in-flight task — exiting for cold/on-demand",
+                     int(idle), idle_exit)
+            # close the channel so the Border deregisters us promptly
+            if svc.border_channel is not None:
+                try:
+                    await svc.border_channel.close()
+                except Exception:
+                    pass
+            return
+
+
+async def _run(idle_exit):
+    member_id = os.environ.get("N2N_MEMBER_ID", "risk/member")
+    base = os.path.expanduser(os.environ.get("N2N_MEMBER_BASE", "~/.openclaw/n2n"))
+    mgr = FederationManager(base_dir=base)
+    svc = FederationService(
+        local_as=int(os.environ.get("NETCLAW_LOCAL_AS", "0") or 0),
+        router_id=os.environ.get("NETCLAW_ROUTER_ID", "0.0.0.0"),
+        display_name=member_id, manager=mgr)
+    # Record our member role/config (idempotent) so the service knows it's a member.
+    svc.risk.set_role("member",
+                      risk_name=os.environ.get("N2N_RISK_NAME"),
+                      border_endpoint=os.environ.get("N2N_BORDER_ENDPOINT"),
+                      self_member_id=member_id)
+    try:
+        svc.member_scope = set(json.loads(os.environ.get("N2N_MEMBER_SCOPE", "[]")))
+    except (ValueError, TypeError):
+        svc.member_scope = set()
+
+    endpoint = os.environ.get("N2N_BORDER_ENDPOINT", "")
+    if ":" not in endpoint:
+        log.error("N2N_BORDER_ENDPOINT (host:port) is required"); return 2
+    host, _, port = endpoint.rpartition(":")
+    token = os.environ.get("N2N_ENROLLMENT_TOKEN", "")
+
+    log.info("iN2N member %s starting — Border %s, scope=%s, model=%s, idle_exit=%s",
+             member_id, endpoint, sorted(svc.member_scope) or "(all)",
+             os.environ.get("N2N_MEMBER_MODEL", "(default)"),
+             idle_exit if idle_exit else "never (always-on)")
+
+    dialer = asyncio.create_task(_dial_loop(svc, host, int(port), token))
+    if idle_exit:
+        await _idle_watch(svc, idle_exit)     # returns → member exits (cold/on-demand)
+        dialer.cancel()
+    else:
+        await dialer                          # always-on: run forever
+    mgr.close()
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description="iN2N lightweight member launcher")
+    ap.add_argument("--idle-exit", type=int, default=int(os.environ.get("N2N_IDLE_EXIT_S", "0")),
+                    help="exit after N idle seconds (cold/on-demand); 0 = always-on")
+    args = ap.parse_args()
+    try:
+        sys.exit(asyncio.run(_run(args.idle_exit)))
+    except KeyboardInterrupt:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/in2n-member.py
+++ b/scripts/in2n-member.py
@@ -84,7 +84,28 @@ async def _idle_watch(svc, idle_exit):
             return
 
 
+def _load_env_file():
+    """Robustly load the member's .env (N2N_MEMBER_ENV_FILE) into os.environ —
+    WITHOUT shell sourcing, so values with spaces/colons/JSON (e.g. an auth
+    header 'X-API-Token: abc', or N2N_MEMBER_SCOPE=[...]) load correctly.
+    Existing environment values win (explicit overrides)."""
+    path = os.environ.get("N2N_MEMBER_ENV_FILE", "")
+    if not path or not os.path.isfile(path):
+        return
+    for line in open(path):
+        line = line.rstrip("\n")
+        if not line.strip() or line.lstrip().startswith("#") or "=" not in line:
+            continue
+        key, val = line.split("=", 1)
+        key = key.strip()
+        val = val.strip()
+        if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+            val = val[1:-1]
+        os.environ.setdefault(key, val)
+
+
 async def _run(idle_exit):
+    _load_env_file()
     member_id = os.environ.get("N2N_MEMBER_ID", "risk/member")
     base = os.path.expanduser(os.environ.get("N2N_MEMBER_BASE", "~/.openclaw/n2n"))
     mgr = FederationManager(base_dir=base)

--- a/scripts/in2n-migrate.py
+++ b/scripts/in2n-migrate.py
@@ -115,9 +115,11 @@ def main():
     with open(os.path.join(staging, "border.env.additions"), "w") as fh:
         fh.write("\n".join([
             "# Append to ~/.openclaw/.env to promote this claw to Border (additive).",
+            "# (values must be clean — no inline comments; .env loaders keep them literally)",
             "N2N_ROLE=border", f"N2N_RISK_NAME={args.risk}",
             "N2N_ENABLED_STACKS=both", "N2N_IN2N_PORT=11790",
-            "N2N_RISK_MODE=production   # DefenseClaw + OpenShell ON",
+            "# N2N_RISK_MODE=production -> DefenseClaw + OpenShell enforced",
+            "N2N_RISK_MODE=production",
         ]) + "\n")
 
     _write_runbook(staging, args, summary)
@@ -198,6 +200,20 @@ def _write_runbook(staging, args, summary):
     lines += ["# test a cold member end-to-end (Border spawns it, waits, delegates):",
               "#   netclaw risk route \"<task for a cold member>\" <capability>",
               "```", "",
+              "## 4b. Slim the Border INCREMENTALLY (no capability gap)",
+              "The Border stays fat through promotion so nothing breaks. Shed each domain",
+              "ONLY AFTER its member is proven in step 3/4 — never a moment where a capability",
+              "is unavailable. After a member handles its tasks, remove that domain's skills +",
+              "MCP servers from the Border's ~/.openclaw (workspace/skills + openclaw.json),",
+              "then `openclaw mcp reload`. End state — the Border keeps ONLY the broker set:",
+              "```",
+              "comms:      slack* webex* twilio* twitter* pagerduty* servicenow* discord*",
+              "broker/meta: n2n-federation protocol-participation gait-session-tracking",
+              "             memory mempalace humanrail-escalation",
+              "utilities:  subnet-calculator rfc-lookup wikipedia-research token-tracker",
+              "```",
+              "Everything else (all member domains) is REMOVED from the Border — it now routes",
+              "to the member instead. Target: ~25 skills on the Border, down from ~190.", "",
               "## 5. Move comms to the Border / decommission the monolith LAST",
               "Once members are proven, the Border is your single door. Keep the backup.",
               "The monolith is retired last — never a gap where Slack/mesh is dark.",

--- a/scripts/in2n-migrate.py
+++ b/scripts/in2n-migrate.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""iN2N migration scaffold generator — GENERATE-ONLY, never touches the live claw.
+
+Decomposes a monolithic NetClaw into a "risk": a Border + one scoped member per
+configured integration. It ONLY *generates* into a staging directory and prints a
+cutover runbook — it does NOT stop, start, remove, or reconfigure anything. You
+read the output, then run the runbook by hand (parallel cutover).
+
+For each offered member profile (env-gated, from in2n-profiles.py) it writes:
+  <staging>/members/<name>/.env      — the member's LEAST-PRIVILEGE env slice
+                                        (its integration keys + memory/gait/humanrail
+                                        + iN2N member vars + a model line to fill in)
+  <staging>/members/<name>/run.sh    — the launch command (in2n-member.py)
+And a top-level:
+  <staging>/border.env.additions     — the N2N_ROLE=border lines to add to ~/.openclaw/.env
+  <staging>/RUNBOOK.md               — the step-by-step parallel-cutover runbook
+
+NOTE: this is ALSO the shape a FRESH install produces per member — migration just
+pre-fills the .env slice from an existing monolith; a fresh member fills it in via
+the installer. Same runtime (scripts/in2n-member.py), same enrollment.
+
+Usage:
+  python3 scripts/in2n-migrate.py --risk johns-risk --border-endpoint 127.0.0.1:11790 \
+      [--staging ./migration-staging] [--hot cml,pyats,ipfabric,viz] [--live-env ~/.openclaw/.env]
+"""
+
+import argparse
+import importlib.util
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _load_profiles():
+    path = os.path.join(REPO, "scripts", "in2n-profiles.py")
+    spec = importlib.util.spec_from_file_location("in2n_profiles", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _read_env(path):
+    """Return {KEY: raw_line} for a .env file (values kept verbatim, never printed)."""
+    out = {}
+    try:
+        with open(os.path.expanduser(path)) as fh:
+            for line in fh:
+                s = line.rstrip("\n")
+                if s.strip() and not s.strip().startswith("#") and "=" in s:
+                    out[s.split("=", 1)[0].strip()] = s
+    except OSError:
+        pass
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description="iN2N migration scaffold (generate-only)")
+    ap.add_argument("--risk", default="johns-risk")
+    ap.add_argument("--border-endpoint", default="127.0.0.1:11790")
+    ap.add_argument("--staging", default=os.path.join(REPO, "migration-staging"))
+    ap.add_argument("--hot", default="cml,pyats,ipfabric,viz",
+                    help="comma-separated always-on members; the rest are cold/on-demand")
+    ap.add_argument("--idle-exit", type=int, default=900,
+                    help="idle seconds before a cold/on-demand member exits")
+    ap.add_argument("--live-env", default="~/.openclaw/.env")
+    args = ap.parse_args()
+
+    prof = _load_profiles()
+    offered = prof.profiles()                      # env-gated: only configured members
+    live_env = _read_env(args.live_env)
+    hot = {h.strip() for h in args.hot.split(",") if h.strip()}
+    staging = os.path.abspath(args.staging)
+    members_dir = os.path.join(staging, "members")
+    os.makedirs(members_dir, exist_ok=True)
+
+    summary = []
+    for name, info in offered.items():
+        mdir = os.path.join(members_dir, name)
+        os.makedirs(mdir, exist_ok=True)
+        member_id = f"{args.risk}/{name}"
+        always_on = name in hot
+        # least-privilege env slice (KEYS only listed here; VALUES copied verbatim)
+        slice_keys = prof.env_slice_keys(name, set(live_env.keys()))
+        env_lines = [live_env[k] for k in slice_keys]
+        # iN2N member config
+        member_cfg = [
+            "# ── iN2N member config (feature 056) ──",
+            "N2N_ROLE=member",
+            f"N2N_RISK_NAME={args.risk}",
+            f"N2N_MEMBER_ID={member_id}",
+            f"N2N_BORDER_ENDPOINT={args.border_endpoint}",
+            f"N2N_MEMBER_BASE={os.path.join(mdir, 'n2n')}",
+            f"N2N_MEMBER_SCOPE={_scope_json(info['skills'])}",
+            "# Pick THIS member's provider/model (any provider incl local/Ollama):",
+            "N2N_MEMBER_MODEL=anthropic/claude-sonnet-5   # <-- edit per member",
+            "# ANTHROPIC_API_KEY / OPENAI_API_KEY / OLLAMA_HOST as needed for the model above",
+            "# N2N_ENROLLMENT_TOKEN=<paste from: netclaw risk add …>   # first run only",
+        ]
+        with open(os.path.join(mdir, ".env"), "w") as fh:
+            fh.write("# Least-privilege .env slice for member %s (generated).\n" % member_id)
+            fh.write("# Integration + base-floor (memory/gait/humanrail) keys only.\n\n")
+            fh.write("\n".join(env_lines) + ("\n\n" if env_lines else "\n"))
+            fh.write("\n".join(member_cfg) + "\n")
+        idle = 0 if always_on else args.idle_exit
+        with open(os.path.join(mdir, "run.sh"), "w") as fh:
+            fh.write("#!/usr/bin/env bash\n")
+            fh.write("set -a; . \"$(dirname \"$0\")/.env\"; set +a\n")
+            fh.write(f"exec python3 {REPO}/scripts/in2n-member.py --idle-exit {idle}\n")
+        os.chmod(os.path.join(mdir, "run.sh"), 0o755)
+        summary.append((name, member_id, "always-on" if always_on else "on-demand",
+                        len(info["skills"]), len(slice_keys)))
+
+    # Border additions (role only — comms secrets stay in ~/.openclaw/.env)
+    with open(os.path.join(staging, "border.env.additions"), "w") as fh:
+        fh.write("\n".join([
+            "# Append to ~/.openclaw/.env to promote this claw to Border (additive).",
+            "N2N_ROLE=border", f"N2N_RISK_NAME={args.risk}",
+            "N2N_ENABLED_STACKS=both", "N2N_IN2N_PORT=11790",
+            "N2N_RISK_MODE=production   # DefenseClaw + OpenShell ON",
+        ]) + "\n")
+
+    _write_runbook(staging, args, summary)
+    _print_summary(staging, summary)
+
+
+def _scope_json(skills):
+    import json
+    from_base = [
+        {"name": "n2n-member-runtime", "type": "skill", "tier": "base"},
+        {"name": "self-status", "type": "skill", "tier": "base"},
+        {"name": "memory", "type": "skill", "tier": "base"},
+        {"name": "gait-session-tracking", "type": "skill", "tier": "base"},
+        {"name": "humanrail-escalation", "type": "skill", "tier": "base"},
+    ]
+    spec = [{"name": s, "type": "skill", "tier": "specialty"} for s in skills]
+    # N2N_MEMBER_SCOPE is a flat list of capability names the member will run
+    return json.dumps([e["name"] for e in from_base + spec])
+
+
+def _write_runbook(staging, args, summary):
+    hot = [s for s in summary if s[2] == "always-on"]
+    cold = [s for s in summary if s[2] == "on-demand"]
+    lines = [
+        f"# iN2N migration runbook — {args.risk} (parallel cutover)",
+        "",
+        "**GENERATED — read before running. Nothing here has touched your live claw.**",
+        "",
+        "## 0. Backup (do first, always)",
+        "```bash",
+        "tar czf ~/netclaw-backup-$(date +%Y%m%d-%H%M).tgz ~/.openclaw",
+        "cd " + REPO + " && git status   # confirm branch 056, work committed",
+        "```",
+        "",
+        "## 1. Tell Slack (affects Nick/Byrn's mesh during the daemon restart)",
+        "Post the heads-up (draft separately) BEFORE step 3.",
+        "",
+        "## 2. Promote this claw to Border (additive — keeps running)",
+        "Append `border.env.additions` to `~/.openclaw/.env`, then restart the mesh daemon.",
+        "eN2N mesh (AS65001/4.4.4.4) reconnects to Nick/Byrn automatically (053 supervisor).",
+        "```bash",
+        "cat " + os.path.join(staging, "border.env.additions") + " >> ~/.openclaw/.env",
+        "# restart the mesh daemon (however you run it) — role=border starts the iN2N listener",
+        "netclaw risk status   # expect role=border, risk=" + args.risk,
+        "```",
+        "",
+        "## 3. Bring up the HOT SET (always-on) — one at a time, verify each",
+        "For each hot member: issue its token, drop it into the member's .env, launch, route a real task.",
+        "```bash",
+    ]
+    api = "127.0.0.1:8179"
+    for name, mid, _mode, _sk, _ek in hot:
+        run = os.path.join(staging, 'members', name, 'run.sh')
+        env = os.path.join(staging, 'members', name, '.env')
+        lines += [
+            f"# --- {mid}  (always-on) ---",
+            f"curl -s -XPOST {api}/n2n/members/add -H 'Content-Type: application/json' \\",
+            f"  -d '{{\"name\":\"{name}\",\"profile\":\"{name}\",\"launch_cmd\":\"bash {run}\",\"on_demand\":false}}'",
+            f"#   -> paste enrollment_token into {env} (N2N_ENROLLMENT_TOKEN=) + set N2N_MEMBER_MODEL",
+            f"bash {run} &                             # persistent (idle-exit 0); dials + enrolls",
+            f"netclaw risk members                     # expect {mid} live",
+            f"netclaw risk route \"<a real {name} task>\" <capability>",
+        ]
+    lines += ["```", "",
+              "## 4. Register the COLD / on-demand members (the rest) — do NOT launch them",
+              "Register each with on_demand=true + its launch_cmd. The Border cold-starts it",
+              "automatically on the first route and it idle-exits after "
+              + str(args.idle_exit) + "s of quiet. Verify by routing a real task and watching it spin up.",
+              "```bash"]
+    for name, mid, _mode, _sk, _ek in cold:
+        run = os.path.join(staging, 'members', name, 'run.sh')
+        env = os.path.join(staging, 'members', name, '.env')
+        lines += [
+            f"curl -s -XPOST {api}/n2n/members/add -H 'Content-Type: application/json' \\",
+            f"  -d '{{\"name\":\"{name}\",\"profile\":\"{name}\",\"launch_cmd\":\"bash {run}\",\"on_demand\":true}}'",
+            f"#   -> paste token + model into {env}   ({mid}: Border cold-starts on route)",
+        ]
+    lines += ["# test a cold member end-to-end (Border spawns it, waits, delegates):",
+              "#   netclaw risk route \"<task for a cold member>\" <capability>",
+              "```", "",
+              "## 5. Move comms to the Border / decommission the monolith LAST",
+              "Once members are proven, the Border is your single door. Keep the backup.",
+              "The monolith is retired last — never a gap where Slack/mesh is dark.",
+              "",
+              "## Rollback",
+              "Remove the border.env.additions lines, restart the daemon (back to standalone),",
+              "stop the member run.sh processes. Your backup restores everything.",
+              ""]
+    with open(os.path.join(staging, "RUNBOOK.md"), "w") as fh:
+        fh.write("\n".join(lines))
+
+
+def _print_summary(staging, summary):
+    print(f"Generated iN2N migration scaffold → {staging}  (GENERATE-ONLY, nothing deployed)")
+    print(f"  {len(summary)} member scaffolds + border.env.additions + RUNBOOK.md\n")
+    print(f"  {'member':16s} {'mode':10s} {'skills':>6s} {'env-keys':>8s}")
+    for name, mid, mode, sk, ek in summary:
+        print(f"  {name:16s} {mode:10s} {sk:6d} {ek:8d}")
+    print(f"\n  Read the runbook:  {os.path.join(staging, 'RUNBOOK.md')}")
+    print("  NOTHING has touched your live claw. Review, then run the runbook by hand.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/in2n-migrate.py
+++ b/scripts/in2n-migrate.py
@@ -105,7 +105,9 @@ def main():
         idle = 0 if always_on else args.idle_exit
         with open(os.path.join(mdir, "run.sh"), "w") as fh:
             fh.write("#!/usr/bin/env bash\n")
-            fh.write("set -a; . \"$(dirname \"$0\")/.env\"; set +a\n")
+            fh.write("# Robust: the launcher parses the .env itself (values may contain\n")
+            fh.write("# spaces/colons/JSON) — no fragile shell sourcing.\n")
+            fh.write('export N2N_MEMBER_ENV_FILE="$(dirname "$0")/.env"\n')
             fh.write(f"exec python3 {REPO}/scripts/in2n-member.py --idle-exit {idle}\n")
         os.chmod(os.path.join(mdir, "run.sh"), 0o755)
         summary.append((name, member_id, "always-on" if always_on else "on-demand",

--- a/scripts/in2n-profiles.py
+++ b/scripts/in2n-profiles.py
@@ -178,6 +178,30 @@ def env_slice_keys(profile, env_keys):
     return sorted(k for k in env_keys if k.startswith(prefixes))
 
 
+# Profile → OpenClaw mcp.servers names to keep in a member's scoped config
+# (many integrations are skill-driven with no MCP server → empty list is fine;
+# the member still gets its workspace skills + .env creds). memory-mcp is always
+# added as base floor by the provisioner.
+MCP_SERVERS = {
+    "ipfabric": ["ipfabric-mcp"], "suzieq": ["suzieq-mcp"], "batfish": ["batfish-mcp"],
+    "forward": ["forward-mcp"], "gns3": ["gns3-mcp"], "azure": ["azure-network-mcp"],
+    "sdwan": ["prisma-sdwan-mcp"], "splunk": ["splunk-mcp"], "github": ["gitlab-mcp"],
+    "gnmi": ["gnmi-mcp"], "checkpoint": ["chkp-management", "chkp-management-logs",
+        "chkp-policy-insights", "chkp-threat-prevention", "chkp-quantum-gaia"],
+    "viz": ["blender-mcp", "sketchfab-mcp"],
+    # skill-driven (no dedicated MCP server): cml, pyats, aci, catalyst-center,
+    # f5, ise, nso, netbox, infoblox, nmap, gtrace, itential, aap, packet, etc.
+}
+
+# Model tier per member (interview: Border=Opus; heavy members=Sonnet; trivial=Haiku).
+_HEAVY = {"cml", "pyats", "itential", "aap", "nso", "aci", "catalyst-center", "f5",
+          "paloalto", "ise", "forward", "ipfabric", "sdwan", "azure", "netbox",
+          "checkpoint", "fortimanager", "batfish"}
+def model_tier(profile: str) -> str:
+    """Default Claude model id for a member of this profile (operator-overridable)."""
+    return "claude-sonnet-5" if profile in _HEAVY else "claude-haiku-4-5-20251001"
+
+
 def _configured_env():
     """Env keys present in ~/.openclaw/.env plus the process environment."""
     keys = set(os.environ.keys())

--- a/scripts/in2n-profiles.py
+++ b/scripts/in2n-profiles.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""iN2N claw profiles — derived from the installed skill catalog (feature 056).
+
+A "profile" is a focused bundle of skills that gives a member claw its specialty
+(CML claw, pyATS claw, …). Profiles are derived by PREFIX/keyword match against
+the live `workspace/skills/` tree so they never drift from what is actually
+installed (FR-019). Every member also gets the mandatory base floor (FR-021a),
+which is emitted tagged `base` and excluded from routing specificity (FR-021b).
+
+Usage:
+    python3 scripts/in2n-profiles.py list                 # profiles + skill counts
+    python3 scripts/in2n-profiles.py show cml             # skills in the cml profile
+    python3 scripts/in2n-profiles.py scope cml            # JSON scope (base + specialty)
+    python3 scripts/in2n-profiles.py scope custom a,b,c   # custom skill set
+No third-party deps (stdlib only), matching scripts/register-all-mcps.py.
+"""
+
+import json
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_SKILLS_DIRS = [
+    os.path.join(REPO, "workspace", "skills"),
+    os.path.expanduser("~/.openclaw/workspace/skills"),
+]
+
+# The mandatory base floor every member carries (mirror of bgp/federation/risk.py
+# BASE_FLOOR — kept here so the installer/profile tool has no cross-import).
+BASE_FLOOR = [
+    {"name": "n2n-member-runtime", "type": "skill", "tier": "base"},
+    {"name": "self-status",        "type": "skill", "tier": "base"},
+    {"name": "member_heartbeat",   "type": "tool",  "tier": "base"},
+    {"name": "member_report_audit","type": "tool",  "tier": "base"},
+]
+
+ENV_FILE = os.path.expanduser("~/.openclaw/.env")
+
+# Profile definitions: skills (prefixes/exact) + `requires_env` (any-of). A
+# profile is offered ONLY when its skills are installed AND its backend is
+# configured — never advertise a member you cannot actually run. Profiles with
+# no `requires_env` run locally and are always offered when their skills exist.
+# Granularity principle (interview): ONE claw per vendor/platform/tool. Real
+# integrations each get a dedicated, env-gated member; only UTILITIES stay grouped.
+PROFILE_MATCHERS = {
+    # ── virtual environments / labs (each dedicated) ──
+    "cml":          {"prefixes": ["cml-"], "requires_env": ["CML_URL"],
+                     "desc": "Cisco Modeling Labs"},
+    "eve-ng":       {"prefixes": ["eve-ng-", "eve-lab-"], "requires_env": ["EVE_NG_HOST", "EVENG_HOST"],
+                     "desc": "EVE-NG lab environment"},
+    "gns3":         {"prefixes": ["gns3-"], "requires_env": ["GNS3_HOST", "GNS3_URL"],
+                     "desc": "GNS3 lab environment"},
+    "containerlab": {"prefixes": ["clab-"], "requires_env": ["CLAB_MCP_SCRIPT"],
+                     "desc": "Containerlab environment"},
+    # ── test ──
+    "pyats":    {"prefixes": ["pyats-"], "requires_env": ["PYATS_MCP_SCRIPT", "PYATS_TESTBED_PATH"],
+                 "desc": "pyATS network test/validation"},
+    # ── assurance / analysis (each dedicated) ──
+    "ipfabric": {"exact": ["ipfabric"], "requires_env": ["IPFABRIC_HOST"],
+                 "desc": "IP Fabric network assurance"},
+    "suzieq":   {"exact": ["suzieq-observability"], "desc": "SuzieQ network observability"},
+    "batfish":  {"exact": ["batfish-config-analysis", "batfish-intent-validation"],
+                 "desc": "Batfish config analysis + intent validation"},
+    "forward":  {"exact": ["forward"], "requires_env": ["FORWARD_API_KEY"],
+                 "desc": "Forward Networks path analysis"},
+    "gtrace":   {"prefixes": ["gtrace-"], "requires_env": ["GTRACE_MCP_BIN"],
+                 "desc": "gTrace IP path analysis + enrichment"},
+    "packet":   {"exact": ["packet-analysis", "kubeshark-traffic"],
+                 "requires_env": ["PACKET_BUDDY_MCP_SCRIPT"],
+                 "desc": "Packet (pcap) capture + analysis"},
+    # ── automation / orchestration (each dedicated) ──
+    "itential": {"exact": ["itential-automation"], "requires_env": ["ITENTIAL_MCP_PLATFORM_HOST"],
+                 "desc": "Itential Platform automation"},
+    "aap":      {"prefixes": ["aap-"], "requires_env": ["AAP_MCP_DIR", "AAP_MCP_ANSIBLE_SCRIPT"],
+                 "desc": "Ansible Automation Platform + EDA + lint"},
+    "nso":      {"prefixes": ["nso-"], "requires_env": ["NSO_ADDRESS"],
+                 "desc": "Cisco NSO device + service management"},
+    "terraform": {"prefixes": ["terraform-"],
+                  "requires_env": ["TERRAFORM_TOKEN", "TFE_TOKEN", "TF_TOKEN", "HCP_CLIENT_ID"],
+                  "desc": "Terraform / HCP orchestration"},
+    # ── vendor network platforms (each dedicated) ──
+    "aci":      {"prefixes": ["aci-"], "requires_env": ["ACI_MCP_SCRIPT"],
+                 "desc": "Cisco ACI fabric"},
+    "catalyst-center": {"prefixes": ["catc-"], "requires_env": ["CATC_MCP_SCRIPT"],
+                        "desc": "Cisco Catalyst Center"},
+    "f5":       {"prefixes": ["f5-"], "requires_env": ["F5_MCP_SCRIPT"],
+                 "desc": "F5 BIG-IP config/health/troubleshoot"},
+    "meraki":   {"prefixes": ["meraki-"], "requires_env": ["MERAKI_API_KEY", "MERAKI_DASHBOARD_API_KEY"],
+                 "desc": "Cisco Meraki dashboard"},
+    "sdwan":    {"prefixes": ["sdwan-", "prisma-sdwan-"], "requires_env": ["SDWAN_MCP_SCRIPT"],
+                 "desc": "SD-WAN (Cisco/Prisma) ops"},
+    # ── security vendors (each dedicated — NOT bundled) ──
+    "ise":         {"prefixes": ["ise-"], "requires_env": ["ISE_MCP_SCRIPT"],
+                    "desc": "Cisco ISE posture + incident response"},
+    "asa":         {"exact": ["pyats-asa-firewall"], "requires_env": ["ASA_MCP_CMD", "ASA_HOST"],
+                    "desc": "Cisco ASA firewall"},
+    "checkpoint":  {"prefixes": ["checkpoint"], "requires_env": ["CHECKPOINT_MCP_CMD", "CHKP_HOST"],
+                    "desc": "Check Point firewall management"},
+    "paloalto":    {"prefixes": ["paloalto-", "fmc-"], "requires_env": ["PANOS_MCP_CMD"],
+                    "desc": "Palo Alto Panorama / FMC firewall ops"},
+    "fortimanager": {"prefixes": ["fortimanager-"], "requires_env": ["FORTIMANAGER_MCP_CMD"],
+                     "desc": "FortiManager"},
+    "zscaler":     {"prefixes": ["zscaler-"], "requires_env": ["ZSCALER_CLIENT_ID", "ZIA_USERNAME"],
+                    "desc": "Zscaler ZIA/ZPA/ZDX"},
+    "claroty":     {"prefixes": ["claroty-"], "requires_env": ["CLAROTY_MCP_CMD", "CLAROTY_HOST"],
+                    "desc": "Claroty OT/ICS security"},
+    "nmap":        {"prefixes": ["nmap-"], "requires_env": ["NMAP_MCP_SCRIPT"],
+                    "desc": "Nmap scanning + service detection"},
+    "nvd":         {"exact": ["nvd-cve"], "requires_env": ["NVD_API_KEY"],
+                    "desc": "NVD CVE lookup"},
+    "fwrule":      {"exact": ["fwrule-analyzer"], "requires_env": ["FWRULE_MCP_DIR"],
+                    "desc": "Firewall-rule analysis"},
+    # ── clouds (each dedicated) ──
+    "aws":      {"prefixes": ["aws-"], "requires_env": ["AWS_ACCESS_KEY_ID"],
+                 "desc": "AWS network/security/cost/architecture"},
+    "azure":    {"prefixes": ["azure-"], "requires_env": ["AZURE_CLIENT_ID"],
+                 "desc": "Azure network + security"},
+    "gcp":      {"prefixes": ["gcp-"], "requires_env": ["GOOGLE_APPLICATION_CREDENTIALS", "GCP_PROJECT"],
+                 "desc": "Google Cloud compute/monitoring/logging"},
+    # ── source of truth / IPAM (each dedicated) ──
+    "netbox":   {"exact": ["netbox-reconcile"], "requires_env": ["NETBOX_URL"],
+                 "desc": "NetBox source of truth"},
+    "nautobot": {"exact": ["nautobot-sot"], "requires_env": ["NAUTOBOT_URL", "NAUTOBOT_TOKEN"],
+                 "desc": "Nautobot source of truth"},
+    "infrahub": {"exact": ["infrahub-sot"], "requires_env": ["INFRAHUB_ADDRESS", "INFRAHUB_API_TOKEN"],
+                 "desc": "Infrahub source of truth"},
+    "infoblox": {"exact": ["infoblox-ddi"], "requires_env": ["INFOBLOX_MCP_CMD"],
+                 "desc": "Infoblox DDI (DNS/DHCP/IPAM)"},
+    # ── devops ──
+    "github":   {"exact": ["github-ops"], "requires_env": ["GITHUB_PERSONAL_ACCESS_TOKEN"],
+                 "desc": "GitHub repository ops"},
+    # ── UTILITIES: grouped, not split (interview: "maybe not utilities") ──
+    "viz":      {"exact": ["threejs-network-viz", "ue5-network-viz", "blender-3d-viz",
+                           "canvas-network-viz", "drawio-diagram", "markmap-viz",
+                           "uml-diagram", "digital-twin-preflight", "aws-architecture-diagram"],
+                 "desc": "Visualization utility (Three.js/UE5/Blender/Canvas + diagrams)"},
+}
+
+# Security posture (interview): a risk-wide MODE, not regular profiles. DefenseClaw
+# (Cisco) + OpenShell (NVIDIA sandbox) are optional security members enabled in
+# PRODUCTION mode and off in TESTING mode. See risk-deployment-design.md.
+SECURITY_POSTURE = {
+    "defenseclaw": {"exact": ["defenseclaw-ops", "codeguard"],
+                    "desc": "DefenseClaw guardrails + CodeGuard (production mode)"},
+    "openshell":   {"desc": "NVIDIA OpenShell sandbox — members run sandboxed (production mode)"},
+}
+
+
+# Per-member .env SLICE (least privilege): the env-key prefixes each member gets.
+# A member receives ONLY its integration's secrets + the base-member keys below +
+# its iN2N/model vars. The Border gets comms secrets and ZERO device creds.
+ENV_PREFIXES = {
+    "cml": ["CML_"], "containerlab": ["CLAB_"], "pyats": ["PYATS_"],
+    "ipfabric": ["IPFABRIC_"], "suzieq": ["SUZIEQ_"], "batfish": ["BATFISH_"],
+    "forward": ["FORWARD_"], "gtrace": ["GTRACE_"],
+    "packet": ["PACKET_BUDDY_", "KUBESHARK_"],
+    "itential": ["ITENTIAL_"], "aap": ["AAP_"], "nso": ["NSO_"], "terraform": ["TERRAFORM_", "TF_", "TFE_"],
+    "aci": ["ACI_"], "catalyst-center": ["CATC_"], "f5": ["F5_"], "meraki": ["MERAKI_"],
+    "sdwan": ["SDWAN_", "PRISMA_"],
+    "ise": ["ISE_"], "asa": ["ASA_"], "checkpoint": ["CHECKPOINT_", "CHKP_"],
+    "paloalto": ["PANOS_", "FMC_"], "fortimanager": ["FORTIMANAGER_"],
+    "zscaler": ["ZSCALER_", "ZIA_", "ZPA_", "ZDX_"], "claroty": ["CLAROTY_"],
+    "nmap": ["NMAP_"], "nvd": ["NVD_"], "fwrule": ["FWRULE_"],
+    "aws": ["AWS_"], "azure": ["AZURE_"], "gcp": ["GOOGLE_", "GCP_"],
+    "netbox": ["NETBOX_"], "nautobot": ["NAUTOBOT_"], "infrahub": ["INFRAHUB_"],
+    "infoblox": ["INFOBLOX_"], "github": ["GITHUB_"],
+    "viz": ["BLENDER_", "UE5_", "SKETCHFAB_", "MARKMAP_", "DRAWIO_"],
+}
+# Base floor every member gets (memory + GAIT + humanrail per the interview).
+BASE_MEMBER_ENV_PREFIXES = ["MEMPALACE_", "GAIT_", "HUMANRAIL_", "MEMORY_"]
+
+
+def env_slice_keys(profile, env_keys):
+    """Return the env-key NAMES a member of `profile` should receive (least
+    privilege): its integration prefixes + the base-member prefixes. Values are
+    the caller's concern (never logged)."""
+    prefixes = tuple(ENV_PREFIXES.get(profile, []) + BASE_MEMBER_ENV_PREFIXES)
+    return sorted(k for k in env_keys if k.startswith(prefixes))
+
+
+def _configured_env():
+    """Env keys present in ~/.openclaw/.env plus the process environment."""
+    keys = set(os.environ.keys())
+    try:
+        with open(ENV_FILE) as fh:
+            for line in fh:
+                line = line.strip()
+                if line and not line.startswith("#") and "=" in line:
+                    keys.add(line.split("=", 1)[0].strip())
+    except OSError:
+        pass
+    return keys
+
+
+def _env_satisfied(meta, env_keys):
+    req = meta.get("requires_env")
+    return (not req) or any(k in env_keys for k in req)
+
+
+def _installed_skills(skills_dir=None):
+    dirs = [skills_dir] if skills_dir else DEFAULT_SKILLS_DIRS
+    for d in dirs:
+        if d and os.path.isdir(d):
+            out = []
+            for name in sorted(os.listdir(d)):
+                p = os.path.join(d, name)
+                if os.path.isdir(p) and os.path.exists(os.path.join(p, "SKILL.md")):
+                    out.append(name)
+            return out
+    return []
+
+
+def _match_profile(profile_id, installed):
+    m = PROFILE_MATCHERS.get(profile_id)
+    if not m:
+        return []
+    prefixes = tuple(m.get("prefixes", []))
+    exact = set(m.get("exact", []))
+    return [s for s in installed
+            if s in exact or (prefixes and s.startswith(prefixes))]
+
+
+def profiles(skills_dir=None, include_unconfigured=False):
+    """Profiles whose skills are installed AND whose backend is configured.
+
+    A profile is offered only when you can actually run it (FR-019 + the operator
+    rule: never advertise a member with no configured backend). Pass
+    include_unconfigured=True to also see profiles gated out for missing env."""
+    installed = _installed_skills(skills_dir)
+    env_keys = _configured_env()
+    out = {}
+    for pid, meta in PROFILE_MATCHERS.items():
+        skills = _match_profile(pid, installed)
+        if not skills:
+            continue
+        configured = _env_satisfied(meta, env_keys)
+        if configured or include_unconfigured:
+            out[pid] = {"description": meta["desc"], "skills": skills,
+                        "configured": configured,
+                        "requires_env": meta.get("requires_env")}
+    return out
+
+
+def scope(profile_id=None, custom_skills=None, skills_dir=None):
+    """Return a member scope: base floor (tier=base) + specialty (tier=specialty)."""
+    out = list(BASE_FLOOR)
+    specialty = []
+    if profile_id and profile_id != "custom":
+        specialty = _match_profile(profile_id, _installed_skills(skills_dir))
+    elif custom_skills:
+        installed = set(_installed_skills(skills_dir))
+        specialty = [s for s in custom_skills if s in installed] or list(custom_skills)
+    for s in specialty:
+        out.append({"name": s, "type": "skill", "tier": "specialty"})
+    return out
+
+
+def _main(argv):
+    cmd = argv[0] if argv else "list"
+    if cmd == "list":
+        show_all = "--all" in argv
+        for pid, info in profiles(include_unconfigured=show_all).items():
+            mark = "" if info.get("configured", True) else "  [backend not configured]"
+            print(f"{pid:16s} {len(info['skills']):3d} skills  — {info['description']}{mark}")
+    elif cmd == "show" and len(argv) > 1:
+        info = profiles().get(argv[1])
+        if not info:
+            print(f"no such profile (or no installed skills match): {argv[1]}", file=sys.stderr)
+            return 1
+        print("\n".join(info["skills"]))
+    elif cmd == "scope" and len(argv) > 1:
+        pid = argv[1]
+        custom = argv[2].split(",") if pid == "custom" and len(argv) > 2 else None
+        print(json.dumps(scope(profile_id=pid, custom_skills=custom), indent=2))
+    else:
+        print(__doc__)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main(sys.argv[1:]))

--- a/scripts/lib/install-steps.sh
+++ b/scripts/lib/install-steps.sh
@@ -1736,6 +1736,63 @@ echo "      2. Restart the mesh daemon so the NCFED channel is live"
 echo "      3. Reload MCP servers (openclaw mcp reload) to pick up n2n-mcp"
 echo "      4. Mutually consent with a peer — see N2N-PEERING-NETCLAWS.md"
 
+# ── iN2N (feature 056): standalone vs part of a "risk" ──────────────
+_in2n_setenv() {  # _in2n_setenv KEY VALUE — upsert into ~/.openclaw/.env
+    local key="$1" val="$2" f="$HOME/.openclaw/.env"
+    if grep -q "^${key}=" "$f" 2>/dev/null; then
+        sed -i "s|^${key}=.*|${key}=${val}|" "$f"
+    else
+        echo "${key}=${val}" >> "$f"
+    fi
+}
+
+if declare -f tui_menu >/dev/null 2>&1; then
+    echo ""
+    echo "  iN2N — is this claw standalone, or part of a RISK (a group of focused"
+    echo "  claws coordinated by one Border Claw)?"
+    tui_menu "NetClaw deployment" \
+        "Standalone NetClaw (a risk of one)" \
+        "Part of a risk — Border Claw (gateway + eN2N + routes to members)" \
+        "Part of a risk — Member Claw (focused specialist; dials the Border)"
+    case "$TUI_CHOICE" in
+        0)
+            _in2n_setenv N2N_ROLE standalone
+            log_info "Configured as standalone NetClaw."
+            ;;
+        1)
+            read -r -p "  Risk name: " _risk_name
+            read -r -p "  Risk description: " _risk_desc
+            tui_menu "Federation stacks for this Border" \
+                "Both eN2N (external) and iN2N (internal)" \
+                "iN2N only (internal members)" \
+                "eN2N only (external peers)"
+            case "$TUI_CHOICE" in
+                0) _stacks=both ;; 1) _stacks=in2n ;; *) _stacks=en2n ;;
+            esac
+            read -r -p "  iN2N listener port for member dial-ins [11790]: " _p
+            _in2n_setenv N2N_ROLE border
+            _in2n_setenv N2N_RISK_NAME "${_risk_name:-my-risk}"
+            _in2n_setenv N2N_ENABLED_STACKS "$_stacks"
+            _in2n_setenv N2N_IN2N_PORT "${_p:-11790}"
+            log_info "Configured as Border Claw of risk '${_risk_name:-my-risk}' (stacks=$_stacks)."
+            echo "      Add members with: netclaw risk add <profile|custom> <name>"
+            echo "      Profiles available: $(python3 "${NETCLAW_DIR:-.}/scripts/in2n-profiles.py" list 2>/dev/null | awk '{printf "%s ", $1}')"
+            ;;
+        2)
+            read -r -p "  Risk name (must match the Border): " _risk_name
+            read -r -p "  This member's name (member_id will be <risk>/<name>): " _mname
+            read -r -p "  Border endpoint (host:port the member dials): " _bep
+            read -r -p "  Enrollment token from the Border: " _tok
+            _in2n_setenv N2N_ROLE member
+            _in2n_setenv N2N_RISK_NAME "${_risk_name:-my-risk}"
+            _in2n_setenv N2N_BORDER_ENDPOINT "$_bep"
+            _in2n_setenv N2N_MEMBER_ID "${_risk_name:-my-risk}/${_mname:-member}"
+            [ -n "$_tok" ] && _in2n_setenv N2N_ENROLLMENT_TOKEN "$_tok"
+            log_info "Configured as Member Claw ${_risk_name}/${_mname}. It will dial the Border on start."
+            ;;
+    esac
+fi
+
 echo ""
 }
 

--- a/scripts/netclaw
+++ b/scripts/netclaw
@@ -37,6 +37,7 @@ render_md() { python3 "$RENDER_MD"; }
 # already-handled condition downstream — it must never trip `set -e` and
 # kill the whole TUI when called bare from a menu case (e.g. `peering_overview; pause`).
 api_get() { curl -s --max-time 3 "$BGP_API$1" 2>/dev/null || true; }
+api_post() { curl -s --max-time 30 -H 'Content-Type: application/json' -d "${2:-{}}" "$BGP_API$1" 2>/dev/null || true; }
 
 ngrok_get() { curl -s --max-time 3 "$NGROK_API$1" 2>/dev/null || true; }
 
@@ -404,6 +405,126 @@ chats_menu() {
     done
 }
 
+# ── iN2N risk views (feature 056) ─────────────────────────────────
+risk_overview() {
+    echo ""
+    echo -e "  ${T_BOLD}Risk — iN2N internal federation${T_NC}"
+    echo ""
+    api_get /n2n/risk | python3 -c '
+import json, sys
+try: d = json.load(sys.stdin)
+except Exception: print("    daemon not reachable (is the mesh daemon running?)"); sys.exit()
+print("    role         : %s" % d.get("role", "?"))
+print("    risk         : %s" % (d.get("risk_name") or "-"))
+if d.get("role") == "border":
+    print("    stacks       : %s" % (d.get("enabled_stacks") or "-"))
+    print("    members      : %s total, %s active" % (d.get("member_count", 0), d.get("members_active", 0)))
+elif d.get("role") == "member":
+    print("    member_id    : %s" % (d.get("self_member_id") or "-"))
+else:
+    print("    (standalone — a risk of one, its own Border)")
+'
+}
+
+risk_members() {
+    echo ""
+    echo -e "  ${T_BOLD}Risk members${T_NC}"
+    api_get /n2n/members | python3 -c '
+import json, sys
+try: d = json.load(sys.stdin)
+except Exception: print("    daemon not reachable"); sys.exit()
+ms = d.get("members", [])
+if not ms: print("    (no members — add one: netclaw risk add <profile> <name>)"); sys.exit()
+for m in ms:
+    live = "●" if m.get("live") else "○"
+    print("    %s %-24s %-9s %-10s specialty:%d" % (
+        live, m.get("member_id","?"), m.get("profile","-"), m.get("state","-"),
+        m.get("specialty_count",0)))
+'
+}
+
+risk_health() {
+    echo ""
+    echo -e "  ${T_BOLD}Member health${T_NC}"
+    api_get /n2n/members/health | python3 -c '
+import json, sys
+try: d = json.load(sys.stdin)
+except Exception: print("    daemon not reachable"); sys.exit()
+for m in d.get("members", []):
+    print("    %-24s %-11s failures:%d live:%s" % (
+        m.get("member_id","?"), m.get("state","-"), m.get("auth_failures",0),
+        m.get("live")))
+'
+}
+
+risk_add() {  # risk_add <profile|custom> <name> [csv-skills]
+    local profile="$1" name="$2" specialty="$3"
+    [ -n "$name" ] || { echo "usage: netclaw risk add <profile|custom> <name> [skill,skill]"; return 1; }
+    local body
+    if [ "$profile" = "custom" ]; then
+        body="{\"name\":\"$name\",\"profile\":\"custom\",\"specialty\":[$(echo "$specialty" | awk -F, '{for(i=1;i<=NF;i++){printf "%s\"%s\"", (i>1?",":""), $i}}')]}"
+    else
+        body="{\"name\":\"$name\",\"profile\":\"$profile\"}"
+    fi
+    api_post /n2n/members/add "$body" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+if "error" in d: print("    error: %s" % d["error"]); sys.exit(1)
+print("    provisioned %s (%s)" % (d["member_id"], d.get("profile")))
+print("    enrollment token: %s" % d["enrollment_token"])
+j = d.get("join", {})
+print("    to bring it up, install NetClaw with:")
+print("      N2N_ROLE=member N2N_RISK_NAME=%s N2N_BORDER_ENDPOINT=%s" % (
+    j.get("N2N_RISK_NAME"), j.get("N2N_BORDER_ENDPOINT")))
+print("      N2N_ENROLLMENT_TOKEN=%s" % j.get("token"))
+'
+}
+
+risk_remove() {  # risk_remove <member_id>
+    local mid="$1"
+    [ -n "$mid" ] || { echo "usage: netclaw risk remove <member_id>"; return 1; }
+    tui_yesno "Remove member '$mid' (unpin key, refuse reconnect)?" n || { echo "  cancelled."; return 0; }
+    api_post /n2n/members/remove "{\"member_id\":\"$mid\"}" | python3 -c '
+import json,sys; d=json.load(sys.stdin); print("    removed:", d.get("removed"), d.get("member_id"))'
+}
+
+risk_token() {  # risk_token [label]
+    api_post /n2n/enroll/token "{\"label\":\"${1:-}\"}" | python3 -c '
+import json,sys; d=json.load(sys.stdin)
+print("    error:", d["error"]) if "error" in d else print("    token:", d["token"])'
+}
+
+risk_route() {  # risk_route "<request>" [capability]
+    local req="$1" cap="$2"
+    [ -n "$req" ] || { echo 'usage: netclaw risk route "<request>" [capability]'; return 1; }
+    local body="{\"request_text\":$(python3 -c 'import json,sys;print(json.dumps(sys.argv[1]))' "$req")"
+    [ -n "$cap" ] && body="$body,\"capability\":\"$cap\""
+    body="$body}"
+    api_post /n2n/route "$body" | python3 -c '
+import json,sys; d=json.load(sys.stdin)
+if "error" in d: print("    %s: %s" % (d["error"], d.get("message","")))
+else: print("    routed to %s → task %s (%s)" % (d.get("member_id"), d.get("task_id"), d.get("state")))'
+}
+
+risk_menu() {
+    while true; do
+        clear
+        tui_menu "Risk (iN2N members)" \
+            "Overview (role · stacks · members)" \
+            "Members (scope · state · live)" \
+            "Member health (quarantine alerts)" \
+            "Enrollment token (issue single-use)" \
+            "← Back" || return 0
+        case "$TUI_CHOICE" in
+            0) risk_overview; pause ;;
+            1) risk_members; pause ;;
+            2) risk_health; pause ;;
+            3) risk_token; pause ;;
+            4) return 0 ;;
+        esac
+    done
+}
+
 # ── menus ─────────────────────────────────────────────────────────
 peering_menu() {
     while true; do
@@ -444,12 +565,14 @@ main_menu() {
             "Launch NetClaw TUI" \
             "Installer (add/remove components)" \
             "Protocol Peering (BGP · MESH · N2N)" \
+            "Risk (iN2N members)" \
             "Exit" || exit 0
         case "$TUI_CHOICE" in
             0) exec openclaw tui ;;
             1) exec "$NETCLAW_ROOT/scripts/install.sh" ;;
             2) peering_menu ;;
-            3) exit 0 ;;
+            3) risk_menu ;;
+            4) exit 0 ;;
         esac
     done
 }
@@ -476,6 +599,17 @@ case "${1:-}" in
             down)     peering_stop_all ;;
             announce) peer_announce ;;
             *)        echo "Usage: netclaw peering [status|bgp|n2n|ngrok|up|down|announce]"; exit 1 ;;
+        esac ;;
+    risk)
+        case "${2:-status}" in
+            status)   risk_overview ;;
+            members)  risk_members ;;
+            health)   risk_health ;;
+            add)      risk_add "${3:-}" "${4:-}" "${5:-}" ;;
+            remove)   risk_remove "${3:-}" ;;
+            token)    risk_token "${3:-}" ;;
+            route)    risk_route "${3:-}" "${4:-}" ;;
+            *)        echo "Usage: netclaw risk [status|members|health|add|remove|token|route]"; exit 1 ;;
         esac ;;
     chats)
         if [ "${2:-}" = "--watch" ] || [ "${2:-}" = "watch" ]; then

--- a/scripts/peering-setup.sh
+++ b/scripts/peering-setup.sh
@@ -25,7 +25,12 @@ DAEMON_OUT="/tmp/bgp-daemon-v2.out"
 
 # Read a value from ~/.openclaw/.env ('' if unset)
 env_get() {
-    grep -m1 "^${1}=" "$OPENCLAW_ENV" 2>/dev/null | cut -d= -f2- || true
+    local v
+    v="$(grep -m1 "^${1}=" "$OPENCLAW_ENV" 2>/dev/null | cut -d= -f2-)"
+    # Strip one surrounding pair of single/double quotes — values like
+    # NETCLAW_BGP_PEERS='[...]' must reach json.loads() unquoted.
+    v="${v#\"}"; v="${v%\"}"; v="${v#\'}"; v="${v%\'}"
+    printf '%s' "$v"
 }
 
 # Prompt with default; re-prompts yes/no questions until the answer is valid
@@ -76,7 +81,7 @@ daemon_start() {
     # Pull only the daemon's keys from .env — values may contain JSON, and
     # other .env lines have unquoted spaces that break plain `source`.
     log_info "Starting mesh BGP daemon..."
-    env $(grep -E "^(NETCLAW_ROUTER_ID|NETCLAW_LOCAL_AS|NETCLAW_LAB_MODE|NETCLAW_MESH_ENABLED|NETCLAW_MESH_OPEN|BGP_LISTEN_PORT|BGP_API_PORT|N2N_ENABLED|N2N_DISPLAY_NAME|N2N_RATE_PER_MIN|N2N_DAILY_REQUESTS|N2N_DAILY_TOKENS)=" "$OPENCLAW_ENV") \
+    env $(grep -E "^(NETCLAW_ROUTER_ID|NETCLAW_LOCAL_AS|NETCLAW_LAB_MODE|NETCLAW_MESH_ENABLED|NETCLAW_MESH_OPEN|BGP_LISTEN_PORT|BGP_API_PORT|N2N_ENABLED|N2N_DISPLAY_NAME|N2N_RATE_PER_MIN|N2N_DAILY_REQUESTS|N2N_DAILY_TOKENS|N2N_ROLE|N2N_RISK_NAME|N2N_RISK_DESCRIPTION|N2N_ENABLED_STACKS|N2N_IN2N_PORT|N2N_RISK_MODE|N2N_BORDER_ENDPOINT|N2N_QUARANTINE_THRESHOLD)=" "$OPENCLAW_ENV") \
         NETCLAW_BGP_PEERS="$(env_get NETCLAW_BGP_PEERS)" \
         nohup python3 "$BGP_DAEMON" >> "$DAEMON_OUT" 2>&1 &
     local pid=$!

--- a/specs/056-in2n-internal-federation/checklists/requirements.md
+++ b/specs/056-in2n-internal-federation/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: iN2N — Internal NetClaw Federation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- **RESOLVED (2026-07-12, /speckit.specify)**: FR-028 member runtime model — a member is a **standalone OpenClaw process/container** over a **network-capable internal transport, selectable per member**.
+- **CLARIFIED (2026-07-12, /speckit.clarify)** — 3 questions resolved into the spec:
+  1. **Enrollment/trust bootstrap** — one-time enrollment token + member-generated self-signed key, pinned trust-on-first-use, no CA (FR-013a/FR-013b).
+  2. **Identity & topology** — stable risk-local member ID bound to pinned key; hub-and-spoke star (no iBGP/mesh); members dial outbound to the Border (FR-007/FR-007a/FR-008/FR-029).
+  3. **Offboarding/revocation** — operator `remove member` + automatic quarantine on repeated health/auth failures (FR-013c/FR-013d).
+- All checklist items pass. Spec is ready for `/speckit.plan`.

--- a/specs/056-in2n-internal-federation/contracts/in2n-daemon-api-delta.md
+++ b/specs/056-in2n-internal-federation/contracts/in2n-daemon-api-delta.md
@@ -1,0 +1,98 @@
+# Contract: iN2N Daemon HTTP API & n2n-mcp Tool Delta
+
+New surfaces added for iN2N. All additive; existing `/n2n/*` eN2N routes and `n2n-mcp` tools are unchanged.
+
+## Daemon HTTP routes (`bgp-daemon-v2.py`)
+
+| Method & path | Purpose | Body / returns |
+|---------------|---------|----------------|
+| `GET /n2n/risk` | This claw's risk identity | `{ role, risk_name, description, enabled_stacks, self_member_id? }` |
+| `POST /n2n/risk` | Set/update role & risk config (install/reconfig) | `{ role, risk_name?, description?, enabled_stacks?, border_endpoint? }` → enforces single-Border (FR-003) |
+| `GET /n2n/members` | Border: list members + scope + health + state | `[ { member_id, display_name, profile, scope, state, health, transport_binding } ]` |
+| `POST /n2n/members/remove` | Border: remove a member (unpin) | `{ member_id }` → confirm-gated |
+| `GET /n2n/members/health` | Border: per-member health incl. quarantine/alerts | `[ { member_id, state, last_seen, auth_failures, in_flight } ]` |
+| `POST /n2n/enroll/token` | Border: issue single-use enrollment token | `{ label?, ttl_seconds? }` → `{ token, token_hash, expires_at }` |
+| `POST /n2n/route` | Border: route an operator request to a member | `{ request_text, target_hint? }` → `{ task_id, member_id }` or `{ error: ERR_NO_CAPABLE_MEMBER }` |
+
+(iN2N `in2n/enroll` and `in2n/hello` are **channel** JSON-RPC methods over the internal transport, not HTTP — see the transport/enrollment contracts.)
+
+## `n2n-mcp` tools (`server.py`) — additions
+
+| Tool | Role | Purpose |
+|------|------|---------|
+| `n2n_risk_status()` | any | show this claw's role, risk, enabled stacks; on a Border, member count/health summary |
+| `n2n_member_list()` | Border | list members with scope + health + state |
+| `n2n_member_add(profile \| custom_skills, name)` | Border | provision a member from a catalog-derived profile or a custom skill set (issues a token, prints join instructions) |
+| `n2n_member_remove(member_id)` | Border | remove + unpin (confirm with operator first) |
+| `n2n_enroll_token(label?, ttl_seconds?)` | Border | issue a single-use enrollment token for a member to join |
+| `n2n_route(request_text, target_hint?)` | Border | ask the Border to route a task-shaped request to the right member; returns a task_id for long work |
+| `n2n_member_health(member_id?)` | Border | per-member channel state, last-seen, in-flight tasks, quarantine alerts |
+
+Reused unchanged from 053 for the internal task lifecycle: `n2n_task_status`, `n2n_task_result`, `n2n_task_cancel` (they key on `task_id`, agnostic to en2n/in2n).
+
+Standalone claws expose these tools as no-ops/`role=standalone` responses (SC-008): `n2n_risk_status` reports standalone; member/route tools report "this claw is standalone (a risk of one)".
+
+## Environment (`.env.example` additions)
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `N2N_ROLE` | `standalone` | `standalone` \| `border` \| `member` |
+| `N2N_RISK_NAME` | (unset) | the risk's name (border/member) |
+| `N2N_ENABLED_STACKS` | `en2n` | border: `en2n` \| `in2n` \| `both` |
+| `N2N_IN2N_PORT` | (reuse mesh port) | optional dedicated iN2N listener on the Border |
+| `N2N_BORDER_ENDPOINT` | (unset) | member: host:port to dial the Border |
+| `N2N_QUARANTINE_THRESHOLD` | `5` | consecutive auth/health failures before auto-quarantine |
+
+## Operator TUI / CLI surface (`scripts/netclaw` + `scripts/lib/tui.sh`)
+
+Follows Nick's established TUI format (PRs #96 installer TUI, #115 `netclaw` command tree, #117 peering lifecycle) — reuse the primitives, do not invent a new prompt style.
+
+### Installer prompts (`scripts/lib/install-steps.sh → component_install_n2n`)
+
+Built from `scripts/lib/tui.sh` primitives, matching the component picker's look/feel and off-TTY degradation:
+
+| Step | Primitive | Options / behavior |
+|------|-----------|--------------------|
+| Standalone vs risk | `tui_menu` | `Standalone NetClaw` · `Part of a risk` |
+| Risk name / description | `read` (as installer already does for text) | free text; skipped when standalone |
+| Role | `tui_menu` | `Border Claw` · `Member Claw` |
+| Border stacks | `tui_menu` | `eN2N only` · `iN2N only` · `Both` (Border only) |
+| Seed / add members | `tui_menu` per profile + `tui_checklist` for Custom | profiles from `scripts/in2n-profiles.py`; Custom uses the category-headed `CL_IDS/CL_LABELS/CL_ON` checklist |
+| Confirm | `tui_yesno` | matches installer confirmation style |
+
+### `netclaw` command — Risk sub-tree (mirrors `peering_menu` / `netclaw peering`)
+
+Interactive (`main_menu` gains a **Risk (iN2N members)** entry → `risk_menu`, dispatched by `TUI_CHOICE` exactly like `peering_menu`):
+
+```
+Risk — <risk-name> (<role>)
+  Overview (role · stacks · member count/health)
+  Members (list scope · state · in-flight)
+  Add member (profile | custom)
+  Remove member
+  Enrollment token (issue single-use)
+  ← Back
+```
+
+Non-interactive (mirrors `netclaw peering [status|bgp|n2n|ngrok]`), reading the daemon HTTP API via the existing `api_get`/`api_post` helpers:
+
+| Command | Maps to |
+|---------|---------|
+| `netclaw risk status` | `GET /n2n/risk` (+ member summary on a Border) |
+| `netclaw risk members` | `GET /n2n/members` |
+| `netclaw risk add <profile\|custom> <name>` | provision + `POST /n2n/enroll/token` |
+| `netclaw risk remove <member_id>` | `POST /n2n/members/remove` (confirm-gated) |
+| `netclaw risk token [label]` | `POST /n2n/enroll/token` |
+| `netclaw risk route "<request>"` | `POST /n2n/route` |
+
+Standalone claws: `netclaw risk status` reports `standalone (a risk of one)`; the sub-menu entry is hidden or shows the standalone note (SC-008).
+
+## HUD (`ui/netclaw-visual/`)
+
+- `server.js` `/api/n2n` folds in `role`, and for a Border its `members` (id, scope badge, state, in-flight tasks).
+- `src/main.js` renders a **risk view**: the Border node at the hub with member spokes; each spoke shows scope badge, health (active/unreachable/quarantined), and live in-flight task progress. A standalone claw renders as today (single node).
+
+## Backwards-compatibility assertions
+
+- With `N2N_ROLE=standalone` (default), no iN2N route/listener/registry is active; the daemon behaves exactly as pre-054 (SC-008).
+- eN2N routes/tools and the mesh `n2n/hello` path are byte-for-byte unchanged (SC-009).

--- a/specs/056-in2n-internal-federation/contracts/in2n-enrollment.md
+++ b/specs/056-in2n-internal-federation/contracts/in2n-enrollment.md
@@ -1,0 +1,77 @@
+# Contract: iN2N Enrollment, Pinning, Removal & Quarantine
+
+The trust-bootstrap path for a Member joining a risk. No CA. Single-use token + member self-signed key, pinned trust-on-first-use (spec FR-013a–d; research R3).
+
+## 1. Token issue (Border, operator action)
+
+**Daemon HTTP**: `POST /n2n/enroll/token` → issue a single-use enrollment token.
+
+Request:
+```json
+{ "label": "cml", "ttl_seconds": 86400 }
+```
+Response (token shown ONCE; only its hash is stored):
+```json
+{ "token": "in2n_<opaque>", "token_hash": "sha256:…", "expires_at": "2026-07-13T…Z" }
+```
+`n2n-mcp` tool: `n2n_enroll_token(label?, ttl_seconds?)` → returns the raw token for the operator to hand to the member at provisioning.
+
+## 2. Member enroll (Member → Border, over the internal channel)
+
+On first outbound dial, before any work, the member sends the enrollment request as the first `in2n/hello` (see internal-transport contract):
+```json
+{ "jsonrpc":"2.0", "id":1, "method":"in2n/enroll",
+  "params": {
+    "token": "in2n_<opaque>",
+    "member_id": "johns-risk/cml",
+    "display_name": "CML claw",
+    "public_key": "-----BEGIN PUBLIC KEY-----\n…",
+    "runtime_kind": "container",
+    "advertised_scope": { "skills": ["cml-lab-lifecycle"], "tools": ["cml_*"] }
+  } }
+```
+Border validates:
+1. token exists, unspent, unexpired → else `-32021 ERR_ENROLL_TOKEN_INVALID`
+2. `member_id` not already actively pinned to a *different* key → else `-32022 ERR_MEMBER_ID_TAKEN`
+
+On success: pins `public_key` to `member_id`, flips token `spent_at`/`spent_by_member_id`, inserts `member` row `state=enrolled`, records an audit event. Response:
+```json
+{ "jsonrpc":"2.0","id":1,"result":{ "member_id":"johns-risk/cml","pinned":true,"state":"enrolled" } }
+```
+
+## 3. Authenticated reconnect (every subsequent dial)
+
+Member proves possession of the pinned key (channel established with the self-signed key; Border verifies the presented key **equals** the pinned key):
+```json
+{ "jsonrpc":"2.0","id":1,"method":"in2n/hello",
+  "params": { "member_id":"johns-risk/cml", "key_fingerprint":"sha256:…" } }
+```
+- key ≠ pinned, or member `removed`/`quarantined` → `-32023 ERR_MEMBER_NOT_TRUSTED` (connection refused; SC-010).
+- success → member `state=active`, `auth_failures=0`.
+
+## 4. Removal (Border, operator action)
+
+**Daemon HTTP**: `POST /n2n/members/remove` `{ "member_id": "johns-risk/cml" }`
+`n2n-mcp` tool: `n2n_member_remove(member_id)` — **confirm with the operator first**.
+Effect: `state=removed`, unpin key, drop from routing, refuse reconnect. Return requires a **new** token (§1–2). Audited.
+
+## 5. Auto-quarantine (Border, automatic)
+
+Border increments `member.auth_failures` on each failed auth or health-check miss. At threshold `N2N_QUARANTINE_THRESHOLD` (default 5): `state=quarantined`, unpin key, stop routing, **alert the operator** (surfaced via `n2n_member_health` + HUD). Recovery requires operator re-pin or re-enrollment (FR-013d). Audited.
+
+## Error codes (new, in the iN2N range; eN2N codes unchanged)
+
+| Code | Name | Meaning |
+|------|------|---------|
+| -32021 | ERR_ENROLL_TOKEN_INVALID | token missing/spent/expired |
+| -32022 | ERR_MEMBER_ID_TAKEN | member_id already pinned to another key |
+| -32023 | ERR_MEMBER_NOT_TRUSTED | key ≠ pinned, or member removed/quarantined |
+| -32024 | ERR_NOT_A_BORDER | enrollment attempted against a non-Border claw |
+
+## Test assertions
+
+- Unspent valid token pins the key and flips to spent; re-presenting the same token → -32021 (single-use, SC-010).
+- Expired token → -32021.
+- Reconnect with a non-pinned key → -32023; with the pinned key → active.
+- `remove` then reconnect on old key → -32023; re-enroll with new token → active again.
+- 5 consecutive auth/health failures → quarantined + unpinned + operator alerted; routing skips it.

--- a/specs/056-in2n-internal-federation/contracts/in2n-internal-transport.md
+++ b/specs/056-in2n-internal-federation/contracts/in2n-internal-transport.md
@@ -1,0 +1,56 @@
+# Contract: iN2N Internal Transport (member-initiated dial, NCFED framing reuse)
+
+The Border↔Member channel. Reuses the **frozen NCFED wire framing** from spec 052 (`channel.py`) over a **member-initiated outbound connection**; adds an `in2n/hello` handshake variant. Hub-and-spoke — members connect only to the Border (research R2; FR-007/FR-007a).
+
+## Framing — REUSED UNCHANGED (frozen)
+
+Identical to eN2N (`contracts/n2n-wire-protocol.md`, spec 052):
+```
+[4-byte big-endian length][1-byte flags][UTF-8 JSON-RPC 2.0 payload]
+flags bit0 = continuation (chunk of a larger message)
+```
+`encode_frames()` / decode, chunking > 64 KB, heartbeats (`NCFED_HEARTBEAT_INTERVAL` / `NCFED_HEARTBEAT_MISS_LIMIT`) all reused. No framing change (FR-018).
+
+## Connection establishment
+
+1. **Member dials outbound** to `risk.border_endpoint` (host:port). Endpoint may be loopback (co-located), a private-network address, or an overlay/VPN/tunnel address (distributed). The member opens **no inbound port**.
+2. **Channel security**: TLS using the member's runtime-generated **self-signed key**; the Border presents its own self-signed key. The Border authenticates the member by comparing the presented key against the **pinned** key (enrollment contract §3). The member authenticates the Border by pinning the Border key it was given at provisioning (`border_endpoint` + Border key fingerprint).
+3. **Discrimination**: on the Border's listener, a connection is classified by its first bytes — existing eN2N/BGP/tunnel discrimination is unchanged; iN2N connections are identified by the `in2n/hello`|`in2n/enroll` first method after the secure channel is up. (If iN2N uses a distinct listener port `N2N_IN2N_PORT`, discrimination is by port; see research R2 — either is acceptable, both keep eN2N framing frozen.)
+
+## Handshake: `in2n/hello` (variant of eN2N `n2n/hello`)
+
+Unlike eN2N's `n2n/hello` (which carries `as`/`router_id` BGP identity + capability descriptor), `in2n/hello` carries the **risk-local member id + pinned-key proof** (no AS, members aren't mesh peers):
+```json
+{ "jsonrpc":"2.0","id":1,"method":"in2n/hello",
+  "params": {
+    "member_id": "johns-risk/cml",
+    "key_fingerprint": "sha256:…",
+    "capabilities": { "protocol_version": "054.1", "async_tasks": true }
+  } }
+```
+Border response includes the risk context and confirms trust:
+```json
+{ "jsonrpc":"2.0","id":1,"result":{ "risk":"johns-risk","trusted":true,"member_state":"active" } }
+```
+The eN2N `n2n/hello` path is **untouched**; `in2n/hello` is a sibling handler.
+
+## Post-handshake dispatch
+
+Once `active`, the same JSON-RPC method set eN2N uses is available over the internal channel, gated to the member's scope:
+- `n2n/inventory/*` — member advertises its (scoped) capabilities to the Border.
+- `n2n/tasks/submit|status|result|cancel` — internal delegation (reused 053 async lifecycle; see routing contract).
+- Heartbeats keep the channel alive; a miss marks the member `unreachable` and increments failure count.
+
+## Reconnect / self-heal (reused 053 pattern)
+
+- **Member side**: a dial supervisor re-dials `border_endpoint` with bounded backoff (5s→60s) if the channel drops — the same supervisor logic as eN2N's reconnect (spec 053), pointed at the Border.
+- **Border side**: `on_close` deregisters the member channel (no zombies); the member re-dials and re-authenticates on its pinned key. No operator action needed for a normal restart.
+- Distributed members surviving a transient network partition rejoin automatically when the private transport recovers.
+
+## Invariants (test assertions)
+
+- A member opens zero inbound listening ports (SC-011).
+- Framing bytes on an iN2N channel are byte-identical to eN2N framing (frozen-core guard).
+- Members cannot address each other — only the Border is dialable in a risk (hub-and-spoke, FR-007a).
+- A dropped internal channel re-establishes from the member side automatically (bounded backoff), result-bearing tasks survive per 053 persistence.
+- eN2N `n2n/hello` and channel behavior are unchanged by the presence of `in2n/hello` (`test_en2n_regression.py`).

--- a/specs/056-in2n-internal-federation/contracts/in2n-routing.md
+++ b/specs/056-in2n-internal-federation/contracts/in2n-routing.md
@@ -1,0 +1,58 @@
+# Contract: iN2N Border Routing (capability match → member select → delegate)
+
+How the Border turns an operator request into work on the right Member. Reuses the spec 052 capability inventory and spec 053 async delegation; adds deterministic member selection and scope enforcement (FR-009–FR-013, FR-023; research R5).
+
+## Operator entry point
+
+`n2n-mcp` tool: `n2n_route(request_text, target_hint?)` — the operator asks the Border to handle a task-shaped request. Daemon HTTP: `POST /n2n/route`.
+
+The Border MAY use reasoning to interpret `request_text`, but **member selection among capability matches is deterministic** (below), so the same request lands on the same member every time.
+
+## Selection algorithm (deterministic)
+
+1. **Match**: find all `active` members whose advertised scope (skills/tools, from the reused inventory) covers the request's required capability.
+2. **No match** → return `-32030 ERR_NO_CAPABLE_MEMBER` with a plain message: "No member in risk `<risk>` can perform that." (FR-011). The Border does **not** attempt the work itself.
+3. **One match** → select it.
+4. **Multiple matches** → deterministic tie-break:
+   - (a) **most-specific scope**: the member advertising the fewest **specialty** capabilities that still cover the request (the true specialist) wins. The mandatory base floor (FR-021a) is tagged `base` and **excluded** from this count so shared base tools don't distort specialist selection (FR-021b);
+   - (b) if still tied, **lexicographically smallest `member_id`**.
+
+## Delegation (reused 053 async lifecycle)
+
+Selected member gets the work as an async delegated task over the internal channel:
+```json
+{ "jsonrpc":"2.0","id":7,"method":"n2n/tasks/submit",
+  "params":{ "target_type":"skill","target_name":"cml-lab-lifecycle","input_text":"<build spec>" } }
+  → { "result": { "task_id":"…","state":"submitted" } }        # returns in ~seconds
+```
+Then `n2n/tasks/status` (poll) and `n2n/tasks/result` (fetch). The operator-facing `n2n_route` returns the `task_id` immediately for long work; `n2n_task_status`/`n2n_task_result` (existing 053 tools) poll it. Short work may return inline. Persistence (053) means the result survives a member restart or channel blip mid-build (SC-006).
+
+## Scope enforcement (member side, FR-023)
+
+- A member's **advertised scope == its allowed scope**. When it receives a `tasks/submit` for a target outside its scope, it refuses with `-32031 ERR_OUT_OF_SCOPE` rather than attempting or self-expanding.
+- This holds even though the member trusts its Border (relaxed internal trust ≠ unlimited authority — FR-027).
+
+## Secret isolation (FR-026)
+
+- The submit carries only the request/input text — never credentials, `.env` values, device addresses, or testbed secrets. The member executes with **its own local configuration**. Enforced by the reused no-secrets guard.
+
+## Audit (FR-024/FR-025, research R8)
+
+- Every route/delegate writes a `remote_invocation_record` with `channel_kind='in2n'`.
+- If an **external (eN2N) request** is satisfied by internal delegation, the Border writes the outer eN2N record **and** the inner iN2N record, `linked_record_id` joining them; the external result is attributed to the risk, not the member (FR-016/FR-025).
+
+## Error codes (new)
+
+| Code | Name | Meaning |
+|------|------|---------|
+| -32030 | ERR_NO_CAPABLE_MEMBER | no active member covers the requested capability |
+| -32031 | ERR_OUT_OF_SCOPE | member asked to act beyond its advertised/allowed scope |
+
+## Test assertions
+
+- Request matching exactly one member routes there; result returns through the Border.
+- Request matching two members always selects the more-specific one; identical specificity → lexicographic member_id (deterministic, repeatable).
+- Request matching no member → -32030, and the Border performs no work itself.
+- Out-of-scope target on a scoped member → -32031.
+- Long build over `n2n_route` returns a `task_id` fast and completes as a background task surviving a member restart.
+- An eN2N request fulfilled internally produces two linked audit records (external + internal).

--- a/specs/056-in2n-internal-federation/data-model.md
+++ b/specs/056-in2n-internal-federation/data-model.md
@@ -1,0 +1,139 @@
+# Phase 1 Data Model: iN2N — Internal NetClaw Federation
+
+Extends the existing SQLite at `~/.openclaw/n2n/federation.db` (spec 052/053). All new tables are additive; existing eN2N tables are untouched except one additive column on `remote_invocation_record`. Keys/tokens live under `~/.openclaw/n2n/keys/` (runtime-generated, never committed).
+
+Timestamps are ISO-8601 UTC strings (`_now()`), matching `manager.py`.
+
+---
+
+## New table: `risk`
+
+Identity and configuration of this claw's risk membership. Exactly one row per claw (this claw's own role in its risk).
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | INTEGER PK | always 1 (singleton for this claw) |
+| `risk_name` | TEXT | name of the risk; NULL when `role='standalone'` |
+| `description` | TEXT | risk description |
+| `role` | TEXT NOT NULL | `standalone` \| `border` \| `member` |
+| `enabled_stacks` | TEXT | Border only: `en2n` \| `in2n` \| `both` |
+| `border_endpoint` | TEXT | Member only: host:port it dials outbound to reach the Border |
+| `self_member_id` | TEXT | Member only: this claw's risk-local id `<risk>/<name>` |
+| `created_at` | TEXT NOT NULL | |
+| `updated_at` | TEXT NOT NULL | |
+
+**Rules**:
+- `role='standalone'` ⇒ behaves exactly as pre-054 NetClaw (FR-004); `risk_name`/stacks ignored.
+- Exactly one Border per risk (FR-003) — enforced at config time; a Member's `border_endpoint` points at that one Border.
+- `enabled_stacks` gates whether the Border runs eN2N, iN2N, or both (FR-015).
+
+---
+
+## New table: `member`
+
+The Border's registry of its Members (rows exist only on a Border). Keyed by risk-local member id, bound to a pinned key.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `member_id` | TEXT PK | `<risk>/<name>`, stable across relocation (FR-008) |
+| `display_name` | TEXT | human label |
+| `pinned_key` | TEXT | member's self-signed public key (PEM/fingerprint), pinned at enrollment (FR-013a) |
+| `profile` | TEXT | provisioning profile (`cml`, `pyats`, `security`, `custom`) |
+| `scope` | TEXT | JSON: advertised/allowed skills + tools (advertised == allowed, FR-023). Each entry tagged `base` (mandatory floor, FR-021a) or `specialty`; only `specialty` entries count toward the routing tie-break (FR-021b) |
+| `runtime_kind` | TEXT | `process` \| `container` (R1, selectable per member) |
+| `transport_binding` | TEXT | `loopback` \| `distributed`; last-seen source info |
+| `state` | TEXT NOT NULL | `enrolled` \| `active` \| `unreachable` \| `quarantined` \| `removed` |
+| `health` | TEXT | JSON: last_seen, heartbeat state, in-flight task count |
+| `auth_failures` | INTEGER NOT NULL DEFAULT 0 | consecutive health/auth failures → quarantine threshold (FR-013d) |
+| `enrolled_at` | TEXT | |
+| `updated_at` | TEXT | |
+
+**State transitions**:
+```
+(none) --enroll(valid token+key)--> enrolled --dial+auth(pinned key)--> active
+active --heartbeat miss / dial drop--> unreachable --re-dial+auth--> active
+active|unreachable --repeated auth/health failure (≥ threshold)--> quarantined   [auto, alert operator]
+any --operator remove--> removed        [unpin key; refuse reconnect]
+removed|quarantined --re-enroll(new token) OR operator re-pin--> enrolled
+```
+- `quarantined`/`removed` ⇒ pinned key no longer honored; reconnect on the old key is refused (FR-013c/d, SC-010).
+- The Border routes work only to `active` members (FR-013d, US5).
+
+---
+
+## New table: `enrollment_token`
+
+Single-use tokens issued by a Border for members to join (FR-013a/b).
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `token_hash` | TEXT PK | hash of the token (raw token shown once to the operator, never stored) |
+| `label` | TEXT | optional (e.g. intended member name/profile) |
+| `issued_at` | TEXT NOT NULL | |
+| `expires_at` | TEXT | optional TTL |
+| `spent_at` | TEXT | set when consumed (pins a member key); NULL = unspent |
+| `spent_by_member_id` | TEXT | which member consumed it |
+
+**Rules**: single-use (reject if `spent_at` set), reject if past `expires_at` (SC-010). A leaked-but-spent token grants nothing.
+
+---
+
+## New column on existing `remote_invocation_record`
+
+Discriminate internal vs external activity so the Border's one audit query covers everything (FR-024/FR-025, R8).
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `channel_kind` | TEXT | `en2n` \| `in2n` (additive migration; default `en2n` for existing rows) |
+| `linked_record_id` | INTEGER | for an external request satisfied by internal delegation: links the outer eN2N record ↔ the inner iN2N delegation (FR-025) |
+
+Added via the same idempotent `ALTER TABLE … ADD COLUMN` migration pattern already in `manager.py`.
+
+---
+
+## Reused table: `delegated_task` (spec 053, unchanged schema)
+
+Internal delegations reuse the 053 async task table as-is. `peer_identity` holds the **member_id** for iN2N tasks (vs the BGP identity for eN2N). `direction`:
+- On the **Border**: `outbound` (Border → member runs it).
+- On the **Member**: `inbound` (member runs work its Border delegated).
+
+Persistence already guarantees results survive channel drops and daemon restarts (SC-006) — inherited free.
+
+---
+
+## Files on disk (not DB)
+
+```
+~/.openclaw/n2n/keys/
+├── border_self.key / border_self.pub     # the Border's own self-signed keypair (also its member-facing identity)
+├── member_self.key / member_self.pub      # a Member's own self-signed keypair (generated at runtime, R3)
+└── pinned/<member_id>.pub                  # keys the Border has pinned (mirror of member.pinned_key)
+```
+Path is gitignored (Constitution XIII); keys are runtime-generated, never in the repo or config.
+
+---
+
+## Entity relationships
+
+```
+risk (this claw: standalone | border | member)
+  │
+  ├─ (border) 1───* member ──1 pinned_key
+  │                     │
+  │                     └── scope (allowed skills/tools) ── enforced == advertised
+  │
+  ├─ (border) 1───* enrollment_token (single-use)
+  │
+  └─ delegated_task (reused): peer_identity = member_id for iN2N
+       └─ audited in remote_invocation_record (channel_kind=in2n [, linked to en2n row])
+```
+
+## Validation rules (from FRs)
+
+- FR-003: at most one `role='border'` per risk (config-time guard).
+- FR-006/FR-007a: a `member` never has a public/inbound endpoint; `border_endpoint` is dialed *by* the member (outbound).
+- FR-013a/b: `member.pinned_key` set only via a valid unspent token; token flips to spent atomically.
+- FR-013c/d: `remove` → `state=removed` + unpin; `auth_failures ≥ threshold` → `state=quarantined` + unpin + alert.
+- FR-023: `member.scope` is both what the member advertises and the ceiling of what it will execute; out-of-scope refused.
+- FR-016: nothing in `member`/`enrollment_token` is ever exposed over eN2N — external peers see only the Border identity.
+- FR-026: no credential/secret column exists on any of these tables; inventories carry names/descriptions only.

--- a/specs/056-in2n-internal-federation/plan.md
+++ b/specs/056-in2n-internal-federation/plan.md
@@ -1,0 +1,134 @@
+# Implementation Plan: iN2N — Internal NetClaw Federation (a "risk" of claws)
+
+**Branch**: `056-in2n-internal-federation` | **Date**: 2026-07-12 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/056-in2n-internal-federation/spec.md`
+
+## Summary
+
+Add **internal federation (iN2N)**: a single operator runs a named group of focused NetClaws — a **"risk"** — coordinated by one **Border Claw**, with the other claws as tightly-scoped **Members**. The operator only ever talks to the Border; the Border routes each request to the Member that owns the capability and returns the result. Members are standalone OpenClaw runtimes (process/container) that **dial outbound** to the Border over a network-capable **internal transport** (loopback when co-located, private-network/overlay/tunnel when distributed across hosts/clouds/datacenters) — no inbound ports, no ngrok, no BGP mesh, no per-peer mutual consent. Trust within a risk is owner-implicit but still authenticated: a member enrolls once with a **single-use enrollment token** and its own **self-signed key**, which the Border **pins (trust-on-first-use)**; every later channel is authenticated by that pinned key. The Border can `remove` a member (unpin) and **auto-quarantines** a member that repeatedly fails health/auth.
+
+The whole thing is a **new transport binding + trust profile over the existing NCFED semantics** — it reuses spec 052's JSON-RPC 2.0 framing, capability inventory, and spec 053's async task delegation, **without changing the frozen eN2N core** (external wire framing, mutual consent, default-deny, no-secrets guard). Two roles collapse cleanly onto the existing daemon: a standalone NetClaw is "a risk of one that is its own Border," and eN2N/iN2N/both is a Border-side setting, not a third role. Installer work adds the risk/role/profile selection and provisions members from catalog-derived profiles.
+
+## Technical Context
+
+**Language/Version**: Python 3.10+ (daemon federation layer + `n2n-mcp`, matching 052/053), Node.js 18+/ES2022 (HUD), Bash (installer), no new languages
+**Primary Dependencies**: Existing `bgp-daemon-v2.py` + `bgp/federation/*` (manager, channel, service, inventory, authorization, invocation, chat, gateway, negotiate, tasks, audit), FastMCP (`n2n-mcp`), Python stdlib `json`/`sqlite3`/`asyncio`/`ssl`/`socket`; `cryptography` (already a repo dependency, spec 003) for self-signed key generation and pinned-key verification. No new third-party packages.
+**Storage**: Extend the existing SQLite at `~/.openclaw/n2n/federation.db` with iN2N tables: `risk` (name/description/role/enabled-stacks), `member` (risk-local id, pinned key, transport binding, scope, health, state), `enrollment_token` (single-use). Reuse `delegated_task` for internal delegation; internal delegations are recorded in the existing `remote_invocation_record` audit table with a `channel_kind` discriminator. Pinned keys and the risk's own key stored under `~/.openclaw/n2n/keys/`.
+**Testing**: pytest — unit tests for enrollment/pin/unpin/quarantine state machine, member registry, hub-and-spoke routing + deterministic tie-break, scope enforcement, and an in-memory internal-transport channel-pair harness (extending the 052/053 two-service loopback harness) for Border↔Member submit/status/result over iN2N. Regression tests asserting eN2N (052/053) behavior is unchanged.
+**Target Platform**: Linux/WSL2 NetClaw hosts (unchanged); Members may additionally run in other hosts/clouds/datacenters reachable over the operator's private transport.
+**Project Type**: Extension of the existing multi-component repo (daemon + `n2n-mcp` + HUD + modular installer).
+**Performance Goals**: Stand up a working risk (Border + 1 Member) and route a specialty task in < 15 min from fresh install (SC-001); a Member carries only its profile's skills (SC-002); long internal delegations complete as background tasks, matching 053 reliability (SC-006); removed/quarantined member refused on next connect 100% (SC-010).
+**Constraints**: Members MUST NOT join the public mesh or open inbound ports (SC-003/SC-011) — outbound-dial only; internal channel MUST be authenticated/encrypted (pinned self-signed key, no CA — FR-013a); hub-and-spoke, no iBGP/mesh (FR-007a); eN2N core frozen (FR-018); no secrets cross any claw boundary (FR-026); Border is the single audit/GAIT/gateway point and the sole external identity (FR-016/FR-024).
+**Scale/Scope**: A handful of Members per risk (single-digit to low-double-digit); one Border per risk; a few concurrent internal delegations. Live testbed: John's risk with a Border + a CML Member + a pyATS Member, one co-located and one in a second location.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| # | Principle | Status | Notes |
+|---|-----------|--------|-------|
+| I | Safety-First Operations | PASS | No new device write path; Members run their own tools under their own local policies; delegation is observe/route, not a new write primitive |
+| II | Read-Before-Write | PASS | Unchanged; scoping refuses out-of-scope work rather than acting blind |
+| IV | Immutable Audit Trail | PASS | Border is the single audit/GAIT point (FR-024); every internal delegation + enrollment/removal/quarantine event is recorded; extends existing `remote_invocation_record` |
+| V | MCP-Native Integration | PASS | Operator surface stays the `n2n-mcp` FastMCP server; new tools follow the proxy pattern; iN2N is a peer transport binding, not a bespoke tool integration; reuses NCFED JSON-RPC lifecycle |
+| VI | Multi-Vendor Neutrality | PASS | No vendor logic added; Members are scoped bundles of existing vendor MCP servers/skills |
+| VII | Skill Modularity | PASS | Extends the single `n2n-federation` skill with iN2N verbs; no duplication |
+| IX | Security by Default | PASS | Least privilege is the whole point (scoped Members, small blast radius); authenticated pinned-key channel; single-use enrollment token; operator revoke + auto-quarantine; no new inbound exposure; Border is the only external face |
+| X | Observability | PASS | Border surfaces member health/scope + in-flight internal tasks; HUD gains a risk/member view (US4/US5) |
+| XI | Full-Stack Artifact Coherence | PASS (planned) | Touches README, `catalog.sh` (risk/role/profile install options under existing `n2n` component), `install-steps.sh`, `verify-catalog-coverage.py`, HUD, SOUL.md, `n2n-federation/SKILL.md`, `n2n-mcp/README.md`, `.env.example` (new `N2N_RISK_*` / member tunables), TOOLS.md, `config/openclaw.json`; enumerated in tasks |
+| XII | Documentation-as-Code | PASS (planned) | Contracts for the iN2N enrollment + internal-transport + routing; SKILL/README same PR |
+| XIII | Credential Safety | PASS | Enrollment token + keys in `~/.openclaw/n2n/keys/` (gitignored path, runtime-generated, never in repo); no secrets in config; no-secrets-cross-boundary guard reused (FR-026) |
+| XIV | Human-in-the-Loop | PASS | Operator approves member removal/re-pin; external (eN2N) approval gate frozen; no autonomous external action added |
+| XV | Backwards Compatibility | PASS | Standalone NetClaw behaves exactly as today (FR-004, SC-008); eN2N unchanged and regression-tested (FR-018, SC-009); additive SQLite tables + migrations |
+| XVI | Spec-Driven Development | PASS | This SDD flow |
+| XVII | Milestone Blog | NOTED | Draft at implement completion (iN2N is a major architectural addition) |
+
+**Initial gate: PASS** — no violations; Complexity Tracking not required. The feature is additive: a new transport binding + trust profile + installer flow over frozen 052/053 primitives, plus one clean role model.
+
+**Post-design re-check (after Phase 1): PASS** — data-model adds `risk`/`member`/`enrollment_token` tables and reuses `delegated_task` + `remote_invocation_record`; contracts add an iN2N handshake/enrollment path and internal-transport dial that live *alongside* the frozen eN2N `n2n/hello`, not replacing it; no new ports beyond the Border's existing reachable endpoint; no new languages or external trust paths. Standalone and eN2N paths untouched.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/056-in2n-internal-federation/
+├── spec.md
+├── plan.md                          # this file
+├── research.md                      # Phase 0 — decisions (transport, enrollment/pin, identity, routing, roles, installer, member runtime)
+├── data-model.md                    # Phase 1 — Risk, Member, EnrollmentToken, MemberDelegation, entity states
+├── quickstart.md                    # Phase 1 — stand-up-a-risk + route-to-CML-member walkthrough (co-located + cross-cloud)
+├── contracts/
+│   ├── in2n-enrollment.md           # token issue + member enroll (self-signed key) + pin/unpin/quarantine
+│   ├── in2n-internal-transport.md   # member outbound dial, NCFED-over-internal-channel handshake variant, framing reuse
+│   ├── in2n-routing.md              # Border capability match → member select (deterministic tie-break), submit/status/result reuse
+│   └── in2n-daemon-api-delta.md     # new /n2n/risk, /n2n/members, /n2n/enroll* HTTP routes; n2n-mcp tool delta
+└── tasks.md                         # Phase 2 (/speckit.tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+mcp-servers/protocol-mcp/bgp/federation/
+├── risk.py               # NEW: Risk + Member + EnrollmentToken models, RiskManager (SQLite),
+│                         #   role (border|member|standalone), enabled-stacks, token issue/verify,
+│                         #   key pinning/unpin, quarantine state machine
+├── internal_channel.py   # NEW: iN2N transport binding — member-initiated outbound dial to Border,
+│                         #   self-signed-key TLS/auth, NCFED framing reuse (encode_frames/decode),
+│                         #   in2n/hello handshake variant (member_id + token/pinned-key, not AS/router-id)
+├── router.py             # NEW: Border-side capability→member routing (uses reused inventory),
+│                         #   deterministic tie-break, scope-enforcement check, "no member can do this"
+├── manager.py            # + risk/member/enrollment_token tables + migrations; channel_kind on audit
+├── service.py            # + iN2N supervisor: accept member dial-ins on Border, register/health/quarantine
+│                         #   members; on Member role, dial supervisor to the Border (reuse 053 backoff)
+├── invocation.py         # + internal delegation path (reuse delegated_task + async submit) over internal_channel
+├── inventory.py          # + member-scope enforcement (advertised == allowed; refuse out-of-scope)
+└── audit.py              # + internal-delegation + enroll/remove/quarantine audit events
+
+mcp-servers/protocol-mcp/bgp/constants.py
+                          # + NCFED_ROLE markers / in2n handshake constants (reuse magic + framing)
+
+mcp-servers/protocol-mcp/bgp-daemon-v2.py
+                          # + /n2n/risk (get/set), /n2n/members (list/remove), /n2n/enroll (issue/consume),
+                          #   /n2n/route (operator ask → route to member); wire iN2N supervisor on start
+
+mcp-servers/n2n-mcp/server.py
+                          # + n2n_risk_status, n2n_member_list, n2n_member_add (profile|custom),
+                          #   n2n_member_remove, n2n_enroll_token, n2n_route (ask the Border to route),
+                          #   n2n_member_health; standalone/border/member aware
+
+ui/netclaw-visual/
+├── server.js             # + /api/n2n risk/member aggregation (border shows its members)
+└── src/main.js           # risk view: Border node + member spokes, per-member scope/health/in-flight tasks
+
+scripts/lib/
+├── catalog.sh            # + risk/role/profile install metadata under the existing `n2n` component
+├── install-steps.sh      # + component_install_n2n: risk/role prompts via tui.sh primitives; member provisioning from profiles
+└── tui.sh                # REUSED AS-IS (Nick #96/#115/#117): tui_menu / tui_checklist / tui_yesno — no new prompt style
+
+scripts/
+├── netclaw               # + risk_menu (mirrors peering_menu) + `netclaw risk [status|members|add|remove|token|route]`
+│                         #   subcommands (mirrors `netclaw peering …`); reuses TUI_CHOICE dispatch, palette, api_get/api_post
+├── in2n-profiles.py      # NEW: derive claw profiles (CML/pyATS/security/…) from the installed skill catalog; Custom via tui_checklist;
+│                         #   layers the chosen specialty on top of the mandatory base floor (FR-021a), tagging base vs specialty
+└── verify-catalog-coverage.py   # unchanged logic; confirm coverage still passes
+
+workspace/skills/n2n-federation/SKILL.md
+                          # + iN2N section: risk/roles, ask-the-Border-to-route, member mgmt, enrollment
+
+tests/n2n/
+├── test_risk.py                 # role model, standalone=risk-of-one, single-Border enforcement
+├── test_enrollment.py           # token issue/single-use, self-signed key pin/re-pin, reject invalid/spent
+├── test_internal_transport.py   # member outbound dial, in2n/hello, NCFED framing reuse, encrypted channel
+├── test_routing.py              # capability match, deterministic tie-break, "no member can do this"
+├── test_scope_enforcement.py    # out-of-scope refused; advertised == allowed; base floor present + non-removable (FR-021a); base excluded from specificity (FR-021b)
+├── test_quarantine.py           # remove unpins + refuses reconnect; auto-quarantine on repeated failure
+├── test_member_delegation.py    # long internal task submit/status/result over iN2N (reuse 053 semantics)
+└── test_en2n_regression.py      # 052/053 eN2N behaviors unchanged (frozen-core guard)
+```
+
+**Structure Decision**: Pure extension of the 052/053 `bgp/federation/` package plus the modular installer. Three new modules keep the new concerns cohesive — `risk.py` (risk/member/enrollment state), `internal_channel.py` (the iN2N transport binding that reuses NCFED framing over a member-initiated dial), and `router.py` (Border-side hub routing). Everything else is additive edits. The `n2n-mcp` operator surface and HUD extend their established proxy/polling patterns; the installer extends the existing catalog/`install-steps` model (spec 049). No restructuring, no repo split (out of scope).
+
+## Complexity Tracking
+
+No constitution violations — table not required.

--- a/specs/056-in2n-internal-federation/quickstart.md
+++ b/specs/056-in2n-internal-federation/quickstart.md
@@ -1,0 +1,117 @@
+# Quickstart: Stand up a risk and route work to a Member
+
+End-to-end walkthrough of iN2N — forming a risk, enrolling a Member (one co-located, one in another cloud), and having the Border route a real task. Maps to US1–US5.
+
+## 0. Concepts in one breath
+
+You run several focused NetClaws — a **risk**. You only ever talk to the **Border Claw**. The Border routes each request to the **Member** that owns the skill and hands you the result. Members dial *out* to the Border, so they need no public address. Trust inside the risk is one-time enrollment + a pinned key — no CA, no mutual consent.
+
+## 1. Install the Border
+
+```
+./scripts/install.sh
+# N2N component prompt:
+#   Standalone NetClaw or part of a risk?          → part of a risk
+#   Risk name / description?                        → johns-risk / "John's lab fleet"
+#   Role?                                           → Border
+#   Enable eN2N / iN2N / both?                      → both
+```
+The Border comes up with the gateway (the only operator-facing interface) and an iN2N listener on its reachable endpoint.
+
+```
+n2n_risk_status()
+→ role=border · risk=johns-risk · stacks=both · members=0
+```
+
+## 2. Provision a Member from a profile (co-located CML claw)
+
+Profiles are derived from your installed skill catalog, so they match what you actually have:
+
+```
+n2n_member_add(profile="cml", name="cml")
+→ member johns-risk/cml provisioned (scope: cml-lab-lifecycle + cml_* tools)
+  enrollment token: in2n_xxxxxxxx   (single-use; hand to the member)
+  join: set N2N_ROLE=member, N2N_BORDER_ENDPOINT=<border>, run enroll with this token
+```
+
+On the member host (same machine here) install as a **Member** of `johns-risk`, point `N2N_BORDER_ENDPOINT` at the Border, and start it with the token. The member generates its own self-signed key, dials out, presents `(token, public_key)`, and the Border pins it:
+
+```
+n2n_member_list()
+→ johns-risk/cml   profile=cml   state=active   transport=loopback   in_flight=0
+```
+
+## 3. Provision a Member in another cloud (pyATS claw)
+
+Same flow — the only difference is where it runs and how it reaches the Border:
+
+```
+n2n_member_add(profile="pyats", name="pyats")   → token in2n_yyyyyyyy
+```
+On a VM in another cloud/datacenter: install as a Member, set `N2N_BORDER_ENDPOINT` to the Border's address reachable over your private transport (VPC peering / WireGuard / tunnel), enroll with the token. No inbound ports opened on the member.
+
+```
+n2n_member_list()
+→ johns-risk/cml     state=active  transport=loopback
+  johns-risk/pyats   state=active  transport=distributed   (dialed in from cloud B)
+```
+
+## 4. Ask the Border — it routes to the specialist
+
+You talk only to the Border. It picks the member and delegates:
+
+```
+"Recreate my NetClaw-Full-Topo lab in CML."
+
+Border → n2n_route(request_text="recreate NetClaw-Full-Topo (10 nodes/12 links)")
+→ matched member johns-risk/cml (CML specialist); task_id=t-abc  state=submitted   # returns in ~2s
+
+n2n_task_status("t-abc")  → working · "nodes 6/10"
+n2n_task_result("t-abc")  → completed · "lab up, OSPF adjacency formed"
+```
+```
+"Run the pyATS testbed against those devices."
+
+Border → n2n_route(...) → matched johns-risk/pyats (in cloud B); task_id=t-def
+n2n_task_result("t-def") → completed · "42/42 tests passed"
+```
+Long builds run as background tasks (reused 053 async delegation) — they survive a member restart or a network blip.
+
+## 5. What the Border refuses / handles
+
+```
+"Configure BGP on the CML member directly."         # cml member has no config skill
+Border → ERR_OUT_OF_SCOPE (member declined; it only does CML lab lifecycle)
+
+"Do something no member covers."
+Border → ERR_NO_CAPABLE_MEMBER: no member in risk johns-risk can perform that
+         (the Border does NOT attempt it itself)
+```
+
+## 6. Security lifecycle
+
+```
+n2n_member_remove("johns-risk/pyats")    # decommission cloud B member (confirm first)
+→ key unpinned, dropped from routing; it cannot reconnect on the old key.
+  To return it must re-enroll with a NEW token.
+```
+If a member repeatedly fails auth/health, the Border **auto-quarantines** it (unpins, stops routing, alerts you) — visible in `n2n_member_health` and on the HUD.
+
+## 7. The outside world sees ONE identity
+
+With eN2N also enabled, a peer *risk* federating with your Border sees only `johns-risk` (the Border) — never `johns-risk/cml` or the cloud-B pyATS member. If the Border satisfies a peer's request by delegating internally, your audit log shows both the external request and the internal delegation, linked — the peer just gets a result attributed to your risk.
+
+## 8. Standalone is unchanged
+
+Choosing **Standalone NetClaw** at install → behaves exactly as today (a risk of one, its own Border). `n2n_risk_status()` reports `standalone`; nothing about members or routing is imposed.
+
+---
+
+**Verification checklist** (acceptance):
+- [ ] Border + 1 member up and routing in < 15 min from fresh install (SC-001)
+- [ ] Member carries only its profile's skills (SC-002)
+- [ ] Members opened zero inbound ports; both reached the Border by dialing out (SC-003/SC-011)
+- [ ] Every routed request produced a logged internal delegation at the Border (SC-004)
+- [ ] Out-of-scope refused; no-capable-member reported plainly (SC-007)
+- [ ] Removed member refused on reconnect; spent token rejected (SC-010)
+- [ ] eN2N mesh behavior unchanged; standalone unchanged (SC-008/SC-009)

--- a/specs/056-in2n-internal-federation/research.md
+++ b/specs/056-in2n-internal-federation/research.md
@@ -1,0 +1,105 @@
+# Phase 0 Research: iN2N — Internal NetClaw Federation
+
+All open decisions from the spec's clarifications and the plan's Technical Context, resolved. Each: Decision / Rationale / Alternatives considered.
+
+---
+
+## R1. Member runtime model
+
+**Decision**: A Member is a **standalone OpenClaw runtime** (its own process or container), not an in-process profile. The runtime model is **selectable per member** so one risk can mix a co-located member and a member in another cloud.
+
+**Rationale**: The distributed-microservices case (members across hosts/clouds/datacenters) is a first-class requirement (spec FR-028, operator's explicit note). In-process profiles cannot leave the host, so they can't satisfy it. Standalone runtimes give real isolation (separate context, separate blast radius — the "focus and token economy" goal) and let the same abstraction cover both co-located and distributed members. Per-member selection avoids forcing container overhead on a small single-host risk.
+
+**Alternatives considered**: (B) in-process scoped agent profiles in one OpenClaw — simplest and cheapest but co-located only; rejected because it can't do distributed members at all. (Always-container) — uniform but pays network+container cost even for a tiny local risk; rejected in favor of per-member choice.
+
+---
+
+## R2. Internal transport & topology
+
+**Decision**: iN2N is a **hub-and-spoke star** centered on the Border. Members communicate **only** with the Border (never member-to-member). Reachability is achieved by **each member dialing OUTBOUND** to the Border's single reachable endpoint. The transport **reuses the NCFED wire framing** (`[4-byte length][1-byte flags][JSON-RPC 2.0]`, chunking, heartbeats from `channel.py`) over this member-initiated connection — a new *binding*, not a new protocol. No iBGP, no routing protocol, no full mesh.
+
+**Rationale**: Single-owner, centralized coordination has no n×n reachability to solve — only member↔Border. Outbound-dial means members need no inbound ports, no public address, and no ngrok, and works from behind NAT or inside a private cloud (SC-011). Reusing NCFED framing means the JSON-RPC method dispatch, chunking, and heartbeat logic already written and tested for eN2N carry straight over. It is literally the eN2N dial pattern pointed inward at the operator's own Border. Distributed members ride the operator's own private network / overlay-VPN (WireGuard/Tailscale) / tunnel — that connectivity is the operator's concern, iN2N just needs a TCP path to the Border.
+
+**Alternatives considered**: A routing-protocol/mesh (iBGP-style) — unnecessary complexity for a star; rejected. Border-initiated dial to members — would require members to have reachable inbound endpoints (defeats the no-inbound-ports goal, breaks NAT/private-cloud members); rejected. A brand-new wire protocol for internal use — needless divergence from the proven, tested NCFED framing; rejected.
+
+---
+
+## R3. Enrollment & channel authentication (no CA)
+
+**Decision**: **Enrollment token + member-generated self-signed key, pinned trust-on-first-use.** At risk creation the Border can issue a **single-use enrollment token**. A member generates its own self-signed keypair at runtime. On first dial it presents `(token, public_key)`; the Border validates the token, **pins** the public key to a risk-local member ID, and marks the token spent. Every subsequent internal channel is authenticated by the pinned key (channel encrypted end-to-end). Key rotation ⇒ re-enroll (new token) or explicit operator re-pin. No certificate authority.
+
+**Rationale**: One operator owns the whole risk, so full mutual-consent (as in eN2N) is unnecessary friction — but the channel must still be authenticated so a rogue local process can't impersonate a member (esp. over a distributed transport). TOFU with a spent-once token gives strong practical security with zero PKI to operate across clouds: the token gates *becoming* a member; the pinned key authenticates *being* one thereafter. This is the operator's explicit choice (clarify Q1), strengthened with runtime self-signed keys (operator's suggestion) instead of a shared long-lived secret.
+
+**Alternatives considered**: Mutual TLS with a risk-local CA — cert-based auth but an operator-run CA to stand up and rotate; rejected as heavier than pinning buys. Shared long-lived risk secret used on every connection — simplest but a single reusable secret is a worse compromise blast radius than a spent-once token + pinned per-member key; rejected. Manual per-member approval only — good control but tedious at provisioning scale; folded in as the *re-pin* path, not the default enroll path.
+
+---
+
+## R4. Member identity scheme
+
+**Decision**: **Risk-local member ID** `<risk-name>/<member-name>` (e.g. `johns-risk/cml`), assigned at provisioning, **bound to the pinned key**. The name is the stable handle used in the registry, audit log, routing, and HUD; the pinned key is the authenticator. The ID is stable across relocation (a member moving between clouds keeps its ID; only its transport binding changes).
+
+**Rationale**: Members don't run BGP, so the eN2N identity `as<AS>-<router-id>` doesn't apply. A human-readable risk-local ID reads well in audit/routing and is stable independent of network location — critical because location can change. Binding it to the pinned key means the name is a convenience, not a security boundary; impersonation is prevented by the key, not the string.
+
+**Alternatives considered**: Key-fingerprint-as-identity (self-sovereign) — stable and unforgeable but opaque in logs/UX; kept as the underlying binding but not the display identity. Reuse BGP-style identity for members — false consistency (members aren't mesh peers, don't have an AS); rejected.
+
+---
+
+## R5. Border-side routing & deterministic tie-break
+
+**Decision**: The Border matches an operator request to a Member using the **reused capability inventory** (skill/tool names + descriptions each member advertises, spec 052 model). Selection is by capability match; when **multiple** members match, tie-break is **deterministic** by a documented rule: (1) most-specific scope (fewest advertised capabilities that still cover the request) wins, then (2) lexicographic member ID. When **no** member matches, the Border reports "no member in this risk can do that" rather than attempting it or silently failing.
+
+**Rationale**: Reusing the inventory means routing rides the same capability data eN2N already exchanges — no new discovery mechanism. "Most-specific scope wins" favors the true specialist (the CML claw over a broader claw that also happens to list CML), which matches the focus goal; lexicographic ID is a stable final tiebreak so the same request always lands on the same member (testable, SC — deterministic). Explicit "no member" is required by FR-011 to avoid the Border quietly doing work no specialist owns.
+
+**Base-floor exclusion (FR-021b)**: specificity is measured over each member's **specialty** capabilities only. The mandatory base floor (R7a) that every member shares is excluded from the count, otherwise the common base tools would blur how specialized a member looks and could tie or invert the true specialist.
+
+**Alternatives considered**: LLM-freeform routing with no tie-break — non-deterministic, hard to test, could fan out; rejected (the Border may still *use* reasoning to interpret the request, but the member *selection* among matches is deterministic). Load-balancing/scoring across equivalent members — out of scope for v1 (spec Out of Scope); a deterministic pick is sufficient.
+
+---
+
+## R6. Role model & standalone equivalence
+
+**Decision**: **Two roles — Border and Member** — plus the identity "a standalone NetClaw is a risk of one that is its own Border." eN2N/iN2N/both is a **Border-side setting**, not a role. The daemon gains a `role` (`standalone|border|member`) and, for a Border, `enabled_stacks` (`en2n`, `in2n`, or both). A standalone install sets `role=standalone` and behaves exactly as today.
+
+**Rationale**: Collapsing "eN2N NetClaw" into "a Border with eN2N enabled" removes a redundant role and matches the operator's own statement that the Border is where the stack is chosen. It also makes backwards-compat trivial: `standalone` is the default and is behaviorally identical to pre-054 NetClaw (SC-008). Exactly-one-Border-per-risk is enforced at config time (FR-003).
+
+**Alternatives considered**: Three roles (Border / eN2N / iN2N-member) as originally brainstormed — the "eN2N" role duplicates "Border with eN2N enabled"; rejected for simplicity per the design discussion. A separate standalone codepath — unnecessary; standalone is just the degenerate risk.
+
+---
+
+## R7. Installer: risk/role selection & profile provisioning
+
+**Decision**: Extend the existing **modular installer** (spec 049: `scripts/lib/catalog.sh` + `install-steps.sh`), not a new installer, and drive every prompt through **Nick's existing TUI primitives in `scripts/lib/tui.sh`** (PRs #96, #115, #117) — no new prompt style. Concretely:
+- **`tui_menu`** for standalone-vs-part-of-a-risk, for role (Border/Member), and for eN2N/iN2N/both (all single-select, arrow-key, → `TUI_CHOICE`).
+- **`tui_yesno`** for confirmations (matches installer style).
+- **`tui_checklist`** (the category-headed multi-select with `CL_IDS/CL_LABELS/CL_ON`, exactly as the component picker uses it) for the **Custom** member skill/tool selection, and for choosing which seed profiles to provision.
+- **Claw profiles derived at runtime from the installed skill catalog** by a new `scripts/in2n-profiles.py` (CML claw, pyATS claw, security claw, … + Custom), so profiles can't drift from what's installed (FR-019); the specialty profile is layered on the mandatory base floor (R7a).
+
+Additionally, the **`scripts/netclaw` command gains a Risk surface that mirrors `peering_menu`**: an interactive `risk_menu` (Overview · Members · Add member · Remove member · Enrollment token) under the main menu, plus non-interactive subcommands `netclaw risk [status|members|add|remove|token|route]` mirroring the existing `netclaw peering [status|bgp|n2n|ngrok]` pattern. Reuses the same neon palette, `TUI_CHOICE` dispatch, off-TTY degradation, and daemon HTTP (`api_get`/`api_post` against `bgp-daemon-v2.py`) as the peering tree.
+
+**Rationale**: Constitution XI mandates the catalog/`install-steps` touchpoints, and spec 049 + Nick's #96/#115/#117 already established the modular installer AND the TUI look-and-feel and the `netclaw` command tree — reusing them is required for consistency and is lowest-friction. Deriving profiles from the live catalog (rather than a hardcoded list) is a direct FR-019 requirement. A `risk` sub-tree parallel to `peering` means an operator navigates iN2N exactly the way they already navigate eN2N/BGP/ngrok.
+
+**Alternatives considered**: A standalone iN2N installer/wizard or a bespoke prompt style — violates the modular-installer convention and Nick's TUI format; rejected. Hardcoded profile definitions — drift from the real catalog; rejected per FR-019. Putting Risk only in the installer with no `netclaw` command surface — inconsistent with how peering is operated day-to-day; rejected.
+
+### R7a. Mandatory base floor for every member (FR-021a)
+
+**Decision**: Every provisioned member — any profile, including Custom — includes a **non-removable base floor**: (a) the iN2N member runtime (enroll/dial/heartbeat, provided by `internal_channel.py` — infrastructure, always present), (b) self-status + capability reporting (so the Border can discover/route to it), (c) audit/GAIT reporting of its own actions back to the Border (Constitution IV), and (d) the constitutional safety behaviors (read-before-write; no unapproved destructive commands — Constitution I/II). `scripts/in2n-profiles.py` layers the chosen specialty profile *on top of* this floor; the floor is tagged as base so it is excluded from the routing specificity tie-break (R5 / FR-021b).
+
+**Rationale**: A member scoped to *only* its specialty can't heartbeat, can't be routed to, can't be audited by the Border, and could bypass the safety principles — all of which the architecture and constitution require. Making the floor explicit and non-removable keeps members focused (small specialty) without leaving them crippled or unsafe. Excluding it from specificity keeps the specialist-selection honest.
+
+**Alternatives considered**: No base floor (profile-only) — leaves members unable to report/heartbeat/audit and risks unsafe behavior; rejected. Counting base tools toward specificity — distorts which member is the true specialist; rejected (hence FR-021b).
+
+---
+
+## R8. Audit centralization & no-secrets guard
+
+**Decision**: The Border is the **single audit/GAIT point** (FR-024). Internal delegations are recorded in the existing `remote_invocation_record` table with a `channel_kind` column (`en2n|in2n`) so one query shows all activity. An external (eN2N) request satisfied by internal delegation writes **both** records, linked (FR-025). The **no-secrets guard reused from 052** applies to iN2N unchanged — inventories carry only capability names/descriptions, and no credentials cross any claw boundary (FR-026).
+
+**Rationale**: Reusing the audit table + guard avoids a parallel audit path and keeps the "one place to see everything" promise real with minimal new code. `channel_kind` is a one-column migration. The no-secrets guard is already the enforcement point for cross-boundary data; iN2N is just another boundary type it covers.
+
+**Alternatives considered**: A separate iN2N audit table — fragments the audit trail against FR-024; rejected. Relaxing the no-secrets guard internally because "one operator" — tempting but a member in another cloud is still a separate trust surface; keeping the guard is safer and costs nothing; rejected relaxation.
+
+---
+
+## Cross-cutting: frozen eN2N core
+
+All of the above are **additive bindings/profiles over 052/053**. The eN2N `n2n/hello` handshake, mutual-consent state machine, default-deny authorization, budget/kill-switch, and no-secrets guard are **not modified**. iN2N adds an `in2n/hello` handshake variant and an internal-transport dial that live alongside them, discriminated at connect time. `test_en2n_regression.py` guards this (SC-009).

--- a/specs/056-in2n-internal-federation/risk-deployment-design.md
+++ b/specs/056-in2n-internal-federation/risk-deployment-design.md
@@ -1,0 +1,129 @@
+# John's Risk — deployment design (interview-driven)
+
+Captured from the design interview (do NOT migrate until this is complete + John
+signs off). Feeds `scripts/in2n-profiles.py`, the base-floor definition, and the
+per-member core configs for the migration.
+
+## Round 1 decisions (confirmed)
+
+- **Border footprint = pure broker + comms.** The Border carries ONLY: comms
+  (Slack, Discord, Webex, Twilio/voice, Twitter, PagerDuty, ServiceNow), routing,
+  audit, memory, humanrail. **No network-domain skills** — every technical ask is
+  delegated to a member. (Maximum focus; smallest Border context.)
+- **Member base floor (every member, non-removable) EXPANDS to:**
+  technical floor (n2n-member-runtime, self-status, member_heartbeat,
+  member_report_audit) **+ memory + GAIT + humanrail escalation.** So every member
+  is context-aware, self-auditing, and can escalate to the operator directly.
+  (These base skills are tier=base → excluded from routing specificity, FR-021b.)
+- **Models = provider-agnostic, operator-assigned per claw.** Each claw is its own
+  OpenClaw install with its own provider+model, so the operator picks provider
+  (Anthropic / OpenAI / Google / local, etc.) and model per claw — all the same,
+  per-role tiers, or per-member override. The installer PROPOSES a sensible default
+  (strongest-reasoning model for the Border; lighter/cheaper for members — the
+  token-economy tier) but it is fully overridable. NOT Claude-only. (Exact
+  strategy TBD round 2.)
+- **Comms = Border-only.** Members never talk to the outside directly; results
+  flow back through the Border.
+
+## Round 2 (partial — confirmed)
+
+- **Model/provider = per-claw, operator-set, with smart defaults.** Any provider
+  per claw — Anthropic, OpenAI, Google, **local/Ollama**, etc. — mixed freely. The
+  installer proposes a default (strong for Border, lighter for members) but every
+  claw is overridable. Fully offline members (local model) explicitly supported.
+- **Runtime = hybrid.** A small always-on "hot set" (e.g. cml, pyats + comms) stays
+  live; the Border spins up other members on first route and idles them out
+  (resource/token economy across ~23 members).
+
+### Granularity principle (John, decisive)
+**One claw per vendor / platform / tool.** Real integrations each get their OWN
+dedicated member with focused skills + MCP tools — do NOT bundle domains:
+- **Security vendors each dedicated:** ISE claw, ASA claw, Check Point claw,
+  Palo Alto claw, FortiManager claw, Zscaler claw, Claroty claw, etc. (No combined
+  "security" bundle.) Local sec utilities (nmap, nvd, fwrule) can be their own
+  small claws too.
+- **Clouds each dedicated:** AWS claw, Azure claw, GCP claw.
+- **Source-of-truth each dedicated:** NetBox claw, Nautobot claw, Infrahub claw,
+  Infoblox claw.
+- **Virtual-environment/lab tools each dedicated:** CML claw, EVE-NG claw, GNS3
+  claw, containerlab claw (split the old bundled "cml" profile).
+- **Automation each dedicated:** Itential, AAP, NSO, Terraform.
+- **Assurance each dedicated:** IP Fabric, SuzieQ, Batfish, Forward, gTrace.
+- **Utilities may stay GROUPED** (NOT split) — e.g. visualizations (viz) as one
+  member; subnet/rfc/wikipedia live on the Border.
+- **Env-gated throughout:** a vendor claw is only offered when its backend is
+  configured (so unconfigured vendors — checkpoint, zscaler, aws, gcp, terraform,
+  meraki — stay dormant until their env is set).
+
+### Security posture — a risk-wide MODE (John, decisive)
+- **DefenseClaw (Cisco) and OpenShell (NVIDIA sandbox)** are optional security
+  claws/members that do their jobs across the risk.
+- **`N2N_RISK_MODE`**: **`testing`** = DefenseClaw + OpenShell OFF (fast iteration);
+  **`production`** = both ENABLED and enforcing (members run sandboxed under
+  OpenShell; DefenseClaw scans/guards). Ties into the existing openclaw.json
+  `security.mode` (hobby ↔ defenseclaw) and spec 027 netshell-security.
+
+### Runtime architecture (confirmed / decided)
+- **Member runtime = OpenClaw EMBEDDED mode, NOT full OpenClaw.** OpenClaw ships
+  `openclaw agent --local --model <provider/model>` (embedded agent, own API keys,
+  no gateway). So a member = a lightweight iN2N launcher (`scripts/in2n-member.py`,
+  TODO) that dials the Border + on a delegated task runs `openclaw agent --local
+  --model <member-model>` over ONLY its scoped MCP servers. No gateway, no comms,
+  no 195-skill catalog, no BGP speaker. (Google ADK = possible FUTURE alt member
+  runtime; not needed now — OpenClaw --local covers it.)
+- **Border runtime = full OpenClaw** (gateway :18789 + comms) + the mesh daemon
+  (eN2N BGP mesh + iN2N Border listener). Keeps AS 65001 / router-id 4.4.4.4.
+- **Transport:** John's risk = all co-located on ONE host → loopback (no ngrok).
+  Cross-host/cross-org case (another org's Border, remote members) = members DIAL
+  OUT to the Border's one reachable endpoint (public/ngrok or VPN/overlay). Still
+  hub-and-spoke, still NO iBGP/mesh — the Border is the hub. (Settles John's
+  recurring "do we need a mesh?" question: no.)
+- **Per-member .env (least privilege):** each member gets its OWN workspace/config
+  dir + a .env slice with ONLY its integration's secrets (cml→CML_*, pyats→PYATS_*
+  +testbed, azure→AZURE_*). Border gets comms secrets + ZERO device creds.
+- **Production mode ready:** OpenShell 0.0.32 + DefenseClaw + Docker all installed
+  and up. Members run sandboxed under OpenShell; DefenseClaw guards.
+- Small code change needed pre-migration: member skill-exec path uses `openclaw
+  agent --local --model <member-model>` (today `gateway.py run_agent_turn` uses
+  gateway mode) — add a `--local`/model variant for members.
+
+### Build status (pre-migration)
+- **Cold/on-demand: DONE + tested.** Member `scripts/in2n-member.py --idle-exit N`
+  self-exits when quiet; Border `ensure_member_up` cold-starts an on-demand member
+  on first route (spawns its launch_cmd, waits for dial-in+auth, then delegates);
+  remote members (no launch_cmd) report unreachable instead of hanging. Registered
+  via `member.launch_cmd`/`on_demand` (add_member + daemon + n2n_member_add).
+- **Member runtime = OpenClaw embedded (`--local --model`)** — done.
+- **Migration scaffold generator `scripts/in2n-migrate.py`** (generate-only) — done:
+  27 least-privilege member .env slices + run.sh + border.env.additions + RUNBOOK.md.
+- **89 tests green** (44 eN2N regression + 45 iN2N). Nothing has touched the live claw.
+- Remaining before "done-done": the live migration itself (= quickstart validation)
+  and the HUD 3D scene geometry (build LIVE while members populate — no browser in
+  the coding env). Then blog.
+
+### Round 3 decisions (confirmed)
+- **`packet` member added** (pcap): packet-analysis + kubeshark-traffic (PACKET_BUDDY).
+- **Don't build unused claws:** nautobot/infrahub/eve-ng/gns3/meraki/zscaler/
+  claroty (+ aws/gcp/terraform/asa/checkpoint) stay DORMANT — John doesn't use
+  them; not provisioned in his risk. (They auto-activate if env is ever added.)
+- **pyATS = one claw** (one framework; not split by target device).
+- **John's risk MODE = production** — DefenseClaw + OpenShell ON, to prove the
+  full defense apparatus works end-to-end.
+- **Hot set (always-on): Border + cml + pyats + ipfabric + viz.** All other
+  members are on-demand (Border spins up on first route, idles out).
+- **Roster for John's migration = 27 offered members** (added packet).
+
+## Member roster (granular — one claw per vendor/tool, env-gated)
+
+**Offered NOW (26, backend configured):** cml, containerlab, pyats, ipfabric,
+suzieq, batfish, forward, gtrace, itential, aap, nso, aci, catalyst-center, f5,
+sdwan, ise, paloalto, fortimanager, nmap, nvd, fwrule, azure, netbox, infoblox,
+github, viz.
+
+**Dormant (12, skills present, no backend env — auto-activate when configured):**
+eve-ng, gns3, terraform, meraki, asa, checkpoint, zscaler, claroty, aws, gcp,
+nautobot, infrahub.
+
+Plus the **Border** (comms/routing/audit/memory/humanrail) and, in PRODUCTION
+mode, the **defenseclaw** + **openshell** security members. viz stays a grouped
+utility. Derived + env-gated by scripts/in2n-profiles.py.

--- a/specs/056-in2n-internal-federation/spec.md
+++ b/specs/056-in2n-internal-federation/spec.md
@@ -1,0 +1,235 @@
+# Feature Specification: iN2N — Internal NetClaw Federation (a "risk" of claws)
+
+**Feature Branch**: `056-in2n-internal-federation`
+**Created**: 2026-07-12
+**Status**: Draft
+**Input**: User description: "iN2N — internal NetClaw federation (a \"risk\" of claws with a Border Claw). Builds on the completed, live-proven eN2N work (spec 052 NCFED protocol + spec 053 ergonomics/reliability). One operator runs a group of focused NetClaws — a \"risk\" — coordinated by a single Border Claw."
+
+## Context & Background
+
+NetClaw already supports **external federation (eN2N)**: independently-operated NetClaws, run by different people on different infrastructure, mutually consent and then discover each other's capabilities, invoke each other's tools/skills, and delegate long tasks over the NCFED protocol (spec 052) with reliability hardening (spec 053). That work is complete and proven live across a three-operator mesh.
+
+This feature adds **internal federation (iN2N)**: a *single* operator running *several* focused NetClaws on their *own* infrastructure, coordinated as one named group. Because NetClaw's mascot is a lobster, the group is called a **"risk"** — the real (and, for a security-adjacent product, fitting) collective noun for a group of lobsters. A standalone NetClaw is simply "a risk of one."
+
+The motivation is **focus and economy**: rather than one NetClaw carrying the entire skill and tool catalog (large, expensive context; broad blast radius), an operator runs a few tightly-scoped member claws — a "CML claw" that only knows CML, a "pyATS claw" that only knows testing — behind one coordinating **Border Claw**. The operator only ever talks to the Border; the Border routes each request to the specialist that should handle it, and is also the single, auditable door to the outside world.
+
+## Clarifications
+
+### Session 2026-07-12
+
+- Q: How does a member prove it legitimately belongs to the risk when it first registers with the Border (esp. a distributed member dialing in from another cloud)? → A: **Enrollment token + runtime self-signed key, pinned (TOFU).** The Border issues a one-time enrollment token at risk creation; each member generates its own self-signed keypair/cert at runtime; on enrollment the member presents the token *and* its public key; the Border validates the token then pins the key; all subsequent channels are authenticated by the pinned key. No CA to run. The token is single-use; cert rotation requires re-enrollment or operator-approved re-pin.
+- Q: How are members named/addressed in the registry, audit, and routing — do we need an iBGP-style mesh since members can be anywhere? → A: **Risk-local member ID + hub-and-spoke star; no mesh.** Members are identified by a stable risk-local ID (`<risk>/<member-name>`) bound to the pinned key (the name is the handle, the key authenticates). No iBGP / no full mesh: iN2N is a star centered on the Border (members talk only to the Border, never to each other). Reachability across hosts/clouds is achieved by **each member dialing OUTBOUND to the Border's single reachable endpoint** — so members need no inbound ports, no public address, and no ngrok even when distributed.
+- Q: Should a risk deploy default members, should profiles be easy, and are there tools EVERY claw needs? → A: **Defaults + easy profiles already specified; added a mandatory base floor.** Default seed members (FR-022) and catalog-derived profiles + Custom (FR-019–021) were already in the spec. NEW: every member — any profile, including Custom — gets a non-removable **base floor** (iN2N runtime/heartbeat, self-status + capability reporting, audit/GAIT-to-Border, constitutional safety behaviors), and that floor is excluded from the routing specificity tie-break so shared base tools don't distort specialist selection (FR-021a/FR-021b).
+- Q: How does a member leave the risk / have its trust revoked? → A: **Operator `remove member` + automatic quarantine.** The operator can remove a member at the Border, which unpins its key, drops it from the registry, and refuses further connections (return requires full re-enrollment with a new token). In addition, the Border **automatically quarantines** a member that repeatedly fails health or authentication — unpinning it and alerting the operator — rather than letting a misbehaving or suspected-compromised member keep reconnecting.
+
+## Terminology
+
+- **Risk**: a named, described group of NetClaws owned and operated by one person/organization on their own infrastructure.
+- **Border Claw**: the single coordinating claw in a risk. The only claw the operator interacts with, the only one exposed to the outside (eN2N), and the single point of reporting, audit, and GAIT logging. Exactly one per risk.
+- **Member Claw**: an internal, tightly-scoped claw within a risk. Talks only to its Border over the risk's internal transport; carries only the skills/tools it needs for its specialty; does **not** join the public federation mesh or do per-peer mutual consent.
+- **Trust domain**: what actually distinguishes iN2N from eN2N. A risk is **one trust domain** (one owner). iN2N is coordination *within* one trust domain (implicit trust). eN2N is federation *between* trust domains (mutual consent). This is a boundary of ownership, **not of physical location** — a risk's members may be co-located on one host or distributed as microservices across multiple hosts, clouds, or datacenters.
+- **eN2N** (external N2N): Border-to-Border federation across *different* risks (trust domains) over the existing NCFED mesh (spec 052/053). Unchanged by this feature.
+- **iN2N** (internal N2N): Border-to-Member coordination *within* one risk (one trust domain) over the risk's internal transport. New in this feature.
+- **Internal transport**: the operator-controlled connectivity between a Border and its members. May be loopback/unix socket (co-located), a private network/VPC, an overlay/VPN (e.g. WireGuard/Tailscale), or the operator's own tunnels when members are geographically distributed. The defining property is that it stays **within the operator's own trust domain** and does not require the public mutual-consent NCFED mesh — **not** that it is physically local.
+- **Claw profile**: a pre-defined bundle of skills/tools that gives a member claw its specialty (e.g. "CML claw", "pyATS claw", "security claw"), plus a "Custom" option to hand-pick.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Stand up a risk and talk only to the Border (Priority: P1)
+
+An operator installs NetClaw and is asked whether this claw is a **standalone NetClaw** or **part of a risk**. Choosing "part of a risk," they name and describe the risk and choose this claw's **role** — Border or Member. They stand up a Border and at least one Member (e.g. a CML member). From then on, the operator interacts *only* with the Border; the Border knows its members and can reach them over the risk's internal transport (whether they are on the same host or distributed across the operator's own hosts, clouds, or datacenters). Members are never addressed directly by the operator and never join the public federation mesh or do per-peer mutual consent.
+
+**Why this priority**: This is the foundational structure. Without the ability to form a risk, designate a single Border, and register members reachable over a local transport, none of the routing or economy benefits exist. It is the minimum viable slice: a two-claw risk (Border + one Member) that the operator drives entirely through the Border.
+
+**Independent Test**: Install one claw as a Border and one as a Member of the same named risk; confirm the operator's interface reaches only the Border, the Border lists the Member as reachable/healthy over the local transport, and the Member has no internet-facing endpoint configured.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh install, **When** the operator chooses "part of a risk" and selects role "Border" with a risk name and description, **Then** the claw is configured as the sole Border of that named risk and exposes the operator-facing interface (gateway).
+2. **Given** a Border exists for a risk, **When** the operator installs a second claw as a "Member" of that same risk (co-located or in another cloud/datacenter), **Then** the Member registers with the Border over the risk's internal transport and appears in the Border's member list as reachable, without joining the public federation mesh or performing mutual consent.
+3. **Given** a running risk, **When** the operator attempts to interact with a Member directly, **Then** the intended interaction path is through the Border (members do not expose an operator-facing interface).
+4. **Given** the operator chooses "standalone NetClaw," **Then** the claw behaves exactly as a NetClaw does today (a "risk of one," its own Border), with no member coordination overhead.
+
+---
+
+### User Story 2 - Ask the Border to route work to the right specialist Member (Priority: P1)
+
+The operator asks their Border a task-shaped request ("recreate my lab in CML," "run the pyATS testbed against these devices"). The Border determines which member claw owns the relevant capability, delegates the work to that member over the local transport, tracks it to completion, and returns the result to the operator — all without the operator needing to know which member did the work.
+
+**Why this priority**: This is the core value of iN2N — a coordinating Border that turns a fleet of narrow specialists into one capable assistant, keeping each member's context small and cheap. Together with US1 it forms the complete "focused fleet" experience.
+
+**Independent Test**: With a Border and a CML member, ask the Border to perform a CML operation; confirm the Border delegates it to the CML member (visible in the Border's audit/trace), the member executes it with its own local tools, and the result returns to the operator through the Border.
+
+**Acceptance Scenarios**:
+
+1. **Given** a risk with a Border and a specialist member that owns a capability, **When** the operator asks the Border for work matching that capability, **Then** the Border delegates it to the correct member and returns the member's result.
+2. **Given** a long-running member task (multi-minute build), **When** the operator issues it through the Border, **Then** it runs as a tracked background task (submit → poll → result), survives transport blips, and does not fail as one blocking call. *(Reuses spec 053 async delegation semantics.)*
+3. **Given** a request that matches no member's capability, **When** the operator asks the Border, **Then** the Border reports that no member in the risk can perform it (rather than silently failing or attempting it without a capable member).
+4. **Given** the Border delegates work internally, **Then** no credentials or secrets are transferred between claws — each member acts with its own local configuration.
+
+---
+
+### User Story 3 - Provision a risk with pre-set member profiles, no hand-assembly (Priority: P2)
+
+When forming a new risk, the operator is offered a set of **pre-set claw profiles** derived from NetClaw's existing skill catalog (e.g. "CML claw," "pyATS claw," "security claw"), plus a **Custom** option to pick individual skills/tools. Selecting profiles provisions those member claws so the operator does not configure each specialist by hand. A new risk can come seeded with a handful of common members.
+
+**Why this priority**: Provisioning is what makes iN2N practical rather than tedious. It's valuable but sits on top of the US1/US2 mechanics — the risk still works if members are added one at a time, so this is P2.
+
+**Independent Test**: Create a new risk and select two pre-set profiles; confirm two members are provisioned, each scoped to only that profile's skills/tools, and each appears in the Border's member list.
+
+**Acceptance Scenarios**:
+
+1. **Given** the risk-formation flow, **When** the operator selects the "CML claw" profile, **Then** a member is provisioned carrying only the CML-related skills/tools of that profile.
+2. **Given** the risk-formation flow, **When** the operator selects "Custom," **Then** they can choose an arbitrary subset of the skill catalog for that member.
+3. **Given** available profiles, **Then** each profile's contents are derived from the actual installed skill catalog (not a hardcoded list that can drift from reality).
+4. **Given** a newly created risk, **When** no explicit choices are made, **Then** the risk is seeded with a small default set of common members (which the operator may edit or remove).
+
+---
+
+### User Story 4 - The Border is the risk's single, auditable face to the outside (Priority: P2)
+
+The operator enables **eN2N**, **iN2N**, or **both** on the Border (only the Border can federate externally). To a peer risk, the whole risk appears as one identity — the Border's — regardless of how many members are behind it. Every internal delegation and every external invocation is recorded centrally at the Border (reporting, audit, GAIT), giving one place to see everything the risk did and everything done to it.
+
+**Why this priority**: Consolidating the external boundary and the audit trail at the Border is the security and observability payoff. It depends on US1's role model, so P2.
+
+**Independent Test**: On a Border with both stacks enabled, have a peer risk query capabilities and delegate a task; confirm the peer sees a single risk identity (the Border), the task is fulfilled (possibly by an internal member) without exposing member identities or secrets externally, and the Border's audit log shows both the external request and any internal delegation it triggered.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Border with eN2N enabled, **When** a peer risk federates and views capabilities, **Then** it interacts with one identity (the Border) and does not receive member-level endpoints or internal topology.
+2. **Given** an external request that the Border satisfies by delegating to a member, **Then** the external peer receives a result attributed to the risk, while the Border's audit trail records both the external request and the internal delegation.
+3. **Given** the Border's role, **When** the operator opens reporting/audit, **Then** all internal (iN2N) and external (eN2N) activity for the risk is visible in one place.
+4. **Given** a Member claw, **Then** it cannot federate externally on its own (only the Border holds the external stack).
+
+---
+
+### User Story 5 - Member scoping is enforced, not just declared (Priority: P3)
+
+A member claw provisioned as a "CML claw" can only do CML-scoped work. If the Border (or a chain of delegation) asks a member to do something outside its scope, the member declines rather than silently expanding its own capability. The Border can see each member's declared scope and health, and surfaces a member that is unreachable or misbehaving.
+
+**Why this priority**: Enforced scoping is what makes the "small blast radius, small context" promise real, and health visibility keeps the fleet operable. It refines US1–US4 rather than enabling them, so P3.
+
+**Independent Test**: Ask a CML-scoped member (through the Border) to perform a non-CML action; confirm it is refused by scope. Stop a member and confirm the Border reports it unreachable.
+
+**Acceptance Scenarios**:
+
+1. **Given** a member scoped to a profile, **When** it is asked to perform work outside that scope, **Then** the request is refused on the grounds of scope, not silently attempted.
+2. **Given** a member becomes unreachable, **When** the Border health-checks it, **Then** the Border reports the member's state (e.g. unreachable) and does not route new work to it.
+3. **Given** the operator asks the Border, **Then** they can see each member's specialty/scope and current health in one place.
+
+---
+
+### Edge Cases
+
+- **Two Borders in one risk**: A risk MUST have exactly one Border. Configuration attempting a second Border for the same risk MUST be rejected/flagged rather than producing an ambiguous coordinator.
+- **Member with no Border / orphaned member**: A member whose Border is unreachable does nothing on its own (it has no operator-facing interface); the operator sees this via the Border once it returns, or via the member's own status if inspected directly.
+- **Border down**: If the Border is down, the risk has no operator interface and no external presence until it returns; members hold no external state that could leak in the meantime.
+- **Capability overlap**: If two members can satisfy the same request, the Border MUST choose deterministically (documented tie-break) rather than fanning out unpredictably.
+- **Standalone → risk migration**: An existing standalone NetClaw that later becomes a Border MUST keep working; its existing skills remain until the operator chooses to slim it down.
+- **External identity churn**: eN2N endpoint churn (ngrok address changes) is handled by the existing spec-053 re-announce; this feature does not regress it. Members never have external endpoints to churn.
+- **Secret isolation across delegation**: Neither internal (iN2N) nor external (eN2N) delegation ever transfers credentials, `.env` values, device addresses, or testbed secrets between claws.
+- **Removed/quarantined member reconnecting**: A member whose key has been unpinned (via operator removal or automatic quarantine) MUST be refused on reconnect and MUST NOT be silently re-trusted; it can only return through full re-enrollment (or explicit operator re-pin).
+- **Enrollment token leak/reuse**: A single-use token already spent (a member's key pinned) MUST be rejected if presented again, so a leaked-but-spent token grants nothing.
+- **Compromised key suspicion**: The operator can remove/quarantine a member to immediately unpin a suspected-compromised key and cut its access at the single Border boundary, without disturbing other members.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Risk formation & roles
+
+- **FR-001**: The installer MUST let the operator choose, at install time, whether a claw is a **standalone NetClaw** or **part of a risk**.
+- **FR-002**: When "part of a risk" is chosen, the installer MUST capture a **risk name and description** and a **role** for the claw: **Border** or **Member**.
+- **FR-003**: A risk MUST have **exactly one Border**; the system MUST prevent or flag configuration of a second Border for the same risk.
+- **FR-004**: A **standalone NetClaw** MUST behave identically to today's NetClaw (a "risk of one," its own Border) with no member-coordination behavior imposed.
+- **FR-005**: Only the **Border** MUST expose the operator-facing interface (gateway); **Member claws MUST NOT** expose an operator-facing interface.
+- **FR-006**: **Member claws MUST NOT join the public federation mesh** (no participation in eN2N mutual consent, no advertised public NCFED endpoint) to function within the risk. Members may be co-located with the Border or distributed across the operator's own hosts, clouds, or datacenters.
+
+#### Internal coordination (iN2N)
+
+- **FR-007**: A Member claw MUST register with, and reach, its Border over the **risk's internal transport** — connectivity within the operator's own trust domain — by **dialing outbound to the Border's single reachable endpoint**. This transport MUST support both co-located members (loopback/socket) and geographically distributed members (private network, overlay/VPN, or operator-controlled tunnel), without requiring per-peer mutual consent, inbound ports on the member, or any public member endpoint.
+- **FR-007a**: iN2N MUST be a **hub-and-spoke star** centered on the Border: members communicate only with the Border, never member-to-member. The system MUST NOT require a routing protocol (e.g. iBGP) or a full mesh among members; adding a member adds one spoke.
+- **FR-008**: The Border MUST maintain a registry of its members keyed by a **stable risk-local member ID** (`<risk>/<member-name>`) bound to the member's pinned key, recording each member's **declared specialty/scope**, its **transport binding**, and its **current health/reachability**. The member ID MUST be stable across relocation of the member (e.g. moving between clouds); the pinned key, not the network location, is the authenticator.
+- **FR-009**: The Border MUST be able to **route/delegate a request to the member** that owns the relevant capability and return that member's result to the operator.
+- **FR-010**: Internal delegation of long-running work MUST use **asynchronous task semantics** (submit → status → result → cancel) reusing spec 053's delegation model, so no internal operation depends on a single long blocking call.
+- **FR-011**: When **no member** can satisfy a request, the Border MUST report that plainly rather than silently failing or attempting it without a capable member.
+- **FR-012**: When **multiple members** can satisfy a request, the Border MUST select one **deterministically** by a documented rule.
+- **FR-013**: iN2N coordination MUST reuse the **NCFED JSON-RPC 2.0 semantics and capability-inventory model** from spec 052, bound to the internal transport, with a **relaxed, owner-implicit trust profile** (members of one operator's risk are auto-trusted within the risk — no per-member mutual-consent handshake). Because a member may be reachable over a distributed transport rather than loopback, the internal channel MUST still be authenticated/encrypted end-to-end so a member cannot be impersonated within the trust domain.
+- **FR-013a**: Member enrollment MUST use a **one-time enrollment token issued by the Border at risk creation** combined with a **member-generated self-signed key**: on first registration the member presents the token and its public key, the Border validates the token and **pins the key** (trust-on-first-use), and all subsequent internal channels are authenticated by the pinned key. The system MUST NOT require a certificate authority.
+- **FR-013b**: An enrollment token MUST be **single-use** (spent once a member's key is pinned); a member rotating or regenerating its key MUST **re-enroll** (new token) or be **re-pinned via explicit operator approval** at the Border. A registration presenting an invalid, expired, or already-spent token, or a key that does not match the pinned key for a known member, MUST be rejected.
+- **FR-013c**: The operator MUST be able to **remove a member** at the Border; removal MUST unpin the member's key, drop it from the registry, refuse its further connections, and stop routing work to it. A removed member MUST require **full re-enrollment** (a new token) to rejoin.
+- **FR-013d**: The Border MUST **automatically quarantine** a member that repeatedly fails health or authentication (by a documented threshold): unpin its key, stop routing to it, and **alert the operator**. The operator alert is surfaced in-band via `n2n_member_health` and the HUD (no external push — see `contracts/in2n-enrollment.md` §5); it is not an autonomous external notification. A quarantined member MUST NOT silently reconnect on its pinned key; recovery requires operator action (re-pin or re-enrollment).
+
+#### External boundary (eN2N) via the Border
+
+- **FR-014**: Only the **Border** MUST be able to federate externally (eN2N); Member claws MUST NOT hold or use the external federation stack.
+- **FR-015**: The Border install/config MUST let the operator enable **eN2N**, **iN2N**, or **both**.
+- **FR-016**: To an external peer risk, the entire risk MUST present as a **single identity — the Border's** — and MUST NOT expose member-level identities, endpoints, or internal topology.
+- **FR-017**: The Border MUST continue to enforce the **full spec 052/053 external trust model** (mutual consent per external peer, default-deny invocation, budgets, kill switch, no-secrets guard) for eN2N unchanged.
+- **FR-018**: The existing **eN2N wire framing, consent, default-deny, and no-secrets guards MUST NOT be changed** by this feature.
+
+#### Provisioning & profiles
+
+- **FR-019**: The risk-formation flow MUST offer **pre-set claw profiles** whose contents are **derived from the installed skill catalog** (so profiles cannot drift from what actually exists).
+- **FR-020**: The flow MUST offer a **Custom** option to select an arbitrary subset of skills/tools for a member.
+- **FR-021**: Selecting a profile MUST **provision a member scoped to that profile's skills/tools plus the mandatory base floor (FR-021a)** — no hand-assembly of each specialist.
+- **FR-021a**: EVERY member, regardless of profile (including Custom), MUST include a minimal **mandatory base floor** that cannot be removed: (a) the iN2N member runtime (enroll/dial/heartbeat), (b) self-status and capability reporting so the Border can discover and route to it, (c) audit/GAIT reporting of its own actions back to the Border (Constitution IV), and (d) the constitutional safety behaviors (read-before-write; no unapproved destructive commands — Constitution I/II). The base floor is the *floor*, not a way to widen a member's specialty.
+- **FR-021b**: The base floor MUST NOT count toward the routing "most-specific specialist" tie-break (FR-012): specificity is measured over a member's **specialty** capabilities only, so the base tools every member shares do not distort which member is the true specialist.
+- **FR-022**: A newly created risk MAY be **seeded with a small default set of common members** (e.g. a CML claw and a pyATS claw), which the operator can edit or remove.
+
+#### Scoping, audit & security
+
+- **FR-023**: A member's capability MUST be **enforced to its declared scope**: work outside scope MUST be refused, not silently attempted or self-expanded.
+- **FR-024**: The Border MUST be the **single point of reporting, audit, and GAIT logging** for the risk, recording **both internal (iN2N) delegations and external (eN2N) activity** in one place.
+- **FR-025**: An external request satisfied by internal delegation MUST be recorded as **both** the external request and the internal delegation it triggered, while the external result is attributed to the risk (not the member).
+- **FR-026**: **No credentials or secrets** MUST ever be transferred between claws over iN2N or eN2N; each claw acts with its own local configuration only.
+- **FR-027**: A Member MUST treat instructions arriving from its Border as trusted-within-the-risk, but MUST still refuse out-of-scope actions (FR-023) — i.e. scope enforcement is independent of the relaxed internal trust.
+
+#### Member runtime model
+
+- **FR-028**: A Member claw MUST be a **standalone OpenClaw process/container** (its own runtime), addressed by its Border over a **network-capable internal transport**. When a member is co-located with its Border, the transport MAY be loopback/socket; when a member is distributed on a different host, cloud, or datacenter, the transport MUST work over the operator's own private network, overlay/VPN, or tunnel. The runtime model MUST be **selectable per member** so the same risk can mix a co-located member and a member in another cloud.
+- **FR-029**: Because members are standalone runtimes rather than in-process profiles, the Border MUST address, health-check, and delegate to each member by its **stable risk-local member ID** over the member's **established outbound channel** (not by dialing a member-side address). The member registry (FR-008) MUST record each member's transport binding (loopback vs. distributed) alongside its ID, pinned key, scope, and health.
+
+### Key Entities
+
+- **Risk**: A named, described group of claws owned by one operator. Attributes: name, description, external federation mode (eN2N/iN2N/both), the set of member references. Has exactly one Border.
+- **Border Claw**: The sole coordinator and external face of a risk. Attributes: risk it belongs to, enabled stacks, member registry, central audit/GAIT log, operator-facing gateway.
+- **Member Claw**: A scoped specialist within a risk. Attributes: parent Border, declared specialty/scope (from its profile), skill/tool set, internal-transport address (co-located or in another cloud/datacenter), health state. No public federation-mesh presence, no operator interface.
+- **Claw Profile**: A named bundle of skills/tools derived from the installed catalog (e.g. CML, pyATS, security) or Custom. Used to provision and scope members.
+- **Internal Delegation**: A task the Border routes to a member (submit/status/result/cancel), recorded in the Border's audit log. Reuses spec 053 task semantics.
+- **Member Registration/Health**: The record of a member being reachable to its Border over the internal transport, plus its **pinned channel key** (from enrollment), its transport binding, and its current reachability/health state.
+- **Enrollment Token**: A one-time secret issued by the Border at risk creation, presented once by a member (alongside its self-signed public key) to enroll. Spent on successful pinning; invalid/expired/reused tokens are rejected.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An operator can stand up a working risk (one Border + one specialist member) and successfully route a specialty task through the Border to the member in **under 15 minutes** from a fresh install, without the member joining the public federation mesh or completing any mutual-consent handshake.
+- **SC-002**: A specialist member's context/skill footprint is **a small fraction of the full catalog** — a member provisioned from a single profile carries only that profile's skills/tools and none of the others.
+- **SC-003**: **100% of member claws** in a risk operate **without joining the public federation mesh** — no eN2N mutual-consent participation and no advertised public NCFED endpoint — whether they are co-located or distributed across clouds/datacenters.
+- **SC-004**: For **every** request the operator issues to the Border that is satisfied by a member, the Border's audit log contains a record of both the request and the internal delegation — i.e. **no internal delegation is unlogged**.
+- **SC-005**: An external peer risk federating with a Border sees **exactly one identity** and **zero** member-level identities, endpoints, or internal-topology details.
+- **SC-006**: A long-running internal task (multi-minute build) delegated through the Border **completes as a tracked background task** and does not fail as a single blocking call, matching eN2N's spec-053 reliability.
+- **SC-007**: An out-of-scope request to a scoped member is **refused 100% of the time** rather than executed.
+- **SC-008**: Standalone NetClaw installs show **no functional regression** versus today's behavior.
+- **SC-009**: Existing eN2N federation (spec 052/053) shows **no regression**: the three-operator mesh behaviors (discover, invoke, delegate, self-heal) still pass their existing tests unchanged.
+- **SC-010**: A removed or quarantined member is refused on its next connection attempt **100% of the time** and cannot rejoin without a fresh enrollment token; a member presenting a spent, invalid, or expired token is rejected **100% of the time**.
+- **SC-011**: Every member is reachable by the Border with **zero inbound ports opened on the member** — 100% of member connectivity is member-initiated outbound to the Border.
+
+## Assumptions
+
+- **Reused foundations**: iN2N reuses the NCFED JSON-RPC 2.0 semantics, capability inventory, and async task delegation from specs 052/053. The eN2N wire framing, consent, default-deny, and no-secrets guards are frozen and untouched.
+- **Single-operator trust, not single-location**: What defines a risk is one owner/one trust domain, *not* one host. Members may be co-located OR distributed as microservices across the operator's own hosts, clouds, or datacenters. Trust *within* a risk is implicit (auto-consent); the mutual-consent model applies only at the eN2N boundary between different risks.
+- **Internal transport stays within the trust domain**: The Border↔Member transport is operator-controlled connectivity — loopback/socket when co-located, or a private network / overlay-VPN / operator tunnel when distributed. It is authenticated/encrypted but does not use the public mutual-consent NCFED mesh. If distributed members traverse shared infrastructure, that is the operator's own encrypted transport, not eN2N federation.
+- **Border-as-broker**: The operator's mental model and interface is a single Border; members are implementation detail the operator provisions but does not converse with directly.
+- **Profiles from the live catalog**: Pre-set profiles are generated from the actually-installed skill catalog rather than a static hardcoded list, so they stay accurate as the catalog evolves.
+- **Deterministic routing**: When capabilities overlap, a documented deterministic tie-break is acceptable for this version (no sophisticated load-balancing or scoring required).
+- **Installer builds on existing modular installer**: The risk/role/profile choices extend NetClaw's existing installer flow rather than introducing a separate installation system.
+
+## Out of Scope
+
+- **Multi-hop federation** chaining three or more risks together (a request hopping Border → peer Border → that peer's peer). Only two-tier (Border↔Member internally, Border↔Border externally) is in scope.
+- **Splitting N2N/NCFED into its own repository** — still deferred until the wire format is versioned and external implementers need it.
+- **Changing the eN2N protocol** in any way (framing, consent, trust model).
+- **Cross-operator member sharing** (a member of one risk directly serving another operator's risk) — external cooperation goes Border-to-Border only.
+- **Sophisticated internal scheduling/load-balancing** across multiple equivalent members beyond a deterministic tie-break.

--- a/specs/056-in2n-internal-federation/tasks.md
+++ b/specs/056-in2n-internal-federation/tasks.md
@@ -1,0 +1,234 @@
+---
+description: "Task list for iN2N — Internal NetClaw Federation (spec 054)"
+---
+
+# Tasks: iN2N — Internal NetClaw Federation (a "risk" of claws)
+
+**Input**: Design documents from `/specs/056-in2n-internal-federation/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/ (all present)
+
+**Tests**: INCLUDED — the plan enumerates a `tests/n2n/` suite and Constitution XV mandates integration testing over frozen eN2N.
+
+**Organization**: By user story (US1–US5, priority order), over the existing `bgp/federation/` package + `n2n-mcp` + `scripts/netclaw`/installer + HUD. All additive; frozen eN2N core (052/053) untouched.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: parallelizable (different file, no incomplete dependency)
+- Absolute-ish repo paths shown; `mcp-servers/protocol-mcp/bgp/federation/` abbreviated `bgp/federation/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Scaffolding the new modules and test harness so all later phases have a home.
+
+- [X] T001 [P] Create empty new modules with module docstrings: `bgp/federation/risk.py`, `bgp/federation/internal_channel.py`, `bgp/federation/router.py` (mirror the header style of `manager.py`/`channel.py`)
+- [X] T002 [P] Create `tests/n2n/` iN2N test files as empty stubs with imports + skip markers: `test_risk.py`, `test_enrollment.py`, `test_internal_transport.py`, `test_routing.py`, `test_scope_enforcement.py`, `test_quarantine.py`, `test_member_delegation.py`, `test_en2n_regression.py`
+- [X] T003 [P] Create `scripts/in2n-profiles.py` skeleton (stdlib-only, matching `scripts/register-all-mcps.py` style) that will derive profiles from the installed skill catalog
+- [X] T004 Add iN2N constants to `mcp-servers/protocol-mcp/bgp/constants.py` (the module `channel.py` imports via `from ..constants import …`): `N2N_ROLE` values, iN2N handshake method names (`in2n/hello`, `in2n/enroll`), new error codes (-32021..-32024, -32030, -32031), default `N2N_QUARANTINE_THRESHOLD=5`, optional `N2N_IN2N_PORT` — reusing existing NCFED framing constants unchanged
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The DB schema, key handling, and role config that every user story needs. **⚠️ No user story can begin until this is done.**
+
+- [X] T005 Extend `bgp/federation/manager.py` SCHEMA with `risk`, `member`, `enrollment_token` tables (per data-model.md) and add idempotent `ALTER TABLE` migrations for `remote_invocation_record.channel_kind` (default `en2n`) and `linked_record_id` — following the existing migration loop pattern
+- [X] T006 [P] Implement key handling in `bgp/federation/risk.py`: generate/load this claw's self-signed keypair under `~/.openclaw/n2n/keys/`, compute fingerprints, pin/unpin a member public key to `~/.openclaw/n2n/keys/pinned/<member_id>.pub` (uses `cryptography`, already a repo dep) — gitignored path
+- [X] T007 Implement `RiskManager` core in `bgp/federation/risk.py` on top of the shared `FederationManager` connection: `get_risk()`, `set_role(role, risk_name?, description?, enabled_stacks?, border_endpoint?)` with **single-Border enforcement** (FR-003), `is_standalone()`, `self_member_id`
+- [X] T008 Add `~/.openclaw/n2n/keys/` to `.gitignore` (Constitution XIII) and add iN2N env vars to `.env.example` (`N2N_ROLE`, `N2N_RISK_NAME`, `N2N_ENABLED_STACKS`, `N2N_IN2N_PORT`, `N2N_BORDER_ENDPOINT`, `N2N_QUARANTINE_THRESHOLD`) with descriptions, no values
+
+**Checkpoint**: DB + keys + role config ready — user stories can begin.
+
+---
+
+## Phase 3: User Story 1 — Stand up a risk and talk only to the Border (Priority: P1) 🎯 MVP
+
+**Goal**: Install one claw as Border and one as Member of a named risk; the Member enrolls (token + self-signed key, pinned) by dialing outbound and appears in the Border's member list as reachable, with no inbound ports. Operator interacts only with the Border.
+
+**Independent Test**: Bring up a Border + one Member over loopback; `n2n_member_list()` shows the member `active`; the member opened zero inbound ports; enrollment rejected without a valid token.
+
+### Tests for User Story 1 ⚠️ (write first, must fail)
+
+- [X] T009 [P] [US1] `tests/n2n/test_risk.py`: role model (`standalone`/`border`/`member`), standalone = risk-of-one behaves as pre-054, single-Border enforcement raises on a second Border, and a **Member role does not expose the operator-facing gateway** while a Border does (FR-005)
+- [X] T010 [P] [US1] `tests/n2n/test_enrollment.py`: valid unspent token pins key + flips token to spent; re-presenting spent token → ERR_ENROLL_TOKEN_INVALID; expired token rejected; reconnect with non-pinned key → ERR_MEMBER_NOT_TRUSTED; reconnect with pinned key → active
+- [X] T011 [P] [US1] `tests/n2n/test_internal_transport.py`: first **extend the 052/053 two-service loopback harness into an in-memory iN2N Border↔Member channel-pair fixture** (shared by T011/T021), then assert: member-initiated outbound dial establishes an encrypted channel; `in2n/hello` returns risk context; wire frames are byte-identical to eN2N framing; member opens zero inbound listening ports; **a member has no dialable peer other than the Border (hub-and-spoke, no member↔member — FR-007a)**; dropped channel re-dials with bounded backoff
+
+### Implementation for User Story 1
+
+- [X] T012 [P] [US1] Implement enrollment token model + issue/verify/spend in `bgp/federation/risk.py`: `issue_token(label?, ttl?)` (store only the hash), `consume_token(token, member_id, public_key, scope, runtime_kind)` → pin + insert `member` row `state=enrolled`, single-use guard (FR-013a/b)
+- [X] T013 [US1] Implement `bgp/federation/internal_channel.py`: member outbound dial to `border_endpoint`, self-signed-key TLS, reuse `encode_frames`/decode + heartbeats from `channel.py`, `in2n/hello`/`in2n/enroll` handshake handlers (member-id + pinned-key proof, NOT AS/router-id) — sibling to eN2N `n2n/hello`, which stays untouched
+- [X] T014 [US1] Extend `bgp/federation/service.py`: iN2N supervisor — on a **Border**, accept member dial-ins, authenticate against pinned key, register/track member channels, `on_close` deregister (no zombies); on a **Member**, dial supervisor to the Border reusing the 053 bounded-backoff reconnect
+- [X] T015 [US1] Implement member registry reads in `bgp/federation/risk.py`: `list_members()`, `get_member()`, health/last-seen update hooks called by the service
+- [X] T016 [US1] Add daemon routes in `mcp-servers/protocol-mcp/bgp-daemon-v2.py`: `GET /n2n/risk`, `POST /n2n/risk` (single-Border guard), `GET /n2n/members`; wire the iN2N supervisor to start when `role in (border, member)`
+- [X] T017 [US1] Add MCP tools in `mcp-servers/n2n-mcp/server.py`: `n2n_risk_status` (role/risk/stacks; member summary on Border; `standalone` note otherwise), `n2n_member_list`
+- [X] T018 [US1] Installer: add role/risk prompts to `scripts/lib/install-steps.sh` `component_install_n2n` using `scripts/lib/tui.sh` — `tui_menu` for standalone-vs-risk and Border/Member, `read` for name/description, `tui_yesno` confirm; write `N2N_ROLE`/`N2N_RISK_NAME`/`N2N_BORDER_ENDPOINT` to `~/.openclaw/.env`
+- [X] T019 [US1] `scripts/netclaw`: add `risk_menu` (Overview · Members) dispatched by `TUI_CHOICE` mirroring `peering_menu`, a **Risk** entry in `main_menu`, and non-interactive `netclaw risk [status|members]` using `api_get` — standalone shows the risk-of-one note
+
+**Checkpoint**: A two-claw risk stands up over loopback; operator drives it via the Border; member enrolled + pinned + reachable, no inbound ports. **MVP.**
+
+---
+
+## Phase 4: User Story 2 — Ask the Border to route work to the right Member (Priority: P1)
+
+**Goal**: Operator asks the Border a task-shaped request; the Border matches it to the owning Member, delegates asynchronously (reusing 053 tasks), and returns the result. No-capable-member is reported plainly; no secrets cross the boundary.
+
+**Independent Test**: With a Border + a CML Member, ask the Border a CML task → it routes to the CML member, runs as a background task, returns the result; a no-match request returns ERR_NO_CAPABLE_MEMBER.
+
+### Tests for User Story 2 ⚠️ (write first, must fail)
+
+- [X] T020 [P] [US2] `tests/n2n/test_routing.py`: single match routes there; two matches → most-specific specialty wins, then lexicographic member_id (deterministic/repeatable); no match → ERR_NO_CAPABLE_MEMBER and Border performs no work itself
+- [X] T021 [P] [US2] `tests/n2n/test_member_delegation.py`: long internal task over iN2N returns a `task_id` fast (submit), status polls advance, result fetched on completion, and result survives a simulated member restart mid-task (reused 053 persistence) — driven over the in-memory channel-pair harness
+
+### Implementation for User Story 2
+
+- [X] T022 [US2] Extend `bgp/federation/inventory.py`: a Member advertises its (scoped) capability inventory to its Border over the internal channel, reusing the 052 inventory build + no-secrets guard (names/descriptions only)
+- [X] T023 [US2] Implement `bgp/federation/router.py`: capability match against member inventories, deterministic tie-break (most-specific **specialty** count excluding base floor per FR-021b, then lexicographic member_id), `ERR_NO_CAPABLE_MEMBER` path
+- [X] T024 [US2] Extend `bgp/federation/invocation.py`: internal delegation path — submit work to the selected member as a 053 `delegated_task` (`peer_identity=member_id`, direction outbound on Border / inbound on Member) over `internal_channel`, reusing submit/status/result/cancel
+- [X] T025 [US2] Add daemon route `POST /n2n/route` in `bgp-daemon-v2.py`: run the router, submit to the member, return `{task_id, member_id}` or the no-capable-member error
+- [X] T026 [US2] Add MCP tool `n2n_route(request_text, target_hint?)` in `mcp-servers/n2n-mcp/server.py`; confirm `n2n_task_status`/`n2n_task_result`/`n2n_task_cancel` (053) work against iN2N task_ids unchanged
+- [X] T027 [US2] `scripts/netclaw`: add `netclaw risk route "<request>"` subcommand → `POST /n2n/route`, and a **Route a request** entry in `risk_menu`
+
+**Checkpoint**: The Border routes real work to the right Member and returns results; US1+US2 = the core "focused fleet" experience.
+
+---
+
+## Phase 5: User Story 3 — Provision a risk with pre-set profiles, no hand-assembly (Priority: P2)
+
+**Goal**: Catalog-derived claw profiles (CML/pyATS/security…) + Custom, each layered on the mandatory base floor; selecting profiles provisions scoped members; a new risk may seed a small default set.
+
+> **What "provision a member" means (FR-028):** a Member is its **own NetClaw install** — a separate OpenClaw process/container — brought up by installing NetClaw with `N2N_ROLE=member`, `N2N_RISK_NAME=<risk>`, `N2N_BORDER_ENDPOINT=<border>`, and the join token. The Border does **not** spawn members. `n2n_member_add`/the installer only compute the member's scope, issue the single-use token, and print the join instructions; the operator (or their orchestration) then stands up that member instance, which dials home and enrolls (US1). The `runtime_kind` (process|container) is recorded on the member row but the actual runtime is created by that separate install.
+
+**Independent Test**: Create a risk, select the CML profile → a member is provisioned carrying only CML skills + the base floor; Custom lets you pick an arbitrary subset; a fresh risk seeds a default member set.
+
+### Tests for User Story 3 ⚠️ (write first, must fail)
+
+- [X] T028 [P] [US3] Extend `tests/n2n/test_risk.py` (provisioning section): a profile provisions a member scoped to that profile's skills + base floor; base-floor items tagged `base`; Custom selects an arbitrary subset; default seed set created on a new risk
+
+### Implementation for User Story 3
+
+- [X] T029 [P] [US3] Implement `scripts/in2n-profiles.py`: parse the installed skill catalog (`workspace/skills/` + `config/openclaw.json`), emit profiles (CML/pyATS/security/…), always layer the **mandatory base floor** (FR-021a) tagged `base` vs specialty, and support a Custom skill set
+- [X] T030 [US3] Implement member provisioning in `bgp/federation/risk.py`: `add_member(name, profile|custom_skills)` → compute scope (base + specialty tagged), create enrollment token, return join instructions; seed-default-members helper (FR-022)
+- [X] T031 [US3] Add MCP tools `n2n_member_add(profile|custom_skills, name)` and `n2n_enroll_token(label?, ttl?)` in `mcp-servers/n2n-mcp/server.py` — `n2n_member_add` computes scope, issues a single-use token, and returns **join instructions** (install NetClaw with `N2N_ROLE=member` + endpoint + token); it does NOT spawn the member runtime (see US3 note, FR-028)
+- [X] T032 [US3] Add daemon route `POST /n2n/enroll/token` in `bgp-daemon-v2.py`
+- [X] T033 [US3] Installer: profile/seed selection in `component_install_n2n` — `tui_menu` per profile and `tui_checklist` (category-headed `CL_IDS/CL_LABELS/CL_ON`) for Custom, sourced from `scripts/in2n-profiles.py`; add the `n2n` risk/role/profile metadata to `scripts/lib/catalog.sh`
+- [X] T034 [US3] `scripts/netclaw`: add **Add member (profile | custom)** to `risk_menu` and `netclaw risk add <profile|custom> <name>` / `netclaw risk token [label]` subcommands
+
+**Checkpoint**: Members provisioned from profiles/Custom without hand-assembly; each scoped + base floor.
+
+---
+
+## Phase 6: User Story 4 — The Border is the risk's single, auditable face to the outside (Priority: P2)
+
+**Goal**: eN2N/iN2N/both is a Border setting; a peer risk sees one identity (the Border) and no member details; all internal + external activity is centrally audited, with linked records when an external request is fulfilled internally.
+
+**Independent Test**: On a Border with both stacks, a peer risk queries caps + delegates → sees only the Border identity; the Border's audit shows the external request and the internal delegation, linked; a Member cannot federate externally.
+
+### Tests for User Story 4 ⚠️ (write first, must fail)
+
+- [X] T035 [P] [US4] `tests/n2n/test_en2n_regression.py`: eN2N `n2n/hello`, consent, default-deny, framing byte-for-byte unchanged with iN2N present; a peer never receives member ids/endpoints/topology (FR-016); a Member role has no external federation stack
+- [X] T036 [P] [US4] Extend `tests/n2n/test_member_delegation.py` (audit section): an eN2N request satisfied by internal delegation writes two `remote_invocation_record` rows (`channel_kind` en2n + in2n) joined by `linked_record_id`; the external result is attributed to the risk, not the member
+
+### Implementation for User Story 4
+
+- [X] T037 [US4] Enforce role gating in `bgp/federation/service.py` + daemon startup (`bgp-daemon-v2.py`): only a Border runs the external (eN2N) stack and exposes the operator-facing gateway; a **Member role does NOT start/expose the gateway** (FR-005) and never opens the mesh/eN2N path (FR-014); Border runs eN2N/iN2N/both per config (FR-015)
+- [X] T038 [US4] Extend `bgp/federation/audit.py`: record internal delegations with `channel_kind='in2n'`; when an external request triggers internal delegation, write + link both records (`linked_record_id`, FR-025); record enroll/remove/quarantine events
+- [X] T039 [US4] Single-identity guard: ensure the external (eN2N) inventory/response path in `bgp/federation/inventory.py` never exposes member ids/endpoints/internal topology — the risk presents only the Border identity (FR-016)
+- [X] T040 [US4] Surface stacks + centralized audit: extend `n2n_risk_status` and add an audit view (reuse `n2n_audit`) so the operator sees all iN2N + eN2N activity in one place; Border-only enablement reflected in `GET /n2n/risk`
+
+**Checkpoint**: The risk has one external face and one audit trail spanning both federation tiers.
+
+---
+
+## Phase 7: User Story 5 — Member scoping enforced + health + quarantine (Priority: P3)
+
+**Goal**: A scoped member refuses out-of-scope work; the operator can remove a member (unpin); the Border auto-quarantines a member that repeatedly fails auth/health and alerts the operator; per-member health is visible (tools + HUD).
+
+**Independent Test**: Ask a CML member (via Border) a non-CML action → ERR_OUT_OF_SCOPE; remove a member → refused on reconnect; force repeated auth failures → auto-quarantine + alert; stop a member → Border reports unreachable.
+
+### Tests for User Story 5 ⚠️ (write first, must fail)
+
+- [X] T041 [P] [US5] `tests/n2n/test_scope_enforcement.py`: out-of-scope target on a scoped member → ERR_OUT_OF_SCOPE (refused, not attempted); advertised == allowed; base floor present + non-removable; base excluded from specificity (FR-021b)
+- [X] T042 [P] [US5] `tests/n2n/test_quarantine.py`: `remove` unpins + refuses reconnect on old key (re-enroll with new token works); N consecutive auth/health failures → auto-quarantine (unpin, stop routing, alert); routing skips non-`active` members
+
+### Implementation for User Story 5
+
+- [X] T043 [US5] Scope enforcement in `bgp/federation/invocation.py` (member side): reject a `tasks/submit` whose target is outside the member's advertised scope with `ERR_OUT_OF_SCOPE`, independent of the relaxed internal trust (FR-023/FR-027)
+- [X] T044 [US5] Removal + auto-quarantine in `bgp/federation/risk.py`/`service.py`: `remove_member(member_id)` (unpin, drop, refuse reconnect); increment `auth_failures` on failed auth/health-miss; at `N2N_QUARANTINE_THRESHOLD` → `state=quarantined` + unpin + operator alert; router selects only `active` members (FR-013c/d)
+- [X] T045 [US5] Daemon routes `POST /n2n/members/remove` and `GET /n2n/members/health` in `bgp-daemon-v2.py`
+- [X] T046 [US5] MCP tools `n2n_member_remove(member_id)` (confirm-gated) and `n2n_member_health(member_id?)` in `mcp-servers/n2n-mcp/server.py`; `scripts/netclaw`: **Remove member** in `risk_menu` + `netclaw risk remove <member_id>`
+- [X] T047 [P] [US5] HUD: `ui/netclaw-visual/server.js` fold `role` + `members` into `/api/n2n`
+- [ ] T048 [US5] HUD: `ui/netclaw-visual/src/main.js` risk view — Border hub + member spokes with scope badge, state (active/unreachable/quarantined), and live in-flight task progress; standalone renders as today
+
+**Checkpoint**: All five stories independently functional; scoping/health/quarantine complete.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Artifact coherence (Constitution XI), docs, and validation.
+
+- [X] T049 [P] Update `workspace/skills/n2n-federation/SKILL.md` with an iN2N section: risk/roles, ask-the-Border-to-route, member management, enrollment (mirror the delegate-vs-chat guidance style)
+- [X] T050 [P] Update `mcp-servers/n2n-mcp/README.md` with the new tools; update `README.md` (iN2N capability, tool count) and `TOOLS.md`
+- [X] T051 [P] Update `SOUL.md` (iN2N capability summary + risk/roles identity references)
+- [X] T052 Run `scripts/verify-catalog-coverage.py` and confirm zero unexplained gaps for the `n2n` component's risk/role/profile additions
+- [X] T053 [P] Add `config/openclaw.json` changes if any new server registration is needed (likely none — `n2n-mcp` already registered; confirm)
+- [X] T054 Run `tests/n2n/` full suite (all iN2N tests green) + the existing 052/053 suite (eN2N regression green, SC-009)
+- [ ] T055 Execute `specs/056-in2n-internal-federation/quickstart.md` end-to-end on the live setup (Border + co-located CML member + distributed pyATS member) and check the SC-001..SC-011 acceptance checklist
+- [ ] T056 Draft the milestone WordPress blog post (Constitution XVII) — present to John before publishing; note GAIT session log
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (P1)**: no deps — start immediately.
+- **Foundational (P2)**: depends on Setup — **blocks all user stories** (schema, keys, role config).
+- **US1 (P3)**: after Foundational. **MVP.**
+- **US2 (P4)**: after Foundational; builds on US1's channel/registry (needs a member to route to for a full test).
+- **US3 (P5)**: after Foundational; independent of US2 (provisioning), but its provisioned members exercise US1's enrollment.
+- **US4 (P6)**: after Foundational; the linked-audit test (T036) needs US2's delegation path; the frozen-core test (T035) is independent.
+- **US5 (P7)**: after Foundational; scope-refusal builds on US2's delegation; health/HUD build on US1's registry.
+- **Polish (P8)**: after all targeted stories.
+
+### User Story Independence
+
+- US1 is fully independent (MVP).
+- US3 is independent of US2/US4/US5 (pure provisioning) — can be built in parallel with US2 by a second dev.
+- US2, US4(audit), US5(scope) share the delegation path — sequence US2 → US4/US5 or coordinate on `invocation.py`.
+
+### Within a story
+
+- Tests first (must fail) → new-file modules → shared-file edits → daemon routes → MCP tools → installer/`netclaw`/HUD.
+
+---
+
+## Parallel Opportunities
+
+- **Setup**: T001, T002, T003 all [P] (distinct new files); T004 after.
+- **Foundational**: T006 [P] (keys, new file) alongside T005 (schema); T007 depends on T005/T006; T008 [P].
+- **US1 tests**: T009, T010, T011 [P] together.
+- **US2 tests**: T020, T021 [P] together.
+- **US3**: T028 [P] (test) and T029 [P] (`in2n-profiles.py`, new file) in parallel.
+- **US4 tests**: T035, T036 [P].
+- **US5 tests**: T041, T042 [P]; T047 [P] (HUD server.js) alongside non-HUD work.
+- ⚠️ Serialize edits to the same file: `service.py` (T014, T037, T044), `bgp-daemon-v2.py` (T016, T025, T032, T045), `n2n-mcp/server.py` (T017, T026, T031, T046), `scripts/netclaw` (T019, T027, T034, T046), `invocation.py` (T024, T043), `risk.py` (T007, T012, T015, T030, T044).
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1)
+
+1. Phase 1 Setup → 2. Phase 2 Foundational → 3. Phase 3 US1 → **STOP & VALIDATE**: a Border + one Member stand up over loopback, member enrolled/pinned/reachable, operator drives via the Border. Demoable.
+
+### Incremental Delivery
+
+US1 (form + enroll) → US2 (route to specialist) → US3 (profile provisioning) → US4 (single face + audit) → US5 (scope + health + quarantine) → Polish. Each adds value without breaking the prior; run `test_en2n_regression.py` continuously to keep the frozen eN2N core honest.
+
+### Notes
+
+- No new third-party packages; `cryptography` already vendored (spec 003).
+- Reuse Nick's `scripts/lib/tui.sh` primitives and the `scripts/netclaw` command tree — no new prompt style (PRs #96/#115/#117).
+- Frozen 052/053 core: never edit eN2N framing/consent/default-deny/no-secrets; add iN2N as siblings.

--- a/tests/n2n/test_cold_start.py
+++ b/tests/n2n/test_cold_start.py
@@ -1,0 +1,83 @@
+"""iN2N Border cold-start-on-route for on-demand members (feature 056, hybrid runtime).
+
+The Border spawns a sleeping on-demand member when routed to it, waits for it to
+dial in + authenticate, then delegates. Remote members (no launch_cmd) can't be
+cold-started. The subprocess spawn is stubbed (no real process in tests).
+"""
+
+import asyncio
+
+import pytest
+
+from bgp.federation.service import FederationService
+from bgp.federation.manager import FederationManager
+
+
+def _border(base):
+    mgr = FederationManager(base_dir=str(base))
+    svc = FederationService(local_as=65001, router_id="4.4.4.4", manager=mgr)
+    svc.risk.set_role("border", risk_name="risk", enabled_stacks="in2n")
+    return svc
+
+
+def test_cold_start_spawns_and_waits(tmp_path):
+    asyncio.run(_cold_start(tmp_path))
+
+
+async def _cold_start(tmp_path):
+    svc = _border(tmp_path / "b")
+    svc.risk.add_member("cml", specialty=[{"name": "cml-lab-lifecycle"}],
+                        launch_cmd="true", on_demand=True)
+
+    class _FakeChan:
+        member_id = "risk/cml"
+
+    real = asyncio.create_subprocess_shell
+    async def fake_spawn(cmd, **kw):
+        # simulate the member process dialing in + authenticating shortly after launch
+        async def _appear():
+            await asyncio.sleep(0.2)
+            svc.member_channels["risk/cml"] = _FakeChan()
+        asyncio.create_task(_appear())
+        return await real("true", **kw)   # harmless real process for the return type
+
+    asyncio.create_subprocess_shell = fake_spawn
+    try:
+        ch = await svc.ensure_member_up("risk/cml", wait_s=5)
+        assert ch is not None                       # cold-started + came up
+        assert "risk/cml" in svc.member_channels
+    finally:
+        asyncio.create_subprocess_shell = real
+    svc.manager.close()
+
+
+def test_remote_member_not_cold_started(tmp_path):
+    asyncio.run(_remote(tmp_path))
+
+
+async def _remote(tmp_path):
+    svc = _border(tmp_path / "b")
+    # a member with NO launch_cmd (e.g. lives on another host) — Border can't spawn it
+    svc.risk.add_member("remote", specialty=[{"name": "x"}])
+    ch = await svc.ensure_member_up("risk/remote", wait_s=1)
+    assert ch is None
+    # delegating to it reports unreachable rather than hanging
+    out = await svc.delegate_to_member("risk/remote", "x", "do it")
+    assert out["error"] == "member_unreachable"
+    svc.manager.close()
+
+
+def test_always_on_member_needs_no_spawn(tmp_path):
+    asyncio.run(_always_on(tmp_path))
+
+
+async def _always_on(tmp_path):
+    svc = _border(tmp_path / "b")
+    svc.risk.add_member("cml", specialty=[{"name": "cml-lab-lifecycle"}])
+
+    class _FakeChan:
+        member_id = "risk/cml"
+    svc.member_channels["risk/cml"] = _FakeChan()     # already live (always-on)
+    ch = await svc.ensure_member_up("risk/cml", wait_s=1)
+    assert ch is svc.member_channels["risk/cml"]      # returned immediately, no spawn
+    svc.manager.close()

--- a/tests/n2n/test_en2n_regression.py
+++ b/tests/n2n/test_en2n_regression.py
@@ -1,0 +1,85 @@
+"""Frozen eN2N core is unchanged by iN2N (feature 056, US4).
+
+Guards FR-014/FR-016/FR-018 and SC-009: a Member never runs the external stack,
+a peer never sees member data, and the eN2N framing/handlers are untouched.
+"""
+
+import json
+
+import pytest
+
+from bgp.federation.service import FederationService
+from bgp.federation.manager import FederationManager
+from bgp import constants
+
+
+def _svc(base, name="claw"):
+    mgr = FederationManager(base_dir=str(base))
+    return FederationService(local_as=65001, router_id="4.4.4.4", display_name=name, manager=mgr)
+
+
+def test_ncfed_framing_constants_unchanged():
+    """iN2N must not have altered the frozen NCFED wire framing (FR-018)."""
+    assert constants.NCFED_MAGIC == b"NCFED"
+    assert constants.NCFED_FRAME_HEADER_SIZE == 5
+    assert constants.NCFED_MAX_PAYLOAD == 65536
+    # iN2N uses a DISTINCT magic so eN2N discrimination is unaffected.
+    assert constants.IN2N_MAGIC != constants.NCFED_MAGIC
+
+
+def test_en2n_handlers_present_alongside_in2n(tmp_path):
+    """The eN2N handler set is intact even though iN2N handlers now exist."""
+    svc = _svc(tmp_path / "a")
+    for m in ("n2n/hello", "n2n/consent_state", "n2n/inventory", "n2n/tools/call",
+              "n2n/tasks/submit", "n2n/chat/open"):
+        assert m in svc.handlers, f"frozen eN2N handler {m} missing"
+    svc.manager.close()
+
+
+def test_member_refuses_outbound_en2n(tmp_path):
+    """FR-014: a Member role does not open external channels."""
+    import asyncio
+    svc = _svc(tmp_path / "m")
+    svc.risk.set_role("member", risk_name="r", border_endpoint="127.0.0.1:9",
+                      self_member_id="r/cml")
+    # lower AS would normally dial, but a member must not federate externally
+    asyncio.run(svc.open_channel(65099, "9.9.9.9", "127.0.0.1", 1))
+    assert svc.channels == {}
+    assert not svc._en2n_allowed()
+    svc.manager.close()
+
+
+def test_border_and_standalone_allow_en2n(tmp_path):
+    svc = _svc(tmp_path / "b")
+    svc.risk.set_role("border", risk_name="r", enabled_stacks="both")
+    assert svc._en2n_allowed()
+    svc.risk.set_role("standalone")
+    assert svc._en2n_allowed()
+    svc.manager.close()
+
+
+def test_peer_inventory_never_leaks_members(tmp_path):
+    """FR-016/SC-005: the eN2N inventory a peer receives contains no member-level
+    identities/topology — the risk presents only the Border identity."""
+    svc = _svc(tmp_path / "border")
+    # Isolate the Border's own skills so the aggregate is deterministic (the real
+    # repo already ships a cml-lab-lifecycle skill).
+    svc.inventory.skills_dir = tmp_path / "empty-skills"
+    svc.risk.set_role("border", risk_name="johns-risk", enabled_stacks="both")
+    # Provision members — their IDs must NOT appear, but their caps aggregate up.
+    svc.risk.add_member("cml", profile=None, specialty=[{"name": "cml-lab-lifecycle"}])
+    svc.risk.add_member("pyats", profile=None, specialty=[{"name": "pyats-run"}])
+    inv = svc.inventory.build("as65007-7.7.7.7")   # what a peer would receive
+    blob = json.dumps(inv)
+    # member IDs / topology never leak (FR-016)
+    assert "johns-risk/cml" not in blob
+    assert "johns-risk/pyats" not in blob
+    assert "member" not in {k.lower() for k in inv.keys()}
+    # ...but the member SPECIALTY capabilities ARE advertised as risk-level caps,
+    # attributed to the risk (aggregate under one identity — the chosen behavior).
+    names = {s["name"] for s in inv["skills"]}
+    assert "cml-lab-lifecycle" in names
+    assert "pyats-run" in names
+    agg = [s for s in inv["skills"] if s.get("risk_aggregate")]
+    assert {"cml-lab-lifecycle", "pyats-run"} <= {s["name"] for s in agg}
+    svc.manager.close()

--- a/tests/n2n/test_enrollment.py
+++ b/tests/n2n/test_enrollment.py
@@ -1,0 +1,76 @@
+"""iN2N enrollment: single-use token + self-signed key pinned TOFU (feature 056).
+
+Covers FR-013a/b and SC-010. See contracts/in2n-enrollment.md.
+"""
+
+import time
+
+import pytest
+
+from bgp.federation.risk import RiskManager, STATE_ENROLLED, STATE_ACTIVE
+
+
+@pytest.fixture
+def border(manager):
+    rm = RiskManager(manager, quarantine_threshold=5)
+    rm.set_role("border", risk_name="johns-risk", enabled_stacks="in2n",
+                border_endpoint="10.0.0.1:1179")
+    return rm
+
+
+def _member_cert():
+    """A fresh member self-signed cert (as a member would generate at runtime)."""
+    cert_pem, _key_pem = RiskManager._generate_self_signed("johns-risk/cml")
+    return cert_pem
+
+
+def test_token_single_use_and_pin(border):
+    tok = border.issue_token(label="cml")["token"]
+    cert = _member_cert()
+    res = border.consume_token(tok, "johns-risk/cml", cert,
+                               scope=[{"name": "cml-lab-lifecycle", "tier": "specialty"}])
+    assert res["pinned"] and res["state"] == STATE_ENROLLED
+    mem = border.get_member("johns-risk/cml")
+    assert mem["key_fingerprint"] == RiskManager.fingerprint_of(cert)
+    # Re-presenting the SAME token is rejected (single-use, SC-010).
+    with pytest.raises(ValueError, match="TOKEN_INVALID"):
+        border.consume_token(tok, "johns-risk/cml", cert)
+
+
+def test_unknown_token_rejected(border):
+    with pytest.raises(ValueError, match="TOKEN_INVALID"):
+        border.consume_token("in2n_bogus", "johns-risk/x", _member_cert())
+
+
+def test_expired_token_rejected(border):
+    tok = border.issue_token(label="cml", ttl_seconds=-1)["token"]  # already expired
+    with pytest.raises(ValueError, match="TOKEN_INVALID"):
+        border.consume_token(tok, "johns-risk/cml", _member_cert())
+
+
+def test_reconnect_pinned_vs_nonpinned_key(border):
+    tok = border.issue_token()["token"]
+    cert = _member_cert()
+    border.consume_token(tok, "johns-risk/cml", cert)
+    fp = RiskManager.fingerprint_of(cert)
+    # correct pinned key → authenticated, marked active
+    assert border.verify_member("johns-risk/cml", fp) is True
+    assert border.get_member("johns-risk/cml")["state"] == STATE_ACTIVE
+    # a different (non-pinned) key → refused
+    other_fp = RiskManager.fingerprint_of(_member_cert())
+    assert border.verify_member("johns-risk/cml", other_fp) is False
+
+
+def test_member_id_taken_by_different_key(border):
+    t1 = border.issue_token()["token"]
+    t2 = border.issue_token()["token"]
+    border.consume_token(t1, "johns-risk/cml", _member_cert())
+    with pytest.raises(ValueError, match="MEMBER_ID_TAKEN"):
+        border.consume_token(t2, "johns-risk/cml", _member_cert())  # different cert
+
+
+def test_enroll_requires_border(manager):
+    rm = RiskManager(manager)
+    rm.set_role("member", risk_name="r", border_endpoint="127.0.0.1:9")
+    with pytest.raises(ValueError, match="NOT_A_BORDER"):
+        rm.consume_token("in2n_x", "r/cml", _member_cert())

--- a/tests/n2n/test_internal_transport.py
+++ b/tests/n2n/test_internal_transport.py
@@ -1,0 +1,115 @@
+"""iN2N internal transport: member-initiated dial + pinned-key auth (feature 056, US1).
+
+Drives a real Border + Member FederationService over a loopback TCP socket
+(the same harness style as test_two_daemon_loopback.py). Covers FR-006/007/007a/
+013a and SC-011. The frozen NCFED framing is reused via InternalChannel.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from bgp.federation.service import FederationService
+from bgp.federation.manager import FederationManager
+from bgp.federation.internal_channel import IN2N_MAGIC, InternalChannel
+from bgp.constants import NCFED_MAX_PAYLOAD
+from bgp.federation.channel import encode_frames
+
+
+def _service(base, local_as, rid, name):
+    mgr = FederationManager(base_dir=str(base))
+    return FederationService(local_as=local_as, router_id=rid, display_name=name, manager=mgr)
+
+
+def test_frames_byte_identical_to_en2n():
+    """InternalChannel reuses the frozen NCFED framing (encode_frames)."""
+    msg = {"jsonrpc": "2.0", "id": 1, "method": "in2n/hello", "params": {}}
+    frames = encode_frames(msg)
+    # single frame, 5-byte header (4 len + 1 flags), same as eN2N
+    assert len(frames) == 1
+    assert len(frames[0]) == 5 + len(json.dumps(msg, separators=(",", ":")))
+
+
+def test_enroll_then_reconnect_over_loopback(tmp_path):
+    asyncio.run(_enroll_then_reconnect(tmp_path))
+
+
+async def _enroll_then_reconnect(tmp_path):
+    border = _service(tmp_path / "border", 65001, "4.4.4.4", "Border")
+    member = _service(tmp_path / "member", 65001, "4.4.4.4", "Member")
+
+    border.risk.set_role("border", risk_name="risk", enabled_stacks="in2n",
+                         border_endpoint="127.0.0.1:0")
+    member.risk.set_role("member", risk_name="risk", border_endpoint="127.0.0.1:0",
+                         self_member_id="risk/cml")
+    token = border.risk.issue_token(label="cml")["token"]
+
+    async def on_conn(reader, writer):
+        await border.accept_internal(reader, writer)
+
+    server = await asyncio.start_server(on_conn, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+
+    async with server:
+        # First contact: member dials out and ENROLLS (token + signed nonce).
+        resp = await member.dial_border("127.0.0.1", port, enrollment_token=token)
+        await asyncio.sleep(0.2)
+        assert resp["pinned"] is True
+        mem = border.risk.get_member("risk/cml")
+        assert mem["state"] == "active"
+        # Border pinned the member's self-signed key.
+        assert mem["key_fingerprint"] == border.risk.fingerprint_of(member.risk.self_cert_pem())
+        # Hub-and-spoke: the member holds no member registry of its own (no
+        # member-to-member), and opened no listener (FR-007a/SC-011).
+        assert member.member_channels == {}
+        assert "risk/cml" in border.member_channels
+
+        # Token is single-use — cannot enroll a second time with it.
+        with pytest.raises(Exception):
+            m2 = _service(tmp_path / "m2", 65001, "4.4.4.4", "M2")
+            m2.risk.set_role("member", risk_name="risk", self_member_id="risk/dup")
+            await m2.dial_border("127.0.0.1", port, enrollment_token=token)
+        await asyncio.sleep(0.1)
+
+        # Drop the member's channel; RECONNECT authenticates via the pinned key
+        # (in2n/hello, no token).
+        await member.border_channel.close()
+        border.member_channels.pop("risk/cml", None)
+        await asyncio.sleep(0.1)
+        resp2 = await member.dial_border("127.0.0.1", port)  # no token → hello path
+        await asyncio.sleep(0.2)
+        assert resp2["trusted"] is True
+        assert "risk/cml" in border.member_channels
+
+    border.manager.close(); member.manager.close()
+
+
+def test_wrong_key_reconnect_refused(tmp_path):
+    asyncio.run(_wrong_key_refused(tmp_path))
+
+
+async def _wrong_key_refused(tmp_path):
+    border = _service(tmp_path / "b", 65001, "4.4.4.4", "Border")
+    border.risk.set_role("border", risk_name="risk", enabled_stacks="in2n")
+    token = border.risk.issue_token()["token"]
+
+    # Enroll a legit member first.
+    member = _service(tmp_path / "m", 65001, "4.4.4.4", "Member")
+    member.risk.set_role("member", risk_name="risk", self_member_id="risk/cml")
+
+    async def on_conn(reader, writer):
+        await border.accept_internal(reader, writer)
+    server = await asyncio.start_server(on_conn, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+
+    async with server:
+        await member.dial_border("127.0.0.1", port, enrollment_token=token)
+        await asyncio.sleep(0.2)
+        # An imposter claiming the same member_id with a DIFFERENT key → refused.
+        imposter = _service(tmp_path / "imp", 65001, "4.4.4.4", "Imposter")
+        imposter.risk.set_role("member", risk_name="risk", self_member_id="risk/cml")
+        with pytest.raises(Exception):
+            await imposter.dial_border("127.0.0.1", port)  # hello with non-pinned key
+        await asyncio.sleep(0.1)
+    border.manager.close(); member.manager.close(); imposter.manager.close()

--- a/tests/n2n/test_member_delegation.py
+++ b/tests/n2n/test_member_delegation.py
@@ -1,0 +1,129 @@
+"""iN2N Border→Member delegation + scope enforcement (feature 056, US2/US5).
+
+Routes a capability to the owning member and delegates it as an async task over
+the internal channel, reusing the 053 TaskManager. The gateway executor is
+stubbed (no live gateway in tests) so we validate the delegation PLUMBING and
+scope refusal (FR-009/010/023, SC-006/SC-007).
+"""
+
+import asyncio
+
+import pytest
+
+from bgp.federation.service import FederationService
+from bgp.federation.manager import FederationManager
+from bgp.federation.risk import BASE_FLOOR
+
+
+def _service(base, name):
+    mgr = FederationManager(base_dir=str(base))
+    return FederationService(local_as=65001, router_id="4.4.4.4", display_name=name, manager=mgr)
+
+
+async def _stand_up_risk(tmp_path, member_scope):
+    border = _service(tmp_path / "border", "Border")
+    member = _service(tmp_path / "member", "Member")
+    border.risk.set_role("border", risk_name="risk", enabled_stacks="in2n")
+    member.risk.set_role("member", risk_name="risk", self_member_id="risk/cml")
+    member.member_scope = set(member_scope)
+    # A member now executes via OpenClaw EMBEDDED mode (gateway.run_agent_turn
+    # local=True). Stub that module fn (no live OpenClaw in tests) — the worker
+    # imports it at call time, so patching the module attribute takes effect.
+    import bgp.federation.gateway as gw
+    async def _fake_run(prompt, session_key="in2n", timeout_s=600, local=False, model=None):
+        return (f"embedded run ok :: {prompt}", 42)
+    gw.run_agent_turn = _fake_run
+
+    # Enroll the member with a scope that covers its specialty so the Border can route.
+    scope = list(BASE_FLOOR) + [
+        {"name": c, "type": "skill", "tier": "specialty"} for c in member_scope]
+    tok = border.risk.issue_token()["token"]
+
+    async def on_conn(reader, writer):
+        await border.accept_internal(reader, writer)
+    server = await asyncio.start_server(on_conn, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    # dial + enroll; then patch the pinned member's scope on the Border side
+    await member.dial_border("127.0.0.1", port, enrollment_token=tok)
+    await asyncio.sleep(0.2)
+    # Border stores scope from enrollment params; ensure the specialty is recorded
+    border.risk._conn.execute(
+        "UPDATE member SET scope=? WHERE member_id=?",
+        (__import__("json").dumps(scope), "risk/cml"))
+    border.risk._conn.commit()
+    return border, member, server
+
+
+def test_route_and_delegate_completes(tmp_path):
+    asyncio.run(_route_and_delegate(tmp_path))
+
+
+async def _route_and_delegate(tmp_path):
+    border, member, server = await _stand_up_risk(tmp_path, ["cml-lab-lifecycle"])
+    async with server:
+        # Operator asks the Border; it routes to risk/cml and delegates.
+        out = await border.route_and_delegate("cml-lab-lifecycle", "build my lab")
+        assert out["member_id"] == "risk/cml"
+        task_id = out["task_id"]
+        assert out["state"] == "submitted"
+        # The task runs on the MEMBER side; poll it to completion.
+        for _ in range(50):
+            st = member.tasks.status(task_id)
+            if st["state"] in ("completed", "failed"):
+                break
+            await asyncio.sleep(0.05)
+        res = member.tasks.result(task_id)
+        assert res["state"] == "completed"
+        assert "cml-lab-lifecycle" in res["output_text"]   # embedded run saw the skill
+    border.manager.close(); member.manager.close()
+
+
+def test_no_capable_member(tmp_path):
+    asyncio.run(_no_capable(tmp_path))
+
+
+async def _no_capable(tmp_path):
+    border, member, server = await _stand_up_risk(tmp_path, ["cml-lab-lifecycle"])
+    async with server:
+        out = await border.route_and_delegate("something-nobody-has", "x")
+        assert out["error"] == "IN2N_ERR_NO_CAPABLE_MEMBER"
+    border.manager.close(); member.manager.close()
+
+
+def test_out_of_scope_refused(tmp_path):
+    asyncio.run(_out_of_scope(tmp_path))
+
+
+async def _out_of_scope(tmp_path):
+    # Member is enrolled with cml scope, but we ask it (directly) for a capability
+    # its runtime scope does not allow → ERR_OUT_OF_SCOPE (FR-023/SC-007).
+    border, member, server = await _stand_up_risk(tmp_path, ["cml-lab-lifecycle"])
+    async with server:
+        # Force-route a capability the member is NOT scoped to run.
+        out = await border.delegate_to_member("risk/cml", "dangerous-config-push", "x")
+        assert out["error"] == "out_of_scope"
+        assert out["code"] == -32031
+    border.manager.close(); member.manager.close()
+
+
+def test_internal_delegation_audited_and_linkable(tmp_path):
+    """FR-024/FR-025: internal delegations are audited channel_kind=in2n, and an
+    external request satisfied internally can link the two records."""
+    from bgp.federation.manager import FederationManager
+    from bgp.federation.audit import Auditor
+    mgr = FederationManager(base_dir=str(tmp_path / "audit"))
+    audit = Auditor(mgr)
+    # An external (eN2N) request arrives...
+    ext = audit.record(direction="inbound", peer_identity="as65007-7.7.7.7",
+                       target_type="skill", target_name="cml-lab-lifecycle",
+                       decision="allowlisted", outcome="pending", channel_kind="en2n")
+    # ...and the Border satisfies it by delegating internally, linking back.
+    intn = audit.record(direction="outbound", peer_identity="risk/cml",
+                        target_type="skill", target_name="cml-lab-lifecycle",
+                        decision="requested", outcome="submitted",
+                        channel_kind="in2n", linked_record_id=ext)
+    rows = {r["id"]: r for r in audit.recent(limit=10)}
+    assert rows[ext]["channel_kind"] == "en2n"
+    assert rows[intn]["channel_kind"] == "in2n"
+    assert rows[intn]["linked_record_id"] == ext      # the two tiers are joined
+    mgr.close()

--- a/tests/n2n/test_member_delegation.py
+++ b/tests/n2n/test_member_delegation.py
@@ -75,6 +75,12 @@ async def _route_and_delegate(tmp_path):
         res = member.tasks.result(task_id)
         assert res["state"] == "completed"
         assert "cml-lab-lifecycle" in res["output_text"]   # embedded run saw the skill
+        # Border-side retrieval must work over the iN2N member channel (regression:
+        # the operator poll used to go down the eN2N path and stall at 'submitted').
+        assert border.is_member_task("risk/cml")
+        polled = await border.poll_member_task("risk/cml", task_id, kind="result")
+        assert polled["state"] == "completed"
+        assert "cml-lab-lifecycle" in polled["output_text"]
     border.manager.close(); member.manager.close()
 
 

--- a/tests/n2n/test_quarantine.py
+++ b/tests/n2n/test_quarantine.py
@@ -1,0 +1,62 @@
+"""iN2N offboarding + auto-quarantine (feature 056, US5).
+
+Covers FR-013c/d and SC-010.
+"""
+
+import pytest
+
+from bgp.federation.risk import (
+    RiskManager, STATE_REMOVED, STATE_QUARANTINED, STATE_ENROLLED,
+)
+
+
+@pytest.fixture
+def border(manager):
+    rm = RiskManager(manager, quarantine_threshold=3)
+    rm.set_role("border", risk_name="risk", enabled_stacks="in2n",
+                border_endpoint="10.0.0.1:1179")
+    return rm
+
+
+def _enroll(border, name="risk/cml"):
+    tok = border.issue_token()["token"]
+    cert, _ = RiskManager._generate_self_signed(name)
+    border.consume_token(tok, name, cert)
+    return cert, RiskManager.fingerprint_of(cert)
+
+
+def test_remove_unpins_and_refuses_reconnect(border):
+    _cert, fp = _enroll(border)
+    assert border.verify_member("risk/cml", fp) is True
+    assert border.remove_member("risk/cml") is True
+    mem = border.get_member("risk/cml")
+    assert mem["state"] == STATE_REMOVED and mem["pinned_key"] is None
+    # reconnect on the old key is refused (SC-010)
+    assert border.verify_member("risk/cml", fp) is False
+    # removed member is not listed
+    assert all(m["member_id"] != "risk/cml" for m in border.list_members())
+
+
+def test_reenroll_after_removal(border):
+    _cert, _fp = _enroll(border)
+    border.remove_member("risk/cml")
+    # a NEW token + key re-enrolls the same member_id
+    tok = border.issue_token()["token"]
+    cert2, fp2 = RiskManager._generate_self_signed("risk/cml"), None
+    cert2_pem = cert2[0]
+    res = border.consume_token(tok, "risk/cml", cert2_pem)
+    assert res["state"] == STATE_ENROLLED
+    assert border.verify_member("risk/cml", RiskManager.fingerprint_of(cert2_pem)) is True
+
+
+def test_auto_quarantine_at_threshold(border):
+    _cert, fp = _enroll(border)
+    # threshold is 3
+    assert border.record_auth_failure("risk/cml") is False   # 1
+    assert border.record_auth_failure("risk/cml") is False   # 2
+    assert border.record_auth_failure("risk/cml") is True    # 3 → quarantine
+    mem = border.get_member("risk/cml")
+    assert mem["state"] == STATE_QUARANTINED and mem["pinned_key"] is None
+    assert border.is_quarantined("risk/cml")
+    # a quarantined member cannot reconnect on its old key
+    assert border.verify_member("risk/cml", fp) is False

--- a/tests/n2n/test_risk.py
+++ b/tests/n2n/test_risk.py
@@ -1,0 +1,122 @@
+"""iN2N risk role model + provisioning (feature 056, US1/US3).
+
+Covers FR-002/003/004/005(role flag)/019/020/021/021a/021b/022.
+"""
+
+import json
+
+import pytest
+
+from bgp.federation.risk import RiskManager, BASE_FLOOR, STATE_PROVISIONED
+
+
+@pytest.fixture
+def rm(manager):
+    return RiskManager(manager, quarantine_threshold=5)
+
+
+# ---- role model (FR-002/003/004) --------------------------------------
+
+def test_default_is_standalone(rm):
+    """A fresh claw is standalone — a 'risk of one', behaves as pre-056 (FR-004)."""
+    assert rm.is_standalone()
+    assert rm.role() == "standalone"
+    assert rm.get_risk()["risk_name"] is None
+
+
+def test_set_border_and_member_roles(rm):
+    rm.set_role("border", risk_name="johns-risk", description="lab fleet",
+                enabled_stacks="both")
+    r = rm.get_risk()
+    assert r["role"] == "border" and r["risk_name"] == "johns-risk"
+    assert rm.is_border()
+
+
+def test_invalid_role_rejected(rm):
+    with pytest.raises(ValueError):
+        rm.set_role("overlord", risk_name="x")
+
+
+def test_single_border_enforcement(rm):
+    """FR-003: a claw cannot be Border of two different risks."""
+    rm.set_role("border", risk_name="johns-risk", enabled_stacks="both")
+    with pytest.raises(ValueError):
+        rm.set_role("border", risk_name="a-different-risk", enabled_stacks="both")
+    # Re-affirming the SAME risk is idempotent, not an error.
+    rm.set_role("border", risk_name="johns-risk", enabled_stacks="in2n")
+    assert rm.get_risk()["enabled_stacks"] == "in2n"
+
+
+def test_member_role_gates_external_stack(rm):
+    """FR-005/014: a Member never runs eN2N; standalone still does."""
+    rm.set_role("member", risk_name="johns-risk", border_endpoint="127.0.0.1:9",
+                self_member_id="johns-risk/cml")
+    assert not rm.stack_enabled("en2n")
+    assert not rm.is_border()
+    # Standalone remains eN2N-capable as before (backwards compat).
+    rm2 = RiskManager(rm.m)
+    rm.set_role("standalone")
+    assert rm.stack_enabled("en2n")
+
+
+def test_border_stack_gating(rm):
+    rm.set_role("border", risk_name="johns-risk", enabled_stacks="in2n")
+    assert rm.stack_enabled("in2n")
+    assert not rm.stack_enabled("en2n")
+    rm.set_role("border", risk_name="johns-risk", enabled_stacks="both")
+    assert rm.stack_enabled("en2n") and rm.stack_enabled("in2n")
+
+
+# ---- provisioning + base floor (FR-019/020/021/021a/021b/022) ---------
+
+def test_profile_provisions_scoped_member_with_base_floor(rm):
+    rm.set_role("border", risk_name="johns-risk", enabled_stacks="in2n",
+                border_endpoint="10.0.0.1:1179")
+    out = rm.add_member("cml", profile="cml",
+                        specialty=[{"name": "cml-lab-lifecycle", "type": "skill"}])
+    assert out["member_id"] == "johns-risk/cml"
+    names = {e["name"] for e in out["scope"]}
+    # specialty present
+    assert "cml-lab-lifecycle" in names
+    # base floor present and non-removable
+    for base in BASE_FLOOR:
+        assert base["name"] in names
+    # a single-use token + join instructions returned (member is a separate install)
+    assert out["enrollment_token"].startswith("in2n_")
+    assert out["join"]["N2N_ROLE"] == "member"
+    # row provisioned, not yet pinned
+    mem = rm.get_member("johns-risk/cml")
+    assert mem["state"] == STATE_PROVISIONED and mem["pinned_key"] is None
+
+
+def test_custom_member_arbitrary_subset(rm):
+    rm.set_role("border", risk_name="r", enabled_stacks="in2n")
+    out = rm.add_member("mix", specialty=["skill-a", "skill-b"])
+    names = {e["name"] for e in out["scope"] if e["tier"] == "specialty"}
+    assert names == {"skill-a", "skill-b"}
+
+
+def test_specialty_count_excludes_base_floor(rm):
+    """FR-021b: base floor must NOT count toward routing specificity."""
+    rm.set_role("border", risk_name="r", enabled_stacks="in2n")
+    out = rm.add_member("cml", profile="cml", specialty=[{"name": "cml-lab-lifecycle"}])
+    assert rm.specialty_count(out["scope"]) == 1        # only the specialty entry
+    assert len(out["scope"]) == len(BASE_FLOOR) + 1     # base floor is in the scope
+    # a broader claw with more specialties is "less specific"
+    out2 = rm.add_member("broad", specialty=["a", "b", "c", "cml-lab-lifecycle"])
+    assert rm.specialty_count(out2["scope"]) == 4
+
+
+def test_covers_and_in_scope(rm):
+    rm.set_role("border", risk_name="r", enabled_stacks="in2n")
+    rm.add_member("cml", profile="cml", specialty=[{"name": "cml-lab-lifecycle"}])
+    mem = rm.get_member("r/cml")
+    assert rm.covers(mem, "cml-lab-lifecycle")
+    assert rm.covers(mem, "self-status")          # base floor is in scope
+    assert not rm.covers(mem, "pyats-run")
+
+
+def test_add_member_requires_border(rm):
+    rm.set_role("member", risk_name="r", border_endpoint="127.0.0.1:9")
+    with pytest.raises(ValueError):
+        rm.add_member("x", profile="cml")

--- a/tests/n2n/test_routing.py
+++ b/tests/n2n/test_routing.py
@@ -1,0 +1,85 @@
+"""iN2N Border routing: deterministic member selection (feature 056, US2).
+
+Covers FR-011/FR-012/FR-021b. The async delegation over the channel is exercised
+in test_member_delegation.py; here we assert the selection algorithm.
+"""
+
+import json
+
+import pytest
+
+from bgp.federation.risk import RiskManager, BASE_FLOOR
+from bgp.federation.router import RiskRouter, NoCapableMember
+
+
+@pytest.fixture
+def border(manager):
+    rm = RiskManager(manager, quarantine_threshold=5)
+    rm.set_role("border", risk_name="risk", enabled_stacks="in2n",
+                border_endpoint="10.0.0.1:1179")
+    return rm
+
+
+def _enroll(rm, name, specialty_names):
+    """Provision + enroll a member scoped to base floor + given specialties."""
+    scope = list(BASE_FLOOR) + [
+        {"name": n, "type": "skill", "tier": "specialty"} for n in specialty_names]
+    tok = rm.issue_token()["token"]
+    cert, _ = RiskManager._generate_self_signed(name)
+    rm.consume_token(tok, name, cert, scope=scope)
+    return name
+
+
+def test_single_match_routes_there(border):
+    _enroll(border, "risk/cml", ["cml-lab-lifecycle"])
+    r = RiskRouter(border)
+    assert r.select_member("cml-lab-lifecycle")["member_id"] == "risk/cml"
+
+
+def test_most_specific_specialist_wins(border):
+    """A narrow specialist beats a broad claw that merely also lists the cap."""
+    _enroll(border, "risk/cml", ["cml-lab-lifecycle"])                     # 1 specialty
+    _enroll(border, "risk/generalist",
+            ["cml-lab-lifecycle", "pyats-run", "meraki", "aci"])            # 4 specialties
+    r = RiskRouter(border)
+    assert r.select_member("cml-lab-lifecycle")["member_id"] == "risk/cml"
+
+
+def test_tie_broken_lexicographically(border):
+    """Equal specificity → smallest member_id (deterministic, repeatable)."""
+    _enroll(border, "risk/bbb", ["shared-cap"])
+    _enroll(border, "risk/aaa", ["shared-cap"])
+    r = RiskRouter(border)
+    assert r.select_member("shared-cap")["member_id"] == "risk/aaa"
+    # repeatable
+    assert r.select_member("shared-cap")["member_id"] == "risk/aaa"
+
+
+def test_no_capable_member(border):
+    _enroll(border, "risk/cml", ["cml-lab-lifecycle"])
+    r = RiskRouter(border)
+    with pytest.raises(NoCapableMember):
+        r.select_member("nonexistent-cap")
+    out = r.route("nonexistent-cap")
+    assert out["error"] == "IN2N_ERR_NO_CAPABLE_MEMBER"
+
+
+def test_quarantined_member_not_selected(border):
+    _enroll(border, "risk/cml", ["cml-lab-lifecycle"])
+    # quarantine it (threshold 5)
+    for _ in range(5):
+        border.record_auth_failure("risk/cml")
+    r = RiskRouter(border)
+    with pytest.raises(NoCapableMember):
+        r.select_member("cml-lab-lifecycle")
+
+
+def test_base_floor_capability_routes_but_specificity_excludes_it(border):
+    """A base-floor capability is coverable; specificity still counts specialty only."""
+    _enroll(border, "risk/cml", ["cml-lab-lifecycle"])
+    r = RiskRouter(border)
+    # self-status is base floor → covered
+    assert r.select_member("self-status")["member_id"] == "risk/cml"
+    # specialty count is 1, not 1+len(BASE_FLOOR)
+    mem = border.get_member("risk/cml")
+    assert border.specialty_count(mem["scope"]) == 1

--- a/tests/n2n/test_scope_enforcement.py
+++ b/tests/n2n/test_scope_enforcement.py
@@ -1,0 +1,79 @@
+"""iN2N member scope enforcement + base-floor rules (feature 056, US5).
+
+Covers FR-021a/FR-021b/FR-023/FR-027 and SC-007.
+"""
+
+import json
+
+import pytest
+
+from bgp.federation.risk import RiskManager, BASE_FLOOR
+
+
+@pytest.fixture
+def border(manager):
+    rm = RiskManager(manager, quarantine_threshold=5)
+    rm.set_role("border", risk_name="risk", enabled_stacks="in2n")
+    return rm
+
+
+def test_base_floor_present_and_nonremovable(border):
+    """Every member carries the base floor regardless of profile (FR-021a)."""
+    out = border.add_member("cml", specialty=[{"name": "cml-lab-lifecycle"}])
+    names = {e["name"] for e in out["scope"]}
+    for base in BASE_FLOOR:
+        assert base["name"] in names
+    # Custom member with NO specialty still has the full base floor.
+    out2 = border.add_member("bare")
+    names2 = {e["name"] for e in out2["scope"]}
+    for base in BASE_FLOOR:
+        assert base["name"] in names2
+
+
+def test_advertised_equals_allowed(border):
+    """A member's scope is both what it advertises and its execution ceiling."""
+    out = border.add_member("cml", specialty=[{"name": "cml-lab-lifecycle"}])
+    mem = border.get_member("risk/cml")
+    # Everything advertised is in-scope; nothing outside is.
+    for e in out["scope"]:
+        assert border.covers(mem, e["name"])
+    assert not border.covers(mem, "pyats-run")
+
+
+def test_base_floor_excluded_from_specificity(border):
+    """Base floor must not distort the routing specialist tie-break (FR-021b)."""
+    out = border.add_member("cml", specialty=[{"name": "cml-lab-lifecycle"}])
+    # 4 base entries + 1 specialty in scope, but specialty_count == 1
+    assert len(out["scope"]) == len(BASE_FLOOR) + 1
+    assert border.specialty_count(out["scope"]) == 1
+    out2 = border.add_member("broad", specialty=["a", "b", "c"])
+    assert border.specialty_count(out2["scope"]) == 3   # base still excluded
+
+
+def test_out_of_scope_refused_at_service(tmp_path):
+    """FR-023/SC-007: a scoped member refuses out-of-scope work over the channel."""
+    import asyncio
+    from bgp.federation.service import FederationService
+    from bgp.federation.manager import FederationManager
+
+    async def _run():
+        mgr = FederationManager(base_dir=str(tmp_path / "m"))
+        member = FederationService(local_as=65001, router_id="4.4.4.4", manager=mgr)
+        member.risk.set_role("member", risk_name="risk", self_member_id="risk/cml")
+        member.member_scope = {"cml-lab-lifecycle"}
+
+        class _Chan:
+            member_id = "risk/border"
+        # in-scope → accepted (returns a task_id); out-of-scope → RpcError -32031
+        from bgp.federation.channel import RpcError
+        # stub the executor so no live gateway is needed
+        async def _fake(skill, text): return ("ok", 1)
+        member.invoker._exec_skill_gateway = _fake
+        ok = await member._in2n_member_submit(_Chan(), {"skill": "cml-lab-lifecycle", "input_text": "x"})
+        assert ok["state"] == "submitted"
+        with pytest.raises(RpcError) as ei:
+            await member._in2n_member_submit(_Chan(), {"skill": "not-my-job", "input_text": "x"})
+        assert ei.value.code == -32031
+        mgr.close()
+
+    asyncio.run(_run())

--- a/ui/netclaw-visual/server.js
+++ b/ui/netclaw-visual/server.js
@@ -935,10 +935,24 @@ async function fetchN2NState() {
       }
     } catch { /* health optional */ }
 
+    // 056 iN2N: fold this claw's risk role + (on a Border) its members so the
+    // HUD can render the hub-and-spoke risk view alongside eN2N peers.
+    let risk = null;
+    let members = [];
+    try {
+      const rRes = await fetch(`${BGP_API}/n2n/risk`, { signal: AbortSignal.timeout(3000) });
+      if (rRes.ok) risk = await rRes.json();
+      if (risk && risk.role === 'border') {
+        const mRes = await fetch(`${BGP_API}/n2n/members`, { signal: AbortSignal.timeout(3000) });
+        if (mRes.ok) members = (await mRes.json()).members || [];
+      }
+    } catch { /* iN2N optional (standalone/pre-056 daemon) */ }
+
     return { available: true, identity: status.identity, peers, approvals,
-             generatedAt: new Date().toISOString() };
+             risk, members, generatedAt: new Date().toISOString() };
   } catch {
-    return { available: false, peers: [], generatedAt: new Date().toISOString() };
+    return { available: false, peers: [], risk: null, members: [],
+             generatedAt: new Date().toISOString() };
   }
 }
 

--- a/ui/netclaw-visual/src/main.js
+++ b/ui/netclaw-visual/src/main.js
@@ -1230,10 +1230,10 @@ function buildRiskMembers() {
     const n = members.length;
     members.forEach((m, i) => {
       const frac = n > 1 ? i / (n - 1) : 0.5;
-      const spread = (frac - 0.5) * Math.PI * 0.95;              // fan across the south
-      const px = C.x + Math.sin(spread) * R * 1.6;
-      const pz = C.z - (R + 16) - Math.abs(Math.cos(spread)) * 8; // south = -Z
-      const py = -3 - (i % 4) * 4;                                // stagger so labels don't overlap
+      const spread = (frac - 0.5) * Math.PI * 1.25;               // wide fan across the south
+      const px = C.x + Math.sin(spread) * R * 3.0;                // spread far out in X
+      const pz = C.z - (R + 40) - Math.abs(Math.cos(spread)) * R * 0.9; // push well south (-Z)
+      const py = -6 - (i % 5) * 7;                                // deeper vertical stagger
       const pos = new THREE.Vector3(px, py, pz);
       const dead = (m.state === 'quarantined' || m.state === 'removed');
       const cold = !m.live;
@@ -1248,6 +1248,11 @@ function buildRiskMembers() {
       // orbiting skills only for LIVE members (keep the scene light for cold ones)
       const names = (m.live ? (m.skills || []) : []).slice(0, 12);
       core.skillSprites = createSkillSprites(pos, names.map((s) => ({ name: s, id: s })), tint, pos);
+      // Show member tools by default (don't hide behind a click like integrations).
+      core.skillSprites.forEach((sp) => {
+        if (sp.mesh) sp.mesh.visible = true;
+        if (sp.wire) sp.wire.visible = true;
+      });
       state.cores.push(core);
       state.memberCores.push(core);
     });
@@ -1551,6 +1556,31 @@ function setDetail(kind, payload, related = []) {
       <p>${state.n2n?.identity || 'local claw'}</p>
       ${renderRiskSection()}
     `;
+    return;
+  }
+
+  if (kind === 'member-core') {
+    const m = payload || {};
+    const st = m.state || 'unknown';
+    const stCls = m.live ? 'federated'
+      : (st === 'quarantined' || st === 'removed') ? 'not-federated' : 'consent-pending-local';
+    const skills = (m.skills || []).map((s) => `<li>${s}</li>`).join('')
+      || '<li class="n2n-muted">—</li>';
+    dom.detailPanel.innerHTML = `
+      <h2>Member Claw</h2>
+      <p>${m.member_id || '—'}</p>
+      <div class="detail-grid">
+        <div class="detail-row"><span>Risk</span><strong>${(state.n2n?.risk?.risk_name) || '—'}</strong></div>
+        <div class="detail-row"><span>Profile</span><strong>${m.profile || '—'}</strong></div>
+        <div class="detail-row"><span>State</span><strong class="n2n-state-${stCls}">${st}${m.live ? ' · live' : ''}</strong></div>
+        <div class="detail-row"><span>Transport</span><strong>${m.transport_binding || '—'}</strong></div>
+        <div class="detail-row"><span>Specialty skills</span><strong>${m.specialty_count ?? (m.skills || []).length}</strong></div>
+      </div>
+      <div class="n2n-section">
+        <h4>Scope (${(m.skills || []).length})</h4>
+        <ul class="n2n-list">${skills}</ul>
+        <p class="n2n-muted">Delegated to over the internal transport; runs its own scoped model. No external comms.</p>
+      </div>`;
     return;
   }
 
@@ -2516,6 +2546,13 @@ function onClick(event) {
       focusTarget(state.localCore.position.clone());
       setDetail('local-core');            // 056: show this claw's risk view (role + member spokes)
       state.selected = { kind: 'local-core' };
+    } else if (hitCore.isMember) {
+      // 056: member claw selected — focus it and show its detail
+      clearSelection();
+      hitCore.nucleus.material.emissiveIntensity = 1.8;
+      focusTarget(hitCore.position.clone());
+      setDetail('member-core', hitCore.memberPayload);
+      state.selected = { kind: 'member-core', member: hitCore.memberPayload?.member_id };
     } else {
       // Peer core selected — show detail
       clearSelection();
@@ -3074,7 +3111,15 @@ async function boot() {
     }
 
     setLoading(58, 'Rendering integration lattice');
-    buildIntegrations(state.graph);
+    // 056: a Border orbits ONLY its broker skills — the domain integrations moved
+    // to their member spokes, so the Border is no longer the 190-skill monolith.
+    const BORDER_KEEP = new Set(['gait', 'protocol', 'n2n', 'memory', 'mempalace',
+      'humanrail', 'slack', 'webex', 'servicenow', 'pagerduty', 'twilio', 'twitter',
+      'msgraph', 'subnet-calculator', 'subnet', 'rfc', 'wikipedia', 'token-tracker']);
+    const _graphForBorder = (state.n2n?.risk?.role === 'border')
+      ? { ...state.graph, integrations: state.graph.integrations.filter((i) => BORDER_KEEP.has(i.id)) }
+      : state.graph;
+    buildIntegrations(_graphForBorder);
 
     // 056: iN2N risk — render member claws as spokes SOUTH of the Border, each
     // with its own orbiting skills, colored by class (green member / red

--- a/ui/netclaw-visual/src/main.js
+++ b/ui/netclaw-visual/src/main.js
@@ -19,6 +19,27 @@ import gsap from 'gsap';
 const QUALITY_MODES = ['focus', 'balanced', 'broadcast'];
 const QUALITY_LABELS = { focus: 'FOCUS', balanced: 'BALANCED', broadcast: 'BROADCAST' };
 
+// ── iN2N "risk" HUD layout (feature 056) ────────────────────────────
+// Design (per operator): the Border Claw sits at the CENTER of the universe;
+// EXTERNAL (eN2N) peer claws arc to the NORTH (+Z); INTERNAL member claws arc to
+// the SOUTH (-Z). Every claw — local, remote peer, and member — carries its own
+// orbiting skill sprites. Distinct colors per class. Spacing is widened so the
+// three tiers read clearly. This config is consumed by the scene-layout pass
+// (createMemberCores / positionClawsByRole) — tune live against the HUD.
+const RISK_LAYOUT = {
+  spacing: 34,             // widened inter-claw spacing (was ~18); tune live
+  borderAtOrigin: true,    // Border = center of the universe
+  externalAxis: +1,        // eN2N peer claws to the north (+Z)
+  memberAxis: -1,          // internal member claws to the south (-Z)
+  tierRadius: 46,          // distance of each tier ring from the Border
+  colors: {
+    border:   0xffd166,    // amber — the one you talk to, center of the universe
+    member:   0x68f5b2,    // neon green — internal, trusted, focused specialists
+    external: 0x38e8ff,    // cyan — external peer risks (other operators)
+    memberQuarantined: 0xff5d6c,  // red — an auto-quarantined / removed member
+  },
+};
+
 const state = {
   graph: null,
   scene: null,
@@ -1365,6 +1386,38 @@ function findFederationPeer(peer) {
   }) || null;
 }
 
+// 056 iN2N: this claw's own risk view (role + members) for the local-core panel.
+function renderRiskSection() {
+  const risk = state.n2n?.risk;
+  if (!risk || risk.role === 'standalone') {
+    return `<div class="n2n-section"><h3>Risk (iN2N)</h3>
+      <p class="n2n-muted">Standalone claw — a risk of one, its own Border.</p></div>`;
+  }
+  if (risk.role === 'member') {
+    return `<div class="n2n-section"><h3>Risk: ${risk.risk_name} (Member)</h3>
+      <div class="detail-row"><span>Member</span><strong>${risk.self_member_id || '—'}</strong></div>
+      <p class="n2n-muted">Focused specialist — dials the Border; not internet-facing.</p></div>`;
+  }
+  // Border: hub with member spokes
+  const members = state.n2n?.members || [];
+  const rows = members.map((m) => {
+    const dot = m.live ? '<span class="n2n-fresh">●</span>' : '<span class="n2n-muted">○</span>';
+    const stCls = m.state === 'active' ? 'federated'
+      : (m.state === 'quarantined' || m.state === 'removed') ? 'not-federated' : 'consent-pending-local';
+    return `<li>${dot} ${m.member_id}
+      <span class="n2n-muted">(${m.profile || 'custom'})</span>
+      <strong class="n2n-state-${stCls}">${m.state}</strong>
+      <span class="n2n-muted">· ${m.specialty_count} specialty</span></li>`;
+  }).join('') || '<li class="n2n-muted">no members — add with `netclaw risk add`</li>';
+  return `<div class="n2n-section n2n-federated">
+      <h3>Risk: ${risk.risk_name} (Border)</h3>
+      <div class="detail-row"><span>Stacks</span><strong>${risk.enabled_stacks || '—'}</strong></div>
+      <div class="detail-row"><span>Members</span><strong>${risk.members_active ?? 0}/${risk.member_count ?? 0} active</strong></div>
+      <h4>Member spokes (${members.length})</h4>
+      <ul class="n2n-list">${rows}</ul>
+    </div>`;
+}
+
 function renderFederationSection(peer) {
   const fp = findFederationPeer(peer);
   if (!state.n2n?.available) {
@@ -1451,6 +1504,15 @@ function wireFederationChat(peer) {
 }
 
 function setDetail(kind, payload, related = []) {
+  if (kind === 'local-core') {
+    dom.detailPanel.innerHTML = `
+      <h2>This NetClaw</h2>
+      <p>${state.n2n?.identity || 'local claw'}</p>
+      ${renderRiskSection()}
+    `;
+    return;
+  }
+
   if (kind === 'integration') {
     dom.detailPanel.innerHTML = `
       <h2>${payload.name}</h2>
@@ -2411,6 +2473,8 @@ function onClick(event) {
     if (hitCore === state.localCore) {
       clearSelection();
       focusTarget(state.localCore.position.clone());
+      setDetail('local-core');            // 056: show this claw's risk view (role + member spokes)
+      state.selected = { kind: 'local-core' };
     } else {
       // Peer core selected — show detail
       clearSelection();

--- a/ui/netclaw-visual/src/main.js
+++ b/ui/netclaw-visual/src/main.js
@@ -1215,6 +1215,47 @@ function deduplicatePeers(peers) {
   return [...seen.values()];
 }
 
+// 056: render this risk's member claws as spokes SOUTH of the Border, each a
+// core with its own orbiting skills, colored by class. Additive + guarded.
+function buildRiskMembers() {
+  try {
+    const risk = state.n2n && state.n2n.risk;
+    if (!risk || risk.role !== 'border') return;
+    const members = (state.n2n.members) || [];
+    if (!members.length) return;
+    state.memberCores = state.memberCores || [];
+    const C = CORE_CENTROID;
+    const R = (typeof RISK_LAYOUT !== 'undefined' && RISK_LAYOUT.tierRadius) || 46;
+    const col = (typeof RISK_LAYOUT !== 'undefined' && RISK_LAYOUT.colors) || {};
+    const n = members.length;
+    members.forEach((m, i) => {
+      const frac = n > 1 ? i / (n - 1) : 0.5;
+      const spread = (frac - 0.5) * Math.PI * 0.95;              // fan across the south
+      const px = C.x + Math.sin(spread) * R * 1.6;
+      const pz = C.z - (R + 16) - Math.abs(Math.cos(spread)) * 8; // south = -Z
+      const py = -3 - (i % 4) * 4;                                // stagger so labels don't overlap
+      const pos = new THREE.Vector3(px, py, pz);
+      const dead = (m.state === 'quarantined' || m.state === 'removed');
+      const cold = !m.live;
+      const tint = dead ? (col.memberQuarantined || 0xff5d6c)
+                        : (cold ? 0x3a6ea5 : (col.member || 0x68f5b2));
+      const name = String(m.member_id || 'member').split('/').pop().toUpperCase();
+      const core = buildCore(state.graph.identity, pos, name, tint);
+      core.isMember = true;
+      core.memberPayload = m;
+      core.orbit = { center: C.clone(), radius: pos.distanceTo(C),
+        angle: Math.atan2(pos.z - C.z, pos.x - C.x), y: pos.y, speed: 0.0004 };
+      // orbiting skills only for LIVE members (keep the scene light for cold ones)
+      const names = (m.live ? (m.skills || []) : []).slice(0, 12);
+      core.skillSprites = createSkillSprites(pos, names.map((s) => ({ name: s, id: s })), tint, pos);
+      state.cores.push(core);
+      state.memberCores.push(core);
+    });
+  } catch (e) {
+    console.warn('buildRiskMembers failed (non-fatal):', e);
+  }
+}
+
 function buildPeerRoutes(peerCore, peer) {
   const routes = peer.adjRibIn || [];
   peerCore.routeDendrites = [];
@@ -2983,7 +3024,10 @@ async function boot() {
     // Build local core — shifted left to make room for peer cores
     const hasPeers = state.bgp?.available && state.bgp.peers.length > 0;
     const localPos = hasPeers ? CORE_POSITIONS.local : new THREE.Vector3(0, 0, 0);
-    const localCore = buildCore(state.graph.identity, localPos, state.graph.identity.name.toUpperCase(), 0x66ccff);
+    // 056: a Border claw is the amber center of its risk; else default cyan.
+    const _isBorder = state.n2n?.risk?.role === 'border';
+    const _localTint = _isBorder ? RISK_LAYOUT.colors.border : 0x66ccff;
+    const localCore = buildCore(state.graph.identity, localPos, state.graph.identity.name.toUpperCase(), _localTint);
     // Orbit data for local core — orbits around the centroid
     const lcDist = localPos.distanceTo(CORE_CENTROID);
     localCore.orbit = {
@@ -3031,6 +3075,11 @@ async function boot() {
 
     setLoading(58, 'Rendering integration lattice');
     buildIntegrations(state.graph);
+
+    // 056: iN2N risk — render member claws as spokes SOUTH of the Border, each
+    // with its own orbiting skills, colored by class (green member / red
+    // quarantined / dim cold). Additive + guarded: no-op for standalone claws.
+    buildRiskMembers();
 
     setLoading(72, 'Placing device ring');
     buildDevices(state.graph);

--- a/workspace/skills/n2n-federation/SKILL.md
+++ b/workspace/skills/n2n-federation/SKILL.md
@@ -108,6 +108,46 @@ flapping?"). Anything build- or task-shaped → `n2n_delegate`.
 - `n2n_connect(peer, host, port)` — add + consent + dial in one call.
 - `n2n_trust(peer, tools="a,b", chat=true)` — consent + grants + chat in one call.
 
+## iN2N — internal federation, a "risk" of claws (feature 056)
+
+Everything above is **eN2N** (external N2N): federating with *other operators'*
+claws across the internet. **iN2N** is the internal counterpart: ONE operator
+runs a group of focused claws — a **risk** — coordinated by a single **Border
+Claw**, with the others as tightly-scoped **Member Claws**.
+
+- **You only ever talk to the Border.** It routes each request to the member
+  that owns the capability (`n2n_route`) and returns the result. Members are
+  specialists (a CML claw, a pyATS claw) carrying a handful of skills, not the
+  whole catalog — smaller context, smaller blast radius.
+- **Members dial the Border outbound** over the risk's internal transport — no
+  ngrok, no public mesh, no inbound ports. Trust within the risk is a **pinned
+  self-signed key** bootstrapped by a **single-use enrollment token** (no CA);
+  the eN2N mutual-consent model is only for the boundary *between* risks.
+- **The Border is the single face + audit point.** A peer risk sees one identity
+  (the Border), never member details; all internal + external activity is logged
+  in one place (`channel_kind` en2n/in2n).
+
+### Roles (set at install, or via `netclaw` / `POST /n2n/risk`)
+- **Standalone** — a "risk of one", behaves exactly as a classic NetClaw.
+- **Border** — gateway + eN2N/iN2N/both + routing + audit. Exactly one per risk.
+- **Member** — focused specialist; dials the Border, never federates externally.
+
+### Workflow (on a Border)
+1. `n2n_member_add(name, profile="cml")` — provision a member from a catalog-
+   derived profile (or `custom` + `specialty`); returns a single-use enrollment
+   token + join instructions. It does NOT spawn the member — that is a separate
+   NetClaw install (`N2N_ROLE=member` + the token).
+2. Bring up the member (its own install); it dials the Border and enrolls.
+3. `n2n_member_list` / `n2n_member_health` — see scope, state, quarantine alerts.
+4. `n2n_route("recreate my lab", target_hint="cml-lab-lifecycle")` — the Border
+   picks the right member and delegates (async; poll with `n2n_task_status` /
+   `n2n_task_result`). `netclaw risk route "…"` from the CLI does the same.
+5. `n2n_member_remove(member_id)` — unpin + refuse reconnect (confirm first).
+
+Profiles are derived from the installed catalog by `scripts/in2n-profiles.py`
+(cml, pyats, ipfabric, forward, itential, viz, security). A member repeatedly
+failing auth/health is **auto-quarantined** and surfaced to the operator.
+
 ## Tools used
 
 US1 capability: `n2n_status`, `n2n_consent`, `n2n_kill`, `n2n_peer_capabilities`,
@@ -116,3 +156,5 @@ US1 capability: `n2n_status`, `n2n_consent`, `n2n_kill`, `n2n_peer_capabilities`
 `n2n_approve`, `n2n_deny`, `n2n_audit`, `n2n_config`. US3 chat: `n2n_chat`.
 053 reliability/ergonomics: `n2n_delegate`, `n2n_task_status`,
 `n2n_task_result`, `n2n_task_cancel`, `n2n_health`, `n2n_connect`, `n2n_trust`.
+056 iN2N (risk): `n2n_risk_status`, `n2n_member_list`, `n2n_member_health`,
+`n2n_member_add`, `n2n_enroll_token`, `n2n_member_remove`, `n2n_route`.


### PR DESCRIPTION
## Summary

Adds **iN2N — internal NetClaw federation**: one operator runs a group of focused, specialized NetClaws — a **"risk"** — coordinated by a single **Border Claw**. You talk only to the Border; it routes each request to the member that owns the capability. Complements the frozen **eN2N** (052/053) federation between *different* operators, which is **regression-tested and unchanged**.

Spec: `specs/056-in2n-internal-federation/` (specify → clarify → plan → tasks → analyze → implement).

## Proven LIVE (monolith → 28-claw risk, driven from Slack)
Decomposed John's live ~190-skill monolith into **Border `johns-risk` + 27 members** (4 always-on: cml/pyats/ipfabric/viz; 23 cold/on-demand) **with Nick (AS65007) & Byrn (AS65099) staying eN2N-federated throughout**. Real end-to-end, through the Slack operator path:
- **cml member (Sonnet) → live CML**: `NetClaw-Full-Topo` 10/12 STARTED, `Frankfurt4x` 12/17, `Craig-Demo` 5/6
- **pyats member → live devices**: `R1 Ethernet0/0 | 10.0.0.0/31 | up/up …`
- **github member (Haiku, cold-started on route) → live GitHub**: real repo list
- Border promotion, enrollment (single-use token + pinned self-signed key, TOFU), pinned-key reconnect, tiered models (Border **Opus** / members Sonnet+Haiku, direct Anthropic), Border slimming (MCP 37→5 **and** a dedicated broker workspace/persona so the agent routes instead of answering like the monolith).

## What's here
- **Runtime**: `bgp/federation/{risk,router,internal_channel}.py` + additive edits. Hub-and-spoke, member-initiated dial, signed-nonce pinned-key auth, deterministic routing, cold-start-on-route, scope enforcement, quarantine, **operator poll over the member channel**. Reuses frozen NCFED framing + 053 async delegation.
- **Operator surface**: daemon `/n2n/risk|members|route|enroll|tasks` routes, 7 `n2n-mcp` tools, installer risk/role/profile prompts, `netclaw risk` command.
- **Tooling**: `scripts/in2n-{profiles,member,member-home,border-workspace,migrate}.py` — env-gated profiles, lightweight member launcher, scoped-home + Border-persona generators, generate-only migration scaffold + runbook.
- **HUD**: `/api/n2n` risk/members; Border-center + member-spoke render with per-member skills + detail panel.
- **Docs**: `docs/N2N-RISK.md` (+ live recipe/gotchas), `docs/N2N-RISK-MIGRATION-FOR-PEERS.md`, milestone blog draft, README, `N2N-PEERING-NETCLAWS.md`, SKILL/SOUL/n2n-mcp README, `.env.example`.

## Tests
**89 tests** in `tests/n2n/` — 44 eN2N regression (frozen core intact) + 45 iN2N, including the operator-poll regression that the live Slack test surfaced.

## ⚠️ Known limitation — "production mode" is flagged, NOT yet enforced
`N2N_RISK_MODE=production` sets a flag; the runtime does **not** yet enforce the defense apparatus. Verified live:
- **GAIT**: SQLite audit works and centralizes at the Border (dual-side, `channel_kind=in2n`), but **GAIT-proper (git immutable trail) is not wired** (`audit._gait_ref` is a stub).
- **DefenseClaw**: model I/O currently **bypasses** it (local proxy was down → direct Anthropic).
- **OpenShell**: members run as plain processes — **not sandboxed** yet.

Tracked for a follow-up **spec 057 — iN2N production-mode enforcement**: launch members under OpenShell, route model calls through DefenseClaw (fail-closed), emit GAIT commits, and refuse the "production" label if any are missing. This PR delivers the federation runtime + live-proven decomposition; hardening the production security posture is 057.

## For federated peers
Nick & Byrn: eN2N is frozen; your federation with John's Border continues with **no re-consent** (Border keeps AS65001/4.4.4.4). See `docs/N2N-RISK-MIGRATION-FOR-PEERS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
