### PR TITLE
fix(n2n): fail-closed eN2N embedded execution + gateway-approval stall bridge + failure audit

### DIFF
--- a/mcp-servers/protocol-mcp/bgp/federation/chat.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/chat.py
@@ -73,7 +73,8 @@ class ChatManager:
         from .gateway import run_agent_turn
         idle = int(os.environ.get("N2N_CHAT_IDLE_TIMEOUT_S", "300"))
         prompt = f"[A federated NetClaw peer is asking you this]\n{text}"
-        return await run_agent_turn(prompt, session_key=session_key, timeout_s=idle)
+        return await run_agent_turn(prompt, session_key=session_key, timeout_s=idle,
+                                    untrusted=True)
 
     # ---- outbound: OUR operator chats with the PEER's agent -----------
 

--- a/mcp-servers/protocol-mcp/bgp/federation/gateway.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/gateway.py
@@ -117,7 +117,9 @@ def _extract_reply(stdout: str):
 
 
 async def run_agent_turn(prompt: str, session_key: str = "n2n", timeout_s: int = 300,
-                         local: bool = False, model: str = None):
+                         local: bool = False, model: str = None,
+                         untrusted: bool = False, on_stall=None,
+                         stall_after_s: int = 120):
     """Run one agent turn. Returns (reply_text, tokens_used).
 
     Two modes:
@@ -129,9 +131,40 @@ async def run_agent_turn(prompt: str, session_key: str = "n2n", timeout_s: int =
         executes a delegated skill: no gateway, no comms, scoped tools, its own
         model/provider (feature 056). `model` is 'provider/model' or a model id.
 
+    `untrusted` marks the prompt as carrying EXTERNAL (eN2N) peer input. An
+    untrusted turn may NEVER run embedded outside verified production
+    containment: embedded mode has no gateway scope-approval gate and no gateway
+    session log, so for an external peer it is only acceptable inside the
+    sandbox + model guard, both fail-closed (2026-07-14 delegation-bypass
+    security review).
+
+    `on_stall(waited_s)` (gateway mode only): called once if the turn produces
+    no result within `stall_after_s` — the signature of the gateway holding the
+    session at its scope-upgrade approval gate (the CLI stays silent while the
+    gateway waits for the operator). It may return extra seconds to wait (e.g.
+    the operator approval window) so an approval can land instead of the turn
+    dying on a blind hard timeout.
+
     Raises TimeoutError on timeout; on non-zero exit returns the stderr tail as
     the reply so the caller can surface a useful message rather than crashing.
     """
+    if local and untrusted:
+        # Fail-closed eN2N gate: never run external-peer input embedded unless
+        # the 057 production controls actually verify. This makes the one-line
+        # `local=True` approval-gate bypass impossible to reintroduce silently.
+        from . import controls
+        if not controls.is_production():
+            raise EnforcementRefused(
+                "embedded (--local) execution refused for untrusted eN2N input "
+                "outside production mode — use the gateway path (approval gate "
+                "+ session logging)")
+        sandbox_ok, sandbox_detail = await controls.sandbox_available()
+        if not sandbox_ok:
+            raise EnforcementRefused(
+                f"embedded execution refused for untrusted eN2N input — "
+                f"sandbox unavailable: {sandbox_detail}")
+        # model-guard is enforced fail-closed by _apply_production_controls below
+
     # US4: use the flag our OWN CLI supports, probed once and cached in
     # negotiate.py (builds differ: --session-id vs --session-key). This is the
     # responder running its own agent, so the local probe is authoritative.
