### PR TITLE
fix(057): expand %h in confined cold-start props — systemd-run does not expand specifiers

### DIFF
--- a/mcp-servers/protocol-mcp/bgp/federation/controls.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/controls.py
@@ -228,8 +228,12 @@ def confined_cold_start(launch_cmd: str, member_id: str) -> list:
     slug = member_id.replace("/", "-")
     argv = ["systemd-run", "--user", "--collect",
             "--unit", f"netclaw-coldmember-{slug}"]
+    # systemd-run sends -p properties over D-Bus, where %-specifiers are NOT
+    # expanded (unlike unit files) — %h must be resolved here or the transient
+    # unit is rejected with "Invalid ReadWritePaths".
+    home = os.path.expanduser("~")
     for p in _CONFINE_PROPS:
-        argv += ["-p", p]
+        argv += ["-p", p.replace("%h", home)]
     argv += ["/bin/sh", "-c", launch_cmd]
     return argv
 


### PR DESCRIPTION
## Summary
- `controls.confined_cold_start()` built the `systemd-run --user` argv with `ReadWritePaths=%h` / `InaccessiblePaths=-%h/.openclaw/.env` taken verbatim from `_CONFINE_PROPS`.
- `systemd-run` passes `-p` properties over D-Bus, where %-specifiers are **not** expanded (unlike unit files), so systemd rejected the transient unit with `Invalid ReadWritePaths` — and since the daemon DEVNULLs the spawn's stderr, **every confined cold-start of an on-demand member failed silently** in production mode (member stuck unreachable, route returns `member_unreachable` after the 90s wait).
- Fix: resolve `%h` to the real home directory when building the argv.

## Verification (live)
- Reproduced the failure verbatim: `systemd-run --user ... -p 'ReadWritePaths=%h' ...` → `Failed to start transient service unit: Invalid ReadWritePaths`.
- With the fix: `POST /n2n/route {"capability":"github-ops"}` cold-started `johns-risk/github` in a confined transient unit; the member dialed in, authenticated (pinned-key hello), and the task was accepted with `enforcement: enforced`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)