### PR TITLE
docs(059): NCFED I-D idnits polish (ASCII + RFC 5737 examples)

### DIFF
--- a/docs/ietf/draft-capobianco-ncfed-00.md
+++ b/docs/ietf/draft-capobianco-ncfed-00.md
@@ -227,7 +227,7 @@ discrimination.
 # Protocol Discrimination {#discrimination}
 
 An NCFED node listens on a single configured TCP port. (In the reference deployment
-this is the operator's BGP/mesh port; NCFED defines no fixed well-known port — see
+this is the operator's BGP/mesh port; NCFED defines no fixed well-known port -- see
 {{iana}}.) The peer that opened the TCP connection is the **initiator** and MUST send
 its protocol preamble (the 0xFF BGP marker, or the 5-octet 'N' magic of
 {{handshake}}) immediately upon connection establishment; the peer that accepted the
@@ -305,7 +305,7 @@ presents its claimed identity to the other at the binary layer. Mutual capabilit
 exchange and the remainder of session establishment then proceed at the JSON-RPC
 layer via `n2n/hello` ({{semantics}}, {{negotiation}}), which the initiator sends
 first. The peer identity used throughout this document is the string
-`as<AS>-<router-id>` (for example, `as65001-4.4.4.4`).
+`as<AS>-<router-id>` (for example, `as65001-192.0.2.1`).
 
 To avoid a simultaneous-open ambiguity (both peers dialing at once), NCFED designates
 a deterministic initiator: of any two peers, the one with the numerically **lower** AS
@@ -506,11 +506,11 @@ version: an unrecognized feature name is simply not used, and no failure is defi
 for a feature one side requires but the other lacks.
 
 Because the binary handshake carries no version indicator, an incompatible change
-cannot be signaled below the JSON-RPC layer, and — as noted in {{handshake}} — a
+cannot be signaled below the JSON-RPC layer, and -- as noted in {{handshake}} -- a
 version octet cannot simply be appended to the handshake. It is RECOMMENDED that any
 future incompatible change be negotiated in-band through this mechanism. A true
-version-negotiation scheme — selecting a common protocol version and defining
-behavior when one side requires a feature the other does not support — is left to a
+version-negotiation scheme -- selecting a common protocol version and defining
+behavior when one side requires a feature the other does not support -- is left to a
 future revision (see {{impl-status}}).
 
 # Capability Cards {#cards}
@@ -526,7 +526,7 @@ An endpoint advertises its capabilities in a card exchanged via `n2n/inventory` 
   `{ "mode", "state", "controls" }` (e.g., mode `production`, state `enforced`, and
   the set of active controls);
 * `llm`: the advertiser's reasoning-model capability, as
-  `{ "primary_model", "guarded" }` — the model family/tier and whether its
+  `{ "primary_model", "guarded" }` -- the model family/tier and whether its
   input/output is routed through a guardrail.
 
 A card MUST NOT contain secrets, credentials, or per-member topology of a risk. A
@@ -536,7 +536,7 @@ tiered models, without revealing individual members.
 Even so, because a card enumerates skills, MCP servers, security posture, and
 reasoning-model family, it discloses metadata about the advertiser's attack surface.
 An endpoint MUST advertise only the subset a given peer is authorized to see, and
-operators SHOULD treat card contents as sensitive — particularly while transport is
+operators SHOULD treat card contents as sensitive -- particularly while transport is
 cleartext ({{seccons-conf}}). A future revision may define a minimized or
 integrity-protected card ({{seccons-priv}}).
 
@@ -550,8 +550,8 @@ example, by the operators exchanging it directly) before consent is granted. Con
 is durable and survives restarts and endpoint (e.g., tunnel address) changes; it is
 keyed by the peer identity, not by a network address.
 
-A peer's federation state is derived from two independent consent bits — the local
-operator's grant and the remote peer's grant — as shown in {{fig-consent}}.
+A peer's federation state is derived from two independent consent bits -- the local
+operator's grant and the remote peer's grant -- as shown in {{fig-consent}}.
 Federation requires both. Which "pending" state a peer occupies depends only on which
 grant has been recorded so far, not on a fixed order.
 
@@ -610,8 +610,8 @@ Member --> Border:  JSON-RPC  in2n/hello | in2n/enroll
 {: #fig-in2n-preamble title="iN2N transport preamble"}
 
 The trailing "1" in the "IN2N1" magic is a preamble version digit. The exact JSON
-parameters and their encodings — PEM certificate, hexadecimal DER-encoded ECDSA
-signature, and hexadecimal key fingerprint — are specified in {{method-ref}}.
+parameters and their encodings -- PEM certificate, hexadecimal DER-encoded ECDSA
+signature, and hexadecimal key fingerprint -- are specified in {{method-ref}}.
 
 Enrollment and pinning:
 
@@ -637,7 +637,7 @@ deterministically (most-specific specialist first, then lexicographically by mem
 identity); if no active member covers the capability it returns NO_CAPABLE_MEMBER,
 and a member asked to act beyond its advertised scope returns OUT_OF_SCOPE. Operator
 removal of a member unpins its key; a member that fails pinned-key authentication more
-than a configurable number of times is automatically quarantined — its key unpinned —
+than a configurable number of times is automatically quarantined -- its key unpinned --
 and must be re-enrolled by the operator to return. The security implications of this
 automatic quarantine are discussed in {{seccons-tofu}}.
 
@@ -650,7 +650,7 @@ the iN2N socket for members reached across an untrusted network; it uses the mem
 self-signed certificate {{RFC5280}} with certificate verification disabled, so it
 supplies confidentiality only and establishes no channel binding. Consequently the
 current design does not exclude an active on-path attacker between a member and its
-Border; the intended hardening — mutual key pinning and channel binding — is described
+Border; the intended hardening -- mutual key pinning and channel binding -- is described
 in {{seccons-peer-auth}}.
 
 # Operational Considerations {#operational}
@@ -676,7 +676,7 @@ in {{seccons-peer-auth}}.
 Because NCFED, BGP-4, and NCTUN share a TCP listening port ({{discrimination}}), the
 NCFED discrimination and handshake parsers are reachable by any host that can reach
 the BGP port. Operators SHOULD protect the shared port with the same controls they
-apply to BGP peers — for example, access-control lists restricting the permitted
+apply to BGP peers -- for example, access-control lists restricting the permitted
 source addresses and, where the deployment allows, the Generalized TTL Security
 Mechanism {{RFC5082}}. Implementations MUST enforce the discrimination read timeouts
 ({{discrimination}}: 30 s for the first octet, 10 s for the magic) and close on any
@@ -736,7 +736,7 @@ The automatic quarantine that unpins a member after repeated failed authenticati
 ({{trust-in2n}}) is itself an availability hazard: an attacker who learns a member
 identifier and can reach the Border's iN2N listener can submit repeated failing
 authentications to drive that member over the quarantine threshold, unpinning it and
-removing it from routing — a denial of service against a legitimate member. Operators
+removing it from routing -- a denial of service against a legitimate member. Operators
 SHOULD restrict reachability of the iN2N listener to member hosts, and a future
 revision SHOULD source-bind or rate-limit failed-authentication accounting rather than
 counting unauthenticated attempts globally (see {{impl-status}}).
@@ -747,7 +747,7 @@ NCFED runs in cleartext by default; it provides neither confidentiality nor
 transport-layer integrity on its own. In the reference deployment it runs over
 private, overlay, or tunneled transports between mutually known peers. For any path
 that crosses an untrusted network, deployments SHOULD carry NCFED over an encrypted
-underlay or tunnel — for example an encrypted data-plane tunnel, a VPN such as
+underlay or tunnel -- for example an encrypted data-plane tunnel, a VPN such as
 WireGuard {{WIREGUARD}}, or a TLS {{RFC8446}} tunnel that terminates below NCFED.
 NCFED does not itself perform a TLS handshake on the shared discrimination port: a
 direct TLS ClientHello is not a recognized discriminator value and is closed
@@ -846,7 +846,7 @@ AS/router-id and mutual consent) and coordinates one operator's agents in a
 hub-and-spoke risk (iN2N, enrollment-token + TOFU), and it **carries** MCP and A2A
 payloads rather than defining new agent-card or task semantics of its own. A
 one-sentence differentiation: *NCFED is a cross-operator federation, identity, and
-transport layer — multiplexed with BGP — that transports A2A/MCP between
+transport layer -- multiplexed with BGP -- that transports A2A/MCP between
 independently operated network agents.*
 
 Hub-and-spoke (rather than a full mesh) was chosen for iN2N so that a single Border
