### PR TITLE
fix(060/063): green n2n suite on Python 3.14/OpenSSL 3.5 — strict-X509 SKI/AKI + wait_closed hangs

### DIFF
--- a/mcp-servers/protocol-mcp/bgp/federation/certs.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/certs.py
@@ -142,6 +142,11 @@ def create_risk_ca(risk_name: str, days: int = 730) -> Tuple[str, str]:
             ),
             critical=True,
         )
+        # SKI is required on CA certs by strict X.509 verification, which
+        # Python 3.13+ enables by default (VERIFY_X509_STRICT) — without it,
+        # peers on a modern stack refuse the chain outright.
+        .add_extension(x509.SubjectKeyIdentifier.from_public_key(key.public_key()),
+                       critical=False)
         .sign(key, hashes.SHA256())
     )
     return _cert_pem(cert), _key_pem(key)
@@ -171,6 +176,14 @@ def issue_cert(ca_cert_pem: str, ca_key_pem: str, subject_cn: str,
         .not_valid_after(now + datetime.timedelta(days=days))
         .add_extension(_san(san or subject_cn), critical=False)
         .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        # AKI (+SKI) are required on CA-issued leaves by strict X.509
+        # verification, on by default since Python 3.13 — a leaf without AKI
+        # fails with "Missing Authority Key Identifier" on a modern peer.
+        .add_extension(x509.SubjectKeyIdentifier.from_public_key(leaf_key.public_key()),
+                       critical=False)
+        .add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_key.public_key()),
+            critical=False)
     )
     if ekus:
         builder = builder.add_extension(x509.ExtendedKeyUsage(ekus), critical=False)

--- a/tests/n2n/test_endpoint_persistence_063.py
+++ b/tests/n2n/test_endpoint_persistence_063.py
@@ -74,7 +74,10 @@ async def _run(tmp_path):
                           manager=FederationManager(base_dir=str(dialer_base)))
     a.manager.local_consent(ACCEPT_AS, ACCEPT_RID)   # dialer consents to acceptor
 
-    async with server:
+    # Not `async with server`: on Python 3.12+ Server.wait_closed() (run by
+    # __aexit__) waits for every connection handler to return — a still-open
+    # channel handler would hang the test forever (seen on the 3.14 host).
+    try:
         # 1. successful dial → endpoint persisted + fresh
         await asyncio.wait_for(a.open_channel(ACCEPT_AS, ACCEPT_RID, "127.0.0.1", port), 15)
         persisted = a.manager.get_peer(ACCEPT_IDENT)
@@ -94,6 +97,8 @@ async def _run(tmp_path):
         assert after_bad["endpoint_host"] == "127.0.0.1"
         assert after_bad["endpoint_port"] == port, "bad dial must not clobber good address"
         assert after_bad["endpoint_updated_at"] == good_freshness
+    finally:
+        server.close()
 
     # 3. simulated restart: fresh manager over the SAME db sees the persisted
     #    address — exactly what the reconnect supervisor reads to auto-redial.

--- a/tests/n2n/test_member_delegation.py
+++ b/tests/n2n/test_member_delegation.py
@@ -60,7 +60,12 @@ def test_route_and_delegate_completes(tmp_path):
 
 async def _route_and_delegate(tmp_path):
     border, member, server = await _stand_up_risk(tmp_path, ["cml-lab-lifecycle"])
-    async with server:
+    # NOTE: not `async with server:` — since Python 3.12.1, Server.wait_closed()
+    # (run by __aexit__) blocks until every accepted connection finishes, and the
+    # member channel here stays open, so the block would never exit (hang seen on
+    # the 3.14 host). close() without wait_closed() is the pre-3.12 semantics
+    # these tests were written against.
+    try:
         # Operator asks the Border; it routes to risk/cml and delegates.
         out = await border.route_and_delegate("cml-lab-lifecycle", "build my lab")
         assert out["member_id"] == "risk/cml"
@@ -81,6 +86,8 @@ async def _route_and_delegate(tmp_path):
         polled = await border.poll_member_task("risk/cml", task_id, kind="result")
         assert polled["state"] == "completed"
         assert "cml-lab-lifecycle" in polled["output_text"]
+    finally:
+        server.close()
     border.manager.close(); member.manager.close()
 
 