@@ -151,14 +184,33 @@ async def run_agent_turn(prompt: str, session_key: str = "n2n", timeout_s: int =
         cmd = ["openclaw", "agent", "--agent", AGENT_ID, flag, session_key, "--json", "-m", prompt]
     proc = await asyncio.create_subprocess_exec(
         *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT)
-    try:
-        out, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
-    except asyncio.TimeoutError:
+    comm = asyncio.ensure_future(proc.communicate())
+    # asyncio.wait (unlike wait_for) does NOT cancel `comm` on timeout, so the
+    # turn keeps running across the stall checkpoint and any extension.
+    remaining = float(timeout_s)
+    if on_stall and not local and stall_after_s and stall_after_s < remaining:
+        done, _ = await asyncio.wait({comm}, timeout=stall_after_s)
+        remaining -= stall_after_s
+        if not done:
+            # Silent this long usually means the gateway is holding the session
+            # at its scope-upgrade approval gate. Surface it to the operator and
+            # let the caller extend the window so the approval can land.
+            try:
+                remaining += max(0, int(on_stall(stall_after_s) or 0))
+            except Exception as e:
+                logger.warning("on_stall notifier failed: %s", e)
+    if not comm.done():
+        await asyncio.wait({comm}, timeout=remaining)
+    if not comm.done():
         try:
             proc.kill()
         except Exception:
             pass
-        raise
+        comm.cancel()
+        raise asyncio.TimeoutError(
+            f"agent turn for session '{session_key}' timed out — if the gateway "
+            f"is holding a scope-upgrade approval, approve it and retry")
+    out, _ = await comm
     stdout = out.decode(errors="replace") if out else ""
     if proc.returncode != 0:
         logger.warning("openclaw agent exited %s", proc.returncode)

--- a/mcp-servers/protocol-mcp/bgp/federation/invocation.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/invocation.py
@@ -169,7 +169,25 @@ class Invoker:
                 if not await self._await_approval(appr["approval_id"]):
                     raise RpcError(ERR_APPROVAL_EXPIRED, "approval not granted")
             progress("running skill")
-            output, tokens = await self._exec_skill_gateway(skill, input_text)
+            try:
+                output, tokens = await self._exec_skill_gateway(
+                    skill, input_text, progress=progress, peer=peer)
+            except asyncio.TimeoutError:
+                self.audit.record(direction="inbound", peer_identity=peer, target_type="skill",
+                                  target_name=skill, request_id=task_id, decision="allowlisted",
+                                  outcome="timeout")
+                raise RpcError(ERR_EXECUTION_TIMEOUT,
+                               f"skill {skill} timed out — a gateway scope approval may "
+                               f"still be pending; approve it and resubmit")
+            except RpcError:
+                raise
+            except Exception:
+                # EnforcementRefused and execution errors must still land in the
+                # audit table + GAIT trail (the pre-fix path recorded nothing).
+                self.audit.record(direction="inbound", peer_identity=peer, target_type="skill",
+                                  target_name=skill, request_id=task_id, decision="allowlisted",
+                                  outcome="error")
+                raise
             self.authz.debit(peer, requests=1, tokens=tokens)
             self.audit.record(direction="inbound", peer_identity=peer, target_type="skill",
                               target_name=skill, request_id=task_id, decision="allowlisted",
@@ -256,16 +274,34 @@ class Invoker:
 
         return await asyncio.wait_for(run(), timeout=self.tool_timeout)
 
-    async def _exec_skill_gateway(self, skill: str, input_text: str):
+    async def _exec_skill_gateway(self, skill: str, input_text: str,
+                                  progress=None, peer: str = None):
         """Delegate a skill to the local gateway agent (its model/policies/budget).
 
         Uses the `openclaw agent` CLI — the gateway is WebSocket-only and has no
-        REST completions route (see gateway.py)."""
+        REST completions route (see gateway.py). The peer's input is marked
+        `untrusted` so embedded (--local) execution stays refused unless
+        production containment verifies (2026-07-14 delegation-bypass review).
+
+        If the gateway holds the session at its scope-upgrade approval gate the
+        CLI goes silent; `on_stall` bridges that hold into the operator's n2n
+        approval notifications and the task's progress state, and extends the
+        wait by the approval window so a human can approve instead of the task
+        dying on a blind hard timeout."""
         from .gateway import run_agent_turn
+
+        def on_stall(waited_s):
+            if progress:
+                progress("awaiting gateway approval")
+            self.service.notify_approval(
+                None, peer or "unknown-peer", "gateway-scope", f"n2n-skill-{skill}")
+            return self.authz.approval_window_s
+
         prompt = (f"A federated NetClaw peer has requested you run the '{skill}' skill. "
                   f"Execute it for the following request and return only the result:\n\n{input_text}")
         return await run_agent_turn(prompt, session_key=f"n2n-skill-{skill}",
-                                    timeout_s=self.skill_timeout)
+                                    timeout_s=self.skill_timeout,
+                                    untrusted=True, on_stall=on_stall)
 
     # ---- outbound: WE ask a peer to run something ----------------------
 

--- a/tests/n2n/test_delegation_bypass_guard.py
+++ b/tests/n2n/test_delegation_bypass_guard.py
@@ -1,0 +1,185 @@
+"""Regression tests for the 2026-07-14 eN2N skill-delegation bypass review.
+
+Locks in the three remediations:
+  * run_agent_turn refuses embedded (--local) execution of untrusted eN2N input
+    unless production containment verifies (fail-closed).
+  * A gateway-held scope approval surfaces through the n2n approval notifier and
+    the task's progress state ("awaiting gateway approval"), with the approval
+    window added to the wait instead of a blind hard timeout.
+  * Timed-out / failed delegated skill runs land in the audit table (and thus
+    the GAIT trail) — the pre-fix path recorded nothing on failure.
+"""
+
+import asyncio
+
+import pytest
+
+from bgp.federation.service import FederationService
+from bgp.federation.manager import FederationManager
+
+
+@pytest.fixture(autouse=True)
+def _prime_descriptor():
+    """Pre-fill the cached CLI capability descriptor so run_agent_turn never
+    probes `openclaw agent --help` against this file's fake PATH binaries."""
+    import bgp.federation.negotiate as neg
+    prev = neg._local_descriptor
+    neg._local_descriptor = {"proto_version": "053", "features": [],
+                             "agent_invoke": "session-id",
+                             "reply_shapes": ["payloads"]}
+    yield
+    neg._local_descriptor = prev
+
+
+def _svc(base):
+    return FederationService(local_as=65007, router_id="7.7.7.7", display_name="Nick",
+                             manager=FederationManager(base_dir=str(base)))
+
+
+PEER = "as65001-4.4.4.4"
+
+
+class _Chan:
+    peer_identity = PEER
+
+
+# ---- fail-closed: untrusted eN2N input may not run embedded ----------------
+
+def test_untrusted_local_refused_outside_production(monkeypatch):
+    from bgp.federation.gateway import run_agent_turn, EnforcementRefused
+    monkeypatch.delenv("N2N_RISK_MODE", raising=False)
+    with pytest.raises(EnforcementRefused):
+        asyncio.run(run_agent_turn("peer text", local=True, untrusted=True))
+
+
+def test_untrusted_local_refused_in_production_without_sandbox(monkeypatch):
+    from bgp.federation import controls
+    from bgp.federation.gateway import run_agent_turn, EnforcementRefused
+    monkeypatch.setenv("N2N_RISK_MODE", "production")
+
+    async def _no_sandbox():
+        return False, "systemd --user manager unavailable"
+    monkeypatch.setattr(controls, "sandbox_available", _no_sandbox)
+    with pytest.raises(EnforcementRefused):
+        asyncio.run(run_agent_turn("peer text", local=True, untrusted=True))
+
+
+def test_trusted_member_local_path_unaffected(monkeypatch, tmp_path):
+    """iN2N members (untrusted=False) keep their embedded testing-mode path."""
+    import bgp.federation.gateway as gw
+    monkeypatch.delenv("N2N_RISK_MODE", raising=False)
+
+    fake = tmp_path / "openclaw"
+    fake.write_text("#!/bin/sh\necho '{\"result\":{\"payloads\":[{\"text\":\"member-ok\"}]}}'\n")
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}:" + __import__("os").environ["PATH"])
+    reply, _ = asyncio.run(gw.run_agent_turn("hi", local=True, untrusted=False, timeout_s=15))
+    assert reply == "member-ok"
+
+
+# ---- stall bridge: gateway approval hold → notifier + progress + extension --
+
+def test_gateway_stall_extends_window_and_completes(monkeypatch, tmp_path):
+    """A turn silent past stall_after_s gets the on_stall extension and can
+    still complete (previously it died on the hard timeout)."""
+    import bgp.federation.gateway as gw
+
+    fake = tmp_path / "openclaw"
+    fake.write_text("#!/bin/sh\nsleep 3\n"
+                    "echo '{\"result\":{\"payloads\":[{\"text\":\"late-ok\"}]}}'\n")
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}:" + __import__("os").environ["PATH"])
+
+    stalls = []
+
+    def on_stall(waited):
+        stalls.append(waited)
+        return 10  # operator approval window
+
+    reply, _ = asyncio.run(gw.run_agent_turn(
+        "hi", timeout_s=2, on_stall=on_stall, stall_after_s=1))
+    assert reply == "late-ok"
+    assert stalls == [1]
+
+
+def test_gateway_stall_timeout_without_extension(monkeypatch, tmp_path):
+    import bgp.federation.gateway as gw
+
+    fake = tmp_path / "openclaw"
+    fake.write_text("#!/bin/sh\nsleep 30\n")
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}:" + __import__("os").environ["PATH"])
+
+    with pytest.raises(asyncio.TimeoutError):
+        asyncio.run(gw.run_agent_turn("hi", timeout_s=1, stall_after_s=5))
+
+
+def test_exec_skill_stall_bridges_approval_notification(tmp_path):
+    """_exec_skill_gateway wires on_stall → progress('awaiting gateway approval')
+    + service.notify_approval, and asks for the approval window as extension."""
+    svc = _svc(tmp_path / "n2n")
+    try:
+        notified = []
+        svc.approval_notifier = lambda *a: notified.append(a)
+        progressed = []
+
+        import bgp.federation.gateway as gw
+        orig = gw.run_agent_turn
+
+        async def fake_run(prompt, session_key="n2n", timeout_s=300, local=False,
+                           model=None, untrusted=False, on_stall=None, stall_after_s=120):
+            assert untrusted, "eN2N skill input must be marked untrusted"
+            ext = on_stall(stall_after_s)
+            assert ext == svc.authz.approval_window_s
+            return "ok", 7
+
+        gw.run_agent_turn = fake_run
+        try:
+            out, tokens = asyncio.run(svc.invoker._exec_skill_gateway(
+                "pyats-health-check", "check", progress=progressed.append, peer=PEER))
+        finally:
+            gw.run_agent_turn = orig
+        assert (out, tokens) == ("ok", 7)
+        assert progressed == ["awaiting gateway approval"]
+        assert notified == [(None, PEER, "gateway-scope", "n2n-skill-pyats-health-check")]
+    finally:
+        svc.manager.close()
+
+
+# ---- failures land in audit (and thus GAIT) ---------------------------------
+
+def test_timeout_recorded_in_audit(tmp_path):
+    svc = _svc(tmp_path / "n2n")
+    try:
+        svc.manager.local_consent(65001, "4.4.4.4")
+        svc.manager.remote_consent(65001, "4.4.4.4")
+        svc.authz.grant(PEER, "skill", "pyats-health-check")
+
+        import bgp.federation.gateway as gw
+        orig = gw.run_agent_turn
+
+        async def fake_run(*a, **kw):
+            raise asyncio.TimeoutError()
+
+        gw.run_agent_turn = fake_run
+
+        async def _run():
+            sub = await svc.invoker.handle_task_submit(
+                _Chan(), {"skill": "pyats-health-check", "input_text": "check"})
+            for _ in range(100):
+                if svc.tasks.status(sub["task_id"])["state"] == "failed":
+                    return sub["task_id"]
+                await asyncio.sleep(0.05)
+            raise AssertionError("task never reached failed state")
+
+        try:
+            task_id = asyncio.run(_run())
+        finally:
+            gw.run_agent_turn = orig
+
+        rows = svc.audit.recent(peer_identity=PEER)
+        timeouts = [r for r in rows if r["outcome"] == "timeout"
+                    and r["request_id"] == task_id]
+        assert timeouts, f"no timeout audit row; rows={rows}"
+    finally:
+        svc.manager.close()