@@ -876,19 +876,19 @@ application-level round-trips were exercised:
 * One long-lived TCP conversation, `192.168.2.61:45722` <-> `13.58.157.220:10416`
   (the initiator to the peer's tunnel edge); 24 packets, 3141 octets, near-symmetric
   (13 in / 1567 octets, 11 out / 1574 octets).
-* TCP health: only ACK and PSH-ACK segments in-window (no SYN/FIN/RST — a persistent,
+* TCP health: only ACK and PSH-ACK segments in-window (no SYN/FIN/RST -- a persistent,
   already-established control channel), with zero retransmissions and zero duplicate
   ACKs.
 * Payload segmentation: 12 zero-length (pure-ACK) segments plus data segments of 5,
-  75, 110, 127, 153, 274, and 352 octets — small, bursty, and request/response-shaped,
+  75, 110, 127, 153, 274, and 352 octets -- small, bursty, and request/response-shaped,
   consistent with a control/chat protocol rather than bulk transfer.
 
 **Capture methodology and limitations (important, honest scope):** this capture was
 taken on the wire *inside the peer's TLS-terminated tunnel transport* (the deployment
 reaches the remote AS over a tunnel provider). The captured payload octets are
 therefore **ciphertext**: the capture is accurate, first-hand evidence of the NCFED
-**channel** — real endpoints, a persistent established session, healthy TCP, and a
-request/response traffic shape between two independently operated ASes — but it does
+**channel** -- real endpoints, a persistent established session, healthy TCP, and a
+request/response traffic shape between two independently operated ASes -- but it does
 **not** expose decrypted NCFED frames, so the segment sizes above are TLS-record
 sizes carrying NCFED, not raw NCFED frame boundaries. A plaintext capture of the NCFED
 frames themselves requires capturing at the application layer (e.g., on loopback,
@@ -931,11 +931,11 @@ SubjectPublicKeyInfo {{RFC5480}}. Examples are illustrative.
 
 ## eN2N methods
 
-`n2n/hello` — request `params` and `result` share the descriptor shape:
+`n2n/hello` -- request `params` and `result` share the descriptor shape:
 
 ~~~
 params: {
-  "identity": "as65001-4.4.4.4",
+  "identity": "as65001-192.0.2.1",
   "display_name": "johns-risk",
   "versions": ["1.0"],
   "capabilities": {
@@ -951,7 +951,7 @@ result: {
 }
 ~~~
 
-`n2n/tools/call` — the `tool` member MUST have the form `server_id/tool_name`;
+`n2n/tools/call` -- the `tool` member MUST have the form `server_id/tool_name`;
 otherwise the callee returns JSON-RPC error -32602 (invalid params). The `result` is
 the MCP {{MCP}} tool-result object from the named server. Authorization failures use
 the codes of {{errors}}.
@@ -959,19 +959,19 @@ the codes of {{errors}}.
 ~~~
 params: { "tool":       "<server_id>/<tool_name>",
           "arguments":  { ...tool-specific JSON... },
-          "request_id": "as65001-4.4.4.4:42" }
+          "request_id": "as65001-192.0.2.1:42" }
 ~~~
 
-`n2n/tasks/submit` — A2A-style {{A2A}} delegation:
+`n2n/tasks/submit` -- A2A-style {{A2A}} delegation:
 
 ~~~
 params: { "skill":      "<skill-name>",
           "input_text": "<free text passed to the skill>",
-          "request_id": "as65001-4.4.4.4:43" }
+          "request_id": "as65001-192.0.2.1:43" }
 result: { "task_id": "<opaque string>", "state": "submitted" }
 ~~~
 
-`n2n/tasks/status`, `n2n/tasks/result`, `n2n/tasks/cancel` — each takes
+`n2n/tasks/status`, `n2n/tasks/result`, `n2n/tasks/cancel` -- each takes
 `params: { "task_id": "<opaque string>" }` and returns:
 
 ~~~
@@ -988,7 +988,7 @@ result: {
 cancel: { "task_id": "...", "cancelled": <boolean> }
 ~~~
 
-`n2n/inventory`, `n2n/inventory_get` — push and pull of the capability card
+`n2n/inventory`, `n2n/inventory_get` -- push and pull of the capability card
 ({{cards}}).
 
 ## iN2N methods
@@ -997,7 +997,7 @@ Each iN2N method is sent by the member after receiving the Border's "IN2N1" prea
 and 32-octet nonce ({{trust-in2n}}); the `signature` proves possession of the
 member's pinned key over that nonce.
 
-`in2n/enroll` — first contact. On success the Border spends the token and pins the
+`in2n/enroll` -- first contact. On success the Border spends the token and pins the
 certificate's SubjectPublicKeyInfo. Errors: NOT_A_BORDER (-32024); MEMBER_NOT_TRUSTED
 (-32023) on possession failure; ENROLL_TOKEN_INVALID (-32021) for a spent or expired
 token, or a member identifier already pinned to another key ({{errors}}).
@@ -1013,7 +1013,7 @@ params: { "token":             "in2n_<url-safe random>",
           "transport_binding": "distributed" }
 ~~~
 
-`in2n/hello` — reconnect. A mismatched fingerprint or signature returns
+`in2n/hello` -- reconnect. A mismatched fingerprint or signature returns
 MEMBER_NOT_TRUSTED (-32023) and counts toward auto-quarantine ({{seccons-tofu}}).
 
 ~~~
@@ -1027,6 +1027,6 @@ result: { "risk": "<risk name>", "trusted": true,
 # Acknowledgments
 {:numbered="false"}
 
-Thanks to the operators of the first three-node NCFED mesh — Nicholas (AS 65007) and
-Byrn (AS 65099) — for interoperation testing, and to the reviewers of the NetClaw
+Thanks to the operators of the first three-node NCFED mesh -- Nicholas (AS 65007) and
+Byrn (AS 65099) -- for interoperation testing, and to the reviewers of the NetClaw
 project.

--- a/docs/ietf/rendered/draft-capobianco-ncfed-00.html
+++ b/docs/ietf/rendered/draft-capobianco-ncfed-00.html
@@ -1658,7 +1658,7 @@ discrimination.<a href="#section-3-3" class="pilcrow">¶</a></p>
 <a href="#section-4" class="section-number selfRef">4. </a><a href="#name-protocol-discrimination" class="section-name selfRef">Protocol Discrimination</a>
       </h2>
 <p id="section-4-1">An NCFED node listens on a single configured TCP port. (In the reference deployment
-this is the operator's BGP/mesh port; NCFED defines no fixed well-known port — see
+this is the operator's BGP/mesh port; NCFED defines no fixed well-known port -- see
 <a href="#iana" class="auto internal xref">Section 14</a>.) The peer that opened the TCP connection is the <strong>initiator</strong> and <span class="bcp14">MUST</span> send
 its protocol preamble (the 0xFF BGP marker, or the 5-octet 'N' magic of
 <a href="#handshake" class="auto internal xref">Section 5</a>) immediately upon connection establishment; the peer that accepted the
@@ -1753,7 +1753,7 @@ presents its claimed identity to the other at the binary layer. Mutual capabilit
 exchange and the remainder of session establishment then proceed at the JSON-RPC
 layer via <code>n2n/hello</code> (<a href="#semantics" class="auto internal xref">Section 8</a>, <a href="#negotiation" class="auto internal xref">Section 9</a>), which the initiator sends
 first. The peer identity used throughout this document is the string
-<code>as&lt;AS&gt;-&lt;router-id&gt;</code> (for example, <code>as65001-4.4.4.4</code>).<a href="#section-5-4" class="pilcrow">¶</a></p>
+<code>as&lt;AS&gt;-&lt;router-id&gt;</code> (for example, <code>as65001-192.0.2.1</code>).<a href="#section-5-4" class="pilcrow">¶</a></p>
 <p id="section-5-5">To avoid a simultaneous-open ambiguity (both peers dialing at once), NCFED designates
 a deterministic initiator: of any two peers, the one with the numerically <strong>lower</strong> AS
 number opens the channel, and the peer with the higher or equal AS number only
@@ -2062,11 +2062,11 @@ feature advertisement with graceful degradation, not selection of a single commo
 version: an unrecognized feature name is simply not used, and no failure is defined
 for a feature one side requires but the other lacks.<a href="#section-9-3" class="pilcrow">¶</a></p>
 <p id="section-9-4">Because the binary handshake carries no version indicator, an incompatible change
-cannot be signaled below the JSON-RPC layer, and — as noted in <a href="#handshake" class="auto internal xref">Section 5</a> — a
+cannot be signaled below the JSON-RPC layer, and -- as noted in <a href="#handshake" class="auto internal xref">Section 5</a> -- a
 version octet cannot simply be appended to the handshake. It is <span class="bcp14">RECOMMENDED</span> that any
 future incompatible change be negotiated in-band through this mechanism. A true
-version-negotiation scheme — selecting a common protocol version and defining
-behavior when one side requires a feature the other does not support — is left to a
+version-negotiation scheme -- selecting a common protocol version and defining
+behavior when one side requires a feature the other does not support -- is left to a
 future revision (see <a href="#impl-status" class="auto internal xref">Appendix B</a>).<a href="#section-9-4" class="pilcrow">¶</a></p>
 </section>
 </div>
@@ -2093,7 +2093,7 @@ the set of active controls);<a href="#section-10-2.3.1" class="pilcrow">¶</a></
 </li>
         <li class="normal" id="section-10-2.4">
           <p id="section-10-2.4.1"><code>llm</code>: the advertiser's reasoning-model capability, as
-<code>{ "primary_model", "guarded" }</code> — the model family/tier and whether its
+<code>{ "primary_model", "guarded" }</code> -- the model family/tier and whether its
 input/output is routed through a guardrail.<a href="#section-10-2.4.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
@@ -2103,7 +2103,7 @@ tiered models, without revealing individual members.<a href="#section-10-3" clas
 <p id="section-10-4">Even so, because a card enumerates skills, MCP servers, security posture, and
 reasoning-model family, it discloses metadata about the advertiser's attack surface.
 An endpoint <span class="bcp14">MUST</span> advertise only the subset a given peer is authorized to see, and
-operators <span class="bcp14">SHOULD</span> treat card contents as sensitive — particularly while transport is
+operators <span class="bcp14">SHOULD</span> treat card contents as sensitive -- particularly while transport is
 cleartext (<a href="#seccons-conf" class="auto internal xref">Section 13.4</a>). A future revision may define a minimized or
 integrity-protected card (<a href="#seccons-priv" class="auto internal xref">Section 13.7</a>).<a href="#section-10-4" class="pilcrow">¶</a></p>
 </section>
@@ -2123,8 +2123,8 @@ consent. The AS/router-id identity of each peer is confirmed <strong>out of band
 example, by the operators exchanging it directly) before consent is granted. Consent
 is durable and survives restarts and endpoint (e.g., tunnel address) changes; it is
 keyed by the peer identity, not by a network address.<a href="#section-11.1-1" class="pilcrow">¶</a></p>
-<p id="section-11.1-2">A peer's federation state is derived from two independent consent bits — the local
-operator's grant and the remote peer's grant — as shown in <a href="#fig-consent" class="auto internal xref">Figure 4</a>.
+<p id="section-11.1-2">A peer's federation state is derived from two independent consent bits -- the local
+operator's grant and the remote peer's grant -- as shown in <a href="#fig-consent" class="auto internal xref">Figure 4</a>.
 Federation requires both. Which "pending" state a peer occupies depends only on which
 grant has been recorded so far, not on a fixed order.<a href="#section-11.1-2" class="pilcrow">¶</a></p>
 <span id="name-en2n-consent-state-derived-"></span><div id="fig-consent">
@@ -2195,8 +2195,8 @@ Member --&gt; Border:  JSON-RPC  in2n/hello | in2n/enroll
           </figcaption></figure>
 </div>
 <p id="section-11.2-4">The trailing "1" in the "IN2N1" magic is a preamble version digit. The exact JSON
-parameters and their encodings — PEM certificate, hexadecimal DER-encoded ECDSA
-signature, and hexadecimal key fingerprint — are specified in <a href="#method-ref" class="auto internal xref">Appendix C</a>.<a href="#section-11.2-4" class="pilcrow">¶</a></p>
+parameters and their encodings -- PEM certificate, hexadecimal DER-encoded ECDSA
+signature, and hexadecimal key fingerprint -- are specified in <a href="#method-ref" class="auto internal xref">Appendix C</a>.<a href="#section-11.2-4" class="pilcrow">¶</a></p>
 <p id="section-11.2-5">Enrollment and pinning:<a href="#section-11.2-5" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="section-11.2-6">
 <li id="section-11.2-6.1">
@@ -2226,7 +2226,7 @@ deterministically (most-specific specialist first, then lexicographically by mem
 identity); if no active member covers the capability it returns NO_CAPABLE_MEMBER,
 and a member asked to act beyond its advertised scope returns OUT_OF_SCOPE. Operator
 removal of a member unpins its key; a member that fails pinned-key authentication more
-than a configurable number of times is automatically quarantined — its key unpinned —
+than a configurable number of times is automatically quarantined -- its key unpinned --
 and must be re-enrolled by the operator to return. The security implications of this
 automatic quarantine are discussed in <a href="#seccons-tofu" class="auto internal xref">Section 13.3</a>.<a href="#section-11.2-7" class="pilcrow">¶</a></p>
 <p id="section-11.2-8">iN2N authenticates the member to the Border: the member proves possession of its
@@ -2238,7 +2238,7 @@ the iN2N socket for members reached across an untrusted network; it uses the mem
 self-signed certificate <span>[<a href="#RFC5280" class="cite xref">RFC5280</a>]</span> with certificate verification disabled, so it
 supplies confidentiality only and establishes no channel binding. Consequently the
 current design does not exclude an active on-path attacker between a member and its
-Border; the intended hardening — mutual key pinning and channel binding — is described
+Border; the intended hardening -- mutual key pinning and channel binding -- is described
 in <a href="#seccons-peer-auth" class="auto internal xref">Section 13.2</a>.<a href="#section-11.2-8" class="pilcrow">¶</a></p>
 </section>
 </div>
@@ -2284,7 +2284,7 @@ change is required for that case.<a href="#section-12-1.4.1" class="pilcrow">¶<
 <p id="section-13.1-1">Because NCFED, BGP-4, and NCTUN share a TCP listening port (<a href="#discrimination" class="auto internal xref">Section 4</a>), the
 NCFED discrimination and handshake parsers are reachable by any host that can reach
 the BGP port. Operators <span class="bcp14">SHOULD</span> protect the shared port with the same controls they
-apply to BGP peers — for example, access-control lists restricting the permitted
+apply to BGP peers -- for example, access-control lists restricting the permitted
 source addresses and, where the deployment allows, the Generalized TTL Security
 Mechanism <span>[<a href="#RFC5082" class="cite xref">RFC5082</a>]</span>. Implementations <span class="bcp14">MUST</span> enforce the discrimination read timeouts
 (<a href="#discrimination" class="auto internal xref">Section 4</a>: 30 s for the first octet, 10 s for the magic) and close on any
@@ -2349,7 +2349,7 @@ for a PKI.<a href="#section-13.3-1" class="pilcrow">¶</a></p>
 (<a href="#trust-in2n" class="auto internal xref">Section 11.2</a>) is itself an availability hazard: an attacker who learns a member
 identifier and can reach the Border's iN2N listener can submit repeated failing
 authentications to drive that member over the quarantine threshold, unpinning it and
-removing it from routing — a denial of service against a legitimate member. Operators
+removing it from routing -- a denial of service against a legitimate member. Operators
 <span class="bcp14">SHOULD</span> restrict reachability of the iN2N listener to member hosts, and a future
 revision <span class="bcp14">SHOULD</span> source-bind or rate-limit failed-authentication accounting rather than
 counting unauthenticated attempts globally (see <a href="#impl-status" class="auto internal xref">Appendix B</a>).<a href="#section-13.3-2" class="pilcrow">¶</a></p>
@@ -2364,7 +2364,7 @@ counting unauthenticated attempts globally (see <a href="#impl-status" class="au
 transport-layer integrity on its own. In the reference deployment it runs over
 private, overlay, or tunneled transports between mutually known peers. For any path
 that crosses an untrusted network, deployments <span class="bcp14">SHOULD</span> carry NCFED over an encrypted
-underlay or tunnel — for example an encrypted data-plane tunnel, a VPN such as
+underlay or tunnel -- for example an encrypted data-plane tunnel, a VPN such as
 WireGuard <span>[<a href="#WIREGUARD" class="cite xref">WIREGUARD</a>]</span>, or a TLS <span>[<a href="#RFC8446" class="cite xref">RFC8446</a>]</span> tunnel that terminates below NCFED.
 NCFED does not itself perform a TLS handshake on the shared discrimination port: a
 direct TLS ClientHello is not a recognized discriminator value and is closed
@@ -2619,7 +2619,7 @@ AS/router-id and mutual consent) and coordinates one operator's agents in a
 hub-and-spoke risk (iN2N, enrollment-token + TOFU), and it <strong>carries</strong> MCP and A2A
 payloads rather than defining new agent-card or task semantics of its own. A
 one-sentence differentiation: <em>NCFED is a cross-operator federation, identity, and
-transport layer — multiplexed with BGP — that transports A2A/MCP between
+transport layer -- multiplexed with BGP -- that transports A2A/MCP between
 independently operated network agents.</em><a href="#appendix-A-2" class="pilcrow">¶</a></p>
 <p id="appendix-A-3">Hub-and-spoke (rather than a full mesh) was chosen for iN2N so that a single Border
 provides one audit, policy, and routing boundary and one external identity for a
@@ -2653,13 +2653,13 @@ application-level round-trips were exercised:<a href="#appendix-B-4" class="pilc
 (13 in / 1567 octets, 11 out / 1574 octets).<a href="#appendix-B-5.1.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-B-5.2">
-          <p id="appendix-B-5.2.1">TCP health: only ACK and PSH-ACK segments in-window (no SYN/FIN/RST — a persistent,
+          <p id="appendix-B-5.2.1">TCP health: only ACK and PSH-ACK segments in-window (no SYN/FIN/RST -- a persistent,
 already-established control channel), with zero retransmissions and zero duplicate
 ACKs.<a href="#appendix-B-5.2.1" class="pilcrow">¶</a></p>
 </li>
         <li class="normal" id="appendix-B-5.3">
           <p id="appendix-B-5.3.1">Payload segmentation: 12 zero-length (pure-ACK) segments plus data segments of 5,
-75, 110, 127, 153, 274, and 352 octets — small, bursty, and request/response-shaped,
+75, 110, 127, 153, 274, and 352 octets -- small, bursty, and request/response-shaped,
 consistent with a control/chat protocol rather than bulk transfer.<a href="#appendix-B-5.3.1" class="pilcrow">¶</a></p>
 </li>
       </ul>
@@ -2667,8 +2667,8 @@ consistent with a control/chat protocol rather than bulk transfer.<a href="#appe
 taken on the wire <em>inside the peer's TLS-terminated tunnel transport</em> (the deployment
 reaches the remote AS over a tunnel provider). The captured payload octets are
 therefore <strong>ciphertext</strong>: the capture is accurate, first-hand evidence of the NCFED
-<strong>channel</strong> — real endpoints, a persistent established session, healthy TCP, and a
-request/response traffic shape between two independently operated ASes — but it does
+<strong>channel</strong> -- real endpoints, a persistent established session, healthy TCP, and a
+request/response traffic shape between two independently operated ASes -- but it does
 <strong>not</strong> expose decrypted NCFED frames, so the segment sizes above are TLS-record
 sizes carrying NCFED, not raw NCFED frame boundaries. A plaintext capture of the NCFED
 frames themselves requires capturing at the application layer (e.g., on loopback,
@@ -2728,11 +2728,11 @@ SubjectPublicKeyInfo <span>[<a href="#RFC5480" class="cite xref">RFC5480</a>]</s
         <h3 id="name-en2n-methods">
 <a href="#appendix-C.1" class="section-number selfRef">C.1. </a><a href="#name-en2n-methods" class="section-name selfRef">eN2N methods</a>
         </h3>
-<p id="appendix-C.1-1"><code>n2n/hello</code> — request <code>params</code> and <code>result</code> share the descriptor shape:<a href="#appendix-C.1-1" class="pilcrow">¶</a></p>
+<p id="appendix-C.1-1"><code>n2n/hello</code> -- request <code>params</code> and <code>result</code> share the descriptor shape:<a href="#appendix-C.1-1" class="pilcrow">¶</a></p>
 <div class="alignLeft art-text artwork" id="appendix-C.1-2">
 <pre>
 params: {
-  "identity": "as65001-4.4.4.4",
+  "identity": "as65001-192.0.2.1",
   "display_name": "johns-risk",
   "versions": ["1.0"],
   "capabilities": {
@@ -2748,7 +2748,7 @@ result: {
 }
 </pre><a href="#appendix-C.1-2" class="pilcrow">¶</a>
 </div>
-<p id="appendix-C.1-3"><code>n2n/tools/call</code> — the <code>tool</code> member <span class="bcp14">MUST</span> have the form <code>server_id/tool_name</code>;
+<p id="appendix-C.1-3"><code>n2n/tools/call</code> -- the <code>tool</code> member <span class="bcp14">MUST</span> have the form <code>server_id/tool_name</code>;
 otherwise the callee returns JSON-RPC error -32602 (invalid params). The <code>result</code> is
 the MCP <span>[<a href="#MCP" class="cite xref">MCP</a>]</span> tool-result object from the named server. Authorization failures use
 the codes of <a href="#errors" class="auto internal xref">Section 8.3</a>.<a href="#appendix-C.1-3" class="pilcrow">¶</a></p>
@@ -2756,19 +2756,19 @@ the codes of <a href="#errors" class="auto internal xref">Section 8.3</a>.<a hre
 <pre>
 params: { "tool":       "&lt;server_id&gt;/&lt;tool_name&gt;",
           "arguments":  { ...tool-specific JSON... },
-          "request_id": "as65001-4.4.4.4:42" }
+          "request_id": "as65001-192.0.2.1:42" }
 </pre><a href="#appendix-C.1-4" class="pilcrow">¶</a>
 </div>
-<p id="appendix-C.1-5"><code>n2n/tasks/submit</code> — A2A-style <span>[<a href="#A2A" class="cite xref">A2A</a>]</span> delegation:<a href="#appendix-C.1-5" class="pilcrow">¶</a></p>
+<p id="appendix-C.1-5"><code>n2n/tasks/submit</code> -- A2A-style <span>[<a href="#A2A" class="cite xref">A2A</a>]</span> delegation:<a href="#appendix-C.1-5" class="pilcrow">¶</a></p>
 <div class="alignLeft art-text artwork" id="appendix-C.1-6">
 <pre>
 params: { "skill":      "&lt;skill-name&gt;",
           "input_text": "&lt;free text passed to the skill&gt;",
-          "request_id": "as65001-4.4.4.4:43" }
+          "request_id": "as65001-192.0.2.1:43" }
 result: { "task_id": "&lt;opaque string&gt;", "state": "submitted" }
 </pre><a href="#appendix-C.1-6" class="pilcrow">¶</a>
 </div>
-<p id="appendix-C.1-7"><code>n2n/tasks/status</code>, <code>n2n/tasks/result</code>, <code>n2n/tasks/cancel</code> — each takes
+<p id="appendix-C.1-7"><code>n2n/tasks/status</code>, <code>n2n/tasks/result</code>, <code>n2n/tasks/cancel</code> -- each takes
 <code>params: { "task_id": "&lt;opaque string&gt;" }</code> and returns:<a href="#appendix-C.1-7" class="pilcrow">¶</a></p>
 <div class="alignLeft art-text artwork" id="appendix-C.1-8">
 <pre>
@@ -2785,7 +2785,7 @@ result: {
 cancel: { "task_id": "...", "cancelled": &lt;boolean&gt; }
 </pre><a href="#appendix-C.1-8" class="pilcrow">¶</a>
 </div>
-<p id="appendix-C.1-9"><code>n2n/inventory</code>, <code>n2n/inventory_get</code> — push and pull of the capability card
+<p id="appendix-C.1-9"><code>n2n/inventory</code>, <code>n2n/inventory_get</code> -- push and pull of the capability card
 (<a href="#cards" class="auto internal xref">Section 10</a>).<a href="#appendix-C.1-9" class="pilcrow">¶</a></p>
 </section>
 </div>
@@ -2797,7 +2797,7 @@ cancel: { "task_id": "...", "cancelled": &lt;boolean&gt; }
 <p id="appendix-C.2-1">Each iN2N method is sent by the member after receiving the Border's "IN2N1" preamble
 and 32-octet nonce (<a href="#trust-in2n" class="auto internal xref">Section 11.2</a>); the <code>signature</code> proves possession of the
 member's pinned key over that nonce.<a href="#appendix-C.2-1" class="pilcrow">¶</a></p>
-<p id="appendix-C.2-2"><code>in2n/enroll</code> — first contact. On success the Border spends the token and pins the
+<p id="appendix-C.2-2"><code>in2n/enroll</code> -- first contact. On success the Border spends the token and pins the
 certificate's SubjectPublicKeyInfo. Errors: NOT_A_BORDER (-32024); MEMBER_NOT_TRUSTED
 (-32023) on possession failure; ENROLL_TOKEN_INVALID (-32021) for a spent or expired
 token, or a member identifier already pinned to another key (<a href="#errors" class="auto internal xref">Section 8.3</a>).<a href="#appendix-C.2-2" class="pilcrow">¶</a></p>
@@ -2813,7 +2813,7 @@ params: { "token":             "in2n_&lt;url-safe random&gt;",
           "transport_binding": "distributed" }
 </pre><a href="#appendix-C.2-3" class="pilcrow">¶</a>
 </div>
-<p id="appendix-C.2-4"><code>in2n/hello</code> — reconnect. A mismatched fingerprint or signature returns
+<p id="appendix-C.2-4"><code>in2n/hello</code> -- reconnect. A mismatched fingerprint or signature returns
 MEMBER_NOT_TRUSTED (-32023) and counts toward auto-quarantine (<a href="#seccons-tofu" class="auto internal xref">Section 13.3</a>).<a href="#appendix-C.2-4" class="pilcrow">¶</a></p>
 <div class="alignLeft art-text artwork" id="appendix-C.2-5">
 <pre>
@@ -2833,8 +2833,8 @@ result: { "risk": "&lt;risk name&gt;", "trusted": true,
       <h2 id="name-acknowledgments">
 <a href="#name-acknowledgments" class="section-name selfRef">Acknowledgments</a>
       </h2>
-<p id="appendix-D-1">Thanks to the operators of the first three-node NCFED mesh — Nicholas (AS 65007) and
-Byrn (AS 65099) — for interoperation testing, and to the reviewers of the NetClaw
+<p id="appendix-D-1">Thanks to the operators of the first three-node NCFED mesh -- Nicholas (AS 65007) and
+Byrn (AS 65099) -- for interoperation testing, and to the reviewers of the NetClaw
 project.<a href="#appendix-D-1" class="pilcrow">¶</a></p>
 </section>
 </div>

--- a/docs/ietf/rendered/draft-capobianco-ncfed-00.txt
+++ b/docs/ietf/rendered/draft-capobianco-ncfed-00.txt
@@ -313,7 +313,7 @@ Internet-Draft                    NCFED                        July 2026
 
    An NCFED node listens on a single configured TCP port.  (In the
    reference deployment this is the operator's BGP/mesh port; NCFED
-   defines no fixed well-known port — see Section 14.)  The peer that
+   defines no fixed well-known port -- see Section 14.)  The peer that
    opened the TCP connection is the *initiator* and MUST send its
    protocol preamble (the 0xFF BGP marker, or the 5-octet 'N' magic of
    Section 5) immediately upon connection establishment; the peer that
@@ -425,7 +425,7 @@ Internet-Draft                    NCFED                        July 2026
    remainder of session establishment then proceed at the JSON-RPC layer
    via n2n/hello (Section 8, Section 9), which the initiator sends
    first.  The peer identity used throughout this document is the string
-   as<AS>-<router-id> (for example, as65001-4.4.4.4).
+   as<AS>-<router-id> (for example, as65001-192.0.2.1).
 
    To avoid a simultaneous-open ambiguity (both peers dialing at once),
    NCFED designates a deterministic initiator: of any two peers, the one
@@ -732,12 +732,12 @@ Internet-Draft                    NCFED                        July 2026
 
    Because the binary handshake carries no version indicator, an
    incompatible change cannot be signaled below the JSON-RPC layer, and
-   — as noted in Section 5 — a version octet cannot simply be appended
+   -- as noted in Section 5 -- a version octet cannot simply be appended
    to the handshake.  It is RECOMMENDED that any future incompatible
    change be negotiated in-band through this mechanism.  A true version-
-   negotiation scheme — selecting a common protocol version and defining
-   behavior when one side requires a feature the other does not support
-   — is left to a future revision (see Appendix B).
+   negotiation scheme -- selecting a common protocol version and
+   defining behavior when one side requires a feature the other does not
+   support -- is left to a future revision (see Appendix B).
 
 10.  Capability Cards
 
@@ -755,7 +755,7 @@ Internet-Draft                    NCFED                        July 2026
       enforced, and the set of active controls);
 
    *  llm: the advertiser's reasoning-model capability, as {
-      "primary_model", "guarded" } — the model family/tier and whether
+      "primary_model", "guarded" } -- the model family/tier and whether
       its input/output is routed through a guardrail.
 
    A card MUST NOT contain secrets, credentials, or per-member topology
@@ -767,7 +767,7 @@ Internet-Draft                    NCFED                        July 2026
    posture, and reasoning-model family, it discloses metadata about the
    advertiser's attack surface.  An endpoint MUST advertise only the
    subset a given peer is authorized to see, and operators SHOULD treat
-   card contents as sensitive — particularly while transport is
+   card contents as sensitive -- particularly while transport is
    cleartext (Section 13.4).  A future revision may define a minimized
    or integrity-protected card (Section 13.7).
 
@@ -796,7 +796,7 @@ Internet-Draft                    NCFED                        July 2026
    the peer identity, not by a network address.
 
    A peer's federation state is derived from two independent consent
-   bits — the local operator's grant and the remote peer's grant — as
+   bits -- the local operator's grant and the remote peer's grant -- as
    shown in Figure 4.  Federation requires both.  Which "pending" state
    a peer occupies depends only on which grant has been recorded so far,
    not on a fixed order.
@@ -866,9 +866,9 @@ Internet-Draft                    NCFED                        July 2026
                     Figure 5: iN2N transport preamble
 
    The trailing "1" in the "IN2N1" magic is a preamble version digit.
-   The exact JSON parameters and their encodings — PEM certificate,
+   The exact JSON parameters and their encodings -- PEM certificate,
    hexadecimal DER-encoded ECDSA signature, and hexadecimal key
-   fingerprint — are specified in Appendix C.
+   fingerprint -- are specified in Appendix C.
 
    Enrollment and pinning:
 
@@ -905,7 +905,7 @@ Internet-Draft                    NCFED                        July 2026
    beyond its advertised scope returns OUT_OF_SCOPE.  Operator removal
    of a member unpins its key; a member that fails pinned-key
    authentication more than a configurable number of times is
-   automatically quarantined — its key unpinned — and must be re-
+   automatically quarantined -- its key unpinned -- and must be re-
    enrolled by the operator to return.  The security implications of
    this automatic quarantine are discussed in Section 13.3.
 
@@ -920,8 +920,8 @@ Internet-Draft                    NCFED                        July 2026
    [RFC5280] with certificate verification disabled, so it supplies
    confidentiality only and establishes no channel binding.
    Consequently the current design does not exclude an active on-path
-   attacker between a member and its Border; the intended hardening —
-   mutual key pinning and channel binding — is described in
+   attacker between a member and its Border; the intended hardening --
+   mutual key pinning and channel binding -- is described in
    Section 13.2.
 
 12.  Operational Considerations
@@ -962,7 +962,7 @@ Internet-Draft                    NCFED                        July 2026
    (Section 4), the NCFED discrimination and handshake parsers are
    reachable by any host that can reach the BGP port.  Operators SHOULD
    protect the shared port with the same controls they apply to BGP
-   peers — for example, access-control lists restricting the permitted
+   peers -- for example, access-control lists restricting the permitted
    source addresses and, where the deployment allows, the Generalized
    TTL Security Mechanism [RFC5082].  Implementations MUST enforce the
    discrimination read timeouts (Section 4: 30 s for the first octet, 10
@@ -1042,7 +1042,7 @@ Internet-Draft                    NCFED                        July 2026
    attacker who learns a member identifier and can reach the Border's
    iN2N listener can submit repeated failing authentications to drive
    that member over the quarantine threshold, unpinning it and removing
-   it from routing — a denial of service against a legitimate member.
+   it from routing -- a denial of service against a legitimate member.
    Operators SHOULD restrict reachability of the iN2N listener to member
    hosts, and a future revision SHOULD source-bind or rate-limit failed-
    authentication accounting rather than counting unauthenticated
@@ -1055,7 +1055,7 @@ Internet-Draft                    NCFED                        July 2026
    reference deployment it runs over private, overlay, or tunneled
    transports between mutually known peers.  For any path that crosses
    an untrusted network, deployments SHOULD carry NCFED over an
-   encrypted underlay or tunnel — for example an encrypted data-plane
+   encrypted underlay or tunnel -- for example an encrypted data-plane
    tunnel, a VPN such as WireGuard [WIREGUARD], or a TLS [RFC8446]
    tunnel that terminates below NCFED.  NCFED does not itself perform a
 
@@ -1357,7 +1357,7 @@ Internet-Draft                    NCFED                        July 2026
    spoke risk (iN2N, enrollment-token + TOFU), and it *carries* MCP and
    A2A payloads rather than defining new agent-card or task semantics of
    its own.  A one-sentence differentiation: _NCFED is a cross-operator
-   federation, identity, and transport layer — multiplexed with BGP —
+   federation, identity, and transport layer -- multiplexed with BGP --
    that transports A2A/MCP between independently operated network
    agents._
 
@@ -1403,11 +1403,11 @@ Internet-Draft                    NCFED                        July 2026
 
 
    *  TCP health: only ACK and PSH-ACK segments in-window (no SYN/FIN/
-      RST — a persistent, already-established control channel), with
+      RST -- a persistent, already-established control channel), with
       zero retransmissions and zero duplicate ACKs.
 
    *  Payload segmentation: 12 zero-length (pure-ACK) segments plus data
-      segments of 5, 75, 110, 127, 153, 274, and 352 octets — small,
+      segments of 5, 75, 110, 127, 153, 274, and 352 octets -- small,
       bursty, and request/response-shaped, consistent with a control/
       chat protocol rather than bulk transfer.
 
@@ -1415,10 +1415,10 @@ Internet-Draft                    NCFED                        July 2026
    capture was taken on the wire _inside the peer's TLS-terminated
    tunnel transport_ (the deployment reaches the remote AS over a tunnel
    provider).  The captured payload octets are therefore *ciphertext*:
-   the capture is accurate, first-hand evidence of the NCFED *channel* —
-   real endpoints, a persistent established session, healthy TCP, and a
-   request/response traffic shape between two independently operated
-   ASes — but it does *not* expose decrypted NCFED frames, so the
+   the capture is accurate, first-hand evidence of the NCFED *channel*
+   -- real endpoints, a persistent established session, healthy TCP, and
+   a request/response traffic shape between two independently operated
+   ASes -- but it does *not* expose decrypted NCFED frames, so the
    segment sizes above are TLS-record sizes carrying NCFED, not raw
    NCFED frame boundaries.  A plaintext capture of the NCFED frames
    themselves requires capturing at the application layer (e.g., on
@@ -1483,10 +1483,10 @@ Appendix C.  JSON-RPC Method Reference
 
 C.1.  eN2N methods
 
-   n2n/hello — request params and result share the descriptor shape:
+   n2n/hello -- request params and result share the descriptor shape:
 
    params: {
-     "identity": "as65001-4.4.4.4",
+     "identity": "as65001-192.0.2.1",
      "display_name": "johns-risk",
      "versions": ["1.0"],
      "capabilities": {
@@ -1501,7 +1501,7 @@ C.1.  eN2N methods
      "capabilities": { ...same shape as params.capabilities... }
    }
 
-   n2n/tools/call — the tool member MUST have the form server_id/
+   n2n/tools/call -- the tool member MUST have the form server_id/
    tool_name; otherwise the callee returns JSON-RPC error -32602
    (invalid params).  The result is the MCP [MCP] tool-result object
    from the named server.  Authorization failures use the codes of
@@ -1516,16 +1516,16 @@ Internet-Draft                    NCFED                        July 2026
 
    params: { "tool":       "<server_id>/<tool_name>",
              "arguments":  { ...tool-specific JSON... },
-             "request_id": "as65001-4.4.4.4:42" }
+             "request_id": "as65001-192.0.2.1:42" }
 
-   n2n/tasks/submit — A2A-style [A2A] delegation:
+   n2n/tasks/submit -- A2A-style [A2A] delegation:
 
    params: { "skill":      "<skill-name>",
              "input_text": "<free text passed to the skill>",
-             "request_id": "as65001-4.4.4.4:43" }
+             "request_id": "as65001-192.0.2.1:43" }
    result: { "task_id": "<opaque string>", "state": "submitted" }
 
-   n2n/tasks/status, n2n/tasks/result, n2n/tasks/cancel — each takes
+   n2n/tasks/status, n2n/tasks/result, n2n/tasks/cancel -- each takes
    params: { "task_id": "<opaque string>" } and returns:
 
    status: {
@@ -1540,7 +1540,7 @@ Internet-Draft                    NCFED                        July 2026
    }
    cancel: { "task_id": "...", "cancelled": <boolean> }
 
-   n2n/inventory, n2n/inventory_get — push and pull of the capability
+   n2n/inventory, n2n/inventory_get -- push and pull of the capability
    card (Section 10).
 
 C.2.  iN2N methods
@@ -1549,7 +1549,7 @@ C.2.  iN2N methods
    "IN2N1" preamble and 32-octet nonce (Section 11.2); the signature
    proves possession of the member's pinned key over that nonce.
 
-   in2n/enroll — first contact.  On success the Border spends the token
+   in2n/enroll -- first contact.  On success the Border spends the token
    and pins the certificate's SubjectPublicKeyInfo.  Errors:
    NOT_A_BORDER (-32024); MEMBER_NOT_TRUSTED (-32023) on possession
    failure; ENROLL_TOKEN_INVALID (-32021) for a spent or expired token,
@@ -1579,7 +1579,7 @@ Internet-Draft                    NCFED                        July 2026
              "display_name":      "<optional>",
              "transport_binding": "distributed" }
 