@@ -90,9 +97,11 @@ def test_no_capable_member(tmp_path):
 
 async def _no_capable(tmp_path):
     border, member, server = await _stand_up_risk(tmp_path, ["cml-lab-lifecycle"])
-    async with server:
+    try:
         out = await border.route_and_delegate("something-nobody-has", "x")
         assert out["error"] == "IN2N_ERR_NO_CAPABLE_MEMBER"
+    finally:
+        server.close()
     border.manager.close(); member.manager.close()
 
 
@@ -104,11 +113,13 @@ async def _out_of_scope(tmp_path):
     # Member is enrolled with cml scope, but we ask it (directly) for a capability
     # its runtime scope does not allow → ERR_OUT_OF_SCOPE (FR-023/SC-007).
     border, member, server = await _stand_up_risk(tmp_path, ["cml-lab-lifecycle"])
-    async with server:
+    try:
         # Force-route a capability the member is NOT scoped to run.
         out = await border.delegate_to_member("risk/cml", "dangerous-config-push", "x")
         assert out["error"] == "out_of_scope"
         assert out["code"] == -32031
+    finally:
+        server.close()
     border.manager.close(); member.manager.close()
 
 

--- a/tests/n2n/test_secured_federation_060.py
+++ b/tests/n2n/test_secured_federation_060.py
@@ -62,7 +62,11 @@ async def _run(tmp_path):
         assert john.manager.get_peer(nick_ident)["verify_state"] == "verified"
 
         server.close()
-        await server.wait_closed()
+        # No `await server.wait_closed()`: since Python 3.12.1 it waits for
+        # every accepted-connection handler to return, and the live secured
+        # channel keeps nick's handler alive — the test would hang forever
+        # (seen on the 3.14 host). close() stops the listener; asyncio.run
+        # teardown reaps the handler task.
     finally:
         os.environ.pop("N2N_CERT_MODE", None)
 

--- a/tests/n2n/test_two_daemon_loopback.py
+++ b/tests/n2n/test_two_daemon_loopback.py
@@ -66,7 +66,10 @@ async def _federation_end_to_end(tmp_path):
     server = await asyncio.start_server(on_conn, "127.0.0.1", 0)
     port = server.sockets[0].getsockname()[1]
 
-    async with server:
+    # Not `async with server`: on Python 3.12+ Server.wait_closed() (run by
+    # __aexit__) waits for every connection handler to return — a still-open
+    # channel handler would hang the test forever (seen on the 3.14 host).
+    try:
         # Lower-AS side dials
         await initiator.open_channel(65007, "7.7.7.7", "127.0.0.1", port)
         # Let hello + inventory exchange settle
@@ -97,3 +100,5 @@ async def _federation_end_to_end(tmp_path):
         ok = await initiator.sever_local(b_ident)
         assert ok
         assert initiator.manager.get_peer(b_ident)["state"] == PeerState.SEVERED.value
+    finally:
+        server.close()


### PR DESCRIPTION
## Summary

Follow-up to #136 (merged): the remaining upgrade fallout in the n2n suite. **177 passed, 0 failed, ~17s** on Python 3.14.4 / OpenSSL 3.5.5.

### Production fix — `bgp/federation/certs.py`
Python 3.13+ enables `VERIFY_X509_STRICT` by default, which rejects chains whose CA lacks a **Subject Key Identifier** or whose leaf lacks an **Authority Key Identifier** — exactly what `create_risk_ca`/`issue_cert` produced ("Missing Authority Key Identifier"). Any domain-verified peer on a modern Python would refuse Border-issued certs. CA now carries SKI; issued leaves carry SKI+AKI. Pinned-model self-signed identities are pin-verified and self-issued (exempt); Let's Encrypt certs already carry AKI. Existing on-disk leaves pick up the extensions at next rotation.

### Test-harness fix — 4 files
Since Python 3.12.1, `Server.wait_closed()` waits for every accepted-connection handler to return; `async with server:` (or explicit `wait_closed()`) with a live federation channel open hangs forever — this is what made the suite hang for 16+ hours on the new host. Replaced with `close()`-only teardown, matching the precedent already present in `test_internal_transport.py`.

## Test plan
- [x] `python3 -m pytest tests/n2n/ -q --timeout=120` → **177 passed** in 16.5s
- [x] Live daemon + members unaffected (comment-level/issuance-path change; live fleet heartbeat ALL HEALTHY post-change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)