### PR TITLE
test(057): fix cold-start test to assert expanded $HOME (green main)

### DIFF
--- a/tests/n2n/test_controls_failclosed.py
+++ b/tests/n2n/test_controls_failclosed.py
@@ -47,7 +47,13 @@ def test_confined_cold_start_uses_systemd_run(monkeypatch):
     argv = controls.confined_cold_start("bash /x/run.sh", "risk/cml")
     assert argv[0] == "systemd-run" and "--user" in argv
     assert "NoNewPrivileges=yes" in argv and "ProtectSystem=strict" in argv
-    assert "InaccessiblePaths=-%h/.openclaw/.env" in argv
+    # %h MUST be expanded to the real home: systemd-run passes -p properties over
+    # D-Bus, where %-specifiers are NOT expanded and a literal %h is rejected with
+    # "Invalid ReadWritePaths" (PR #124). Assert the resolved absolute path.
+    home = os.path.expanduser("~")
+    assert f"InaccessiblePaths=-{home}/.openclaw/.env" in argv
+    assert f"ReadWritePaths={home}" in argv
+    assert not any("%h" in a for a in argv)
     assert argv[-3:] == ["/bin/sh", "-c", "bash /x/run.sh"]
 
 


### PR DESCRIPTION
## Problem
`main` has a failing test. PR #124 corrected `controls.confined_cold_start()` to expand `%h` → real home (systemd-run rejects a literal `%h` over D-Bus with `Invalid ReadWritePaths`), but the test `test_confined_cold_start_uses_systemd_run` still asserts `"InaccessiblePaths=-%h/.openclaw/.env"`. Against the merged fix that assertion is false, so the test fails on main.

## Fix
Test-only: assert the resolved absolute paths (`ReadWritePaths=$HOME`, `InaccessiblePaths=-$HOME/.openclaw/.env`) and that no `%h` survives in the argv. Verified green against current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)