### PR TITLE
fix(056): wire scoped member home via OPENCLAW_CONFIG_PATH/STATE_DIR in generated .env

### DIFF
--- a/scripts/in2n-migrate.py
+++ b/scripts/in2n-migrate.py
@@ -91,6 +91,17 @@ def main():
             f"N2N_MEMBER_ID={member_id}",
             f"N2N_BORDER_ENDPOINT={args.border_endpoint}",
             f"N2N_MEMBER_BASE={os.path.join(mdir, 'n2n')}",
+            # Point the member's OpenClaw runtime at the scoped home that
+            # scripts/in2n-member-home.py builds (~/.openclaw-<risk>-<member>/openclaw.json).
+            # openclaw agent --local honors OPENCLAW_CONFIG_PATH / OPENCLAW_STATE_DIR from
+            # the env (verified: OPENCLAW_PROFILE as an env var is ignored — only the
+            # --profile flag takes it). in2n-member.py loads this .env into os.environ and
+            # gateway.py spawns `openclaw agent --local` inheriting that env, so without
+            # these two vars the member silently loads the default ~/.openclaw home
+            # (scope not enforced). Path is absolute (expanduser) because the .env loader
+            # uses os.environ.setdefault with the raw string (no shell ~ expansion).
+            f"OPENCLAW_CONFIG_PATH={os.path.expanduser('~/.openclaw-' + args.risk + '-' + name)}/openclaw.json",
+            f"OPENCLAW_STATE_DIR={os.path.expanduser('~/.openclaw-' + args.risk + '-' + name)}",
             f"N2N_MEMBER_SCOPE={_scope_json(info['skills'])}",
             "# Pick THIS member's provider/model (any provider incl local/Ollama):",
             "N2N_MEMBER_MODEL=anthropic/claude-sonnet-5   # <-- edit per member",


### PR DESCRIPTION
## What this fixes

When a member claw is generated by `in2n-migrate.py`, its launch file (`run.sh` + `.env`) never told OpenClaw which config to use. So the member silently started up using the Border's full config (`~/.openclaw/openclaw.json`) instead of its own scoped home (`~/.openclaw-<risk>-<member>/openclaw.json`).

The result: the member was NOT actually scoped to its specialty. It loaded the wrong config, which undermines the focused-member design that iN2N is built to provide.

## The change

We add two lines to the generated member `.env`:

- `OPENCLAW_CONFIG_PATH` -> the member's own `openclaw.json`
- `OPENCLAW_STATE_DIR` -> the member's own state directory

Because the launch chain (`run.sh` -> `in2n-member.py` -> `openclaw agent --local`) inherits that environment, the member now loads its correct scoped home.

(Note: we tried `OPENCLAW_PROFILE` first, but OpenClaw only honors that as a command-line flag, not as an environment variable — so `OPENCLAW_CONFIG_PATH`/`OPENCLAW_STATE_DIR` are the correct vars to use.)

## Why it matters

The design (specs/056-in2n-internal-federation/risk-deployment-design.md, lines 68-83) requires each member to run with its own scoped MCP servers and its own config directory. This change ensures the generated launcher points the member at its own scoped home, as the design intends.

## How it was verified

- End-to-end test with `strace`: with the fix, the member process opens only its own `~/.openclaw-<risk>-<member>/openclaw.json`. Without it, it opens the Border's config.
- Full N2N test suite: 177 passed, 0 failed.

## Scope

One file changed: `scripts/in2n-migrate.py` (11 lines added). The Border daemon, `in2n-member.py`, and `in2n-member-home.py` are untouched.