--- a/tests/n2n/test_internal_transport.py
+++ b/tests/n2n/test_internal_transport.py
@@ -51,7 +51,12 @@ async def _enroll_then_reconnect(tmp_path):
     server = await asyncio.start_server(on_conn, "127.0.0.1", 0)
     port = server.sockets[0].getsockname()[1]
 
-    async with server:
+    # Not `async with server`: on Python 3.12+ Server.wait_closed() (run by
+    # __aexit__) waits for every connection handler to return, and the border's
+    # accept_internal handlers live as long as the member channel stays open —
+    # the test would hang forever. close() alone stops the listener; asyncio.run
+    # teardown reaps the handler tasks.
+    try:
         # First contact: member dials out and ENROLLS (token + signed nonce).
         resp = await member.dial_border("127.0.0.1", port, enrollment_token=token)
         await asyncio.sleep(0.2)
@@ -81,6 +86,8 @@ async def _enroll_then_reconnect(tmp_path):
         await asyncio.sleep(0.2)
         assert resp2["trusted"] is True
         assert "risk/cml" in border.member_channels
+    finally:
+        server.close()
 
     border.manager.close(); member.manager.close()
 
@@ -103,7 +110,9 @@ async def _wrong_key_refused(tmp_path):
     server = await asyncio.start_server(on_conn, "127.0.0.1", 0)
     port = server.sockets[0].getsockname()[1]
 
