### PR TITLE
fix(n2n): guard non-dict n2n/hello result in open_channel

### DIFF
--- a/mcp-servers/protocol-mcp/bgp/federation/service.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/service.py
@@ -581,6 +581,13 @@ class FederationService:
                                                "cert_pem": self.risk.self_cert_pem(),
                                                "signature": self.risk.self_sign(nonce, binding).hex(),
                                                "capabilities": local_descriptor()})
+            # A well-behaved peer returns a dict; guard against a peer that returns
+            # a bare string or other shape so one odd hello reply can't abort the
+            # whole dial (normalize() already tolerates a non-dict descriptor).
+            if not isinstance(resp, dict):
+                logger.warning("Peer %s returned non-dict n2n/hello result (%s) — "
+                               "treating as empty", ident, type(resp).__name__)
+                resp = {}
             ch.display_name = resp.get("display_name")
             self.peer_caps[ident] = normalize(resp.get("capabilities"))  # US4
             self.manager.remote_consent(peer_as, router_id)


### PR DESCRIPTION
Caught live dialing a peer whose build returned a non-dict `n2n/hello` result: `open_channel` did `resp.get('display_name')` and threw `'str' object has no attribute 'get'`, aborting the entire outbound dial. Guard `resp` — if not a dict, log and treat as empty (`normalize()` already tolerates a non-dict descriptor). Latent since 052; a peer's odd hello reply should degrade gracefully, not break federation. Happy-path tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)