### PR TITLE
feat(063): NCFED protocol hardening — tie-break, reassembly bounds, task ownership, MEMBER_ID_TAKEN

### DIFF
--- a/mcp-servers/protocol-mcp/bgp/constants.py
+++ b/mcp-servers/protocol-mcp/bgp/constants.py
@@ -198,6 +198,26 @@ NCFED_MAX_PAYLOAD = 65536         # 64 KB max per frame; larger messages chunk
 NCFED_FLAG_CONTINUATION = 0x01    # payload is a chunk; concatenate until flag clear
 NCFED_HEARTBEAT_INTERVAL = 30     # seconds of silence before sending an empty frame
 NCFED_HEARTBEAT_MISS_LIMIT = 3    # missed heartbeats before channel considered down
+NCFED_MAX_MESSAGE = 16 * 1024 * 1024  # aggregate reassembled-message bound (NCFED -00 §7/§14.7)
+NCFED_REASSEMBLY_TIMEOUT = 30.0   # seconds a partial reassembly may stay open before close
+
+
+def ncfed_initiates(local_as: int, local_router_id: str,
+                    peer_as: int, peer_router_id: str) -> bool:
+    """Deterministic-initiator rule (NCFED -00 §5): peers are ordered by the
+    tuple (AS, router-id), router-ids compared as unsigned 32-bit integers in
+    network byte order. The numerically lower tuple dials; the other accepts.
+    Equal tuples are a configuration error (two peers MUST NOT share both) —
+    neither side dials, so the misconfiguration surfaces instead of colliding."""
+    import socket
+    import struct
+
+    def _rid(rid: str) -> int:
+        try:
+            return struct.unpack("!I", socket.inet_aton(rid))[0]
+        except OSError:
+            return 0
+    return (local_as, _rid(local_router_id)) < (peer_as, _rid(peer_router_id))
 
 # ── iN2N — Internal NetClaw Federation (feature 056) ────────────────
 # iN2N reuses the NCFED wire framing above over a member-initiated internal

--- a/mcp-servers/protocol-mcp/bgp/federation/channel.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/channel.py
@@ -14,11 +14,13 @@ import asyncio
 import json
 import logging
 import struct
+import time
 from typing import Awaitable, Callable, Optional
 
 from ..constants import (
     NCFED_MAGIC, NCFED_MAX_PAYLOAD, NCFED_FLAG_CONTINUATION,
     NCFED_HEARTBEAT_INTERVAL, NCFED_HEARTBEAT_MISS_LIMIT,
+    NCFED_MAX_MESSAGE, NCFED_REASSEMBLY_TIMEOUT,
 )
 
 logger = logging.getLogger("n2n.channel")
@@ -147,12 +149,40 @@ class FederationChannel:
                     break
                 chunk = await self.reader.readexactly(length) if length else b""
                 if flags & NCFED_FLAG_CONTINUATION:
+                    # NCFED -00 §7/§14.7: bound both the aggregate reassembled
+                    # size and how long a partial reassembly may stay open. A
+                    # peer can otherwise hold memory forever with 64 KiB frames,
+                    # or hold the buffer open with a drip of zero-length
+                    # fragments (legal, and each resets heartbeat liveness).
+                    if not self._recv_buf:
+                        self._reasm_started = time.monotonic()
                     self._recv_buf += chunk
+                    if len(self._recv_buf) > NCFED_MAX_MESSAGE:
+                        self.logger.warning(
+                            "Reassembly exceeds %d-octet aggregate bound — closing",
+                            NCFED_MAX_MESSAGE)
+                        break
+                    if (time.monotonic() - self._reasm_started
+                            > NCFED_REASSEMBLY_TIMEOUT):
+                        self.logger.warning(
+                            "Reassembly open longer than %.0fs — closing",
+                            NCFED_REASSEMBLY_TIMEOUT)
+                        break
                     continue
+                if not length and self._recv_buf:
+                    # §7: a Length-0, CONTINUATION-clear frame is a heartbeat and
+                    # is legal only between messages, never mid-reassembly.
+                    self.logger.warning("Heartbeat inside reassembly — closing")
+                    break
                 full = self._recv_buf + chunk
                 self._recv_buf = b""
                 if not full:
                     continue  # heartbeat
+                if len(full) > NCFED_MAX_MESSAGE:
+                    self.logger.warning(
+                        "Reassembled message exceeds %d-octet bound — closing",
+                        NCFED_MAX_MESSAGE)
+                    break
                 await self._dispatch(full)
         except (asyncio.IncompleteReadError, ConnectionError):
             self.logger.info("Channel closed by peer")