-    async with server:
+    # See _enroll_then_reconnect: no `async with server` — wait_closed() on
+    # Python 3.12+ would block on the live member-channel handler forever.
+    try:
         await member.dial_border("127.0.0.1", port, enrollment_token=token)
         await asyncio.sleep(0.2)
         # An imposter claiming the same member_id with a DIFFERENT key → refused.
@@ -112,4 +121,6 @@ async def _wrong_key_refused(tmp_path):
         with pytest.raises(Exception):
             await imposter.dial_border("127.0.0.1", port)  # hello with non-pinned key
         await asyncio.sleep(0.1)
+    finally:
+        server.close()
     border.manager.close(); member.manager.close(); imposter.manager.close()

--- a/tests/n2n/test_scope_enforcement.py
+++ b/tests/n2n/test_scope_enforcement.py
@@ -67,7 +67,7 @@ def test_out_of_scope_refused_at_service(tmp_path):
         # in-scope → accepted (returns a task_id); out-of-scope → RpcError -32031
         from bgp.federation.channel import RpcError
         # stub the executor so no live gateway is needed
-        async def _fake(skill, text): return ("ok", 1)
+        async def _fake(skill, text, progress=None, peer=None): return ("ok", 1)
         member.invoker._exec_skill_gateway = _fake
         ok = await member._in2n_member_submit(_Chan(), {"skill": "cml-lab-lifecycle", "input_text": "x"})
         assert ok["state"] == "submitted"

