### PR TITLE
fix(n2n): route on bare path — query strings 404'd every parameterized GET

### DIFF
--- a/mcp-servers/protocol-mcp/bgp-daemon-v2.py
+++ b/mcp-servers/protocol-mcp/bgp-daemon-v2.py
@@ -17,6 +17,7 @@ import logging
 import os
 import re
 import sys
+import urllib.parse
 from ipaddress import IPv4Network
 import struct
 
@@ -708,6 +709,12 @@ async def handle_http(reader, writer):
             return
 
         method, path, *_ = lines[0].split(" ")
+        # Route on the bare path — clients (n2n-mcp) pass GET parameters as a
+        # query string, which must not defeat the exact-match routing below.
+        # Query params are merged into `body` (JSON body wins) since handlers
+        # read GET options from there.
+        path, _, _query = path.partition("?")
+        _query_params = {k: v[-1] for k, v in urllib.parse.parse_qs(_query).items()}
 
         # Determine Content-Length and read the remainder of the body
         content_length = 0
@@ -733,6 +740,8 @@ async def handle_http(reader, writer):
                 body = json.loads(raw_body)
             except Exception as e:
                 logger.warning("Bad JSON body on %s %s: %s", method, path, e)
+        for k, v in _query_params.items():
+            body.setdefault(k, v)
 
         resp_code = 200
         resp_body = {}


### PR DESCRIPTION
## Summary
- The daemon's hand-rolled HTTP router compared the **raw request path including the query string** against exact route strings, so every parameterized GET — `/n2n/audit?limit=5`, `/n2n/tasks?task_id=…` (as issued by the n2n-mcp tools) — fell through to `unknown n2n route`.
- Surfaced live today: a federated peer asked whether a chat round-trip was in the audit log, and the Border could not answer because `n2n_audit` 404'd.
- Fix: partition the path at `?` before route matching, parse the query string, and merge its params into `body` (JSON body wins) since handlers read GET options from `body`.

## Verification (live)
- Before: `GET /n2n/audit` → records; `GET /n2n/audit?limit=5` → `{"error": "unknown n2n route /n2n/audit?limit=5"}`.
- After (daemon restarted): `GET /n2n/audit?limit=5` → records; bare-path routes, POST bodies, BGP, eN2N channel to AS65007, and all member channels re-verified healthy.

Related: #124 (the other demo-blocking fix from this debugging session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)