--- a/mcp-servers/protocol-mcp/bgp/federation/invocation.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/invocation.py
@@ -217,15 +217,22 @@ class Invoker:
         tm.run(task_id, worker)
         return {"task_id": task_id, "state": "submitted"}
 
+    # Retrieval is bound to the submitting peer (NCFED -00 §9.2/§14.6): the
+    # authenticated channel identity must match the task's recorded owner, and
+    # a non-owner is answered as if the task did not exist.
+
     async def handle_task_status(self, channel, params):
-        return self.service.tasks.status(params.get("task_id", ""))
+        return self.service.tasks.status(params.get("task_id", ""),
+                                         owner=channel.peer_identity)
 
     async def handle_task_result(self, channel, params):
-        return self.service.tasks.result(params.get("task_id", ""))
+        return self.service.tasks.result(params.get("task_id", ""),
+                                         owner=channel.peer_identity)
 
     async def handle_task_cancel(self, channel, params):
         task_id = params.get("task_id", "")
-        return {"task_id": task_id, "cancelled": self.service.tasks.cancel(task_id)}
+        return {"task_id": task_id,
+                "cancelled": self.service.tasks.cancel(task_id, owner=channel.peer_identity)}
 
     async def _await_approval(self, approval_id: int) -> bool:
         deadline = time.time() + self.authz.approval_window_s

--- a/mcp-servers/protocol-mcp/bgp/federation/service.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/service.py
@@ -555,8 +555,9 @@ class FederationService:
             logger.info("iN2N Member role — not opening outbound eN2N channel (FR-014)")
             return
         ident = peer_identity(peer_as, router_id)
-        if self.local_as >= peer_as:
-            logger.debug("Not initiating to %s — higher/equal AS waits", ident)
+        from ..constants import ncfed_initiates
+        if not ncfed_initiates(self.local_as, self.router_id, peer_as, router_id):
+            logger.debug("Not initiating to %s — higher (AS, router-id) tuple waits", ident)
             return
         # An explicit (re)dial always replaces any existing channel. A channel
         # can silently die (ngrok resets the long-lived TCP) without being
@@ -833,7 +834,19 @@ class FederationService:
                 display_name=params.get("display_name"),
                 transport_binding=params.get("transport_binding", "distributed"))
         except ValueError as e:
-            raise RpcError(_ERR_NOT_TRUSTED if "TRUSTED" in str(e) else -32021, str(e))
+            # Map the risk-layer sentinel to its wire code: a member_id already
+            # pinned to a different key is MEMBER_ID_TAKEN (-32022), distinct
+            # from a spent/expired token (-32021). (NCFED -00 §9.3)
+            from ..constants import (IN2N_ERR_ENROLL_TOKEN_INVALID,
+                                     IN2N_ERR_MEMBER_ID_TAKEN)
+            msg = str(e)
+            if "TRUSTED" in msg:
+                code = _ERR_NOT_TRUSTED
+            elif "MEMBER_ID_TAKEN" in msg:
+                code = IN2N_ERR_MEMBER_ID_TAKEN
+            else:
+                code = IN2N_ERR_ENROLL_TOKEN_INVALID
+            raise RpcError(code, msg)
         channel.member_id = member_id
         channel.peer_identity = member_id
         channel.trusted = True
@@ -1217,7 +1230,11 @@ class FederationService:
         from ..constants import IN2N_ERR_OUT_OF_SCOPE
         skill = params.get("skill", "")
         input_text = params.get("input_text", "")