--- a/tests/n2n/test_tasks.py
+++ b/tests/n2n/test_tasks.py
@@ -129,7 +129,7 @@ async def _async_delegation(tmp_path):
     nick.authz.grant(john.local_identity, "skill", "cml-clone")
 
     # Stub Nick's executor to take a few seconds (proves submit is async)
-    async def slow_exec(skill, input_text):
+    async def slow_exec(skill, input_text, progress=None, peer=None):
         await asyncio.sleep(3)
         return f"built {skill}: 10 nodes, 12 links", 100
     nick.invoker._exec_skill_gateway = slow_exec


### PR DESCRIPTION
## Summary

Remediations from the 2026-07-14 eN2N delegation-bypass security review, prompted by the post-mortem of delegated task `83d1176e` (peer-submitted `pyats-health-check` that appeared stuck in `working`, refused cancellation, and finally failed with an empty error).

### Fail-closed embedded execution for untrusted peer input
`run_agent_turn` gains an `untrusted` flag, set for inbound peer chat and delegated skill runs. Embedded (`--local`) execution of untrusted eN2N input is now **refused unless 057 production containment verifies** (production mode + sandbox available; model guard already fail-closed). This makes the one-line `local=True` approval-gate bypass impossible to reintroduce silently. iN2N members (`untrusted=False`) keep their embedded testing-mode path.

### Gateway approval holds are no longer silent hangs
When the gateway holds a session at its scope-upgrade approval gate, the CLI goes quiet and the old code just died on a blind hard timeout. Now, after `stall_after_s` of silence the `on_stall` bridge:
- notifies the operator through the n2n approval notifier,
- sets the task's progress to `awaiting gateway approval`,
- extends the wait by the operator approval window so the approval can land.

Timeouts also raise with a descriptive message — task `83d1176e` recorded `{"error": ""}`.

### Failures land in the audit trail
Timed-out and errored delegated skill runs now write an audit row (`outcome=timeout|error`), and therefore reach the GAIT trail. The pre-fix path recorded nothing on failure.

### Test-suite fix (separate commit)
`tests/n2n/test_internal_transport.py` hung forever on Python 3.12+ because `async with server:` awaits `Server.wait_closed()`, which now waits for connection handlers that live as long as the member channel stays open. Replaced with `try/finally: server.close()`.

## Testing

- `tests/n2n/test_delegation_bypass_guard.py` (new, 7 tests): fail-closed refusal outside production and without sandbox, trusted-member path unaffected, stall bridge extends the window and completes, stall notification wiring, timeout audit row.
- `tests/n2n/test_scope_enforcement.py`, `tests/n2n/test_tasks.py`, `tests/n2n/test_internal_transport.py` pass (16 + 3).
- Full `tests/n2n/` suite: 61+ tests green through the transport tests on Python 3.14 (previously wedged at `test_enroll_then_reconnect_over_loopback`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fu8ovWEiNiZrc8uK9oe3GB