### PR TITLE
H14: possession tier for TLS-verified listeners on dialed channels

### DIFF
--- a/docs/ietf/NCFED-HARDENING-BACKLOG.md
+++ b/docs/ietf/NCFED-HARDENING-BACKLOG.md
@@ -231,6 +231,25 @@ rendered artifacts stay FROZEN and coherent; fold the text below when cutting `-
   missing completion as failure, and SHOULD reconcile in-flight tasks after a
   channel re-establish.
 
+### H14. Tier asymmetry on dialer-initiated channels — *FIXED (found live 2026-07-18)*
+- **Reality:** `channel.attestation` was only ever set on the ACCEPTOR side
+  (`_on_hello` verifies the dialer's possession proof). On a channel the local claw
+  dialed, the LISTENER never received an attestation, so its `endpoint_update` /
+  execution requests were denied at tier-0 forever — observed as a 33-second denial
+  loop against both live mesh peers, silently disabling `endpoint_reannounce` on
+  every dialed channel (the lowest-AS claw dials everyone, so the hub saw it for all
+  peers).
+- **Fix (shipped):** on the dialer side, after `_secure_dial` verifies the
+  listener's certificate (pin / domain SAN), the TLS handshake itself constitutes
+  the listener's possession proof for that certificate; the channel now records
+  `attestation="possession"` + the listener's leaf. Cleartext channels are
+  unchanged (still self-asserted).
+- **Draft:** `-02`'s admission-tier prose should state explicitly that on an
+  encrypted channel the acceptor's tier at the initiator is established by the TLS
+  server authentication (certificate verification + the handshake's key-possession
+  property), while the initiator's tier at the acceptor is established by the
+  `n2n/hello` possession proof — the two proofs are asymmetric by construction.
+
 ### Cutting `-02` (supervised)
 **CUT 2026-07-17 at John's direction** (ahead of H12/mesh-TLS, which `-02` documents
 honestly as staged/optional rather than claiming done): `draft-capobianco-ncfed-02.md`

--- a/mcp-servers/protocol-mcp/bgp/federation/service.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/service.py
@@ -599,6 +599,19 @@ class FederationService:
                                    peer_as=peer_as, peer_router_id=router_id,
                                    manager=self.manager, is_initiator=True, handlers=self.handlers)
             ch.cred_status = self._cred_status()
+            sslobj = writer.get_extra_info("ssl_object")
+            if self.cert_mode and sslobj is not None:
+                # Dialer-side tier: the TLS handshake proved the LISTENER possesses
+                # the key for the certificate _secure_dial just verified (pin /
+                # domain SAN), which is the same possession property _on_hello
+                # establishes for a dialer. Without this, attestation is only ever
+                # set on the acceptor side, so a listener's endpoint_update /
+                # execution surface is tier-0 forever on every channel it did not
+                # itself dial (observed live 2026-07-18 against both mesh peers,
+                # which silently disabled endpoint_reannounce on dialed channels).
+                from . import tls as _tls
+                ch.attestation = "possession"
+                ch.cert_pem = _tls.peer_leaf_pem(sslobj)
             self._register_channel(ident, ch)
             await ch.start()
             from .negotiate import local_descriptor, normalize


### PR DESCRIPTION
channel.attestation was acceptor-only; listeners on dialed channels were tier-0 forever (live 33s endpoint_update denial loop against both mesh peers). TLS server auth = possession proof of the verified cert, so the dialer now records it. 177 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)