-        border = channel.member_id or "border"
+        # Record the task's owner as the channel's peer_identity (== member_id
+        # once authenticated) so it always matches the identity the retrieval
+        # handlers authorize against (owner-bound tasks, NCFED -00 §14.6).
+        border = (getattr(channel, "peer_identity", None)
+                  or getattr(channel, "member_id", None) or "border")
         self.member_last_activity = time.time()   # reset idle-exit timer (cold/on-demand)
         if self.member_scope and skill not in self.member_scope:
             self.audit.record(direction="inbound", peer_identity=border,

--- a/mcp-servers/protocol-mcp/bgp/federation/tasks.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/tasks.py
@@ -76,7 +76,9 @@ class TaskManager:
                 self._workers.pop(task_id, None)
         self._workers[task_id] = asyncio.create_task(_run())
 
-    def cancel(self, task_id: str) -> bool:
+    def cancel(self, task_id: str, owner: Optional[str] = None) -> bool:
+        if owner is not None and not self._owns(task_id, owner):
+            return False
         w = self._workers.get(task_id)
         if w and not w.done():
             w.cancel()
@@ -84,8 +86,23 @@ class TaskManager:
         return False
 
     # ---- queries -------------------------------------------------------
+    #
+    # `owner` binds retrieval to the submitting peer (NCFED -00 §9.2/§14.6):
+    # remote-facing handlers pass the authenticated channel identity, and a
+    # task the caller did not submit is answered exactly like a task that
+    # does not exist, so a leaked/guessed task_id is no longer a bearer
+    # capability and cannot even be probed for existence. Local callers
+    # (HUD, reconciliation) pass no owner and see everything.
 
-    def status(self, task_id: str) -> dict:
+    def _owns(self, task_id: str, owner: str) -> bool:
+        row = self.manager._conn.execute(
+            "SELECT 1 FROM delegated_task WHERE task_id=? AND direction='inbound' "
+            "AND peer_identity=?", (task_id, owner)).fetchone()
+        return row is not None
+
+    def status(self, task_id: str, owner: Optional[str] = None) -> dict:
+        if owner is not None and not self._owns(task_id, owner):
+            return {"task_id": task_id, "state": "unknown"}
         row = self.manager._conn.execute(
             "SELECT state, progress, target_name FROM delegated_task WHERE task_id=?",
             (task_id,)).fetchone()
@@ -94,7 +111,9 @@ class TaskManager:
         return {"task_id": task_id, "state": row["state"], "progress": row["progress"],
                 "target": row["target_name"]}
 
-    def result(self, task_id: str) -> dict:
+    def result(self, task_id: str, owner: Optional[str] = None) -> dict:
+        if owner is not None and not self._owns(task_id, owner):
+            return {"task_id": task_id, "state": "unknown"}
         row = self.manager._conn.execute(
             "SELECT state, result_ref, tokens_used FROM delegated_task WHERE task_id=?",
             (task_id,)).fetchone()

--- a/tests/n2n/test_protocol_hardening.py
+++ b/tests/n2n/test_protocol_hardening.py
@@ -1,0 +1,231 @@
+"""NCFED -00 pre-submission protocol hardening.
+
+Covers the four spec-relevant patches:
+  1. (AS, router-id) tuple tie-break for the deterministic initiator (§5)
+  2. Aggregate reassembly bound + timeout + heartbeat-mid-reassembly (§7/§14.7)
+  3. Task retrieval bound to the submitting peer (§9.2/§14.6)
+  4. MEMBER_ID_TAKEN (-32022) emitted on the wire (§9.3)
+"""
+
+import asyncio
+import struct
+
+import pytest
+
+from bgp.constants import (
+    NCFED_FLAG_CONTINUATION,
+    IN2N_ERR_MEMBER_ID_TAKEN,
+    ncfed_initiates,
+)
+from bgp.federation.channel import FederationChannel, RpcError, encode_frames
+
+
+# ---- 1. deterministic-initiator tuple ordering --------------------------
+
+def test_lower_as_initiates():
+    assert ncfed_initiates(65001, "192.0.2.9", 65007, "192.0.2.1")
+    assert not ncfed_initiates(65007, "192.0.2.1", 65001, "192.0.2.9")
+
+
+def test_equal_as_lower_router_id_initiates():
+    assert ncfed_initiates(65001, "192.0.2.1", 65001, "192.0.2.2")
+    assert not ncfed_initiates(65001, "192.0.2.2", 65001, "192.0.2.1")
+
+
+def test_router_id_compared_as_network_order_integer():
+    # 10.0.0.2 (0x0A000002) < 192.0.2.1 (0xC0000201), regardless of string order
+    assert ncfed_initiates(65001, "10.0.0.2", 65001, "192.0.2.1")
+
+
+def test_equal_tuple_neither_initiates():
+    assert not ncfed_initiates(65001, "192.0.2.1", 65001, "192.0.2.1")
+
+
+# ---- 2. reassembly bounds ------------------------------------------------
+
+class _NullWriter:
+    def write(self, b):
+        pass
+
+    async def drain(self):
+        pass
+
+    def close(self):
+        pass
+
+
+class _FakeManager:
+    def is_federated(self, ident):
+        return True
+
+
+def _frame(payload: bytes, continuation: bool) -> bytes:
+    flags = NCFED_FLAG_CONTINUATION if continuation else 0
+    return struct.pack("!IB", len(payload), flags) + payload
+
+
+def _run_channel(frames: list):
+    """Feed frames to a channel's read loop; return (channel, dispatched params)."""
+    seen = []
+
+    async def go():
+        reader = asyncio.StreamReader()
+        for f in frames:
+            reader.feed_data(f)
+        reader.feed_eof()
+
+        async def on_hello(channel, params):
+            seen.append(params)
+
+        ch = FederationChannel(reader, _NullWriter(),
+                               local_identity="as65001-192.0.2.1",
+                               peer_as=65007, peer_router_id="192.0.2.7",
+                               manager=_FakeManager(), is_initiator=True,
+                               handlers={"n2n/hello": on_hello})
+        await ch._read_loop()
+        return ch
+
+    ch = asyncio.run(go())
+    return ch, seen
+
+
+def _hello_frames() -> list:
+    return encode_frames({"jsonrpc": "2.0", "method": "n2n/hello", "params": {"ok": 1}})
+
+
+def test_chunked_message_within_bound_dispatches():
+    msg = {"jsonrpc": "2.0", "method": "n2n/hello", "params": {"blob": "A" * 200000}}
+    ch, seen = _run_channel(encode_frames(msg))
+    assert len(seen) == 1 and seen[0]["blob"] == "A" * 200000
+
+
+def test_aggregate_reassembly_bound_closes(monkeypatch):
+    import bgp.federation.channel as chmod
+    monkeypatch.setattr(chmod, "NCFED_MAX_MESSAGE", 1024)
+    frames = [_frame(b"A" * 600, True), _frame(b"B" * 600, True),
+              _frame(b"C" * 100, False)] + _hello_frames()
+    ch, seen = _run_channel(frames)
+    assert ch._closed
+    assert seen == []          # nothing dispatched, later frames never processed
+
+
+def test_reassembly_timeout_closes(monkeypatch):
+    import bgp.federation.channel as chmod
+    monkeypatch.setattr(chmod, "NCFED_REASSEMBLY_TIMEOUT", -1.0)
+    frames = [_frame(b"A" * 10, True), _frame(b"B" * 10, False)] + _hello_frames()
+    ch, seen = _run_channel(frames)
+    assert ch._closed
+    assert seen == []
+
+
+def test_heartbeat_mid_reassembly_closes():
+    # Length-0 CONTINUATION-clear inside a reassembly is a protocol error (§7);
+    # before the patch it silently terminated the message instead.
+    frames = [_frame(b"A" * 10, True), _frame(b"", False)] + _hello_frames()
+    ch, seen = _run_channel(frames)
+    assert ch._closed
+    assert seen == []
+
+
+def test_zero_length_continuation_fragment_is_legal():
+    # §7: a Length-0 frame WITH the continuation flag is a legal empty fragment.
+    payload = b'{"jsonrpc":"2.0","method":"n2n/hello","params":{"ok":2}}'
+    frames = [_frame(payload[:10], True), _frame(b"", True),
+              _frame(payload[10:], False)]
+    ch, seen = _run_channel(frames)
+    assert len(seen) == 1 and seen[0]["ok"] == 2
+
+
+# ---- 3. task retrieval bound to the submitting peer ----------------------
+
+@pytest.fixture
+def ledger(manager):
+    from bgp.federation.tasks import TaskManager
+    return TaskManager(manager, audit=None)
+
+
+def test_task_owner_sees_status_and_result(ledger):
+    tid = ledger.create(direction="inbound", peer_identity="as65007-192.0.2.7",
+                        target_type="skill", target_name="demo", input_text="x")
+    assert ledger.status(tid, owner="as65007-192.0.2.7")["state"] == "submitted"
+    assert ledger.result(tid, owner="as65007-192.0.2.7")["state"] == "submitted"
+
+
+def test_task_non_owner_sees_unknown(ledger):
+    tid = ledger.create(direction="inbound", peer_identity="as65007-192.0.2.7",
+                        target_type="skill", target_name="demo", input_text="x")
+    # Existence must not be probeable: apart from the echoed task_id, the answer
+    # is exactly the missing-task shape
+    got = ledger.status(tid, owner="as65099-192.0.2.99")
+    missing = ledger.status("no-such-task", owner="as65099-192.0.2.99")
+    assert got == {"task_id": tid, "state": "unknown"}
+    assert missing == {"task_id": "no-such-task", "state": "unknown"}
+    assert ledger.result(tid, owner="as65099-192.0.2.99")["state"] == "unknown"
+    assert ledger.cancel(tid, owner="as65099-192.0.2.99") is False
+
+
+def test_task_outbound_rows_not_retrievable_remotely(ledger):
+    # A peer must not read our record of a task WE submitted to someone,
+    # even if it somehow learns the id — remote retrieval serves inbound only.
+    ledger.record_outbound("out-1", "as65007-192.0.2.7", "skill", "demo")
+    assert ledger.status("out-1", owner="as65007-192.0.2.7")["state"] == "unknown"
+    assert ledger.status("out-1")["state"] == "submitted"   # local view unrestricted
+
+
+def test_task_local_callers_unrestricted(ledger):
+    tid = ledger.create(direction="inbound", peer_identity="as65007-192.0.2.7",
+                        target_type="skill", target_name="demo", input_text="x")
+    assert ledger.status(tid)["state"] == "submitted"
+
+
+# ---- 4. MEMBER_ID_TAKEN emitted on the wire -------------------------------
+
+def test_enroll_maps_member_id_taken_to_32022():
+    from bgp.federation.service import FederationService
+
+    class _Risk:
+        def is_border(self):
+            return True
+
+        def verify_possession(self, cert, nonce, sig):
+            return True
+
+        def consume_token(self, *a, **kw):
+            raise ValueError("IN2N_ERR_MEMBER_ID_TAKEN: already pinned to another key")
+
+    class _Chan:
+        nonce = b"\x00" * 32
+
+    svc = FederationService.__new__(FederationService)
+    svc.risk = _Risk()
+    with pytest.raises(RpcError) as ei:
+        asyncio.run(svc._in2n_on_enroll(_Chan(), {
+            "token": "in2n_x", "member_id": "r/cml",
+            "cert_pem": "PEM", "signature": ""}))
+    assert ei.value.code == IN2N_ERR_MEMBER_ID_TAKEN == -32022
+
+
+def test_enroll_maps_spent_token_to_32021():
+    from bgp.federation.service import FederationService
+    from bgp.constants import IN2N_ERR_ENROLL_TOKEN_INVALID
+
+    class _Risk:
+        def is_border(self):
+            return True
+
+        def verify_possession(self, cert, nonce, sig):
+            return True
+
+        def consume_token(self, *a, **kw):
+            raise ValueError("IN2N_ERR_ENROLL_TOKEN_INVALID: token spent")
+
+    class _Chan:
+        nonce = b"\x00" * 32
+
+    svc = FederationService.__new__(FederationService)
+    svc.risk = _Risk()
+    with pytest.raises(RpcError) as ei:
+        asyncio.run(svc._in2n_on_enroll(_Chan(), {
+            "token": "in2n_x", "member_id": "r/cml",
+            "cert_pem": "PEM", "signature": ""}))
+    assert ei.value.code == IN2N_ERR_ENROLL_TOKEN_INVALID == -32021


### PR DESCRIPTION
Closes the four spec-documented implementation gaps ahead of the NCFED -00 Datatracker submission, so the draft can specify these protections as running code instead of known limitations:

| # | Gap (draft §) | Fix |
|---|---|---|
| 1 | Equal-AS initiator deadlock (§5) | `ncfed_initiates()` orders peers by (AS, router-id) tuple; NCFED channel dial uses it |
| 2 | Unbounded CONTINUATION reassembly (§7/§14.7) | 16 MiB aggregate cap + 30 s reassembly timeout + heartbeat-mid-reassembly is a protocol error; all close the channel |
| 3 | task_id as bearer capability (§9.2/§14.6) | status/result/cancel verify the authenticated channel identity against the task owner; non-owners get the missing-task shape (no existence oracle); outbound rows never served remotely |
| 4 | MEMBER_ID_TAKEN never emitted (§9.3) | enroll handler maps the risk sentinel to -32022 instead of flattening to -32021 |

Deliberately not done: NCTUN tunnel initiation stays AS-keyed (its registry and wire preamble carry only the AS; equal-AS NCTUN needs a wire change and NCTUN is explicitly out of scope for the NCFED document). Delegation hop count also deferred — transitive delegation doesn't exist in the implementation, so the field would be speculative wire surface.

**Interop note for Nick/Byrn:** all changes are backward compatible on the wire for the live mesh (distinct ASes, no legal traffic hits the new bounds; task retrieval by the submitting peer is unchanged). A peer that retrieves tasks it didn't submit — which nothing does today — would now get `unknown`.

Tests: 16 new in `tests/n2n/test_protocol_hardening.py`; full n2n suite 192 passed (baseline 177, zero regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)