### PR TITLE
fix(057): resolve openclaw for confined N2N daemon (nvm CLI ENOENT — restores distributed RAG over NCFED)

### DIFF
--- a/mcp-servers/protocol-mcp/bgp/federation/gateway.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/gateway.py
@@ -12,13 +12,63 @@ generate replies without assuming a REST endpoint that doesn't exist.
 """
 
 import asyncio
+import glob
 import json
 import logging
 import os
+import re
+import shutil
 
 logger = logging.getLogger("n2n.gateway")
 
 AGENT_ID = os.environ.get("N2N_AGENT_ID", "main")
+
+
+def _openclaw_bin() -> str:
+    """Absolute path to the ``openclaw`` CLI (resolved fresh on each call — cheap
+    next to spawning the process, and robust to PATH changes over the daemon's
+    lifetime).
+
+    A ``systemd --user`` service does not source the shell rc, so an
+    nvm-managed openclaw/node -- the common install -- is NOT on the service
+    PATH even though it is in an interactive shell (nvm edits PATH only per
+    interactive shell). The confined mesh/member units (feature 057) therefore
+    could not find ``openclaw`` and every delegated agent turn failed with
+    ENOENT. Resolve it explicitly: an OPENCLAW_BIN override, then whatever is on
+    PATH, then the newest nvm node that ships it, then common prefixes."""
+    cand = os.environ.get("OPENCLAW_BIN")
+    if cand and os.path.exists(cand):
+        return cand
+    cand = shutil.which("openclaw")
+    if cand:
+        return cand
+
+    def _ver(p):
+        m = re.search(r"/v(\d+)\.(\d+)\.(\d+)/", p)
+        return tuple(int(x) for x in m.groups()) if m else (0, 0, 0)
+    nvm = sorted(glob.glob(os.path.expanduser(
+        "~/.nvm/versions/node/*/bin/openclaw")), key=_ver, reverse=True)
+    cand = next((p for p in nvm if os.path.exists(p)), None)
+    if cand:
+        return cand
+    for p in ("~/.local/bin/openclaw", "/usr/local/bin/openclaw"):
+        p = os.path.expanduser(p)
+        if os.path.exists(p):
+            return p
+    logger.warning("openclaw CLI not found via OPENCLAW_BIN, PATH, nvm, or "
+                   "common prefixes — agent turns will fail; set OPENCLAW_BIN")
+    return "openclaw"
+
+
+def _agent_env() -> dict:
+    """Child environment that can launch openclaw under a confined systemd PATH:
+    prepend the directory holding openclaw so its ``#!/usr/bin/env node`` shebang
+    (node lives beside it in the nvm bin) resolves too."""
+    env = dict(os.environ)
+    b = _openclaw_bin()
+    if os.sep in b:
+        env["PATH"] = os.path.dirname(os.path.abspath(b)) + os.pathsep + env.get("PATH", "")
+    return env
 
 
 class EnforcementRefused(RuntimeError):
@@ -189,7 +239,7 @@ async def run_agent_turn(prompt: str, session_key: str = "n2n", timeout_s: int =
     from .negotiate import local_descriptor
     flag = "--" + local_descriptor().get("agent_invoke", "session-id")
     if local:
-        cmd = ["openclaw", "agent", "--local"]
+        cmd = [_openclaw_bin(), "agent", "--local"]
         if model:
             cmd += ["--model", model]
         cmd += [flag, session_key, "--json", "-m", prompt]
@@ -199,9 +249,10 @@ async def run_agent_turn(prompt: str, session_key: str = "n2n", timeout_s: int =
         # run unprotected. Testing mode runs unwrapped (fast iteration, FR-006).
         cmd = await _apply_production_controls(cmd, prompt)
     else:
-        cmd = ["openclaw", "agent", "--agent", AGENT_ID, flag, session_key, "--json", "-m", prompt]
+        cmd = [_openclaw_bin(), "agent", "--agent", AGENT_ID, flag, session_key, "--json", "-m", prompt]
     proc = await asyncio.create_subprocess_exec(
-        *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT)
+        *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
+        env=_agent_env())
     comm = asyncio.ensure_future(proc.communicate())
     # asyncio.wait (unlike wait_for) does NOT cancel `comm` on timeout, so the
     # turn keeps running across the stall checkpoint and any extension.

--- a/tests/n2n/test_gateway_openclaw_resolve.py
+++ b/tests/n2n/test_gateway_openclaw_resolve.py
@@ -1,0 +1,47 @@
+"""Gateway openclaw resolution under a confined systemd PATH (nvm regression).
+
+The mesh/member units (feature 057) run with a minimal Environment=PATH that
+excludes the nvm bin where openclaw/node live, so bare `openclaw` was ENOENT and
+every delegated agent turn (n2n chat / task) failed. gateway._openclaw_bin()
+resolves it explicitly and _agent_env() puts its dir on the child PATH so the
+`#!/usr/bin/env node` shebang resolves too.
+"""
+
+import os
+
+import bgp.federation.gateway as gw
+
+
+def test_env_override_wins(tmp_path, monkeypatch):
+    fake = tmp_path / "openclaw"
+    fake.write_text("#!/bin/sh\n")
+    monkeypatch.setenv("OPENCLAW_BIN", str(fake))
+    assert gw._openclaw_bin() == str(fake)
+
+
+def test_falls_back_to_newest_nvm(tmp_path, monkeypatch):
+    monkeypatch.delenv("OPENCLAW_BIN", raising=False)
+    # no openclaw on PATH
+    monkeypatch.setattr(gw.shutil, "which", lambda _: None)
+    # fake ~/.nvm with two node versions, newest should win
+    for v in ("v20.16.0", "v25.1.0"):
+        d = tmp_path / ".nvm" / "versions" / "node" / v / "bin"
+        d.mkdir(parents=True)
+        (d / "openclaw").write_text("#!/usr/bin/env node\n")
+    monkeypatch.setattr(os.path, "expanduser",
+                        lambda p: p.replace("~", str(tmp_path)))
+    got = gw._openclaw_bin()
+    assert got.endswith("v25.1.0/bin/openclaw"), got
+
+
+def test_agent_env_prepends_openclaw_dir(tmp_path, monkeypatch):
+    fake = tmp_path / "nodebin" / "openclaw"
+    fake.parent.mkdir()
+    fake.write_text("#!/usr/bin/env node\n")
+    monkeypatch.setenv("OPENCLAW_BIN", str(fake))
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    env = gw._agent_env()
+    # the openclaw (and node) dir must be first so a confined PATH can still
+    # launch it and resolve the node shebang
+    assert env["PATH"].split(os.pathsep)[0] == str(fake.parent)
+    assert "/usr/bin" in env["PATH"]


### PR DESCRIPTION
## What broke

Delegated agent turns over N2N (chat + task delegation) failed with `[Errno 2] No such file or directory: 'openclaw'`. Root cause: `openclaw`/`node` are **nvm-managed** (`~/.nvm/versions/node/vX/bin`), and nvm only edits `PATH` in interactive shells. The mesh/member units (feature 057) run as **confined `systemd --user` services** with a minimal `Environment=PATH` that excludes the nvm bin — so bare `openclaw` was unreachable and every remote chat/RAG query died before the agent turn ran.

Concretely: Byrn's claw (AS 65099) asked *"summarize the book Automate Your Network by John Capobianco"* over NCFED — the channel, identity, and chat routing all worked, but the handler couldn't launch the local agent, so the RAG-grounded answer never happened. (The book is in RAG and retrieves at 0.99 fidelity; the transport was never the problem.)

## Fix

`gateway._openclaw_bin()` resolves the CLI explicitly: `OPENCLAW_BIN` override → `PATH` → newest nvm node that ships it → common prefixes. `_agent_env()` prepends its directory to the child `PATH` so the `#!/usr/bin/env node` shebang (node lives beside openclaw) also resolves under the confined PATH. Resolved fresh per call — cheap next to the subprocess spawn, robust to PATH changes, no stale cache.

Covers **both** agent-turn paths (`chat.py` and `invocation.py` go through `run_agent_turn`): eN2N chat and iN2N member delegation.

## Why code, not a systemd PATH edit

A code resolver adapts to each operator's node install automatically, so other claws just `git pull` + restart — no per-machine unit editing. `OPENCLAW_BIN` is the escape hatch for exotic installs.

Tests: `tests/n2n/test_gateway_openclaw_resolve.py` (+3, incl. nvm-newest selection and child-PATH prepend). n2n suite **199 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)