-   in2n/hello — reconnect.  A mismatched fingerprint or signature
+   in2n/hello -- reconnect.  A mismatched fingerprint or signature
    returns MEMBER_NOT_TRUSTED (-32023) and counts toward auto-quarantine
    (Section 13.3).
 
@@ -1591,9 +1591,9 @@ Internet-Draft                    NCFED                        July 2026
 
 Acknowledgments
 
-   Thanks to the operators of the first three-node NCFED mesh — Nicholas
-   (AS 65007) and Byrn (AS 65099) — for interoperation testing, and to
-   the reviewers of the NetClaw project.
+   Thanks to the operators of the first three-node NCFED mesh --
+   Nicholas (AS 65007) and Byrn (AS 65099) -- for interoperation
+   testing, and to the reviewers of the NetClaw project.
 
 Author's Address
 

--- a/docs/ietf/rendered/draft-capobianco-ncfed-00.xml
+++ b/docs/ietf/rendered/draft-capobianco-ncfed-00.xml
@@ -208,7 +208,7 @@ discrimination.</t>
     <section anchor="discrimination">
       <name>Protocol Discrimination</name>
       <t>An NCFED node listens on a single configured TCP port. (In the reference deployment
-this is the operator's BGP/mesh port; NCFED defines no fixed well-known port — see
+this is the operator's BGP/mesh port; NCFED defines no fixed well-known port -- see
 <xref target="iana"/>.) The peer that opened the TCP connection is the <strong>initiator</strong> and <bcp14>MUST</bcp14> send
 its protocol preamble (the 0xFF BGP marker, or the 5-octet 'N' magic of
 <xref target="handshake"/>) immediately upon connection establishment; the peer that accepted the
@@ -294,7 +294,7 @@ presents its claimed identity to the other at the binary layer. Mutual capabilit
 exchange and the remainder of session establishment then proceed at the JSON-RPC
 layer via <tt>n2n/hello</tt> (<xref target="semantics"/>, <xref target="negotiation"/>), which the initiator sends
 first. The peer identity used throughout this document is the string
-<tt>as&lt;AS&gt;-&lt;router-id&gt;</tt> (for example, <tt>as65001-4.4.4.4</tt>).</t>
+<tt>as&lt;AS&gt;-&lt;router-id&gt;</tt> (for example, <tt>as65001-192.0.2.1</tt>).</t>
       <t>To avoid a simultaneous-open ambiguity (both peers dialing at once), NCFED designates
 a deterministic initiator: of any two peers, the one with the numerically <strong>lower</strong> AS
 number opens the channel, and the peer with the higher or equal AS number only
@@ -554,11 +554,11 @@ feature advertisement with graceful degradation, not selection of a single commo
 version: an unrecognized feature name is simply not used, and no failure is defined
 for a feature one side requires but the other lacks.</t>
       <t>Because the binary handshake carries no version indicator, an incompatible change
-cannot be signaled below the JSON-RPC layer, and — as noted in <xref target="handshake"/> — a
+cannot be signaled below the JSON-RPC layer, and -- as noted in <xref target="handshake"/> -- a
 version octet cannot simply be appended to the handshake. It is <bcp14>RECOMMENDED</bcp14> that any
 future incompatible change be negotiated in-band through this mechanism. A true
-version-negotiation scheme — selecting a common protocol version and defining
-behavior when one side requires a feature the other does not support — is left to a
+version-negotiation scheme -- selecting a common protocol version and defining
+behavior when one side requires a feature the other does not support -- is left to a
 future revision (see <xref target="impl-status"/>).</t>
     </section>
     <section anchor="cards">
@@ -581,7 +581,7 @@ the set of active controls);</t>
         </li>
         <li>
           <t><tt>llm</tt>: the advertiser's reasoning-model capability, as
-<tt>{ "primary_model", "guarded" }</tt> — the model family/tier and whether its
+<tt>{ "primary_model", "guarded" }</tt> -- the model family/tier and whether its
 input/output is routed through a guardrail.</t>
         </li>
       </ul>
@@ -591,7 +591,7 @@ tiered models, without revealing individual members.</t>
       <t>Even so, because a card enumerates skills, MCP servers, security posture, and
 reasoning-model family, it discloses metadata about the advertiser's attack surface.
 An endpoint <bcp14>MUST</bcp14> advertise only the subset a given peer is authorized to see, and
-operators <bcp14>SHOULD</bcp14> treat card contents as sensitive — particularly while transport is
+operators <bcp14>SHOULD</bcp14> treat card contents as sensitive -- particularly while transport is
 cleartext (<xref target="seccons-conf"/>). A future revision may define a minimized or
 integrity-protected card (<xref target="seccons-priv"/>).</t>
     </section>
@@ -604,8 +604,8 @@ consent. The AS/router-id identity of each peer is confirmed <strong>out of band
 example, by the operators exchanging it directly) before consent is granted. Consent
 is durable and survives restarts and endpoint (e.g., tunnel address) changes; it is
 keyed by the peer identity, not by a network address.</t>
-        <t>A peer's federation state is derived from two independent consent bits — the local
-operator's grant and the remote peer's grant — as shown in <xref target="fig-consent"/>.
+        <t>A peer's federation state is derived from two independent consent bits -- the local
+operator's grant and the remote peer's grant -- as shown in <xref target="fig-consent"/>.
 Federation requires both. Which "pending" state a peer occupies depends only on which
 grant has been recorded so far, not on a fixed order.</t>
         <figure anchor="fig-consent">
@@ -662,8 +662,8 @@ Member --> Border:  JSON-RPC  in2n/hello | in2n/enroll
 ]]></artwork>
         </figure>
         <t>The trailing "1" in the "IN2N1" magic is a preamble version digit. The exact JSON
-parameters and their encodings — PEM certificate, hexadecimal DER-encoded ECDSA
-signature, and hexadecimal key fingerprint — are specified in <xref target="method-ref"/>.</t>
+parameters and their encodings -- PEM certificate, hexadecimal DER-encoded ECDSA
+signature, and hexadecimal key fingerprint -- are specified in <xref target="method-ref"/>.</t>
         <t>Enrollment and pinning:</t>
         <ol spacing="normal" type="1"><li>
             <t>The Border issues a single-use enrollment token, conveyed to the member out of
@@ -692,7 +692,7 @@ deterministically (most-specific specialist first, then lexicographically by mem
 identity); if no active member covers the capability it returns NO_CAPABLE_MEMBER,
 and a member asked to act beyond its advertised scope returns OUT_OF_SCOPE. Operator
 removal of a member unpins its key; a member that fails pinned-key authentication more
-than a configurable number of times is automatically quarantined — its key unpinned —
+than a configurable number of times is automatically quarantined -- its key unpinned --
 and must be re-enrolled by the operator to return. The security implications of this
 automatic quarantine are discussed in <xref target="seccons-tofu"/>.</t>
         <t>iN2N authenticates the member to the Border: the member proves possession of its
@@ -704,7 +704,7 @@ the iN2N socket for members reached across an untrusted network; it uses the mem
 self-signed certificate <xref target="RFC5280"/> with certificate verification disabled, so it
 supplies confidentiality only and establishes no channel binding. Consequently the
 current design does not exclude an active on-path attacker between a member and its
-Border; the intended hardening — mutual key pinning and channel binding — is described
+Border; the intended hardening -- mutual key pinning and channel binding -- is described
 in <xref target="seccons-peer-auth"/>.</t>
       </section>
     </section>
@@ -738,7 +738,7 @@ change is required for that case.</t>
         <t>Because NCFED, BGP-4, and NCTUN share a TCP listening port (<xref target="discrimination"/>), the
 NCFED discrimination and handshake parsers are reachable by any host that can reach
 the BGP port. Operators <bcp14>SHOULD</bcp14> protect the shared port with the same controls they
-apply to BGP peers — for example, access-control lists restricting the permitted
+apply to BGP peers -- for example, access-control lists restricting the permitted
 source addresses and, where the deployment allows, the Generalized TTL Security
 Mechanism <xref target="RFC5082"/>. Implementations <bcp14>MUST</bcp14> enforce the discrimination read timeouts
 (<xref target="discrimination"/>: 30 s for the first octet, 10 s for the magic) and close on any
@@ -795,7 +795,7 @@ for a PKI.</t>
 (<xref target="trust-in2n"/>) is itself an availability hazard: an attacker who learns a member
 identifier and can reach the Border's iN2N listener can submit repeated failing
 authentications to drive that member over the quarantine threshold, unpinning it and
-removing it from routing — a denial of service against a legitimate member. Operators
+removing it from routing -- a denial of service against a legitimate member. Operators
 <bcp14>SHOULD</bcp14> restrict reachability of the iN2N listener to member hosts, and a future
 revision <bcp14>SHOULD</bcp14> source-bind or rate-limit failed-authentication accounting rather than
 counting unauthenticated attempts globally (see <xref target="impl-status"/>).</t>
@@ -806,7 +806,7 @@ counting unauthenticated attempts globally (see <xref target="impl-status"/>).</
 transport-layer integrity on its own. In the reference deployment it runs over
 private, overlay, or tunneled transports between mutually known peers. For any path
 that crosses an untrusted network, deployments <bcp14>SHOULD</bcp14> carry NCFED over an encrypted
-underlay or tunnel — for example an encrypted data-plane tunnel, a VPN such as
+underlay or tunnel -- for example an encrypted data-plane tunnel, a VPN such as
 WireGuard <xref target="WIREGUARD"/>, or a TLS <xref target="RFC8446"/> tunnel that terminates below NCFED.
 NCFED does not itself perform a TLS handshake on the shared discrimination port: a
 direct TLS ClientHello is not a recognized discriminator value and is closed
@@ -1230,7 +1230,7 @@ AS/router-id and mutual consent) and coordinates one operator's agents in a
 hub-and-spoke risk (iN2N, enrollment-token + TOFU), and it <strong>carries</strong> MCP and A2A
 payloads rather than defining new agent-card or task semantics of its own. A
 one-sentence differentiation: <em>NCFED is a cross-operator federation, identity, and
-transport layer — multiplexed with BGP — that transports A2A/MCP between
+transport layer -- multiplexed with BGP -- that transports A2A/MCP between
 independently operated network agents.</em></t>
       <t>Hub-and-spoke (rather than a full mesh) was chosen for iN2N so that a single Border
 provides one audit, policy, and routing boundary and one external identity for a
@@ -1259,13 +1259,13 @@ application-level round-trips were exercised:</t>
 (13 in / 1567 octets, 11 out / 1574 octets).</t>
         </li>
         <li>
-          <t>TCP health: only ACK and PSH-ACK segments in-window (no SYN/FIN/RST — a persistent,
+          <t>TCP health: only ACK and PSH-ACK segments in-window (no SYN/FIN/RST -- a persistent,
 already-established control channel), with zero retransmissions and zero duplicate
 ACKs.</t>
         </li>
         <li>
           <t>Payload segmentation: 12 zero-length (pure-ACK) segments plus data segments of 5,
-75, 110, 127, 153, 274, and 352 octets — small, bursty, and request/response-shaped,
+75, 110, 127, 153, 274, and 352 octets -- small, bursty, and request/response-shaped,
 consistent with a control/chat protocol rather than bulk transfer.</t>
         </li>
       </ul>
@@ -1273,8 +1273,8 @@ consistent with a control/chat protocol rather than bulk transfer.</t>
 taken on the wire <em>inside the peer's TLS-terminated tunnel transport</em> (the deployment
 reaches the remote AS over a tunnel provider). The captured payload octets are
 therefore <strong>ciphertext</strong>: the capture is accurate, first-hand evidence of the NCFED
-<strong>channel</strong> — real endpoints, a persistent established session, healthy TCP, and a
-request/response traffic shape between two independently operated ASes — but it does
+<strong>channel</strong> -- real endpoints, a persistent established session, healthy TCP, and a
+request/response traffic shape between two independently operated ASes -- but it does
 <strong>not</strong> expose decrypted NCFED frames, so the segment sizes above are TLS-record
 sizes carrying NCFED, not raw NCFED frame boundaries. A plaintext capture of the NCFED
 frames themselves requires capturing at the application layer (e.g., on loopback,
@@ -1327,10 +1327,10 @@ fingerprint is the lowercase hexadecimal SHA-256 <xref target="RFC6234"/> of the
 SubjectPublicKeyInfo <xref target="RFC5480"/>. Examples are illustrative.</t>
       <section anchor="en2n-methods">
         <name>eN2N methods</name>
-        <t><tt>n2n/hello</tt> — request <tt>params</tt> and <tt>result</tt> share the descriptor shape:</t>
+        <t><tt>n2n/hello</tt> -- request <tt>params</tt> and <tt>result</tt> share the descriptor shape:</t>
         <artwork><![CDATA[
 params: {
-  "identity": "as65001-4.4.4.4",
+  "identity": "as65001-192.0.2.1",
   "display_name": "johns-risk",
   "versions": ["1.0"],
   "capabilities": {
@@ -1345,23 +1345,23 @@ result: {
   "capabilities": { ...same shape as params.capabilities... }
 }
 ]]></artwork>
-        <t><tt>n2n/tools/call</tt> — the <tt>tool</tt> member <bcp14>MUST</bcp14> have the form <tt>server_id/tool_name</tt>;
+        <t><tt>n2n/tools/call</tt> -- the <tt>tool</tt> member <bcp14>MUST</bcp14> have the form <tt>server_id/tool_name</tt>;
 otherwise the callee returns JSON-RPC error -32602 (invalid params). The <tt>result</tt> is
 the MCP <xref target="MCP"/> tool-result object from the named server. Authorization failures use
 the codes of <xref target="errors"/>.</t>
         <artwork><![CDATA[
 params: { "tool":       "<server_id>/<tool_name>",
           "arguments":  { ...tool-specific JSON... },
-          "request_id": "as65001-4.4.4.4:42" }
+          "request_id": "as65001-192.0.2.1:42" }
 ]]></artwork>
-        <t><tt>n2n/tasks/submit</tt> — A2A-style <xref target="A2A"/> delegation:</t>
+        <t><tt>n2n/tasks/submit</tt> -- A2A-style <xref target="A2A"/> delegation:</t>
         <artwork><![CDATA[
 params: { "skill":      "<skill-name>",
           "input_text": "<free text passed to the skill>",
-          "request_id": "as65001-4.4.4.4:43" }
+          "request_id": "as65001-192.0.2.1:43" }
 result: { "task_id": "<opaque string>", "state": "submitted" }
 ]]></artwork>
-        <t><tt>n2n/tasks/status</tt>, <tt>n2n/tasks/result</tt>, <tt>n2n/tasks/cancel</tt> — each takes
+        <t><tt>n2n/tasks/status</tt>, <tt>n2n/tasks/result</tt>, <tt>n2n/tasks/cancel</tt> -- each takes
 <tt>params: { "task_id": "&lt;opaque string&gt;" }</tt> and returns:</t>
         <artwork><![CDATA[
 status: {
@@ -1376,7 +1376,7 @@ result: {
 }
 cancel: { "task_id": "...", "cancelled": <boolean> }
 ]]></artwork>
-        <t><tt>n2n/inventory</tt>, <tt>n2n/inventory_get</tt> — push and pull of the capability card
+        <t><tt>n2n/inventory</tt>, <tt>n2n/inventory_get</tt> -- push and pull of the capability card
 (<xref target="cards"/>).</t>
       </section>
       <section anchor="in2n-methods">
@@ -1384,7 +1384,7 @@ cancel: { "task_id": "...", "cancelled": <boolean> }
         <t>Each iN2N method is sent by the member after receiving the Border's "IN2N1" preamble
 and 32-octet nonce (<xref target="trust-in2n"/>); the <tt>signature</tt> proves possession of the
 member's pinned key over that nonce.</t>
-        <t><tt>in2n/enroll</tt> — first contact. On success the Border spends the token and pins the
+        <t><tt>in2n/enroll</tt> -- first contact. On success the Border spends the token and pins the
 certificate's SubjectPublicKeyInfo. Errors: NOT_A_BORDER (-32024); MEMBER_NOT_TRUSTED
 (-32023) on possession failure; ENROLL_TOKEN_INVALID (-32021) for a spent or expired
 token, or a member identifier already pinned to another key (<xref target="errors"/>).</t>
@@ -1398,7 +1398,7 @@ params: { "token":             "in2n_<url-safe random>",
           "display_name":      "<optional>",
           "transport_binding": "distributed" }
 ]]></artwork>
