### PR TITLE
docs: BISQUE blog published (062 milestone)

### DIFF
--- a/docs/blog/2026-07-17-rag-mcp.md
+++ b/docs/blog/2026-07-17-rag-mcp.md
@@ -1,9 +1,14 @@
-# Draft blog post — for John's review before publishing (Constitution XVII)
+# Published blog post (Constitution XVII — approved by John 2026-07-18)
 
-**Proposed title:** NetClaw gets a bookshelf: an offline, agentic RAG knowledge base
+**Title:** BISQUE: NetClaw gets a bookshelf — an offline, agentic RAG knowledge base
 
-**Status:** DRAFT — do not publish until John approves. Target: WordPress via the
-`wordpress-site` MCP.
+**Status:** PUBLISHED 2026-07-18 as post 1614 —
+https://www.automateyournetwork.ca/uncategorized/bisque-netclaw-gets-a-bookshelf-an-offline-agentic-rag-knowledge-base/
+
+The knowledge base was christened **BISQUE** (Base of Ingested Semantic Queries
+for Unified Embeddings) at publication — the tastiest thing you can make from
+claws. The published version also adds the first-ingest validation numbers
+(212 pages / 389 chunks / ~2m20s, honest-miss test) from the live Slack upload.
 
 ---
 


### PR DESCRIPTION
RAG milestone post approved and published as BISQUE (post 1614). Repo copy updated with URL + validation numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)