-        <t><tt>in2n/hello</tt> — reconnect. A mismatched fingerprint or signature returns
+        <t><tt>in2n/hello</tt> -- reconnect. A mismatched fingerprint or signature returns
 MEMBER_NOT_TRUSTED (-32023) and counts toward auto-quarantine (<xref target="seccons-tofu"/>).</t>
         <artwork><![CDATA[
 params: { "member_id":       "<risk-local id>",
@@ -1411,424 +1411,424 @@ result: { "risk": "<risk name>", "trusted": true,
     </section>
     <section numbered="false" anchor="acknowledgments">
       <name>Acknowledgments</name>
-      <t>Thanks to the operators of the first three-node NCFED mesh — Nicholas (AS 65007) and
-Byrn (AS 65099) — for interoperation testing, and to the reviewers of the NetClaw
+      <t>Thanks to the operators of the first three-node NCFED mesh -- Nicholas (AS 65007) and
+Byrn (AS 65099) -- for interoperation testing, and to the reviewers of the NetClaw
 project.</t>
     </section>
   </back>
   <!-- ##markdown-source:
-H4sIAAAAAAAAA919a3bbSJbmf6wiRv6Rkoqg9bQzJZe7ZVnOVKctayy5sutU
-15FAEpRQJgEWAEpmOt1nFjELmLXMUmYlc7/7CARAynZV5/wZ5TlOiQTicePG
-fT/iOI7qrJ6kB27t8jZ1Z2l9PEnu47qI9Vf3Kh2lZVJnRe7Oy6IuhsXErZ8d
-vzp5ubEWJYNBmd7Ry/zBWjRM6vSmKBcHLv04i0bFME+mNPaoTMZ1PExmxSBL
-8mER58NxOoq3tqJqPphmVUWj14sZPXl6cvkqyufTQVoeRCMa7SAaFnmV5tW8
-OnDjZFKlEc23G31IF/dFOTqIXOzGfon4K8ni5CbN6wp/TIcz/mwnwf8GN/zX
-dD6ps9kk/ZjlN9Fdms9pFudusvp2PqC9JPO6mNLUi2Je5mlN03x4TP8fEjTW
-6LkJfVXV9NxtXc+qg8eP5cX+sJg+/uKrEX17W5RYMg3j3Hg+mQh81v6tuM3d
-sYfPGn9flDdJnv3KG6NnjnRs92caHCeF0eXJdJpkE3pkVgPG/3qDP7Ee+XZe
-ZsFqVyyxP0xodXlR0ufZHQPj3avjvZ2n2/rr9zv7P+iv+zvfb9mve/7XJ1s/
-+F93dvfw679dvD17d358wEswHMOHMX3qdvpb7mKWDrNxNuQNylLrpLxJCba2
-2Pv7+/7fqiIvZ8M+geNxFb7Cb3iY8k8MoIXz/ELbo1N2P5bFfCZzMFa5na3t
-XfrzzfF5e4VvilE6cceEj+nH2mP86tVN8exQHp3pk/2sWLFKm3Nnn/482jlq
-z3kEdN3hf906fbvxlXkJm2M/H224O0WU5ePOYe5vfb9jB7S7u2+/7u3br093
-t+y0n+75B77f3nliv+7t8a+/nL47+fH90buX7T38kpXpj/OEbiShJkHuxzQ3
-svFzSog2MYx1l/Oc/nz4vO9ppBuMxDdqlszSsnrcfDgbjVcevN2khNDFHfXd
-yyJP83E6GXVO/Sn9+eejs3j5FGazCZ3ZIJtk9cIVY5xTQ/IIoH4Hb5KcKMwU
-x8WHVq3eDE2Z1GUy/JCW/Sytx4zBRBMfCzlcJHmMkxyld9kwFZoVJ+EiHn8B
-w/+c5C6tXTLpr63AsLOLFRjmzghE7iItMR8h2tnFxoE7cu9zQpOySibuJQF5
-WBP55t1epMN5mbqjU9kkfVsNC3py4ZJ85E4J68uCzkbX+k+BIE/K5G/JJImT
-vPrSZs/0uYd2HMUx0fhBhanqKLq8zSpHs8z5iPQ2ppWr/2EO16O9RnomeCCe
-JIu0dHb5aMSkdpO0rlyWj9JZSv/k9YSwB4Cp0xGgp0Q2TvObLE/TEkxHGJRb
-X9M1VGsbbqTwdYS4NG1Bqy2/qxxRdAEx7aBH09wVH1JXptOCOEFdFJMKaxxF
-RInSG3CHOqk+VI4HmhT5TTyh0x25y+NzV6XMaKu+4801bJBAk9FqAjY6vE1w
-Sd09sTb34sfzeI8PnXAuqapimPHear7IoK44ZjebJLRwAmLiKvpwkrpJVtVp
-jv3OirLuuTk+d+OsrOq4GNZ0mB6Q2HyZTbOc5++7U1rPLFlMimTk6DBDvkFC
-RlkuMNJqWu3Wiahv8HqXCascjEDh8r5wdTmv6ogJeeUSQvdROqZTIio2nddz
-uhPyAl0HEUNqvho0HdE0+rYBmRvQMadpHo2y8Tgt8SSPTXhI3Dins07Pds4Y
-oUYuzctiMgF2Eh5+SOnloqiBvTOGeMRvxoRuAqt5Rdf18u2r9xuOxB43y/Kc
-AUkrIcGDLs8ormZAi2A5GCdrziKyfRBGhety6xmWZSgxKggXCPUIweg4iUoQ
-KOkOghQeEo7gKJJoWBZVFXvANJMSegL/iRrINmlDeYWjd3Jt+Lbg9PQyTukM
-6KpG/qqOUmDBQK+qR46E8HNKiIpnCO9o1fiaFpDHFUkxQ3+r8crfiIRFmJ3W
-OpsPCAdv6R0a4uQjrTjDGHRwdUGHkAwISbMOIeOV84tDgsJdlt73hb5Ms9GI
-ABk9Au0ri9F8yFcleg2aR4QhJ/5EvzAuOb3gvGMlBkYIaMZxmdBp0wAgsMC6
-LB+WacJHtaCrPJsUC1k0X+FyLgdeCemu5Fri8rtkSH9X2A4JOLQRogYQSIBe
-/AdIg80rsKrA2mjy+rbvfrkl3KMvXTUf3tqasR5PvwYL1yD0LCmZCkUgTSkA
-fJdM5lg9aGCNJeJUaQX6/oHQMr5/02ThbovJqEPQQDp6hGLRXUIHc0OnXmQC
-OVoF5iHcGX6odK0YziMegaWiYfMF8f6yLO6J7hIFnQFwvJNgnenfcZf9ammB
-5YhpjS15kNJtGTWki1cBSAGaxFQIB+SGJKNRSRAnMA5oebSZys4Da4OY4vEW
-VAx/3NGtqA6iaLvvXn2d9tExCdrwfD2lvp8+qUT++XNPSTGYYECNAchYaLAQ
-ZvCwy/dnBNw574Rh4wCRDVo2zXOLk/Y7Jg6BET3Ndnxx1z99ai/v8+cNgsVO
-nwQHEs9mBJqQ6hDbGNG4RIp4C0IOmPemCWHYjNgfUIpmhzaTF9NiXrmLBU05
-xeSi+Mn+FKGbMcoe3UdhIZ6K06EqycEcyYQu0Yikl2RK+JWUGHJcFlPA0Mmt
-mgrf/fTJr1Q2tIsN0R6zKQ05IVZd35KITbzgI4F2SgcO1KRrO8X0fNwJo0aW
-z2Xn40lyIwvHrL8SSYl1GLwFuNPlGaQJg1QHwlnSSuwbWckeVlKRRkeDD5Vw
-Esre32bD2+buLCAJ0F5IWOuF0gA9MSFOBhZIQ9O/NGiPMQX0mEQDp4IC1gyW
-SE/Rv/QU33vS2hm7mfa0lLVPn1Sh+/wZwylIGJS22Eo2sE94n8cDTAi5EhPh
-92DpeXpT1Jmu4dOn4E8Z4UnAm2PStROm4swhlFPTW/wtPf8wpxaOyyQQOnKX
-5/7BgaV6bqqM0O45EQ3gtzCdhITeuugxZ8SnaW1o0GMOybIG6RPKIomiPMwk
-HxuPfPw19piVJgJVtKxHj0jeIY1OwMYzthSWT49ausNniMEpwUtegZDmLwCz
-cVcRqk9wkLegDg/IryafglOXaSNG6IUmEkwjTZKBoL6YFpiIEdH8cKi7CBiL
-XVFQNUwdgSQA3RhD6L00DeXfnhvMAfI58Q36hP5MSepJjTY2InPpICTRm9Fq
-yblP6gyxL9rTBMKJET1/PuBOoxRnW8g4BLm8mECIGoq07ta93FmoAFKOMPWY
-hrud5yNso/qQ0fXbgFBR0Mebm2VWfdjcPKDfb2CBoKcjz6zGJPZUTF6E6gmU
-iGDlynn9Ml/IVLIORhMmjhXd/L/P6YJUUV2oQLWOU9fn6Zh5JzI+2D59hxUJ
-JttfEP7Tybi/4XlcVZE8VtHyAw3CtAcTdD0GKdGm4eUi0s4+5MV9zkdbbW72
-nL/CYFOkMQxSOQjsUTDEoxXzzAxT0wo3NyERZjckj0PYxdHmC7CMHgt/EBsI
-9yB9VUT20pYkyhJg3Qi0SU08ZgZtMJlGROOIzSX5MG1wiFX+ec5LZ0ZV8fgi
-CcaQu9tyG25EWhG+AVgzVinAUmcpw1Vk7GVqJXT4NhXtGveW1Jcqs3VXEdPT
-IUgYKLdcq1LGhISoqEfvliowE3hYCpzhhuW0AxqL6Ensr3MUrMXRNLdCanJR
-dYDPUP6w62G5mNXFDakhhPXCrKGPg1wNlVrT/Yz8CmM8EuORz59ZG8HSIE/T
-vKTk3BWTOd7aEOp1USf1XKRP6OdeXXvJQv9MhGlW3TPeCVGkjEQnkPbGStxr
-y/Sbm6FUv7nJh6JGBNCSD1WUjAoe20/MsrAIIbA2t02EJt/hA7HI1IWYZpiP
-+I+E1xbT6Tz3sEn7N/0ewyAdj0HWiXeUN6ypQQjBF9c8AEt+1+5FVo6qOCrG
-cRK/Svlg6MRFtqdnbwowNVCX8ZwVBQJgPkrwziVMKt7CIVqUu463tq6BjmlZ
-A+dld956LqCp0+EtVjxh6UV5gVnt4zydE1OaMNaBIg5SuiqxGHUI4FgahElY
-B0gcymhtAG46wgEDkSGR8EXAAC8ZvQSrmRfhDsFmX7m1N+8vLtd68n939pZ/
-f3fy39+fvjt5id8vfjp6/dr/EukTFz+9ff/6ZfNb8+bx2zdvTs5eysv0qWt9
-FK29Ofrzmlymtbfnl6dvz45er4keGVqK+KIVtGtRCkkUqhnNItNLWfd8cXz+
-v//XNkTy/0Yy+c729g+E/fLH99tP9+iP+9tUKVCRE5WTP+lIFzAlkbSHUUA5
-iUFlhLZQ00A7cAUhnhM0N/8CyPz1wD0bDGfbe8/1A2y49aHBrPUhw2z5k6WX
-BYgrPloxjYdm6/MOpNvrPfpz62+De/Dhs3+ZZMSf4u3v/+V5JDgyJhmtuGe1
-LC2nIjOASZL6ZDr+Ol3tNfaobBxEMGC2dOSjU2WTdMlENQa7JLm2gKK2whbX
-EhNw2E7ManQK74g5yhQwLo88C3eYvRJSuyxLkOSRjKBKwKADE7xp5JDDveZp
-HF5YNfHttSNmxmsqQNKTpMIP+f28IDEL9HVSDCpR8iFiOjN30F0lHlaDgctw
-WDSgqSvDchnnhN0zRABeXkfVWLNa9Ky3JGMAMCpMiGWB9fnKyxHfBUOZkEtQ
-fJOKN0/g2FbUeWXeVNWsbpTRtYDiOqCtjzAveJSJQeCJwvFoTWb4HAlh5xvH
-MqGI02LIpGVAGSAavWy5Yyx6tWTI00OmhT1o0Wu+8PILK1uhvEOHrPqJqiW0
-lIyXwjTm25aShFsHJPQUDHSQ8sK1tUQuWpBwu0YDcqIBYTTWgQKrIi3vHIz/
-6MI9du9YBY9PXxpC7antYkl7D1V3e2hJgXdQLs2GB3S6VUm+sRswl1o4Ih4E
-rywf0sveCB2MVLFeAOIgxsq/z7OSd1oXrHQsRNmoVHgcLFraobIp5lpeDLmA
-xuLe3sHGlt4LNZLFsS6Da8lqmggeQq0J9KTMZzcxP/L5M434n//5n9Ef4v/a
-zx+i30y5E2XKFGx1S5hauOEe+vmNRhDnpnP5Tv6YKdpj2AYefGXlCKzUhqo7
-6UCjngwJP8PjTyya1b2Khbsene98Uvf6/f5nGuH3gMNJPiyIYN4cuPeXr+Lv
-20aJb9jF77GGV2KuIUj8xXD7xYlaif76l239CBag6q9/0bP5axuQ9sMPuUFW
-b7k/uuO3Z5enZ++PwBgPdTyHLxpj0e+4iVVWuvXtXcerrzYOvo4NGuXh/uCe
-eUJw8Tz8U658nI3c+un53d7G89/3IF62LaWqDLEhc6SWSzZbrtyL7GHr46tX
-zWfxc7Wv6s86CXEOZlZiqeUHksdXjPDd2Xe05TUBBUaQO7nekiVXX832AJfv
-z2wA+jV0oq2HJtuN1gC/BxjhDCTq7k7Pv3TmD/38HmsAlfx04B552ime6j+u
-KX0zoszfrX02lql6dJwRAYIyDXuwOosqGFnNQAsu5AkFU231iJKwpmagXiQ8
-NGYdRfyZ3h7HHMe0YmJayVQ8RYRgycgMKYJ2MV6IOu7LFmPpIO2nRx2DehQd
-5YpDOenoisdVy5NKTItANS/Vk4s5SWQ8zdUuwFLIMA1MfFGtirR6ykwyJWx/
-zCY/DHFoXj/2ebLOKAbv+3QyidUSAnj8n//xP51o/lmSJ8TnNlgaYAuBubjA
-ZzEZ1kfLzVN2j9kSNjcVzkW5ucnnw/oMSQOjCID2J+6hvY7X+LaC9ct1ZIsM
-Pt9XeoOrNE1usiEMa22jvsumJLNnYmiaz4o8XFXLqHwo3ka/GZEtZTvRqq3I
-A34nsGjCg953b80Uw0gYTChmAXsvkjfwETt4hQSz6YuhMpzACClKQDP7uPsC
-FkTiD402TNlEp9Lg7hbBld5ks/GmO135IiDbW5oDdmEhiGruc+pJBWRTFsRF
-88CZiBJFeHgkR6ReEmJeEFUH6Q2EZPWVbD/RE5ODZLsGCSMkuEKGD7xbhFp0
-Hby7V+6MiPIkP7NZcmk3uZpi6wL6QHO7UgHnFJwuo3O9S7IJ+3xlG8EmSGdk
-Z7g49xPM3iOpkYYrU/iBYEoTS5m9O1jQ8KThEbZuwCw9TGCAZujBT1qlGGhG
-cBXnLOiGQK4LCW8bCrdkJIbHF8tNc8vbwOE1Ap3YN8pv01n1WF+U5YRoyH79
-RcXguA2IWYkQwlzs2SqZy+RmcQcCqLfU44apZQ0ufAnf9k7cOt3XDcE6JnXB
-PfB6/54KJP46QGt+8ELgc3sj0AfaF2K7uRAAJUMMciqm2/enASpSpRM5siD8
-4CCiFza98LPOO6F/dvHPE/yzj3/2SILqrJBNEOkIVgXoXzyARH42sphF2iy7
-JHVSlhJak+7v4R+e9OQbJqUBLF7KHMSmFavkkVVtH7GYcgNpRldzlC/UJ29Q
-Y4/6QXOgD5Ivxozm/QA5vuVtb3lMcHIzKNJ9tRWH0UQdRzo2EHobKr44YvwW
-+wW9QEgAFzZdwl50+frCHb0+PxN6hIhIeGjF82pOStiIxHWCp1m28Gw0oDww
-HETDCeR4xCbpK8R1Sn+5wSgDKsL4LtegCgIAxIOh7pCIGDkiOwkOmL2R49uS
-sIjAK2iKvHY8yehMfyIeX4B3EO2UC7r9RJgunlnzY695SzEitDcMHpm6VXDZ
-ips8+5XU7wAAhEGMGz2EMyQEGkQW8sjBqSopDVbN1mggAMT5D3DmGcbM82Yi
-LyRwVAgUfRg32HvREuOyypsGeuKajao59Go1vjXeEpYrJGpiQJJMQjyLjofF
-DfFRebnRsSQqMlpaRl2RVDxrAziL2LaJHevhdLBTBDD4Oxt/CsQ8WBECHxC/
-Nq+8mGtuI7Ym/X0OhsA+FQBRpI5GgiXCzKJooPr95FHm06OG3kTRaSAsJeM6
-FTHLaB4Tx566d1iM4wARSEyQ4Cr3vRvPSz4nIcUHLom+aisSZDdD6MNWo3Xa
-E0JIRxF0SvPQbNDhm6skWJ847es0uByEBl7N7YXGm0iMNwHdVQOOW2Va2F7x
-2c6Kz3bx+jZ9tUucad89cU8JPD/8I5+RgvVf/M9sDpCPRWnTv487f7/q/H1i
-f/+Oa3jZmmMZHc4EHdYHECa2+v2d3Y3fcw1HF259Z6/f393e8Pt0jWlTLRXL
-0/9uS/BTySpWjNnSh4MYqlAnXhllFdhv1jTi48Hrlql/WG2iuzvxADSRaPuN
-hBhZnCAzJZaoIwLKTQzZN8k3VAxdup6sNNjtlYvqwovad0eTScTBxmYpy1L4
-DTJTe1luW5q8L/vxeqMwp5U6Z8NTjKIuBa0poaIzjrZ3dR0BiWjIX98EWNPW
-2JtTV52JmKFAms40/i8ye8Hy8AfLxLRF/MLZSEcnhIWv2dvSBPANHFhMukvL
-bLxQXw4L8DMEVARK1/KcGNW/cHTxuLHW6XEuGk04q1V/Ae/0+voq4SxiBn2f
-VWK8bxNejsBkBSIxR9JjWWr60dzIFtzGEUWIhYjUTyBh6cNJksH7Zi4lExtE
-LtDdDOiky4XIY333Rj0u3m4d+dks/iJUeLxC0441Q+SDidM2j1mVIgnZussS
-dw1r+C2kqetONByi+9rBbSY91a0DZdSMWFbrN4YVv18OEqpv6bRuWAhuO63V
-KkFCJALtr5Pq2dHF8/iZP9vn1x21lh55sr+1tR3v9fm/aygblySl3RWZRMDi
-rpKaQCQEAWy5I1kru5ljKesc9MrRMeyjY4mDriJJIbQ3syaBwkAGjkjwS8XR
-CEF72Gz5gKVREu4QfKzBNnymedogL9EtQvIhRxQhFOk+hcXl6CKyiKMZzGSM
-jKLP9PzpMgD9QLfZza0EiUkcMF0wGyKfLCL1JfZheCCcn2RDvtoxNmiB8BWv
-Nv3ICsON19pMgoXxsXVoSrwMd9uXTeTB1j2xeKdWCA7vPIjAQaAFEiPE1Tfj
-qHWJorZ9Lwff0BLvE5Lwl2N7onZsT0/TH4JIh5WBPrIzCavOCx/i6U0xra0d
-2vdsPKkaLQrjc4xotBwACt+X2luS7vgrxVShbgEUk6hKxoRJCRMLRsdJE0dD
-Gh8il+sMpiAhC40FR1iL8LKiylSRjDTgaiIUcloQ/DEsZ/nlHatNg14a1cgq
-AZPoeYk4hFHk9Vl/s9hcI8GRsU8A4JthIXENKQ1CLtRimS+ihzeHuZcBvxx5
-K+oOIxGnN9A62ZvOvnlWO2UyB4f7cCEIX6Z/Y4sJdF08HAaYTbOKTWEcvure
-qH1QvWmkgFgYdBQd8VkmyENA0MZ4PmlwqMeWQtLqxmPYefPwxrMaRHeSVSAO
-tKbLwOJ95H2z/PH/f6K9/bwWt+G6ZUuZnmOCXs+9OGl5o34/0f4VOzMD9UF+
-znUl67o0FVBdv9//whpWgPtLP0tw6P4Es63++T3gEMrtEuffltnxEQRzgQSi
-KN6vlr97KwRgpPLMc8tRce0DZtbVR66n/8IixCBaQWR5sr+/+8QeX3+y537O
-XoC6Ssxs6Q32/B7d+4pYX00jJhy77tMD9V5p9h5WEvqt2aONQdXoqsK5WHYT
-xU5k19MntREGWdmXjIWMWoDXW7Nq990LAtcWTKFb20SrwkUccIwdyVF1rwUq
-Vk1o+TcsKUHk4Pz91u69bDvgJYDNSniWFx8sCJ8lxflAzC61goUGxBlNZKJp
-KkanwP7chhabBHkrFREIFeqIPCRM1i9O3v3p5OUhzoCFwrQ0NxlLn1Nwsy1L
-jzF48xOEU4WECU8BPTkxDlgHk7a9Nlpbn+OOZSccEQ8L2kiynjwecYQSLfiO
-B44UDwgKTeCT5YEcsAwIrUH0LIPGMgT4kFIEXEddYDave5+Pknk7oPZpetFL
-VxG1T+IB6Iehb8zM5eU+GNON5AfpdBGbEkn5Azpwts/NnIRi6IhH4RyvLXID
-J9PdrCAhWObEIQJ9EfktmFuLRPcBh9rRUel1FZ9RRcrEANO98P6lVh5RmDoU
-Zc19i7fa9yOWjfOSRVg0caeZRMSzOzEFkGx5A909sgg0O+deawn0CmfasJjg
-4+bMAte8I+P6aLZIv/mu8sdZHa5GwXQKT1UwJelPE8DBo7SYdc0/V0mSIkvO
-wektE6higGzKtAWz6CGY+Vnb4AoA5TRyFqb8mr1ryJT1Xu20LAsVBxt650MT
-j5pxg2wzPk8PzFbckz3STb5y73SPVaTrkfhJ1towZ10g+bXKfk3FHbBqXtMl
-pukUpQBIs5XsC5Ib/W4bOPSCXSWNXiRBt+KIYv0c6zh07fSBUUGr1uj1JgfY
-MjYkKgGUUMtpuOSGZuckdx0OVOkhv2gzUCO7p6iLMRQ1c10MRXgplug1cbs9
-cj95ZMPWXhM8c+z506PmuuHMvokAMBL1Ao4APpUXS4gUGWh7cu5+KmBug/2W
-HUYjGI/z/AvXZZCyy+uOwxTrImLLUhBJqP6q7FuvbitZEdA5Ci6pohjuXuuK
-CmBo2rL4mE1FWWOCH0QmsDEvCigJWM1dMoF8kkPlEMRVikVKzWSuCqF/hyGV
-IrkWh0/oPNGTiiQoo0rVaGcLJnKDLJJ0FNtsImCpvzOIFnbhNvGNxVgw5FuL
-45d3xR0znHO4to1Om2wD4Qe//Q3xbA8196el0oxSPVW5VFmtmUbiUMMemJhY
-AMOHNJ0l2LpbB3g3IgvMJlGUlreOSTdwmRKS56pWqAXiVXiSNv+X1N0mLIoO
-ygxkeuSWTMVcqsnQBF7xfWD4wLaZDD8U4zHfqgtLaTX14NOjhnZF0buAEnmB
-C1LRirDPIBe1halaqUhsCMZknE/bS9z1NCW9e3RtKXF81dQs6dazMRPuSVX4
-e3adja43oBYnEVESX9PHnjUSs3EYcKQgTZDOHCMIUK4l6OAaw10zQ7iOdAHq
-0nYnnFOp67E1JCRgZvSRDDVEyEPeeCVzVhS8VTGywVxKTyLv8UVSN4MSmDwk
-afhkUW34qAlOs2ghgopykQah+TeLAWcdzFj9X2IgwmuX+YqglYQscYAZTAr0
-fXPA7LHPKsQYa0qocbHUTYqbm3R0yBZhvoyzgFUMFpHkMJq/l9Ha1BV/qy9F
-yxgirwdyAl3fWq00cja6s4r5HZujBWEYRlZHRk1j8k1M7IdtCy/ENBN4aTT9
-GFeV7XVt47KkG3uKWy2L4JGYVtjwqMsoGttK24Ko36+Htmg2+tIkh9F1FnwM
-7OO/JR1AnpPFeI2HydasxP1X0YVuF/8iYgbi3HLJqGg4/pJFu2UZF+u2pDHL
-YiVLnzSoyD8GhU9t9976PZvM1cjbRKGPNGVQFtY1H16yIXliUEOeDCR+luI1
-momXHpwVOEmTMdGXJQUZ9q0/r1DiiFZ6PieSJ9VCJhPTRzqx8lgf/q/CRTsW
-n7d7fE7ix2KSWro+l/hRMsMymuQehTn+fE58YUiVZakJVq85465k6chKJpMU
-MjbtPvbJnEWpFeXcrCCxYGGL4mh+DeYP4vs1rj/4REP8g0+GSKTlzRztHPnN
-cFUBEoMX+ZC03Bz+yG79Abl4pP2kxNogXIxGmVZ1kKOrLKlyqCWbOF+IUK7e
-4BSRQWopJYc+ddfepCurN8gU8Tcnlz+9fXlFctLVq7fvz162kZpR8+gLy4XM
-1yQb8ZcmtLEmKaq8hvnUXPED5iGBKV6J4+ecowS6hN/t7o+ilfap/8Az44QU
-jy89IMDHM5hMnA588IDsvORcTFfMEjAQXnPgueXQw+vu8V8fNuiDUFU+n7Rq
-VB1TEFSPnhjx9M6wEHWu2et43cWfa3Uq0iE2/I53IqjRGUu+u6a7jS0wfBEL
-JaZftVd5+YlIV+WrqMh09Pe8vIOQhCgib2dy3QjqaCnwNGUlWXE0RC4kTTXu
-2y5ok4lUMRgRk4LosOSvFfCa967xajfoYsMerpogarwB43k+1KxbCAskGpc0
-WECHQgsX66eSwgQTE1hhN6mbcVwJ6ZcVM/DRXAhV6W6ScoD6R5a3SBdGKIyI
-14YrtT9AhEqxw2w6I8qWDzkIC6BeBAlPY/6syf+Wa3rCPGlYEB8gMVLvsFUv
-4JQAL6sI+1K+zqEIFnQQqEVpMN4Y3gYNHIVA5Udqo0ashcK4KBMRWBmiZH/L
-ery7s7W1BUKM3374YSMUWQ8lNp9zF0T5Uyhq4rVnVsLJmsjYh1YMSmerMaZP
-xOc3d4ygShjnufBfx/j9m2Vj/LYiQwOJKryJbbxNBPPo9eu3v7w+vbgkyEke
-C3+9Q18fnZ+/e/uno9dX5ydnL0/Pfgy+3g2/Pvn3c6QqB1/v0dcv3r/88eSS
-vvzp6L2M7r/ep6/fHV2eXL0+fXMqE4dzP6GvT/795Pg9FO2ry9M3J2/fXzZf
-P6WvL07+dPLOXmy//T19zWUs3x2dvr568frt8c/0oH29vaX7Jkw5wRpehm8/
-YbAssxOPKpVm6m/QG58OzCfAQkdwcBax800n7MITXpkN87Uj/4ZjD49+B3s8
-OXv39vXrq8u3P5+cXZ2e0TGeBie0s8NgePPi5N3V6curyyN6qgPnnd3mEUDq
-8p2ecvDInuHY1Yu37wjcy6e1K8dxdXx0fvTi9cmVDNh+BMslBLh6++rq4vjt
-+Uk4SnMG2Yoz6O5gXfa2IaZ8vt8C9nYO7T0Hn5smGcZDRVblBjm1kjWRBDZz
-YhzLnGc55YErEOWjFS7oMkWMp1a1W3VCsoNtrR+iR6URu4u0Zqsq3icajUVw
-1bLV9jDS5Wi58ayozAQAiYTL1tWuo1dEbb2CodcsdAUSyDJ3xer2p6BW1HHD
-vM6CWlGfHoWivtH7MXE0WpDWFxrdISaiCvzcWGizTgnQ1TgFjRpqso8j1sC9
-GuZHY1PsKv1DhbxPbo1tvVcarrB24Na29nfXkA2+ZgukD/+yxgLxFUs1qFVh
-U10RwuTI8x+m+Ni769f+ykNwSYMrKf6JsfUw4mwkU3BI1RWXn5FpxmC2R5WU
-uan/lFWIB7hMP9YY3ewra391n0VsvG6t/lpjBVVsnCSDdOJDxMSSMkiqlAOc
-w9gi7HlnDZjAm9+wwHiNWhf/BjybHEKDMIUyqySPE1qHVhj10PcCR5bTJYkC
-+LPgCksAm8T6Ib4wQ5U8PYs9wu1FxCFkNf7lQIpFIQIpkuIwnIWfSABF5UTC
-r4qJ1iiSBDXoGcPUUAcSG+lW13a412JP6WmQnYWnBZqqRj22AHYdHiyLyjAT
-NWd5vYHKihwZF8FSSBiZzOpWBNx3yIXPJqNlo6ULjZbBQlgGlCplohaqid6O
-VE5RErdy8Vl56FSplZuZphC4s2raik2J7EF/dYRWYrCbMhmmCO0YpfTrSKOO
-cMCSduM1Xp/0OJ0ShVKkPJDo1SALwKbK1e3K+R0Lb8sShEJOo1IszgdhJhpJ
-cpQNAFGdoavWI6ku0ByiVKCEjcdihJZJR2iat5glVDAawh7Sk3pGS5E5URMc
-JEFKbKEgYaAVayhWe9kOMjETvhVmhwqi1+XbqB0ypVMocAZs3EmDZL6w9oIE
-Gv0+4UWNQhwiCxgKSS2pLTIOawFWw1tCF802ZYzQNErgQZMiGlYVtBpW0SC9
-Te4yOtZ7qxPaPtHmtIPLaQQGWSGW54o6D+mY71hiu0Yd2MrqX612GgUk6Bj2
-HmJWYvdp+0wCjsKxrWHtGY6zYqORRauOGj3YW5+u3ePoeskedc0FOTnQDwVL
-iQQeIOPqWgrSKWWZDmdXoq5U1wdta5WVx/YLRaEsepVtqIXWz5EESz5QEI6e
-huBBal34KBUzNgFiWsZ8ld3JrWsJOtRLaRw06IngJgUKVBGp2TjEHgbJ6CbF
-iocFoslCRlwnNxU/Q8vDSem2PJRBHcNioT59Rp/vScGfa+LfqI8G5si6KX7R
-qj3Vmvt8bXYoPOTALLX6L4kT/Ly7VtfiSAwblkKpaVfDsAxQJbsiKXLVaqXI
-G0FTCwk3mw3WOiuzKVGfK34Ea+XS+OmIlwokliBFvM9W1sXjOlNDN10Pxv2M
-i+dk+WxePy7mNf2PBTYEqTZ3N3E8cIl2EjB/MYJ5Z6NimpoRUHm4TFlI4JJW
-qJ1HuKDycV3QsRc3C3U7Z9UHuGisqk37UsCK58Gg2zBjUc5GUBAlK4GDEpS1
-FBG8J3E2Y9enFN7r+bxBusCpRCsHVeV0BNrZyR2ih4owj1fuIYcgc6SIXCQp
-96l3qLcKnRC43zlCOQJOGIB3Y8KVqKZpnXDFh2RQKLNp4UFSc1mEal6OiWv2
-W0SET8A/LbZuRjfE0yBc4gaeUA1IrrzZV0g+UTBZZlPKsxW74ImI1OxkNzHi
-YO+EMHN4xXA+SUqubIawiDDhLsh5XO/mtbE20aWoUnhTDUpcgJcXyvEGNckJ
-BF3udSF2XDOp+7jkMrszCnzJXpaTlpfl0yMpvChWo+XaTwfiCdDH4hSatBRA
-+mLlJx1AQS9U0EeOd8rRRlb3ia05K7IupNlEUx9Z9L5xxs6xzU3NzAVP3dxk
-6TEKMtSFmzVFWYVxaKq6ZF1OFhvm9rDKuJBx6dDYxnQsn8EVOZqXnB6Py6b2
-UtaAkbVaaeF6RUErdig5k5aSpxJBpREGUctE2oqP93mSiQ98tHQhEBqVrgMP
-jZBZFuFKjqSQvPn7Iqxc6zfIuVxGCJmdhAXwee9hJgiIik4p36mY1anypKPD
-3xekVDZCYyE11eGKXdMI9jVdeCLbL4bD+Qy8VpZcabkyzYCJZPLbBEVW09xJ
-ci6rIkRESoEZlwWRMh2WJsVxzSt/6IUrQ9YHvAjreZoxR+DJN1Y+9Ljz93/4
-p4RVy7qXfhSy/G173LvVy5Xv8KiC+krBeKVDyU/3Szlg7OU+NcQ+dMl9ktUM
-dg1/Xucj6Hw/r1Zv+T+6IHjAB+MkuIpHrR56qr3fuwce8nUBHjoq/flt5bcV
-x9itE2FFJ4jgXFbv7+uL4QH/8aWUqd0Tty54wWsBnUSNjX9uNS08ZudZv99v
-RV/bnKGt1T5Td0ObchhhUC9kg6lsE3zLsRuBeQt81OrCKDW99iu6RuRd458N
-PLjobiGhNzERqAUKQfsy7WIhUw/lesfKvkG67oS9bY1ILRfJs/PKW00U+7hq
-Hsf8sgP/jl1zTJzURzyYkyRda74QM7BJhtzGiNBmPJGFqH0jND8T+2m5/y+A
-GeAxgmxVAExPWiNxw4WBTeshr3KQp1xFAtrwduMwxBownKJcHrUXiUez0TRY
-rqRTCpGD5G8+X61SIH0naHR7gGSQRn1ulwzqLWWdcc4Z8nksGqq1oS/meGno
-4ZfTuVqiTJNitXEoFqR5HRdj0aa9qKCigTrQB8Vdqsa6Ts3Rqk5nPSvRgLjo
-KWrSt3LAyqIYiz/tdLkU5YE4GUwyykQy+qXdVSasLCV1xZMwtKq1VeL13AuD
-O0t4a3IxjuCHnIxjTYtAKUrvJFX9QM3oCCltzO/SEMfLEU19yHoRoaB7u+im
-7AaFjMKGOQfNetUrrBy5VXBUxGX/pNd/hB404YBBURfvYq6s3OdcjMibm1ZI
-goQ53Z4Vk/AqsVXEWFExQupcLbfkkOLOXhBvapYtCTE4ydi+92lRuhRQVq3X
-6tzaKS18e82t7/sUnt9+I3jDCrq+u+MzjWhWEow3tNArj6FlaF1jw3KNr8D9
-5gJHASg+x2JVbOE7OX55ceTWz+Od/Sc90kyO8MuGmMfEWHen8ZK8kJ4hFYbR
-qGUsQirTsuFWkKeDY3gcGUIarsHeOtck7dCAj/3SgxCnXJrOdJlPC6YtV9Py
-kZjXr4ZWjduwtr1mRNcg7hMak+Ykzeo1ym40JBRW5GHNII58NJsPzyCFONXa
-mSIKn5+8cUOojBzFSJC7pfdH6ZBbnrw8eRfz4wQePoLIQ1xL/QYP446SxnaD
-EtmZSctfjZA7ae4uu7ml3qz0xbm8DZoWVHO+KkJiuPlVt3JtT6q4LhojpvU4
-YGUJhyspjq3EZ45qpcNGNiGRQ7s0XAr3NrE6VOVU/FpXzwSvn0v4JvdQQa+3
-hPTA7Z3vRcWA4gajzmxxGBIsZWCSPVlXhsbeisFaOjfwIa0xKxfSUeey2ceN
-dE8MDCJcojfJOOFd6fmBXhYOfEUHzs+foR2cnSKtitQ3mNYcXyR5BP06UZ0c
-tnhbkby7s7sH9ieUPbgo/97f3/ohRBqMKGPtYCxpnPM21zpD2ivJrbccgRvh
-AfnM/tqDXmsas9TfzNSCJ0ky2UhqL0E1FdWpPcLmJiFURUS1mew7HhOAE16h
-ufVCDzxD1QgcA4iF8TUrkWEuJLzunNtB/JwuTvNxId16aPsS3R6kMwVFjtZD
-L2kLFgByFWxTJtrd0fIRQmibLDRZN22nDRrEFZn11t9ZVqL1CS3j3QQ6t6+M
-ZMPc590gy15jg49aWfwsxqwjBTr2mRn8SwJGJqjQE2KJFrvDlviDctg8b2QH
-QMJfNobXRK2knh+D4HVDKjkxX8LalsIBepEkxlk7leqDut6HcLAsCi2dHXiI
-pdqZDRgGD9CpmvkGqsGddWLQsec5kI2H4/NIWsCEv8n4DjcO6TTRmMJPxkG8
-iS/syXaXppMKrnelMhS31BHo/X2eQBJmlyb7KmQBsh79kKEwhbWKU85juYWN
-GcYL4By8j63LvfC2TDg3dKm+W0fk1xGsQcJStDxVp2BAXYznTB+YC4aSYNVC
-viLA5YM2oSg46DAUFZlMNPegEQXs/sidYT9WWDatNX94ebScpUzJHcAUd3w/
-lYULQ9WNP3umzLzWu1O9pJBU0nSFQyyGMqWvQNIK+R75e5uO9MbrzpngN7tP
-ap+EIVXkBnOLpne+SH4dCoHsEPbubRQiuy/h+yuZBWm9NFY0+IyqYvghlVwY
-b1qHURKCtwRYsv/V9qVWO7b0+SK8nu6GTCQgpSHvEMoWfimkTC8J4RXuxIgL
-yGW1FW5T26i6Gdh2yiZY2CZ9ADc7Ye0sBhkbidoJr3zsnSY63htIJzWZj7iq
-nNKkgqQ71IQTo3yYyugxRpmYINahhsNrMY5bOGdYb8WlVc0k7OTJ2T7t9Zov
-0hfkiL5QkOORkis56nZHIVLhAg/YZ3gFX2fjdLgYojNwZaq8RXwocUiGTeHV
-ZS3fVPVG23eu0fdFjA4KWwbGddJtJVhAy4cQeFQ/5B3VRaxV5WhZkW8zJy3x
-JKvNbOSMnGKu5tqtgSm+ReYay4KUw/1pMShJQfcylO+tgEQqTr3jgAQ2uttF
-UHauSSlD0i1iMYrTEtmVzBnLI0StotLgaOL7SkIgZY/03+cZQieOkZglF1h6
-wVRW0YKDsLgeDdo6BhJEpwMe2s/nHLdPB8nSKJwg2SS9oc1ozopp4KwbgWZY
-CHzjKhKfHXMQcbQ0xWTFnH3IhKosppnEygSdxIKbwm7hoOVa4wGUip+qXHE0
-tLQhAYhHqQm40vNDh7cMIZN57TIh21Gd/ygGq2WjmuKOQQJfwpVBHz3UXouT
-zqSyovSk8lUTO30vfc8J/wIX+v7cBIGE7TmFkksxVWurifKe39BMU1q5LBUQ
-tfiGJr5EigpLlFuD+1zGEo1VK0snT3L5mik7VyNmXvC26+1Tp1pob2h2Xltm
-vfms8Qm3LxLjCI/LXjKQqbaWxRVcYn2RQSBOpDIb1kGUgIQgRtrAt2mrylfo
-nkkEngy6FiZcG1WsdNJefsK+wsvL1/68ozc+LEl4zdb3O8h0PG1FV2qGv6UD
-8zxt2EvBZiIQdIG5KVv34A44mdV3PQsKrfa43rD/hnX5jSChk092EZEirVIF
-mhfmVmzNyxY9wJnNs4CeQElKYEs7s8EiNDPx4Uei3Kp5erkm/SN3vqKnW4Dh
-nqlYbGVLivqyMZNjxSBIYJRVzk6JNQ1qF3brtXOQpXcfs1lVs8uV3Wh0fGAM
-J8HUZ2LUmvHRrRcnGcUrbsgS6oOR+RTo9mKH0vo8xVNLMxyqHzEsb+dfjdRi
-a5ZFLIFdRqzEqj5MWFIPb5kP+3a21qQRZk/x0KW+5RKacBul9WZVmIX8CTRn
-0yi5mjAinLJCybgCtA95yqyYRq13FPJtYUu0Y182NxR62TIGkTxa9vzLOa4P
-RP8VbI71zjc0ZrmKcTgU018OIsgbQez+tuCzGSxmCTf7wg3zA2p1fj1qPmN6
-GEk+RLqKPHDMSjB3G2Fr7mPpLbiZQUxKZIBhiYPdaPV9mnyQ73yIGXeEXdJ+
-olXaj1tngzxA3FZ62sr/Q0rPRi9ijSBseflFrUeZuXXKrFaqCpGK4dWDgrrK
-577P9QrRe6lIsiqc36L0uLbSA9Q9FHvcA9rCF4R2aSNbpkDcrO4HzSaDOuE9
-n/DENaiJ/PpUTA58a3WRN6mkZ3XIEEjhm4dwe9SYREl4cTg5MRae2WrUCzrY
-7ty7MlAG8RmeR8CqMVpV069D2xEZTUcA01kTgllpOQVCQ+vX2vbU8Pl3lDOf
-X7+390QKW3pFjiR6dFXz7QHktjAyY+PhceYjySZQtUfCoxBeKApoQBwFUPSg
-xD6bfElvc/31kCNIB1SPKOqfEP/fPR85p/SzArkw3IxMzQKblvIoQcdW2pKm
-e1gHT2n86Y2GHFksZeykEGg1p1WqDfmI+w9yAs4FuokNOR327AJyyHuuUISn
-WXc0WYULS1a9VpNy8zNFZSoxIpq3xrL0mMPrlg78MGAAfrElJ/7TAJBV1Qke
-rWih7p2LkEmaqKOeE9nNhY7sB5KKQ3pteYQ9leMCE2LcZIqLtQp42DiA5xN2
-OkdtzTEwlzSddwLmMXZdXiEyj8SFFWakhuzeiDxsp9LmgATnjK32Lc9ry+HK
-RkCNFGoxi3aA1SGbVKJmwFan8cCS+F215PzseDmb1sF9HgV04G4+gfSrnUwa
-iucpnUkV7bEgzvbdSceXUgWppIxytwkP9bCro9dUjPMump6pFRp/kEfi2eh1
-yjg01Wm0H1MoYbTh7qs2FIw8XAmBgwJLDcNottYLLYc6GbGEmYkoZtwPnVZq
-TjRFtG2nCtBf6FJgUIC4oUgh8QUkual1hNNRmAa2PNdcUjo4CEgS86qh5Qxx
-jvgKttdrzSpmaJBhsT23HAki5qilt/JVWFAHDa2e+Jg1qdur9OIFNblwACox
-RtaEZXcwae7wRnGfabWdgkPm51rZ16zHkbTO2Nvdh4oE3SXJzDo4SEqx1cBm
-gd6MAcpW1mgoLD2hKlT0zzNS6R+feUtpwk4aonV0bzUJ5PznUw3kWGnjZpak
-9v7G2sdmJrQFYsyRJP0OKa6WxB41baBMCe6sdCOSpd8mvyalVF9pibbQhoKJ
-ozDDXGrLBvKtFwhbLSr4Ickqb68YkllnyUDGEfhDGGLdSJwtsAC1SBfpqfNB
-Q04l/nlqConE4oBMmkkT+JRn4k+plDsaUnCZPGIMU5FXxCjvDRdW0sxsCWYF
-yULNpL1136+W1T81uFsd4MjHIFshK1FLIBlwKjqtIhYFXA447ijOydDX5wyq
-3kb+w3nelqu0alLlbibFQLxoD6WTcDftlubF18MiogMGxgqWqeusgmV5oEUP
-Fsa2D9tSuqqUXQUvJ1LjPQixyDbNtJyox7a5FQmsgaUmqwNtEOZJFqzx1wQp
-cr7ZShp0a6m8Ud2LpdqBToogv2JhAU7w+laq2LNXIl3tl2iLUi3eJKAS9hP0
-jYlW9ILpGLdaz4f9lORxRD/96fxMpbsq+oW0wx+RP0FH/MvpuxNON4ccw3QH
-UnYgUtuU3ebMkg7Ga+6HRhnOixRi8m1NgVYEE6FLS9CZJ+gLtKq9j1vR3seo
-tvTsWWUns3o8plzyBQ2dUUtU8v+lN+mg5UrSs2TBLkeGxpddSEEfBK21xwLe
-iLsLRg9I5A+F+Gm9GVYrgpI4wggCO7WK0ZGWUPG1gySlq1tRR7NXhp6ao+RH
-8oEz4kAvEZs6LkmuK+dDpoG+e4SEBmhRSA5ltU7qffeyuUqcVSb5JxaGas8H
-Ua84V4bFeqgzHDY5EmK827BcKbuftGiEReUW0CpizD8Wy3poC9R0Fm1eJa7u
-xpnJRtug0zZcqEjoXOfwXK0a02MAw8nDGVIbsJU1pIaTp8yaorHENyyNivLJ
-giKTHMhcM2D437QyivM17g6FXNgyFRKKXywOzlBmhVPowSRLSTzjberDk+JG
-I1CaEOngMNqxlCz0zEcWOQxX8I0E9qQfuYAhtx2/zZhRNolunMrUZIOpqyav
-pMOhSotBMlmwPPFOB0hKlBn6Npw66R27tAq4DtlN1uyAQVkxEOFJIxpwx9WW
-0ZhBqzB9vUJNM2sssxYQBWax1n1ERjaqLWcd7wDvTnwUwqAk/ynYgxVCHI00
-L8YXFlUhg0btpjp1LDiqKdGoQ0FqyAy0OC1KqWZERke76uwRbRVPA3lZEh/C
-PGW8Fn+tgNGq4kVRp7gsuFv3wWxlwaEDM6oyGE2EFR9hpMpzdySzzSUsekm5
-J+WFCXIFu/4bhb9pb8S8b+bwFbNO3B67I/a5rtg3EFzntzQgRMmhb3LG7wf0
-zqAJCbAEa0ApdtDzl0uybUDIC04GDouTD8ECObBZqrMz4ZSyoq3Cq1YagWOi
-sAQtOCtFRC1jETy4734q7kEMekFFSi2VFhZlZLmcBSer1emDj6J2eXcu+n0Y
-FhxXuBHaifOX+B/WLfe8MLStmWL7GX05Tl5/0jypZYYJqElT3+brpYajlaWG
-LTL2nykKLCa8vFtlePmGHa7Apc7dVgKEa1QXN5Jxqzp5UPlX/YvaNsnXwm3M
-gp0S3+qgsugDfB2GdtAD7Aoh6Ay4Z1BSeddhnH68JTyR2mq0TNKnDpu8QVOt
-1L8bpnHjdj32LLjxrHDmgRnkNMCZHcoaNhatNsY1afIx53KycjAMFRpO6ZRk
-4wcrKYaJuXU3c1aCEkYrM3ajlRm7S0nXkrGr7CWzZNxYk3F97i5cUdG3Z+U+
-mI/bkisjtc77EI3VidTB6X05fzfy+buQbyVOc6JupEZPbOLUvyltN3owbdc9
-lLbLYRmnR2dHyyEZ3FRc3TGemfuKtXzB+UW6ltDs1ePuq2YZqZU6IEJV1PAe
-sRUe4L30G/SN2c/xlzYffMdDEx2SgOhdtl9B1jULPgY6cNf5kCSUa/p8ebwD
-hHzQNy+10gon0Zyl9bHWrtRfw26c9ioiZSpWcGiOfytuc9yTYkBwGRbu2aym
-q1D8680UafjDYvqcHj+WUOtvfPqdkcODtsREXwVAOIDvxOsCMAV29E1/4Cu7
-xB+y0BNYAayByEd6XZXuXOzVhrpx0NdekC/rFmQMRxSTaKuFPYklYdtdFZNX
-NADsexjz2s4KVOi0Zc2UlvClmOekupEuhAAe8TeGTlXw2vcvz1F1aVASG8ej
-Pdmq/CpmCvze76J0K5rCVK5E0bpctINJVvY0jlDwwq1rW7+e9YeWoLqFBOQ2
-7ksOopEKigrOvru4ZUmrvs3KUYxkfvTGq0EifLgvJCi6VTOQOnaAgUoaBfCb
-CSiAurNsH5Emh7NBhT6/0Chxwfl3FrRF62Jnak0f3WXpvRUGEaPI9s4TEWbj
-OOY64iAf5yUqvBxJqAYuGlx/75T/pWoF++5rTaGJ2hAFRYVXFK+YZSV3dRdT
-cbsjNAwV0Td0hGYeFNTu86VqmjqSPFTQF211y2i31DI6bNIOjNSu7OYszepI
-/BEx2tbkQeCalb4wWxIoJa0BwdGocMMtL0gB46vc4y4+MSR5WIVV8JR4G8T5
-h4WmRYrTqhylJ7ioHIUvaKm/pIMLCSYWYrq3v4/7h3m17lbLdYZSpOwxDRyW
-3ga00k0pk5OMwcF3YUl7O5uxNexUc2As/ekl1LUhKH0znJoJCxc4mSIqxoKD
-T08uXzmxKNYFCTV/PjqLpbTx+tpRy/2Afe0cNewFF+9Maxu8IZy7kVJYbPKp
-1tgultSRlD5QgxTeJwppFRGmzVv3lni5uampl518TylNsbnZi5rYZJXWUGdW
-ICwVk9TmLmYUJnkPBwKIhaYJKdGQncByAj9aU4EBksWspcEbF0FtkMIL4+WC
-vUOm7lem7qt1ZnPTl94gUtlIOlxTvec116iNSN6VbH5YDbsrWEkTCp+3klZ1
-VkA2amWGSlwqF2nvBa67WBKO/uA0+VRiZ2i5Wv2LFgtxEx/TWUa+kUHYFc9K
-VtEx32tcActsIP5cHNcXvxUXpZjbjyJaeoxNibHdwJNptu6mR+REDOOxd1g2
-h9UL6m9wnTovxIilX8LTjWuPGmIipTSSOjTX0wYfY7OKb9EDWODLewg2bEbR
-Ty1Ar4ewSaQAFNj7hrtHGLS0O/BFT43u+QxkMWtF3rHBZZfFviX8RCV8dUF5
-O59ooCmHrpQt6sIWsgjnf+gDwKWBUSfhNwi/NLpjkjATH07Wg+IQ+So+EIHb
-CukFa5UQggMdM/p0IP7eLC/Hwz+uoWLamknIlYacSXUQ6/7KoxDCiDzWNWhZ
-GJnRJismS1eIo5qqFotW1sP9QyQcrWbzN7T8T5/+BZzwhz0Jq5XOlIWYF7Di
-UaShEDPOlNMB2UlD7yEofLMNgQPN2UM311jjXE1UpvVyC4T1a/XNposCVlzG
-qMf0f4SUo3+tID9TB7mT3M+A0ye0lab4z9yIpGLuqOuTWrhtDPsz0+bKAAGj
-9aMLx51ye05/e2q/oaQzh/wJWe5QFaEdPrHAckMss43WjO71xyC9CaL2m2Np
-ySoi7i63k5bP2TADr8NUGxUFjXF86nLHWtjz1fmCsnvaEMzHQEUSAyXlVFGl
-wo7LQ5FujPLl/EZO1H+kvNC35VnnhuDQSmcQHzdw2onbfdrfj6UVjn0jrgc+
-Cz5Mb98xdvY3UnSqWEBrByOHcJYNm8+eCt0Qp4ciso82itZFgYubwWKS9j/E
-O1s7T7aebu/1Z7Sca1/jU9EPZWxJhS7KxYaVvAK6RIHIF0+IQkxAZoiw1aT+
-VaQeodHEx7QcItyClUk0M5yQdBFPuBAJ5DlOZC4rPYnr7R92+ttPvu/v9J9s
-H+ztP93ZuXbP4uf0xW5///v+9v7T/s7O1sH21t72k2vSQdZb+zNnhBlZxaWY
-jm5S0hB29qQ7O7j+7vbets/fJ8GtjKvFdAq75hCDbu8CBI/d9v6Tp/6x7W0O
-i8GnT/esIgDUKmyDkG9S3x6I1ePo+Gc+mPOLn2L8XqXaV4+wjzT2UXGPUgfu
-4s9nj1+dnj1+d3GpoQFa0h+qHrJgtB1u0JnDRBpzzW1IiTf3K6Ef22W541sl
-ygyWwF+M5nJO0CZpPRUWbV2IdG3KRbd3+I14Yk1VCTOxhY1mD9yPhCu3+Y8I
-dfex4Kf7gNIW/bNDlGJ7f7fndp5qcsjuvhVMkPqWCGmBykGKirEoHz8uHXxi
-LgE7wsBNdKlZERUOj4fsqTD6EbLSwXzyQdj1mItEbW4e600ToiDl+DBxE+VK
-AhasuiVqBvfcLZE19DlGluyGkGmxWfMo90hyNNeiT2DazNi2E2IhSZGxd2iP
-vJ/bBIlNweFGKI8k7bBSQ4D4Ii8sXkxfV35fqntZFzXqNklNONPWwttITMtm
-9Bf0q81NXwHTyv4Se59LCLDoj7fs2QkajNWW3EbAVAQkqOA42bVqlkBuktig
-cthZxqJUe3phFrg85jHqIoDvecyI4Alhp+ZZKGsdXaSCXkEoeGQGB03WgrtJ
-AhiCHrVVz8LcFKnZTO/NvCWrr7FIHJF85dtcaSIU1IMyuQ9HNWkrQx+qI7o5
-CXjHxzqk+Q1Mtb1o4+xrKqvJ89psvqtsi+iqNgf8XRQzGAx6JomwLMNow92Y
-OBC5SWFoUo0895ccC3zE8cYydBPOsXFoFo8AedQ8IqKuBEUI/qJ6raSBajvy
-EaE0+7lrxk0BlfIPX8W2U0rDu4J47HbRX6vyx3f8Zxb/whvti8hpzeO2IbdP
-iHEKgwWq0kgAd2CxkuS0ci7hXagOoiZ/n5gq0RPM6rizylAi4TSgq0n26PSy
-kLQdXutNMquM4ZrS3RZf+d3Vxi0hUZIATNSovGFXeWunGhml++21aKRV2dXp
-x2XxK10wJmSc9X4db21d+xRcCX7QAOumovlXo/AlGvjhvAwi8P94ZoZblZlB
-I7XCXtaXg1i4fFf6UCbxpu/SHrip1EEmCN04KrXhNd0BJjeo4OA9Z+zkU4dg
-yU77ZadXexnSC5Rt1e2oym4BAdYnSBuIm2jEJkDS9LBOHCWtgFN5gvJUgesZ
-Dw9YJahWhSd2V2qlDTa1fEzgn1/yzvsOzGGIj7n4e/69xkHvPfy4hC5oHKT9
-gujGEGO5zWZL8JNoez7CL/Sz8Iofn1irG4RFCDctJxonKR/hNzadsJVZwTgs
-6VTVjjWrYhToH2tMPv/BsvGRW1U4/oFK4baiVqM4s857Bm/50loavXFEdclf
-aJME4+cMQB9jHCUIopyKVW7GSUtt5ZutAF5D02Z43kPjPj0K6ibpGqVke/bR
-swXtGvWVFoaSDi4EUAblGtKhQtf1t3T95cvhJdxCySYBTeb6U0HzzUOrXMhl
-F7Vp4X2mXUZbFfybTHXpXz5CeoLWrEJwohbZb4p/SS9tVOVDpnerKBWCgi25
-YqmaVTNE1KqWZJHNJeHRHcznnD0EB38YSkiznp+88SMGYYd4EnH0YWJBZpUS
-Vq1yRd2l1SWHVtUbCss4EaQkKFUOIZuQWqK2YPG0M59SWqLRg1rKUgRW8T5d
-S+k133pCOpRKDruI5b5tBEuh2u/ECrZ9QvMRs5yhMUlSsWIe7/X5P+lOoqkY
-V3DQ4qFG+5bv9ZpK55Lt/pY2PQmL06/JXO4LfVZ+l04rX++18l/otkJvf44+
-RwJlBV4XNjBHrK3cPqrOcU6+qANJpWXz+uGDqGmHOaSrSzdk1CoiX+ND3wW3
-yfoRvzoqoEnAxFU24vd5ddeHkb/Kqjq1+gx2Wq5xn6wdeHS5epcuVvU1j2kZ
-px+x0dz6X2LCuEXMmoqt0gtTFkeUqNVXQNt8sJMpEla2VLy030Fft4bZCLry
-s/bM7/v542d+58/14PUh33QT7/Gx8JJ9MSwAgs+h9ZbeOBp6xT052NtZc61T
-Cxsy8rkt99ZsZIrurSSkRfCL7Yu2hT/jFXvhmM0rKGVY1bNxmaKv40dJ0GnK
-6/H7nVe/sqFdbMijOgGadqTPPtPGQkKynzddF3DbrP/hSnhIS8meW9VPcrld
-JMNN0mNIVSJxPjz3h5eDJgrCUBmxrY8nz623NnibThobEOWDh+sCe8XmftM+
-oL/5HqC/ibj7m+/n+Zs2NJUhLBxOJlBWV7p8jmPp0pTl1fkV2Go58+8KUWL0
-6TOJ/XvOM0n8boMSlkvI4bl+ubozvlfLj8leeGHaHLYDcl2G3ywWMaBLRKT5
-eevcm7YnPbei64m0JPiGPrxRuw8v8cesxR+571fwEefoYT9aNa2T+IVISKtl
-4tOuutXBuBJbp5xfN9tBhO5rL55cry58VvuiAd9VK4oBJDo87azdg40TWMLa
-jFyusJpzjZYwLHxlTUVOesPULdFkdSlE6cmJkJqwk5/oBHu0zeX2b5G1f3Oc
-jtJtMHf4ZS1DlXysu3acojNDVEmk9UH5y2Vdb0VjPolLljKR7X7AS5yCRvas
-wtNPVAqdl0T+k3GqpXA7hFKWIZjvP3zGzgfJGshGnTcA76tZOg1nW+PujC9O
-fjw9c8cn7y5PX50eH12e8KeO71M4gkeo1pwkiUI2Vpm4XUm3swS2+nZ3+8xb
-IoLrxU92eYNU17oiGud3DRoGtGs/2ZF/OvN0hvVG4yu1ZoCWIGSnzAbzFs/I
-luRd9dZylb+skqzdUTsjuAw0DSX+0RfaFmpwwZzLmRb38OF3DBNhMKWYDVbg
-1TJ6fBk5CFOvgmUz9cXBBhVMV93Q7vkuIcjX0KPNzll6P9ClOmV2OCHOjaFv
-4LNedQ08K5KkdX9kj9zREAyPuIG4VaJPB8KX0tEf18bJpFIXeJJ/qHwHPB8Z
-omRfiJ14c3Mo7Kb9EosAHpxlw9tigpI3jb8QtsMXizK3z+Dctcy/0NkJP0eq
-rvCkKbhYcvRa2qxBvdeRug/70f8FHUioMGbNAAA=
+H4sIAAAAAAAAA91963bbSJLmfzxFrvyjKDVB3e0qye1ZWparNGXLWkvumjo9
+fSSQBCm0SYANgJJZtudZ9ln2yTa+iMgLQMp293j/rOocl0QCeYmMjPsljuOo
+zuppemQ2rm5Tc57WJ9PkPq6LWH81L9NRWiZ1VuTmoizqYlhMTef85OXpi82N
+KBkMyvSOXuYPNqJhUqeTolwemfTDPBoVwzyZ0dijMhnX8TCZF4MsyYdFnA/H
+6Sje2YmqxWCWVRWNXi/n9OTZ6dXLKF/MBml5FI1otKNoWORVmleL6siMk2mV
+RjTffvQ+Xd4X5egoMrEZuyXirySLk0ma1xX+mA3n/Nlegv8NJvzXbDGts/k0
+/ZDlk+guzRc0izGTrL5dDGgvyaIuZjT1sliUeVrTNO+36f9DgsYGPTelr6qa
+nrut63l1tL0tL/aGxWz7i69G9O1tUWLJNIwx48V0KvDZ+PfiNjcnDj4b/H1R
+TpI8+4M3Rs/0dWzzOw2Ok8Lo8mQ6S7IpPTKvAeP/OcGfWI98uyizYLVrltgb
+JrS6vCjp8+yOgfH25cnB3pNd/fXHvcOf9NfDvR937K8H7tfHOz+5X/f2D/Dr
+v1++OX97cXLES7A4hg9j+tTs9XbM5TwdZuNsyBuUpdZJOUkJtnax9/f3vb9X
+RV7Ohz0Cx3YVvsJvOJjyTwyghfP8RtujUzY/l8ViLnMwVpm9nd19+vP1yUVz
+ha+LUTo1J4SP6YfaYfz61c3w7FAeneuTvaxYs0o7594h/dnf6zfn7ANd9/hf
+06FvN78yL2Fz7OajDbeniLJ83DrMw50f9+wB7e8f2l8PDu2vT/Z37Gk/OXAP
+/Li799j+enDAv/529vb053f9ty+ae/gtK9OfFwndSEJNgtzPaW7Jxq8pIdrU
+Yqy5WuT058PnfU8jTTAS36h5Mk/Latt/OB+N1x68vUkJoYvp98yLIk/zcTod
+tU79Cf35e/88Xj2F+XxKZzbIplm9NMUY5+RJHgHU7eB1khOFmeG4+NCq9Zuh
+KZO6TIbv07KXpfWYMZho4raQw2WSxzjJUXqXDVOhWXESLmL7Cxj+e5KbtDbJ
+tLexBsPOL9dgmDknEJnLtMR8hGjnl5tHpm/e5YQmZZVMzQsC8rAm8s27vUyH
+izI1/TPZJH1bDQt6cmmSfGTOCOvLgs5G1/ovgSBPyuTvyTSJk7z60mbP9bmH
+dhzFMdH4QYWp6ii6us0qQ7Ms+Ij0NqaVqf9pDtelvUZ6JnggnibLtDT28tGI
+SW2maV2ZLB+l85T+yespYQ8AU6cjQE+JbJzmkyxP0xJMRxiU6WzoGqqNTTNS
++BpCXJq2oNWWP1SGKLqAmHbQpWnuivepKdNZQZygLopphTWOIqJE6QTcoU6q
+95XhgaZFPomndLojc3VyYaqUGW3VM7w5zwYJNBmtJmCjw9sEl9TcE2szz3++
+iA/40AnnkqoqhhnvreaLDOqKYzbzaUILJyAmpqIPp6mZZlWd5tjvvCjrrlng
+czPOyqqOi2FNh+kAic2X2SzLef6eOaP1zJPltEhGhg4z5BskZJTlEiOtp9Wm
+Q0R9k9e7SljlYAQKV/eFqctFVUdMyCuTELqP0jGdElGx2aJe0J2QF+g6iBhS
+89Wg6Yim0bceZGZAx5ymeTTKxuO0xJM8NuEhceOczjo93ztnhBqZNC+L6RTY
+SXj4PqWXi6IG9s4Z4hG/GRO6CawWFV3Xqzcv320aEnvMPMtzBiSthAQPujyj
+uJoDLYLlYJzMn0Vk90EYFa7LdDIsy6LEqCBcINQjBKPjJCpBoKQ7CFJ4TDiC
+o0iiYVlUVewA4ycl9AT+EzWQbdKG8gpHb+Ta8G3B6ellnNEZ0FWN3FUdpcCC
+gV5VhxwJ4eeMEBXPEN7RqvE1LSCPK5Jihu5W45W/EwmLMDutdb4YEA7e0js0
+xOkHWnGGMejg6oIOIRkQkmYtQsYr5xeHBIW7LL3vCX2ZZaMRATJ6BNpXFqPF
+kK9K9Ao0jwhDTvyJfmFcMnrBecdKDCwhoBnHZUKnTQOAwALrsnxYpgkf1ZKu
+8nxaLGXRfIXLhRx4JaS7kmuJy2+SIf1dYTsk4NBGiBpAIAF68R8gDXZegVUF
+1kaT17c989st4R59aarF8NauGetx9GuwNB6h50nJVCgCaUoB4LtkusDqQQNr
+LBGnSivQ94+ElvH9myVLc1tMRy2CBtLRJRSL7hI6mAmdepEJ5GgVmIdwZ/i+
+0rViOId4BJaKhs2XxPvLsrgnuksUdA7A8U6Cdab/wF12q6UFliOmNXbJg5Ru
+y8iTLl4FIAVoElMhHJAbkoxGJUGcwDig5dFmKnseWBvEFIe3oGL4445uRXUU
+Rbs98/LrtI+OSdCG5+sq9f34USXyz5+7SorBBANqDEDGQoOFMIOHXb07J+Au
+eCcMGwOIbNKyaZ5bnLTbMXEIjOhotuGL2/n4sbm8z583CRZ7PRIcSDybE2hC
+qkNsY0TjEiniLQg5YN6bJoRhc2J/QCmaHdpMXsyKRWUulzTlDJOL4if7U4T2
+Y5Rduo/CQhwVp0NVkoM5kildohFJL8mM8CspMeS4LGaAoZFbNRO++/GjW6ls
+aB8boj1mMxpySqy6viURm3jBBwLtjA4cqEnXdobp+bgTRo0sX8jOx9NkIgvH
+rH8QSYl1GLwFuNPlGaQJg1QHwlnSSuw3spIDrKQijY4GHyrhJJS9v82Gt/7u
+LCEJ0F5IWOuG0gA9MSVOBhZIQ9O/NGiXMQX0mEQDo4IC1gyWSE/Rv/QU33vS
+2hm7mfY0lLWPH1Wh+/wZwylIGJR2sZVs4JDwPo8HmBByJSbC78HS83RS1Jmu
+4ePH4E8Z4XHAm2PStROm4swhlFPTW/wtPf8wpxaOyyQQOnKb5/7JgKU6bqqM
+0N5zIhrAb2E6CQm9ddFlzohP09qiQZc5JMsapE8oiySK8jCT3LY8cvtr7DEr
+rQhU0bIePSJ5hzQ6ARvP2FBYPj5q6A6fIQanBC95BUKauwDMxk1FqD7FQd6C
+Ojwgv1r5FJy6TL0YoReaSDCNNE0GgvpiWmAiRkTz/bHuImAs9oqCqmHqCCQB
+6MYYQu+laSj/ds1gAZAviG/QJ/RnSlJPammjF5lLAyGJ3ozWS849UmeIfdGe
+phBOLNFz5wPuNEpxtoWMQ5DLiymEqKFI66bj5M5CBZByhKnHNNztIh9hG9X7
+jK7fJoSKgj7e2iqz6v3W1hH9PoEFgp6OHLMak9hTMXkRqidQIoKVK+d1y3wu
+U8k6GE2YOFZ08/+xoAtSRXWhAlUHp67P0zHzTmR8sH36DisSTLZ/QfhPp+Pe
+puNxVUXyWEXLDzQIqz1YQddhkBJtGl4uIu3sfV7c53y01dZW17grDDZFGsMg
+lYPAHgVDHFoxz8wwNa1wawsSYTYheRzCLo42X4JldFn4g9hAuAfpqyKylzYk
+UZYAay/QJjXxmDm0wWQWEY0jNpfkw9TjEKv8i5yXzoyq4vFFEowhdzflNtyI
+tCJ8A7DmrFKApc5ThqvI2KvUSujwbSraNe4tqS9VZtddRUxPhyBhoNxyrUoZ
+ExKioh69W6rATOBhKXCOG5bTDmgsoiexu85RsBZD09wKqclF1QE+Q/nDrofl
+cl4XE1JDCOuFWUMfB7kaKrWm+xm5FcZ4JMYjnz+zNoKlQZ6meUnJuSumC7y1
+KdTrsk7qhUif0M+duvaChf65CNOsume8E6JIGYlOIO3eStxtyvRbW6FUv7XF
+h6JGBNCS91WUjAoe203MsrAIIbA2N02EVr7DB2KRqQsxzTAfcR8Jry1ms0Xu
+YJP2Jr0uwyAdj0HWiXeUE9bUIITgixsegCW/G/M8K0dVHBXjOIlfpnwwdOIi
+29OzkwJMDdRlvGBFgQCYjxK8cwWTirNwiBZlbuKdnRugY1rWwHnZnbOeC2jq
+dHiLFU9ZelFeYK32cZ4uiClNGetAEQcpXZVYjDoEcCwNwiSsAyQOZbQ2ADcd
+4YCByJBI+CJggBeMXoLVzItwh2Czr8zG63eXVxtd+b85f8O/vz39X+/O3p6+
+wO+Xv/RfvXK/RPrE5S9v3r164X/zb568ef369PyFvEyfmsZH0cbr/u8bcpk2
+3lxcnb0577/aED0ytBTxRSto16IUkihUM5pFVi9l3fP5ycX/+d+7EMn/B8nk
+e7u7PxH2yx8/7j45oD/ub1OlQEVOVE7+pCNdwpRE0h5GAeUkBpUR2kJNA+3A
+FYR4TtDc+isg87cj83QwnO8ePNMPsOHGhxZmjQ8ZZqufrLwsQFzz0ZppHDQb
+n7cg3Vxv//fG3xbuwYdP/22aEX+Kd3/8t2eR4MiYZLTintWytJyJzAAmSeqT
+1fE7dLU32KOyeRTBgNnQkftnyibpkolqDHZJcm0BRW2NLa4hJuCwjZjV6BTe
+EnOUKWBcHjkWbjB7JaR2VZYgySMZQZWAQQcmeKuRQw53mqfl8MKqiW9v9JkZ
+b6gASU+SCj/k9/OCxCzQ12kxqETJh4hprLmD7irxsBoMXIbDogFNXRmWyzgn
+7J4hAvDyOipvzWrQs+6KjAHAqDAhlgXW5ysnR/wQDGWFXILi61S8eQLHpqLO
+K3OmKr+6UUbXAorrgLY+wrzgUVYMAk8UjkdrsobPkRB2vnEsE4o4LYZMWgaU
+AaLRq5Y7xqKXK4Y8PWRa2IMWPf+Fk19Y2QrlHTpk1U9ULaGlZLwUpjHftpQk
+3DogoadgQQcpL1xbQ+SiBQm38xqQEQ0Io7EOFFgVaXkXYPz9S7Nt3rIKHp+9
+sAh1oLaLFe09VN3tQysKvIFyaW14QKdbleS93YC51NIQ8SB4ZfmQXnZG6GCk
+ivUCEAcxVv5jkZW807pgpWMpykalwuNg2dAOlU0x13JiyCU0FvPmDja29F6o
+kSyOdRlcS1bTRPAQak2gJ2U+m8T8yOfPNOJ//dd/RX+K/3s/f4o+WeVOlCmr
+YKtbwqqFm+ahn080gjg3jcn38m2maNuwDTz4ytoRWKkNVXfSgUZdGRJ+hu2P
+LJrV3YqFuy6d72Jad3u93mca4XvA4TQfFkQwJ0fm3dXL+MemUeIbdvE91vBS
+zDUEib9a3H5+qlaiv/11Vz+CBaj621/1bP7WBKT94YfMIKt3zJ/NyZvzq7Pz
+d30wxmMdz+ALbyz6jptYZ6Xr7O4bXn21efR1bNAoD/Mn89QRgstn4Z9y5eNs
+ZDpnF3cHm8++70G8aFpKVRliQ+ZILZdstly7F9nDzoeXL/1n8TO1r+pPh4Q4
+AzMrsdTyPcnja0b44fwH2vKGgAIjyJ3sNGTJ9VezOcDVu3M7AP0aOtE6ocl2
+szHA9wAjnIFE3c3ZxZfO/KGf77EGUMmPR+aRo53iqf7zhtI3S5T5u43PlmWq
+Hh1nRICgTMMerM6iCkZWa6AFF3KEgqm2ekRJWFMzUDcSHhqzjiL+TGePY45j
+tWJiWslMPEWEYMnIGlIE7WK8ELXclw3G0kLaj49aBvUo6ueKQznp6IrHVcOT
+SkyLQLUo1ZOLOUlkPMvVLsBSyDANTHxRrYq0esqsZErYvs0mPwxxbL1+7PNk
+nVEM3vfpdBqrJQTwiGMjin+W5AmxuU0WBthAYD1cYLOYC8uj1eYpe8fsCra2
+FMxFubXFx8PqDAkDowhwdgfugN3Ba3xZwfnlNrJBBp8fKrnBTZolk2wIu1rT
+pm+yGYnsmdiZFvMiD1fVsCkfi7PRbUZES9lOtG4r8oDbCQyacKD3zBtriWEc
+DCYUq4B9L5I38BH7d4UCs+WLoTKcwgYpOoCffdx+AQsi6YdGG6ZsoVNhcH+H
+4EpvstV4y5ytfRGQ7a7MAbOw0EO19hl1pAKyKcvhonjgTESHIjTsyxGpk4R4
+FyTVQTqBjKyukt3HemJykGzWIFmE5FaI8IFzi1CLboPz9sqVEUmexGe2Sq7s
+JldLbF1AHfCXKxVwzsDoMjrXuySbsstXthFsglRG9oWLbz/B7F0SGmm4MoUb
+CJY0MZTZdwdLGp4UPMLWTVilhwnszww9uEmrFAPNCa7imwXZEMi1IeFMQ+GW
+LIXh8cVw4y95Ezi8RqATu0b5bTqrLquLspwQDdmtv6wYHLcBLSsRQZiLOVsF
+c5ncGtyBAOosdbhhtTKPC1/Ct4NT06H7uilYx5QuuAdO7T9QecRdByjND14I
+fG7fCNSB5oXY9RcCoGSIQUzFdIfuNEBFqnQqRxZEHxxF9MKWk306vBP6Zx//
+PMY/h/jngASo1grZApGOYFSA+sUDSOCnF8VsoM2qR1InZSGhMenhAf7hSU+/
+YVIawIZLWf+wVYpV8MiqpotYLLmBMKOr6edLdclbqLFD/cgf6IPkizHDvx8g
+x7e87QyPCU5uDj26p6biMJio5UfHBkJnQ8UXR2zfYr6gFwgJ4MGmS9iNrl5d
+mv6ri3OhRwiIhINWHK/WRwkTkXhO8DSLFo6LBpQHdoNoOIUYj9AkfYW4Tuku
+NxhlQEUY3+UaVIH/XxwY6g2JiI8jsJPggNm9GN8UhEUCXkNT5LWTaUZn+gux
++AK8g2inXNDdx8J08cyGG3vDGYoRoL1p4ZGpVwWXrZjk2R+kfQcAIAxi3Ogi
+miEh0CCwkEcOTlVJabBqNkYDASDNv4cvz2LMIvcTOSGBg0Kg58O2wc6LhhSX
+Vc4y0BXPbFQtoFar7c07S1iukKCJAUkyCfEsOh4WN8RF5cRGw4KoiGhpGbUl
+UnGsDeArYtMmdqyH08JOkb/g7vTuFEh5MCIELiB+bVE5Kdd6jdiY9I8FGAK7
+VABEkTq8AEuEmSXRQPP7xaHMx0ee3kTRWSAsJeM6FTHL0jwmjl317rAYx/Eh
+kJggwVXmRzNelHxOQoqPTBJ91VQkyG7toA8bjTq0J0SQjiKolNZBs0mHbz0l
+wfrEZ1+nweUgNHBabje03URiuwnortpvzDrLwu6az/bWfLaP13fpq33iTIfm
+sXlC4Pnpn/mM9Kv/5n/W5AD5WHQ2/fuk9ffL1t+n9u/vuIYXjTlW0eFc0KEz
+gDCx0+vt7W9+zzX0L01n76DX29/ddPs03rKphorV6b/bEtxUsoo1YzbU4SCE
+KlSJ1wZZBeabDQ34ePC6ZeoeVpPo/l48AE0k2j6RCCMbJshMiSXqiIAyiSH7
+JvmmiqEr15OVBnt75aKa8KL2TH86jTjW2BrKshRug8xqvSy3rUzek/04vVGY
+01qd0/MUS1FXYtaUUNEZR7v7uo6ARHjy17MCrNXW2JlTV62JmKFAms40/C+y
+5oLV4Y9WiWmD+IWzkYpOCAtXszOlCeA9HFhMukvLbLxUVw4L8HPEUwRK1+qc
+GNW90L/c9sY6Pc6l14SzWvUX8E6nr68TziJm0PdZJbb7JuHlAExWIBLrR9qW
+paYfrBfZxrZxQBFCISJ1E0hU+nCaZHC+WY+SFRtELtDdDOiky6XIYz3zWh0u
+zmwdudls+EWo8DiFphlqhsAHK07beaxRKZKIrbssMTcwht9CmrppBcMhuK8Z
+22alp7pxoIyaEctqPW9YcfvlGKH6lk5rwkJw02etVgkSIhFnf5NUT/uXz+Kn
+7myf3bTUWnrk8eHOzm68+9Neb6e319u9gbpxRXLaXZFJCCxuKykKREQQwZYb
+krayyQKL6XDUK4fHsJOOZQ66jCSH0O6sOQk0BlJwRKJfKp5GiNpDv+kjlkdJ
+vEP0sUbb8KnmqUdfolyE5kMOKUIs0n0Km0v/MrIhR3PYyRgdRaPpuvNlELqB
+brPJrUSJSSAwXTE7RD5dRupM7MH0QFg/zYZ8uWNs0EbCV7za9AOrDBOnt1kZ
+FtbHxrEp+bLY27xuIhE2booNeGrE4PDOgxAcRFogM0J8fXMOW5cwarvv1egb
+WuJ9QjL+anBP1Azu6Wr+QxDqsDbSR3YmcdV54WI8nTGmsbVj+z2bTyqvR2F8
+DhKNViNA4fxSi0vSHn+toCr0LYBiElXJmDApYXLB6Dj1gTSk8yF0uc5gDBLC
+4G04wlyEmxVVpqpkpBFXU6GRs4Lgj2E5zS9v2W08emlYIysFTKQXJQIRRpHT
+aN3NYoONREfGLgOAb4aNifPENIi5UJtlvowe3hzmXgX8auitKDyMRJzfQOtk
+dzo751nxlMkMPO7DpSB8mf6dbSbQdvFwGGE2yyo2hnH8qnmtFkJ1p5EKYuOg
+o6jPZ5kgEQFRG+PF1ONQl22FpNeNx7D05uGNZ0WI7iQrQRxpTZeBBfzIOWf5
+4///hHv780r8hh2bLmU1HSvqdc3z04Y76vsJ9y/ZmxkoEPJzoSvp6NJURDW9
+Xu8La1gD7i/9rMCh/RPMtv7ne8AhlNwl0L8pteMjiOYCCYRRvFsvgXfXiMDI
+5VnkNknFNA+YWVcPyZ7uCxsiBuEKQsvjw8P9x/bxzuMD82v2HNRVgmZLZ7Ln
+9+jeV8T6ahox4eB1lx+o90rT97CS0HHNLm0MqmZXFc/FtpsodiK9nj6pLWGQ
+lX3JXMioBXi9sXbtnnlO4NqBMXRnl2hVuIgjDrIjSaruNkDFygktf8KyEkQO
+TuBv7N5JtwNeAtisxGc58cFG4bOsuBiI4aVWsNCAOKOpTDRLxewUWKCb0GKj
+IG+lIgKhYh2Rh4TJ+uXp27+cvjjGGbBYmJbWUcby5wzcbMfmx1h48xOEU4XE
+Cc8APTkxjlgHk7Z79XpbjwOPZSccEg8b2kjSnhwecYgSLfiOB44UDwgKPvLJ
+JoIcsQwIvUE0LQuNVQjwIaWIuI7awPSvO6+Pknl7QM3TdKKXriJqnsQD0A9j
+35iZy8s9MKaJJAjpdBEbE0n9Azpwus9kQUIxtMR+OMcrG7qBk2lvVpAQLHNq
+EIK+jNwWrGOLhPcBx9rRUel1Fa9RRerEANM9dx6mRiJRmDsUZf6+xTvN+xHL
+xnnJIixaccdPIuLZnRgDSLacQHuPbAiaPeduYwn0CqfasJjgAuesDc6/I+O6
+cLZIv/mhcsdZHa9HwXQGX1UwJWlQU8DBobQYdq2HrpIsRZacg9NbJVDFAOmU
+aQNm0UMwc7M2wRUAymjoLIz5NfvXkCrr/NppWRYqDnp652IT+37cIN2Mz9MB
+sxH4ZB9pZ1+Zt7rHKtL1SAAla22Ysy6Q/Vplf6TiEFg3r9UlZukMtQBIt5X0
+C5Ib3W49HLrBrhKvF0nUrbiiWEPHOo5NM39gVNCqNXzdJwHblA0JSwAl1Hoa
+JpnQ7JzlrsOBKj3kGfUDedk9RWGMoaiZHTEV4aVYwtfE8fbI/OKQDVt7RfDM
+seePj/x1w5l9EwFgJOoGHAF8Ki9WECmyoO3KubupgLke+216GI1geZzjX7gu
+g5SdXnccp1gXEduWglBC9Vhl33p1G9mKgE4/uKSKYrh7jSsqgKFpy+JDNhNl
+jQl+EJvA5rwooCRgNXfJFPJJDpVDEFcpFik104UqhO4dhlSK7FocPqHzVE8q
+krCMKlWznV0wkRukkaSj2M4mApZ6PINwYRNuE9/YKAuGfGNx/PK+OGSGC47X
+tqPTJptA+Mltf1N820NN/mmoNKNUT1UuVVZrqpG41LAHJiY2hOF9ms4TbN10
+AN7NyEZmkyhKy+tg0k1cpoTkuaoRbIGIFZ6kyf8ld9fHRdFBWROZHrnNpmIu
+5VM0gVd8Hxg+sG4mw/fFeMy36tLmtFr14OMjT7ui6G1AiZzABaloTdxnkIza
+wFQtVSQ2BMtkjMvbS8zNLCW9e3Rjc+L4qqlh0nSyMRPuaVW4e3aTjW42oRYn
+EVESV9THPmtJzOZxwJGCPEE6c4wgQLmRsIMbDHfDDOEm0gWoU9ucclKlrseu
+ISEBM6OPZKghgh5y75fMWVFwdsXIDmZSehKJj8+T2g9KYHKQpOGTZbXp4iY4
+z6KBCCrKRRqF5t4sBpx2MGf1f4WBCK9d5SuCVhK0xBFmMCnQ9/6A2WefVQgy
+1pxQy8VSMy0mk3R0zDZhvozzgFUMlpEkMVqPL6O1VVfcrb4SLWOIxB7ICXR9
+a7XSyNnozirmd2yQFoRhGNlCMmoak29iYj9sW3guppnAT6P5x7iqbK9rmpcl
+39hR3GpVBI/EtMKGR11G4W0rTQuift8JrdFs9qVJjqObLPgY2Md/Sz6APCeL
+cRoPk615ifuvogvdLv5FxAxEuuWSUuE5/opNu2EbF/u25DHLYiVNnzSoyD0G
+hU+t987+PZ8u1Mjrw9BHmjMoC2ubD6/YkDy1UEOiDCR+luI1nomXHpwVOIlP
+mejJkoIU+8af16hxRCu9WBDJk3Ih06nVR1rB8lgf/q/CRTMYn7d7ckHix3Ka
+2nx9rvGjZIZlNEk+CpP8+Zz4wpAqy1ITrF4Lxl1J05GVTKcpZGzafeyyOYtS
+S8qZeUFiwdIuisP5NZo/CPDXwP7gE43xDz4ZIpOWN9Pf67vNcFkBEoOX+ZC0
+3BweyXYBArl4pP2kxNogXIxGmZZ1kKOrbFblUGs2ccIQoVy9yTkig9TmlBy7
+3F37Jl1ZvUFWEX99evXLmxfXJCddv3zz7vxFE6kZNftfWC5kPp9txF9aoY01
+SVHlNdCn5pIfMA8JTPFKHD/jJCXQJfxu7/4oWmuf+k88M05I8fjSAwJ8PIPJ
+xOnABw/ILkpOxjTFPAED4TUHvlsOPrxpH//NsUcfBKvy+aSVV3WsgqB69NQS
+T+cOC1Hnhv2ON238uVG3Ih2i53e8E0GN1ljy3Q3dbWyB4YtoKDH9qr3KyU9E
+uipXRkWmo78X5R2EJMQROTuTaYdQRyuhpykryYqjIXIha8o7cNugTaZSxmBE
+TAqiw4rHVsBr/Xfer+3RxQ57vG6CyHsDxot8qGm3EBZINC5psIAOhRYu1k8l
+hwkmJrDCdlY347gS0i8rZuCjuRCq0kyScoACSDZxkS6MUBgRry2u1O4AESzF
+DrPZnChbPuQwLIB6GWQ8jfkznwAu1/SUedKwID5AYqTeYVu+gHMCnKwi7Ev5
+Ogcj2LCDQC1Kg/HG8DZo6CgEKjdSEzVirRTGVZmIwMoQJftbOvH+3s7ODggx
+fvvpp81QZD2W4HxOXhDlT6GomdeOWQkn87GxD60YlM6uxjJ9Ij6fzAnCKmGc
+58p/LeP3J5uO8WlNigYyVXgTu3ibCGb/1as3v706u7wiyEkiC3+9R1/3Ly7e
+vvlL/9X1xen5i7Pzn4Ov98OvT//jArnKwdcH9PXzdy9+Pr2iL3/pv5PR3deH
+9PXb/tXp9auz12cycTj3Y/r69D9OT95B0b6+Ont9+ubdlf/6CX19efqX07f2
+xebbP9LXXMfybf/s1fXzV29OfqUH7de7O7pvwpRTrOFF+PZjBssqO3GoUmmq
+/ia98fHI+gRY6AgOzsbsfNMJm/CE16bDfO3Iv+HYw6Pfwx5Pz9++efXq+urN
+r6fn12fndIxnwQnt7TEYXj8/fXt99uL6qk9PteC8t+8fAaSu3uopB48cWBy7
+fv7mLYF79bT25TiuT/oX/eevTq9lwOYjWC4hwPWbl9eXJ28uTsNR/Blka86g
+vYOO7G1TTPl8vwXszSTaew4/t5pkGBEV2TI3SKqVvIkksJkT41jlPKtJD1yC
+KB+tcUGXKaI8tazduhOSHexqARE9Ko3ZXaY1W1XxPtFoLILLlq23h5EuR8uN
+50VlTQCQSLhuXW1aekXU1CsYen6ha5BAlrkvVre/BMWiTjzzOg+KRX18FIr6
+lt6PiaPRgrTA0OgOMRFV4OfGQv06JURX4xQ0bsinH0esgTs1zI3Gpth1+ocK
+eR/NBtt6rzVcYePIbOwc7m8gHXzDLpA+/OsGC8TXLNWgWIWd6poQJkei/zDF
+x85dv/E3HoJrGlxL9U+MrYcRZyOZgoOqrrn+jEwzBrPtV1Lnpv5LViEe4Cr9
+UGN0a1/Z+Jv5LGLjTWP1NxotqGLjNBmkUxckJpaUQVKlHOIcRhdhz3sbwATe
+/KYNjde4dfFvwLPJITQIUyizShI5oXVoiVEHfSdwZDldkiiAPwuusASwSawX
+4gszVEnUs7FHuL2IOYSsxr8cSbUoRCBFUh2G0/ATCaCojEj4VTHVIkWSogY9
+Y5ha1IHERrrVjT3cG7GndDXMzgaoBZqqxj02AHYTHiyLyjAT+bO82URpRY6N
+i2ApJIxM5nUjBu4HJMNn09Gq0dKERstgISwDSpkyUQvVRG+PVE5RUrdy8Vk5
+6FSprTczSyFwZ9WsEZsS2Qfd1RFaicEmZTJMEdoxSunXkUYd4YAl8cZpvC7r
+cTYjCqVIeSTxq0EegJ0qV7crZ3gsnS1LEApJjUqxOCOEmWgk6VF2AIjqDF21
+Hkl5AX+IUoISNh4bI7RKOkLTvI1ZQgmjIewhXSlotBKZE/ngIAlSYgsFCQON
+aEOx2istj3Fc9I41QwXh6/xl1AyY0gkUNAM27aRBMl9YekHCjL5PcJFXh0NU
+ATshmSW1i4zDUoDV8JaQRZJNGR00ixJI4DNEw5qCtoJVNEhvk7uMzvTeVglt
+Hqc/6uBmWuqCpBDNckWRh3TM9yuxe0YR2MoWv1rvMArIzwlsPcSoxObT9JcE
+3IQjW8PCMxxjxQYjG6s68jqwszzdmO3oZsUWdcPVODnID9VKifwdId/qRqrR
+KVWZDefXoqpUN0dNS5Wtje0WiipZ9CrbTwstniPplXycIBpdDb+DxLp0ESrW
+0ASIaQ3zdTYn09H6cyiW4p0zaIhgpgWqUxGZ2TzGHgbJaJJixcMCkWQhE66T
+ScXP0PJwUrotB2VQxrBSqEue0ee7Uu3nhng3iqOBMbJeil+0ZE+1YT7fWBsU
+HjJglFr6l0QJft7cqFtxJEYNm0CpSVfDsAZQJbsiCXLdaqXCG0FTqwj7zQZr
+nZfZjCjPNT+CtXJd/HTESyUclvhEvM4G1uV2namNmy4HY37GhXOyfL6ot4tF
+Tf9jWQ3xqf7iJobHLdFKApYvxi/nZ1REUwsCqg6XKcsHXM4KdfMIFVQ0rgs6
+9WKyVI9zVr2Hd8ZWtGneCRjwHBR0G9ZOlLP9ExTJlr9B+claCgjekySbsddT
+iu51XdIg3d9UApWDinI6Au3s9A6BQ0WYxCvXkKOPOUhE7pGU+tQr1F2HTYja
+b52gHAFnC8CxMeUqVLO0TrjaQzIolM800CCpuSRCtSjHxDB7DRrCJ+CeFjM3
+YxtCaRApMYETVGORK2fxFXpPBEyW6ct4NsIWHA2Rep3sIUYI7B1TZQ6sGC6m
+SclFzRAQESbbBfmOnXZOG+sRbXoqNTfVlMS1d3mdHGlQk4RAwOU2F2LBtcZ0
+F5FcZneW/l6xf+W04V/5+EhqLoq9aLXs05H4APSxOIUOLbWPvlj0SQdQyAsN
+dDHjrUq0kS35xHacNRkX0mfCl0YWjW+csVtsa0uzcsFPt7ZYboyC7HRhZb4e
+q7ANTVOXjMvpctM6PGxRXEi3dGhsXTqRz+CEHC1KTo3HXVNLKeu+yFittGa9
+YqCtcyj5kjYdT6WBSmMLooZxtBEZ73IkExfyaFOFQGdUrg58M0JkWXgrOYZC
+cubvi7Bordsg53EpGWReEpa+562HSSAgKTqjfCfyVau8k44NP1+QTOmFxUKK
+qcMFu6GR6xu67EQ2XwyHizn4rCy40jplmvsSydy3CaqrprmRtFxWQYiClAIx
+rgci9TlsghTHM6/9oReuLao+4D3o5GnG7IAn31z70Hbr7/90TwmblnWv/Chg
++dvmuHfrlyvf4VEF9bWC8VqHkp/2l3K+2Mt9atH62CT3SVYz2DXsucNH0Pp+
+Ua3f8n+2QfCA78VIUBWPWj30VHO/dw885CoCPHRU+vNp7bcVx9Z1iKyiBURw
+Luv39/XF8ID//FLK1N4T0xG84LWASqK6xr+2mgYes9Os1+s1oq7tnKGN1X6m
+boYm3bB0Qb2PHlPZFviGYzYCsxaYqK0Io7T0xq3oBhF33i8beG7R1kJCbmIi
+T0tUgHb12cUypp7JTsu6vkk67pS9bF6clovkeHnlrCWKfVwuj2N92XF/xy45
+Jk7qGx4sSIquNU+I2dc0Q1ZjRGgznspC1K4Rmp2J+TTc/pfADHAYQbYqAKaj
+rJG438KApk7IqQyEKVORdDa83TwOsQbspihXR+1G4sn0WgYLlXRKIXKQ7M3n
+q/UJpOEEjW4fIAnE683NYkHdlWwzzjVDHo+Ngmps6Iu5XRpy+OU0roYg41Or
+No/FcrSo42IserQTFFQwUMf5oLhL1UjXKjZa1em8a4szIB56hmL0jdyvsijG
+4kc7W61BeSTOBSsXZSIX/dZsJxOWlJKC4kkYUtXYKnF6boLBLSWcFbkYR/A/
+TsexpkOgBqVzjqpyoOZzhJJ6s7t0wnFShC8MWS8jVHJvVtuU3aCEUdgp58iv
+V73BypEblUZFVnZPOuVH6IEPAwzKuTjXcmXrfC7EeLy1ZUtIkCin27NlJJw6
+bGthrKkVIRWuVntxSFVnJ4b7YmUrQgxOMrbfu3QoXQooqxZqNWbjjBa+u2E6
+hy5159Mngjesn539PZdhRLOSWLypFV55DK0/a7ztyngfgflkAgcBKD7HYFVs
+2Ts9eXHZN52LeO/wcZfUkj5+2RSzmBjp7jROkhfStUiFYTRaGYuQkrRssBXk
+aeEYHkdmkIZpsJfO+GQdGnDbLT0Ibcql20yb+TRg2nAxrR6J9fbVUKlxGzZ2
+NyzRtRB3iYyJP0lr8BplEw0FhfV4WDOIIxfF5sIySBtOtWgmC8IXp6/NEOoi
+By8S4G7p9VE65FYnL07fxvw0QYdPIHIA1xK/wcO4oqSuTVAaO1NZ+atxcaf+
+5rJzW8rMSjucq9ugV0G14IsiBIZ7XrUL1naleOvSGy9tawNWlHC0ktjYSHjm
+WFY6auQQEjG0V4Yr4N4mtv5UORNv1vVTwepnErTJrVPQ4i0hHXB370dRL6C0
+wZwzXx6H5ErZl+RM1pVFYmfAYAWd+/aQxpiVS2mkc+X3MZGmiYEthCvzJhkn
+uis1P9KrwuGuaLz5+TN0g/MzJFOR6gajmuFrJI+gTSeKksMCb1ck7+7tH4D5
+CV0Prsl/9A53fgpxBiPKWHsYS/rlvMm1vpC2SDKdhvtvMzwgl9FfO9BrKWOW
++f1MDXiSHJONpOYS1FJRnJojbG0RQlVEUv1kP/CYAJxwCs2pF2rg2KnG3ViA
+2OA9vxIZ5lKC6i64C8Sv6fIsHxfSpIe2LzHtQRJTUNyoE/pGG7AAkKtgmzLR
+/p6WjRAy63PPZN20nSZoEE1k7bbuyrICrU9o9W4f3ty8MpIDc5+3Qyu73vge
+NXL3WYjpIPE5dvkY/EsCNiao0BVSic66w4bwgyrYPG9kD4BEv2wMX4naRx03
+BrlrB1JyOr4Es60EAXQjSYezXVSq9+pwH8Ktsiy0YnbgF5YqZ3bAMGSATtWa
+bqAY3NkGDDr2Igey8XB8HkkDmPAyWa7D/UJavTNm8I5x6G7i6nmyzcU3UMH1
+rlSC4k46Ar1/LBLIwezIhJNC5pflyGcMgxnsVJxmHssd9AYYJ3xzwD42LrfC
+GTHh1NCFuhYdkVtFsAIJRdGiVK0iAXUxXjB1YA4YSoFVA/WKAJOPmmSi4EDD
+UExkIuFvgRcD7O2RG8Peq7BYWmP+8OpoEUuZktt+Kea4JipLE4anW97sGDLz
+WedCdVJCUkmnFQ6rGMqUru5II8x75G5tOtL7rjtncu93n9Qu8UJqxw0WNoLe
+uMr4dSgAshPYubRRfuy+hMevZAakVdJYyeAzqorh+1TyX5xNHeZICN0SVMk+
+V7svtdexjc9V3nVUN2QhASENOYfQtfBLIWR6RQivcCNGXDYuq225NrWKqn+B
+raZsfIVV0gVts+PVnsUgYwNRM8mVj73VOcc5AemkposR15JTilSQZIdKcGKN
+D9MXHcYoCxPEOtYQeC3AcQunTC6hvlYpCbt3coJPc7nqgXQlOKIvlOB4pKRK
+DrrZRIiUt8Dv9Rm+wFfZOB0uh2gGXFkl3sZ4KGlIhr7Y6qp+b5V0r+cb4zV9
+EaCDYpaBUZ20WgkP0IIhBBzVDHlHdRFrJTlaVuQ6y0kXPMljs7ZxRk0xU3O9
+1sAE3yBy3qYgJXB/WQ5KUs2d/OTaKSB1ipPtOASBje32Gigr1zSUIWkVsRjD
+aYnsP+Yc5RHiVFFdcDR1rSQhjLIb+h+LDMESJ0jFkusr7V8qW8OCw664Ag06
+OQbSQ6vpHTrO5xypTwfJkiicH9k0ndBmNEvF6t6sFYFi2KB37yESVx2zD3Gw
++AKyYsg+ZjJVFrNMomOC5mHBPWFncNBlzTv+pMqnqlUc/yydRwDiUWqFW2nz
+ocPbnCAr79qrhPxG9fijAKyWivIFHYOUvYSrgT56qKMWp5lJNUVpQ+UqJbZa
+Xbo2E+4Fru392Yd9hB05hY5LAVXbSRMlPb+hf6Z0b1kpGmqDGnxEiRQSlrg2
+j/tcuhK9VCubQJ7k8jXTda5AzJzgTdvJp8600NLgd17bXHrrqcYn3LFIzCI8
+LnvHiEo1FSwu2RLrewwB8R2V2bAOQgMk5jDSlr2+kSrfoHumEHgy6FOYcDlU
+Mc9JQ/kpuwivrl65445euzgkYTQ7P+4htfGsEU6pKf02/5fnaYJeajQTfaD7
+y23Y2ud2xNmrrs9ZUFu1yyWG3TesxG8GGZx8sMuIVGgVKdCuMLf11Zxg0QWY
+2S4L6AmUpOq1NDAbLEP7Ep99JHqt2qVXq9A/MhdrurgFCO54ig2mbIhQX7Zi
+cnAYpAiMss7HKcGlQbnCdol2jqp0XmO2p2o6uXIbDYcPrOAklbrUi1pTPNol
+4iSFeM0FWcF88DGX89xc7FCanad4amWGY/UfhhXt3KuRmmqtSRFLYF8R66+q
+ChOW1MNbZsOuga1tywh7p7jmUtdkCW23LaF19lTYg9wJ+LPx+q1miAijrFAl
+rgDpQ2Iy66RR4x2FfFPSEsXYVcoNJV42iUEej1Yd/nKOnYGovoLNsd55T2JW
+CxeHQzH55diB3Eth97cFn81gOU+4vRdumBtQC/LrUfMZ08PI6iHKVeSBR1ai
+t5sIW3PnSme6zSzEpCYG+JX41S2pvk+T9/KdCyvjHrArqk+0TvUxHbbEA8RN
+jaep9z+k8Wx2I1YHwiaXX1R5lJfb3pjVWj0hUhm8elBKV+HcdbZeI3ev1EVW
+bfNbNB7T1HiAusdiintAVfiCxC6NY8sUiJvVvaC9ZFAavOsynLjsNJFfl3vJ
+0W6NvvFWKOnawmOIn3DtQrghakySJNw3nI0YC8tstOYFHWz26l0bH4OwDMcj
+YNAYrSvi16LtCIWmI4DVzEddVlo/gdDQdmhtumj4/FuamUuoPzh4LLUsnRZH
+Aj36qLmOAHJbGJmx8fA485GkD6jSI0FRiCkU7TMgjgIoelCCna14SW9zyfWQ
+I0jPU4co6pgQx989Hznn8LP2uLS4GVklC2xa6qEEPVppS5rfYXt2SqtPZy/k
+UGKpWye1P6sFrVLNx33uOMgZN5foHzbk/NfzS8gh77gkEZ5mxdHKKlxJsuo2
+2pJbB1NUphIcoolqLEqPOahu5cCPAwbgFltypj8NAFFVvd/RmqbpzqsImcQH
+G3WNyG4m9GA/kEUc0mubONhVOS6wHsY+NVxMVcBD7/ldTNnbHDUVx8BW4nvt
+BMxjbNq8QmQeCQcrrH0aorsXedhIpe0ACc4ZG+wbLteGp5Xtfxoh1GAWzbiq
+Y7anRH7ARm/xwIj4Q7Xi9Wy5N32z4B6PAjpwt5hC+tXmJZ7iOUpnpYrmWBBn
+e+a05UapgtxRRrnbhId62MvR9SXinHema7UKDTzII3FqdFt1G3w5Gu3AFEoY
+Tbi7Mg0FIw+XPuBYwFLjL/zWuqHZUCcjljC3Ioq164fuKrUlWj20aaQK0F/o
+UmBPgLihSCGBBSS5qXGE80+YBjZc1lxFOjgISBKLytNyhjiHegXb6zZmFQs0
+yLCYnRs+BBFz1MxbubIrKHyG5k58zJrF7TR6cX9auXAAKjFGmoRN52DS3OKN
+4jnT8joFh8kvtJSvNR1H0i3jYP8QKhJ0lySzpsFBUoqpBiYLdGMMULayvYXC
+WhOqQkX/OiOVjvGZM5Mm7J8hWkf3VrM+Ln490wiOtQZuZklq6vemPrYyoRMQ
+Y45k5bdIcbUi9qhlA3VJcGelAZEs/Tb5Iyml3EpDtIU2FEwchSnlUkw2kG+d
+QNjoSsEPSRp5c8WQzFpLBjKOwB/CwGovcTbAAtQiXaSrjgeNNJWo55lVSCQI
+B2RSDZpApzwTT0qlzNHiBJfFI74wE3FFDPLObGFLmFlTgrWBZKFi0ty5a1DL
+2p8a223d38hFHtvCVaKVQDDg1HNaRSz6t5xv3NKbk6GrxxlUuY3ch4u8KVZp
+laTKTKbFQPxnD6WQcPvshuLFt8PGQQf8i/Urq62zBpblgRI9WFqufdwU0lWj
+bOt3OVEa5z2IRbTx03JiHlvm1iSsBoaarA6UQRgnWa7GX1OkxLn2KmnQn6Vy
+BnUnlWrLOSl6/JJlBbi/61upW88eiXS9T6IpSTVYk4BKuE/QKSZa0/2ladpq
+PB42UJKnEfT0l4tzle2q6DfSDX9GzgSd8G9nb085uxxSDFMdyNiBQG1nbDdj
+luwvXnIvNMlwGqSQkm/rArQmhghtWYJWPEEjoHX9fMyafj6WZkuTnnVWMlt+
+x6qWfD9DP9QKjfx/6Ug6aniR9CxZrMuRlfFl71HQ+EBL67F4N+J2gtED8vhD
+kX1aXoaViqACjrCBwEitQnSkFVNcqSDJ4moX0NGMlaGj5ajwkbznHDiQS4Sk
+jkuS6srFkEmgaxchMQFaA5IjWG3n9J554W8SJ5JJzomNPrXPB8GuOFeGRSfU
+GI59YoSY7jZtepS9nrRoREPlNo5VhJh/LoT12C5QU1i0W5V4ub0fk022QWdt
+eE+Rv9nhqFwtEtNlAMPDw1lRm7CUeUrDCVPWlqIhxBOWRUX1ZDGRKQ4krjkw
+/O9aCMW4knbHQi7sMhUSil8sDM5RVYUz5sEjS8k1423qw9NioqEnPjI6OIxm
+CCWLPIuRDRiGF3giET3pB65XyG3GbzPmkz63jdOXfAaY+mnySloaqqwYJJAF
+yxPHdICkRJihbcOjk96xP6uA35B9ZH4HDMqKgQg3GtGAOy6ujD4MWnTp6wVp
+/KyxzFpAEpjHWuYRCdgorpy1fAO8O/FQCH+SnKdgD7bu4WikyTCujqjKGDRq
+O7+pZb9RPYlGHQpSQ2SgxWkNSjUiMjraq87u0EatNJCXFekhTEvGa/HX6hWt
+q1UUtWrJgru1H8zW1hc6siZVBqMVYMVBGKnq3B7JWuYSlrykupPywgT5gW3v
+jcLf6m7EuycLOIpZI26O3ZL6TFvqGwiu81saC6Lk0HU14/cDemehCQGwBGtA
+5XXQ8xcrom1AyAvO/w1rkQ/BAjmeWYqxM+GUKqKNOqu2EgIHQ2EJWl9Waoba
+LEXw4J75pbgHMegGBSi1MlpYg5GlcpabbGlOF3UUNau5c43v47C+uMKN0E48
+v8T/sG6554VF25optpvRVd/k9Sf+Sa0qTEBNfDmbr1cWjtZWFrYBsf9KDWAx
+4OXtosKrN+x4DS617rYSIFyjuphIlq1q5EGhX/Uuap8kV/rWGwVbFb3VPWVD
+D/B1GNdBD7AjhKAz4CZBSeUch3H64ZbwREqp0TJJnTr2yYJWs1Lnbpi5jdu1
+7Viw96twwoE1x2lcM3uTNWIsWm+K85nxMSdwsm4wDPUZzuOUBOMHCyeGybh1
+O1tWIhJGa7N0o7VZuit51pKlq+wlswm4sSbgunxdOKKib8/EfTAHtyFXRmqb
+d/EZ65Ong9P7cs5u5HJ2Id9KgOZUnUheTfTh6d+Uqxs9mKtrHsrV5ZiMs/55
+fzUeg7uIqzPGMXNXoJYvOL9I1xKKvfrbXZEsS2ql7IdQFTW7R2yDB3iv3AZd
+I/YL/KXdBt/y0ESHJBJ6n61XkHWt/R4DHZmbfEgSyg19vjreEeI96JsXWliF
+c2fO0/pES1Xqr2H7TfsqwmQqVnBojn8vbnPck2JAcBkW5um8pqtQ/M/JDKn3
+w2L2jB4/kRjrb3z6rSWHR02Jib4KgHAEz4nTBWAIbOmb7sDXdoU/ZqEnMALY
+fiEf6HXVuXOxVlvUjYM+9oJ8Wbv+YjiiGEQbLetJLAn77KqYvKbjX8/BmNd2
+XqAgp13WXGkJX4pFTqob6UKI3hFvY+hSBa999+ICRZYGJbFxPNqVrcqvYqXA
+7702SjdiKazKlShal8tmKMnaJsYRalyYjvbx69qG0BJRt5RYXO+85BAaKZio
+4OyZy1uWtOrbrBzFyOBHM7waJMJF+kKCols1B6lj9xeopKUAbjMBBVBnlt1H
+pBnhbE+hzy81PFxw/q2N2KJ1sSu1po/usvTe1gIRo8ju3mMRZuM45rLhIB8X
+JWq69CVQAxcNjr+3yv9SNYL98LUu0ERtiIKioCsKVsyzktu4i6G42QIahoro
+G1pAMw8KSvW54jS+bCQPFbRBW98j2qz0iA67sgMjtQ27dZVmdSTeiBhdavIg
+as2Wu7C2JFBKWgPiolHUhjtckALGV7nLTXtiSPKwCavgKdE2CPAP60qLFKeV
+OEpHcFEoCl/QUn9LB5cSRyzE9ODwEPcP82qZrYbjDJVH2V8auCudDWitk1Im
+JxmDI+/CCvb2bMa2Q6daA2NpSC9xrp6g9Kzd1JqwcIGTGWJibFzw2enVSyMG
+xbogoeb3/nkslYw7G/2G8wH72ut79oKLd64FDV4Tzk2k8hWbfKoNtosldST1
+DtQghfeJQtoyCDP/1r3Nt9za0ozLVpqn1KPY2upGPixZpTWUlRUIS40kNbmL
+GYVJ3sNhAGKh8QElGrATWE7gRfNlFyBZzBsavOUiKAhSOGG8XLJvyKr7lVX3
+1TqzteXqbRCp9JIOl1DvOs01aiKScyRbL6wG3RWspAmFzxu5qjorIBs1EkIl
+KJVrsncDx10smUZ/MppzKpEztFwt9kWLhbiJj+ksI9e3IGyCZ4tU0THfa1QB
+y2wg/lwL19W6FQelWNv7ES09xqbE1m7Bk2mS7pZD5ETs4rFzV/rD6gZFN7gs
+nRNixNDPkemWaY88LeHyGUkd2uppe9vYqmJb9AAOuIoeggtbUfRLA8ydEDKJ
+VHwCc98094iAlt4GrsKppXou7ViMWpHzanCNZbFuCTdR+V7dT87KJ/pnymEr
+ZYO2sH0swukfu9hv6VbUyvINQi8t1bFyMJMeztGD2hC5uj0QgJvq6CXrlBCB
+Aw0z+ngkvt4sL8fDP2+gQNqGlY8rDTeTkiC22SuPQugi0ljbnGVDyCxlspVj
+6QJxRFPVYNDKeLhZiISi1Wz8ho7/8eO/gQ/+dCAhtdKGshDjAlY8ijQMYs4J
+cjoge2joPcSDbzUhcKSpemjdGmuMqxWUab3c76Bzo37ZdFnAhssYtU3/RzQ5
+mtUK6jNtkBvJzQs4c0L7ZorzzIxIJuYGui6bhXvEsC8z9RcGCBh1+peGG+N2
+jf72xP6G+s0c7idEuUVThHK4nAKbFGIT2mjNaFZ/AsKbIGDfH0tDUhFhd7V7
+tHzOZhn4HGbalSjoguPylVu2wq4rxhdU2dPuXy7+KZL4J6mditIU9rgcFOnG
+KFfOJ3Ki7iPlhK4HT4f7f0MnnUN43MRpJ2b/Se8wlr439htxPPBZ8GE6645l
+Zn8nNaeKBbT2YOQQzrOh/+yJ0A1xeSgiu0ijqCPqW+wHi0nWfx/v7ew93nmy
+e9Cb03JuXEFPRT/UrCUFuiiXm7bKFdAlCgS+eEoUYgoyQ4StJuWvIuUIXSU+
+pOUQoRasSqJz4ZRki3jK1UcgzXH+clnpSdygBfPu4x97e73Hu0cHh0/29m7M
+0/gZfbHfO/yxt3v4pLe3t3O0u3Ow+/iGNJBOY3/WFWFNrOJQTEeTlPSDvQNp
+xg6ev797sOuS9klsK+NqOZvBqjnEoLv7AMG22T18/MQ9trvLITH49MmBLQMA
+pQrbIOSb1rdHYvPon/zKB3Nx+UuM36tUm+gR9pG+PiruUd/AXP5+vv3y7Hz7
+7eWVhAVo+X7oech/0da3QRcOK89Yv9ym1HQzfxD2sVGWu7tVoslgBfzFaCHH
+BFWSllNhzbbjkC5NWejuHr8RT20DVUJM7GDTb4F7j3CpNvcRYe4hFvzkEEDa
+oX/2iFDsHu53zd4TTQvZP7RFEriaJYJZoG6QkmIZlIscl2Y9MVd7HWFcH1dq
+LYgKhu0heyks9QgZ6WAxfS/Mesx1oba2TvSeCUmQ8nuY2Me3knAFi26J8sBd
+c0tEDS2NkRq7KURa7NU8yj1yG61b0WUubWVs1wlxkCTI2DmzR87HbcWILcFg
+L5BHkm1YqRFA/JCXNlJMX1duX6prWRc1avdDTTi91ga2kYiWzekv6FZbW67g
+pa3wS8x9IcG/ojveslcn6CVW26w2AqbiH0GFTpO9qtYIyO0QPSKHPWRseGpX
+b8sSN8c6i9rn77obMx44KtiqcRYKWv3LlJErCAGPrKlBc7TgaJLQhaAZbdW1
+4W2K0WygdwbekhXXWKSNSL5y/aw0/wmKQZnch6NaSStDw6k+XZsEfONDHdJ7
+D1HtI+rdfL6UmjyvXeXbarYIrWptwN9FMYepoGulEJZjGGm47RIHIPvUBZ9i
+5Di/5FbgI44zlqF9IMfmsbV1BKijhhERcyUcQrAXlWol91P7jo8IodnDXTNm
+CqiUd7iKta3qGc4JxGM3y/vaon58w39l0S+8z65qnBY3bppwe4QYZzBVoAyN
+BG4HtirJSSsXEtaFeiBq7Hf5qBI3wWyOW6gMJQJOI7l8kkeraYWk6/BaJ8m8
+sszWqttN0ZXfXW/WEgIlWb9Ei8oJO8kbO9WQKN1vt0EhbUldnX5cFn/Q/WIy
+xqnuN/HOzo3LvJWwBw2s9qXLvxp9L1HAD+djEHn/5zMyzLqMDBqpEfDSWQ1f
+4Xpd6UMJxFuuHXvgoFLXmCC0d1FqZ2u6A0xuULTB+czYvaeuwJLd9avuruYy
+pOknW6mb0ZTtqgGsS5AmEPsoRB8YaXWwVvwkrYBTeIJ6VIHTGQ8PWB2o1sUl
+tldq6xlsacWYwDO/4pd3rZbD4B7r3O+697xr3vn2cQlN0CFIGwPRjSG+cpvN
+V+AnUfZ8hF9oXOGUPj6xRtsHGxnse0t49ygf4Td2l7ArsxXisKQzVTk2bNmi
+QPfYYPL5T9aHj8y6CvEPVAW3K2p0hLN2ecfebZq0VkH3Lqg2+QutkeD7nPnn
+YoujBNGTM7HHzTlZqal4swXAaWfa9c75ZszHR0GpJF2jVGfPPji2oO2hvtKr
+ULLAhQDKoFwwOlTm2p6Wtqd8NbCEeyXZSUCTueBU0GXz2JYq5DqL2p3wPtN2
+oo1S/T5BXRqVj5CWoEWqEJao1fR9tS9pmo0yfEjwbpShQjSwTapYqV/lh4ga
+BZJsRHNJeHQHwzlnDcG1HwYR0qwXp6/diEHAIZ5E/HyYUJDZAgnrVrmm1NL6
+KkPrSgyFlZsIUhKOKoeQTUknUSuw+NiZTykt0bhBrV3J4qq4nW6k1JprMSGd
+SCVzXWRy1x6CZVDta2ILtH1EkxFrNEMDkqRinTyGCrtDCuyu9CHRHIxr+Gbx
+mFe95Xu9p9KjZLe3o+1NwlL0GzKb+UJHle/SU+XrXVX+G31V6O3P0edI4Kzg
+a8MGtoiNtdtHnTnOxRd1IKm0UF4vfBBV7DCH9G9pR4tqBeQbfOba3fpsH/Go
+o+iZhEpcZyN+nRd3cxy5q6yKU6OhYKu3GjfE2oMvlwt26VpVW3OolnHaEZvL
+baNLTBg3iJkv0SpNL2VxRIkaTQS0nwe7lyJhZSvVSnst/DUbmI2AKz8bT92+
+n20/dTt/pueuD7numniPT4WX7OpfARB8DI239MrR0GsvytHB3oZpHFvYexEH
+t9pF0wsV7XtJSIu4F7sx2hf+jNdshsM1r6GVYVlPx2WKDo4fJDPHl9Tj91uv
+fnVH+9iRQ3aCNW1Jn36qTYSEaj/zXRZw32yvw7UAkfaRXbOud+Rqa0gAThJj
+SFkigT48+YdXg54JwlIZtW3LTp5ar23wNp011i/qBw/XhvaavX3Slp+fXLvP
+TyLwfnKtOz9p71IZwobCyQTK7EqTL3AubaKyujq3Artazvm7RoQYffpU4v6e
+8UwSu+txwmYRcmiuW67ujG/W6mOyF16Y9oFtgVyX4TaLRQzoGhFtftY4dt/l
+pGvWNDnhFgTf0HE3anbcJQaZNRgkd/gKPuLkPGxHa6W1Mr4QBGmLmLh8q3ZN
+MK6/1irh1050EKn7xsknN+vLndWuWsAP1ZoqAIkOTztrdltD6kpYjpErFFYL
+rs0SBoSvLaPIyW6YuSGarK9+KM03EUwTtuwTneCAdrna5y2yfd4MJ6K0O8kd
+f1nLUCUf664NJ+fMEU8SaUlQ/nJV11vTgU8ikqUyZLPx7wqnoJEdq3DkE8VB
+FyWR/2Scau3bFp2UZQjeuw+fsuNB8gWyUesNwPt6ns7C2Ta4DePz05/Pzs3J
+6durs5dnJ/2rU/7U8G0KR3D41JiTJFHIxioTN0vntpbANt/2bp86S0Rwu/jJ
+NmuQolrXROHcrkHBgHbNJ1viT2ue1rDOZHyt1gxQEgTrlNlg0WAYWVveVUct
+V/bLKknWHTUTgctA0VDKH32hPaFGFSy4gGlxD+d9yy4RRlGK1WANWq1ix5dx
+gxD1Olg2k16ca1CzdN0FbR/vCn58DTuarJxl9yNdqlFOhwPipBj6Bu7qdbfA
+8SHJVXcn9sj0h+B2xArEpRJ9PBKmlI7+vDFOppV6v5P8feU63bmQECX6QuvE
+kZtDX7fKLzEIQoPzbHhbTFHoxnsKYTl8vixz+xncuprwF3o54eJI1Qee+BKL
+JQetpX4F6raO1G/Yi/4vjXpgTU3NAAA=
 
 -->
 


### PR DESCRIPTION
## Summary

Follow-up polish to the NCFED Internet-Draft (`draft-capobianco-ncfed-00`) after running the **authoritative idnits** check via `kdrfc -i`. PR #121 merged the draft itself; this cleans the two cosmetic idnits warnings.

- **Non-ASCII → ASCII:** converted 33 em-dashes (`—`) to `--`. Non-ASCII line count is now **0**.
- **Example addresses → RFC 5737:** illustrative router-id examples moved from `4.4.4.4` to the `192.0.2.0/24` documentation range.
- **Real capture addresses left intact:** the packet-capture addresses (`192.168.2.61`, `13.58.157.220`) in the `removeinrfc` RFC 7942 Implementation Status section are evidence and are deliberately unchanged.

## idnits result (authoritative, via kdrfc remote)

`0 errors, 0 flaws, 3 warnings` — the 3 remaining warnings are all benign and correct to leave (2 = the real capture addresses in the removed-before-RFC section; 1 = the "submission date unknown" note the Datatracker fills on upload). RFCXML v3, 0 lines over 72 columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)