### PR TITLE
spec(064): knowledge capability cards & knowledge-aware routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # netclaw Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-07-17
+Auto-generated from all feature plans. Last updated: 2026-07-20
 
 ## Active Technologies
 - N/A (stateless server; subscription state held in-memory during runtime) (003-gnmi-mcp-server)
@@ -83,6 +83,8 @@ Auto-generated from all feature plans. Last updated: 2026-07-17
 - `~/.openclaw/rag/` — ChromaDB (`chroma/`, dense vectors), SQLite (`rag.db`: document registry, retrieval log, telemetry, schema version), BM25 pickles (`bm25/<collection>.pkl`), retained originals (`sources/`), intake dir (`intake/`). Never touches `~/.openclaw/memory/` (FR-030) (062-rag-mcp)
 - Python 3.10+ (daemon + `bgp/*`, `bgp/federation/*`); Bash (none new); Node/ES2022 (HUD posture render only) + existing `bgp-daemon-v2.py`, `bgp/agent.py`, `bgp/session.py`, `bgp/federation/{tls,service,manager,channel,inventory,posture}.py`; stdlib `ssl`/`asyncio`/`sqlite3`. **No new third-party packages.** (063-ncfed-wire-hardening)
 - extend existing SQLite `~/.openclaw/n2n/federation.db` (reuse `federation_peer.endpoint_host/endpoint_port/endpoint_updated_at`); reuse keys under `~/.openclaw/n2n/keys/`. No new stores. (063-ncfed-wire-hardening)
+- Python 3.10+ (daemon + `bgp/federation/*`, matching 052–063); Markdown (SOUL/skill docs + NCFED draft §11 for -01) + Existing only — `bgp/federation/inventory.py` (card), `router.py` (selection), `invocation.py`/`gateway.py` (retrieval turn), the feature-062 rag-mcp (`rag_list`, `rag_search`). No new third-party packages. (064-knowledge-capability-cards)
+- Reuses `~/.openclaw/rag/rag.db` (documents registry, read-only for advertisement) and the issued capability card. Per-peer visibility reuses existing federation.db rows. No new store. (064-knowledge-capability-cards)
 
 - Python 3.10+ + FastMCP (MCP framework), grpcio + grpcio-tools (gRPC transport), pygnmi (gNMI client library), protobuf, cryptography (TLS handling) (003-gnmi-mcp-server)
 
@@ -102,9 +104,9 @@ cd src [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLO
 Python 3.10+: Follow standard conventions
 
 ## Recent Changes
+- 064-knowledge-capability-cards: Added Python 3.10+ (daemon + `bgp/federation/*`, matching 052–063); Markdown (SOUL/skill docs + NCFED draft §11 for -01) + Existing only — `bgp/federation/inventory.py` (card), `router.py` (selection), `invocation.py`/`gateway.py` (retrieval turn), the feature-062 rag-mcp (`rag_list`, `rag_search`). No new third-party packages.
 - 063-ncfed-wire-hardening: Added Python 3.10+ (daemon + `bgp/*`, `bgp/federation/*`); Bash (none new); Node/ES2022 (HUD posture render only) + existing `bgp-daemon-v2.py`, `bgp/agent.py`, `bgp/session.py`, `bgp/federation/{tls,service,manager,channel,inventory,posture}.py`; stdlib `ssl`/`asyncio`/`sqlite3`. **No new third-party packages.**
 - 062-rag-mcp: Added Python 3.10+ (server, matching repo MCP convention; memory-mcp packaging style with hatchling pyproject), Node.js 18+/ES2022 (HUD panel + Express endpoints), Bash (installer step) + `fastmcp`/`mcp`, `chromadb>=0.4`, `sentence-transformers>=2.2` (+ `torch` CPU), `rank_bm25`, `pymupdf` (PDF), `beautifulsoup4` + `httpx` (HTML/URL), `python-docx`, `openpyxl`, `python-pptx`, `vsdx` (modern office), LibreOffice headless (`soffice`, optional system package) for legacy DOC/XLS/PPT/VSD conversion
-- 060-claw-cert-security: Added Python 3.10+ (daemon + `bgp/federation/*`, matching 052/053/056/057); Node.js 18+/ES2022 (HUD render only); Bash (installer/patch) + Existing `bgp-daemon-v2.py` + `bgp/federation/*` (channel, internal_channel, risk, service, manager, audit, gateway, negotiate); `cryptography` (already a repo dependency — keys, CSRs, X.509 issuance/verification); **lego** (single-binary ACME client, vendored/downloaded at install, drives DNS-01 across 100+ providers); Python stdlib `ssl`/`asyncio`/`sqlite3`/`json`. No new Python packages.
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/docs/ietf/NCFED-HARDENING-BACKLOG.md
+++ b/docs/ietf/NCFED-HARDENING-BACKLOG.md
@@ -260,3 +260,26 @@ note (endpoint persistence) plus a "Changes from -01" appendix. Rendered via `kd
 --v3` (0 over-length lines; idnits authoritative server-side at Datatracker, per the
 `-01` checklist precedent) into `rendered/draft-capobianco-ncfed-02.{txt,xml}`.
 A future `-03` (or pre-submission refresh of `-02`) picks up H12 once mesh-TLS ships.
+
+## `-01` (next submission) seed — knowledge capability cards (spec 064, 2026-07-19)
+
+Spec 064 (implemented) adds a **knowledge** surface to the A2A capability card and a
+dedicated retrieval method. The next NCFED submission after `-00` should document it
+in the draft (FR-010):
+
+- **§11 Capability Cards:** add a `knowledge` array alongside `skills`/`mcp_servers` —
+  one content-free A2A-skill-shaped entry per RAG collection (`collection_id`, name,
+  semantic `description` of topics/titles, `tags`, doc/page/chunk counts,
+  `retrieval` = `n2n/knowledge/query`). MUST NOT contain document content, embeddings,
+  or source paths; per-peer visibility applies (item_type `knowledge`).
+- **§9 Method families / Appendix C:** add `n2n/knowledge/query` — a dedicated method
+  (NOT the MCP `tools/call` proxy) taking `{collection_id, query, k}` and returning an
+  agent-composed, cited answer `{answer, provenance:{peer, collection_id, citations}}`.
+  Default-deny + possession tier; unknown/hidden `collection_id` answered as
+  "no such collection" (no existence oracle); audited with peer + collection + GAIT.
+- **Framing note:** this is the on-wire form of *federated query* (knowledge stays
+  home, only the answer travels) — the sovereignty-preserving counterpart to the
+  deferred RAG2RAG *replication* idea (spec 065, out of scope).
+- Selection (which peer collection answers) is deterministic embedding-cosine over the
+  advertised descriptions with a configurable threshold — an implementation/agent
+  concern, not a wire element, so it need not appear in the draft beyond a sentence.

--- a/mcp-servers/n2n-mcp/server.py
+++ b/mcp-servers/n2n-mcp/server.py
@@ -188,8 +188,8 @@ async def n2n_set_visibility(item_type: str, item_name: str, visibility: str,
     """Control what we advertise to federated peers.
 
     Args:
-        item_type: 'skill' or 'tool'
-        item_name: Name of the skill or tool
+        item_type: 'skill', 'mcp_server', or 'knowledge' (a RAG collection, feature 064)
+        item_name: Name of the skill / mcp_server / RAG collection
         visibility: 'all_federated', 'selected_peers', or 'hidden'
         peers: Comma-separated peer identities (for 'selected_peers' visibility)
     """

--- a/mcp-servers/n2n-mcp/server.py
+++ b/mcp-servers/n2n-mcp/server.py
@@ -146,6 +146,43 @@ async def n2n_kill(peer: str) -> str:
 # ── Capability ─────────────────────────────────────────────────────────────
 
 @mcp.tool()
+async def n2n_knowledge_route(query: str) -> str:
+    """Choose which knowledge collection should answer a question (feature 064).
+
+    Scores the query against every advertised collection description — your own
+    and federated peers' — and returns a routing decision: target ('peer',
+    'local', or 'model'), the peer identity and collection_id when a peer/local
+    collection matches, and the score. Use this BEFORE answering a document or
+    factual question so an authoritative collection answers it. If target is
+    'peer', follow up with n2n_knowledge_query; if 'model', answer normally.
+
+    Args:
+        query: The question to route.
+    """
+    data = await _post("/n2n/knowledge/route", {"query": query})
+    return _gcf_dumps(data)
+
+
+@mcp.tool()
+async def n2n_knowledge_query(peer: str, collection_id: str, query: str) -> str:
+    """Ask a federated peer to answer a question from its RAG collection (064).
+
+    Returns the peer's agent-composed, cited answer with provenance. The peer's
+    documents never leave its infrastructure — only the answer travels. Marked
+    remote-untrusted. The peer must have granted your claw access to the
+    collection (default-deny).
+
+    Args:
+        peer: Peer identity string (e.g. as65099-10.255.255.1).
+        collection_id: The advertised collection id (e.g. knowledge:documents).
+        query: The question to answer from that collection.
+    """
+    data = await _post("/n2n/knowledge/query",
+                       {"peer": peer, "collection_id": collection_id, "query": query})
+    return _gcf_dumps(data)
+
+
+@mcp.tool()
 async def n2n_peer_capabilities(peer: str, query: Optional[str] = None) -> str:
     """Query a federated peer's capability inventory.
 

--- a/mcp-servers/protocol-mcp/bgp-daemon-v2.py
+++ b/mcp-servers/protocol-mcp/bgp-daemon-v2.py
@@ -302,6 +302,27 @@ async def handle_n2n(method, path, body):
                 code = getattr(e, "code", None); msg = getattr(e, "message", str(e))
                 return 200, {"error": {"code": code, "message": msg}}
 
+        if path == "/n2n/knowledge/route" and method == "POST":
+            # Feature 064: choose which advertised collection (local or peer)
+            # should answer a query — eN2N selection, deterministic (H2/H3).
+            q = body.get("query")
+            if not q:
+                return 400, {"error": "missing required field 'query'"}
+            return 200, fed.invoker.route_knowledge(q)
+
+        if path == "/n2n/knowledge/query" and method == "POST":
+            # Feature 064: retrieve a cited answer from a peer's advertised
+            # collection over the dedicated n2n/knowledge/query method.
+            if not body.get("peer") or not body.get("collection_id"):
+                return 400, {"error": "missing required field 'peer' or 'collection_id'"}
+            try:
+                return 200, await fed.invoker.query_remote_knowledge(
+                    body["peer"], body["collection_id"], body.get("query", ""),
+                    k=int(body.get("k", 8)))
+            except Exception as e:
+                code = getattr(e, "code", None); msg = getattr(e, "message", str(e))
+                return 200, {"error": {"code": code, "message": msg}}
+
         if path == "/n2n/approvals" and method == "GET":
             return 200, {"pending": fed.authz.pending_approvals()}
 

--- a/mcp-servers/protocol-mcp/bgp/federation/inventory.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/inventory.py
@@ -176,6 +176,11 @@ class InventoryBuilder:
         servers = [s for s in all_servers
                    if self._visibility("mcp_server", s["name"], peer_identity)]
         badges = _derive_badges([s["name"] for s in servers])
+        # Feature 064: advertise local RAG collections as content-free knowledge
+        # entries (one per collection), visibility-filtered per peer and secret-
+        # scanned. Advertised by default (FR-003); collection hidden via
+        # visibility_setting item_type "knowledge".
+        knowledge = self._load_knowledge(peer_identity)
         inv = {
             "identity": self._local_identity(),
             "issued_at": _now(),
@@ -183,12 +188,28 @@ class InventoryBuilder:
             "skills": skills,
             "mcp_servers": [{"name": s["name"], "tools": s["tools"],
                              "invocable_tools": s["tools"]} for s in servers],
+            "knowledge": knowledge,
             "badges": badges,
             "posture": self._posture_card(posture),
             "llm": self._llm_card(),
         }
         self._assert_no_secrets(inv)
         return inv
+
+    def _load_knowledge(self, peer_identity: str) -> list:
+        """Build the per-peer visible knowledge entries (feature 064). The
+        collection name is the visibility key: an operator hides a collection
+        from a peer with visibility_setting(item_type="knowledge",
+        item_name=<collection>). Each entry is asserted content-free (FR-002)."""
+        from . import knowledge as _knowledge
+        out = []
+        for entry in _knowledge.build_entries():
+            collection = entry["collection_id"].split(":", 1)[-1]
+            if not self._visibility("knowledge", collection, peer_identity):
+                continue
+            _knowledge.assert_entry_clean(entry)
+            out.append(entry)
+        return out
 
     def _posture_card(self, posture: Optional[dict]) -> dict:
         """Compact security posture for the A2A card (feature 057). Uses the live

--- a/mcp-servers/protocol-mcp/bgp/federation/invocation.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/invocation.py
@@ -234,6 +234,111 @@ class Invoker:
         return {"task_id": task_id,
                 "cancelled": self.service.tasks.cancel(task_id, owner=channel.peer_identity)}
 
+    # ---- feature 064: federated knowledge retrieval -------------------
+
+    async def handle_knowledge_query(self, channel, params):
+        """Server side of `n2n/knowledge/query` (a dedicated NCFED method, not the
+        MCP tools/call proxy). Default-deny + possession tier + per-peer grant,
+        no existence oracle, agent-composed cited answer, audited (FR-004/007/008)."""
+        from . import knowledge as _knowledge
+        peer = channel.peer_identity
+        collection_id = params.get("collection_id", "")
+        query = params.get("query", "")
+        req_id = params.get("request_id", "")
+        collection = collection_id.split(":", 1)[-1] if collection_id else ""
+
+        # Tier-0 default-deny: a self-asserted (keyless) peer may not retrieve.
+        from .negotiate import allows
+        if not allows(getattr(channel, "attestation", "self-asserted"), "knowledge/query"):
+            self.audit.record(direction="inbound", peer_identity=peer, target_type="knowledge",
+                              target_name=collection_id, request_id=req_id,
+                              decision="not_allowlisted", outcome="denied")
+            raise RpcError(ERR_NOT_ALLOWLISTED,
+                           "possession proof required for knowledge/query (tier-0 peer)")
+
+        # No existence oracle: a collection this peer may not see is answered
+        # exactly like one that does not exist (same shape), before any grant check.
+        visible = {e["collection_id"] for e in self.service.inventory._load_knowledge(peer)}
+        if collection_id not in visible:
+            self.audit.record(direction="inbound", peer_identity=peer, target_type="knowledge",
+                              target_name=collection_id, request_id=req_id,
+                              decision="not_found", outcome="denied")
+            return {"answer": None, "not_found": True,
+                    "provenance": {"peer": self.service.local_identity,
+                                   "collection_id": collection_id}}
+
+        # Default-deny per-peer grant (reuses the tools/call authorizer path).
+        decision = self.authz.authorize(peer, "knowledge", collection_id)
+        if not decision.allowed and decision.code != "approval_required":
+            self.audit.record(direction="inbound", peer_identity=peer, target_type="knowledge",
+                              target_name=collection_id, request_id=req_id,
+                              decision=decision.code, outcome="denied")
+            raise RpcError(_CODE_MAP.get(decision.code, -32000), decision.reason)
+        if decision.code == "approval_required":
+            inv_id = self.audit.record(direction="inbound", peer_identity=peer,
+                                       target_type="knowledge", target_name=collection_id,
+                                       request_id=req_id, decision="approval_required",
+                                       outcome="pending")
+            appr = self.authz.create_approval(inv_id)
+            self.service.notify_approval(inv_id, peer, "knowledge", collection_id)
+            if not await self._await_approval(appr["approval_id"]):
+                raise RpcError(ERR_APPROVAL_EXPIRED, "approval not granted")
+
+        # Compose an agent-grounded, cited answer from the LIVE local RAG. The
+        # gateway agent has the rag-mcp tools; the prompt scopes it to this
+        # collection. External peer input → untrusted turn (never embedded).
+        from .gateway import run_agent_turn
+        prompt = (f"A federated peer ({peer}) asks about your knowledge collection "
+                  f"'{collection}'. Using your RAG knowledge base, answer the question "
+                  f"and cite the source document(s) and page(s). If the collection does "
+                  f"not contain the answer, say so plainly.\n\nQuestion: {query}")
+        self.authz.debit(peer, requests=1)
+        try:
+            answer, tokens = await run_agent_turn(
+                prompt, session_key=f"n2n-knowledge-{peer}", untrusted=True,
+                timeout_s=self.tool_timeout)
+        except asyncio.TimeoutError:
+            self.audit.record(direction="inbound", peer_identity=peer, target_type="knowledge",
+                              target_name=collection_id, request_id=req_id,
+                              decision="allowlisted", outcome="timeout")
+            raise RpcError(ERR_EXECUTION_TIMEOUT, "knowledge query timed out")
+        result = {"answer": answer,
+                  "provenance": {"peer": self.service.local_identity,
+                                 "collection_id": collection_id}}
+        ref = self.audit.store_result(req_id or f"{peer}-{collection_id}", result)
+        self.audit.record(direction="inbound", peer_identity=peer, target_type="knowledge",
+                          target_name=collection_id, request_id=req_id,
+                          decision="allowlisted", outcome="success", result_ref=ref)
+        return result
+
+    async def query_remote_knowledge(self, ident, collection_id, query, k: int = 8):
+        """Client side: ask peer `ident` to answer from its `collection_id`."""
+        ch = await self._channel(ident)
+        req_id = f"{self.service.local_identity}:{int(time.time()*1000)}"
+        self.audit.record(direction="outbound", peer_identity=ident, target_type="knowledge",
+                          target_name=collection_id, request_id=req_id,
+                          decision="requested", outcome="pending")
+        result = await ch.call("n2n/knowledge/query",
+                               {"collection_id": collection_id, "query": query,
+                                "k": k, "request_id": req_id},
+                               timeout=self.tool_timeout + 5)
+        return {"source": ident, "trust": "remote-untrusted", "result": result}
+
+    def route_knowledge(self, query: str):
+        """Choose a collection for `query` across local + cached peer cards
+        (data-model Knowledge Route Decision). eN2N selection lives in
+        knowledge.py, not the iN2N router (finding H2)."""
+        from . import knowledge as _knowledge
+        sources = [{"source": "local", "entries": _knowledge.build_entries()}]
+        for ident in list(self.service.channels):
+            if not self.service.manager.is_federated(ident):
+                continue
+            card = self.service.inventory.load_remote(ident) or {}
+            entries = card.get("knowledge") or []
+            if entries:
+                sources.append({"source": ident, "entries": entries})
+        return _knowledge.select_collection(query, sources)
+
     async def _await_approval(self, approval_id: int) -> bool:
         deadline = time.time() + self.authz.approval_window_s
         while time.time() < deadline:

--- a/mcp-servers/protocol-mcp/bgp/federation/knowledge.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/knowledge.py
@@ -100,6 +100,93 @@ def build_entries(topic_only: Optional[bool] = None,
     return entries
 
 
+def _match_threshold() -> float:
+    try:
+        return float(os.environ.get("N2N_KNOWLEDGE_MATCH_THRESHOLD", "0.5"))
+    except ValueError:
+        return 0.5
+
+
+def _embed_texts(texts: list):
+    """Embed texts with the RAG embedder (feature 062). Lazy-loaded and cached;
+    returns a list of vectors, or None if the embedder cannot be loaded — the
+    caller then falls back to lexical scoring so a missing model never breaks the
+    daemon. Deterministic: the same model yields the same vectors (FR-005)."""
+    global _EMBEDDER
+    try:
+        if _EMBEDDER is None:
+            from sentence_transformers import SentenceTransformer  # heavy, lazy
+            model = os.environ.get("RAG_EMBED_MODEL", "all-MiniLM-L6-v2")
+            _EMBEDDER = SentenceTransformer(model)
+        return [list(map(float, v)) for v in _EMBEDDER.encode(texts)]
+    except Exception:
+        return None
+
+
+_EMBEDDER = None
+
+
+def _cosine(a: list, b: list) -> float:
+    import math
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a)) or 1.0
+    nb = math.sqrt(sum(y * y for y in b)) or 1.0
+    return dot / (na * nb)
+
+
+def _lexical(query: str, desc: str) -> float:
+    """Deterministic token-overlap (Jaccard) fallback when no embedder is loaded."""
+    q = {w for w in query.lower().split() if len(w) > 2}
+    d = {w for w in desc.lower().split() if len(w) > 2}
+    if not q or not d:
+        return 0.0
+    return len(q & d) / len(q | d)
+
+
+def score_query(query: str, descriptions: list) -> list:
+    """Similarity of `query` to each description, in [0,1]. Embedding cosine when
+    the embedder loads (deterministic), else lexical overlap."""
+    if not descriptions:
+        return []
+    vecs = _embed_texts([query] + list(descriptions))
+    if vecs:
+        qv, dvs = vecs[0], vecs[1:]
+        return [max(0.0, _cosine(qv, dv)) for dv in dvs]
+    return [_lexical(query, d) for d in descriptions]
+
+
+def select_collection(query: str, sources: list, threshold: Optional[float] = None) -> dict:
+    """Choose which advertised collection answers `query`. `sources` is a list of
+    {"source": "local"|<peer_identity>, "entries": [knowledge entries]}. Returns a
+    Knowledge Route Decision (data-model.md): highest-scoring collection at/above
+    the threshold, deterministic tiebreak by ascending source then collection_id;
+    fallback to the model when nothing clears the threshold (FR-005/FR-006). Never
+    emits a peer/collection when nothing matches (no fabricated source)."""
+    if threshold is None:
+        threshold = _match_threshold()
+    cands = [(s["source"], e) for s in sources for e in s.get("entries", [])]
+    if not cands:
+        return {"query": query, "target": "model", "peer_identity": None,
+                "collection_id": None, "score": 0.0,
+                "rationale": "no advertised collections"}
+    scores = score_query(query, [e["description"] for _, e in cands])
+    ranked = sorted(
+        zip(scores, cands),
+        key=lambda x: (-x[0], str(x[1][0]), x[1][1]["collection_id"]))
+    best_score, (src, entry) = ranked[0]
+    if best_score < threshold:
+        return {"query": query, "target": "model", "peer_identity": None,
+                "collection_id": None, "score": round(best_score, 4),
+                "rationale": f"best score {best_score:.4f} < threshold {threshold}"}
+    target = "local" if src == "local" else "peer"
+    return {"query": query, "target": target,
+            "peer_identity": None if target == "local" else src,
+            "collection_id": entry["collection_id"], "score": round(best_score, 4),
+            "rationale": f"{target} collection {entry['collection_id']} scored "
+                         f"{best_score:.4f} (>= {threshold}); deterministic tiebreak "
+                         f"by source then collection_id"}
+
+
 def assert_entry_clean(entry: dict) -> None:
     """Defense in depth (FR-002): a knowledge entry MUST carry only the allowed
     content-free keys — no source path, hash, chunk text, or other registry

--- a/mcp-servers/protocol-mcp/bgp/federation/knowledge.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/knowledge.py
@@ -1,0 +1,111 @@
+"""Knowledge capability cards & eN2N knowledge selection (feature 064).
+
+Advertisement: build content-free A2A-style entries — one per RAG collection —
+from the feature-062 registry (`~/.openclaw/rag/rag.db`, `documents` table), read
+directly (cheapest path; no MCP spawn). Only ready documents are advertised, and
+only registry metadata (title, doc_type, collection, page/chunk counts) is used —
+never chunk text, embeddings, source paths, hashes, or capture commands.
+
+Selection (eN2N): choosing which advertised collection answers a query lives here
+too (finding H2 — NOT the iN2N `router.py`). It is added in a later task (US2) as
+`select_collection()`; this module currently ships the advertisement builder.
+"""
+
+import os
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+RETRIEVAL_METHOD = "n2n/knowledge/query"
+
+# Registry columns that are safe to read for advertisement. Everything else in
+# the documents table (source_path, content_hash, capture_commands, ...) is
+# deliberately NOT read, so no path/secret can reach the card.
+_SAFE_KEYS = {"collection_id", "name", "description", "tags",
+              "doc_count", "page_count", "chunk_count", "retrieval"}
+
+
+def _rag_db_path() -> Path:
+    base = os.environ.get("RAG_DATA_DIR", "~/.openclaw/rag")
+    return Path(os.path.expanduser(base)) / "rag.db"
+
+
+def _topic_only_default() -> bool:
+    return os.environ.get("N2N_KNOWLEDGE_TOPIC_ONLY", "").strip().lower() in (
+        "1", "true", "yes", "on")
+
+
+def build_entries(topic_only: Optional[bool] = None,
+                  db_path: Optional[Path] = None) -> list:
+    """Return one content-free knowledge entry per RAG collection with >=1 ready
+    document. Empty list if there is no RAG db or no ready documents (absence,
+    not an empty entry). `topic_only` omits document titles from the description
+    (research D5); defaults to the N2N_KNOWLEDGE_TOPIC_ONLY env toggle."""
+    if topic_only is None:
+        topic_only = _topic_only_default()
+    path = Path(db_path) if db_path else _rag_db_path()
+    if not path.exists():
+        return []
+    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT collection, title, doc_type, page_count, chunk_count "
+            "FROM documents WHERE ingest_status='ready'").fetchall()
+    except sqlite3.Error:
+        return []
+    finally:
+        conn.close()
+
+    by_coll: dict = {}
+    for r in rows:
+        coll = r["collection"] or "documents"
+        agg = by_coll.setdefault(coll, {"titles": [], "doc_types": set(),
+                                        "doc_count": 0, "page_count": 0,
+                                        "chunk_count": 0})
+        if r["title"] and r["title"] not in agg["titles"]:
+            agg["titles"].append(r["title"])
+        if r["doc_type"]:
+            agg["doc_types"].add(r["doc_type"])
+        agg["doc_count"] += 1
+        agg["page_count"] += int(r["page_count"] or 0)
+        agg["chunk_count"] += int(r["chunk_count"] or 0)
+
+    entries = []
+    for coll in sorted(by_coll):
+        agg = by_coll[coll]
+        tags = sorted(agg["doc_types"])
+        if topic_only:
+            desc = f"Knowledge collection '{coll}'"
+            if tags:
+                desc += " covering " + ", ".join(tags)
+            desc += f"; {agg['doc_count']} document(s)."
+        else:
+            desc = f"Knowledge collection '{coll}'"
+            if agg["titles"]:
+                desc += ": " + "; ".join(agg["titles"][:20])
+            if tags:
+                desc += f" ({', '.join(tags)})"
+            desc += "."
+        entries.append({
+            "collection_id": f"knowledge:{coll}",
+            "name": f"Knowledge: {coll}",
+            "description": desc,
+            "tags": tags,
+            "doc_count": agg["doc_count"],
+            "page_count": agg["page_count"],
+            "chunk_count": agg["chunk_count"],
+            "retrieval": RETRIEVAL_METHOD,
+        })
+    return entries
+
+
+def assert_entry_clean(entry: dict) -> None:
+    """Defense in depth (FR-002): a knowledge entry MUST carry only the allowed
+    content-free keys — no source path, hash, chunk text, or other registry
+    column can slip onto the card. Raises ValueError on any unexpected key."""
+    extra = set(entry) - _SAFE_KEYS
+    if extra:
+        raise ValueError(
+            f"knowledge entry has forbidden key(s) {sorted(extra)} — only "
+            f"{sorted(_SAFE_KEYS)} may be advertised (FR-002)")

--- a/mcp-servers/protocol-mcp/bgp/federation/manager.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/manager.py
@@ -60,7 +60,7 @@ CREATE TABLE IF NOT EXISTS consent_record (
     revoked_at    TEXT
 );
 CREATE TABLE IF NOT EXISTS visibility_setting (
-    item_type  TEXT NOT NULL,               -- skill | mcp_server
+    item_type  TEXT NOT NULL,               -- skill | mcp_server | knowledge (feature 064)
     item_name  TEXT NOT NULL,
     visibility TEXT NOT NULL,               -- all_federated | selected_peers | hidden
     peer_list  TEXT,                        -- JSON array when selected_peers

--- a/mcp-servers/protocol-mcp/bgp/federation/negotiate.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/negotiate.py
@@ -74,6 +74,7 @@ def peer_supports(peer_descriptor, feature: str) -> bool:
 # local gateway agent under the peer's identity).
 TIER0_DENIED = frozenset({
     "tools/call", "tasks/submit", "endpoint_update", "chat/open", "chat/message",
+    "knowledge/query",
 })
 
 

--- a/mcp-servers/protocol-mcp/bgp/federation/service.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/service.py
@@ -95,6 +95,7 @@ class FederationService:
             "n2n/tasks/status": self.invoker.handle_task_status,
             "n2n/tasks/result": self.invoker.handle_task_result,
             "n2n/tasks/cancel": self.invoker.handle_task_cancel,
+            "n2n/knowledge/query": self.invoker.handle_knowledge_query,
             "n2n/chat/open": self.chat.handle_chat_open,
             "n2n/chat/message": self.chat.handle_chat_message,
             "n2n/heartbeat": self._on_heartbeat,

--- a/specs/064-knowledge-capability-cards/contracts/knowledge-card-and-retrieval.md
+++ b/specs/064-knowledge-capability-cards/contracts/knowledge-card-and-retrieval.md
@@ -1,0 +1,90 @@
+# Contract: Knowledge on the Capability Card + Retrieval Skill
+
+Two wire contracts, both carried over the existing NCFED channel — no new methods.
+
+## 1. Capability card: `knowledge` array (via `n2n/inventory` / `n2n/inventory_get`)
+
+The card gains a `knowledge` array alongside `skills` / `mcp_servers`. Each element is the
+Knowledge Skill entity (data-model.md). Content-free; visibility-filtered per peer.
+
+```json
+{
+  "identity": "as65001-4.4.4.4",
+  "version": 42,
+  "skills": [ ... ],
+  "mcp_servers": [ ... ],
+  "knowledge": [
+    {
+      "id": "knowledge:documents",
+      "name": "Knowledge: documents",
+      "description": "Automate Your Network (John Capobianco) — network automation, Ansible, CI/CD NDLC, data models, templates, reconnaissance, automated documentation.",
+      "tags": ["install-guide"],
+      "doc_count": 1,
+      "page_count": 212,
+      "chunk_count": 389,
+      "retrieval": "n2n-knowledge/query"
+    }
+  ],
+  "badges": [ ... ],
+  "posture": { ... },
+  "llm": { ... }
+}
+```
+
+**Rules**
+- A peer that does not understand `knowledge` MUST ignore it (backwards compatible, FR/Const XV).
+- `description` MAY omit document titles in topic-only mode (D5); everything else unchanged.
+- The card MUST still pass `_assert_no_secrets`; `id` is opaque and safe to expose.
+
+## 2. Retrieval: invocable knowledge-retrieval skill (via `n2n/tools/call`)
+
+The `retrieval` name from the card entry is invoked with the advertised `id`.
+
+**Request** (`n2n/tools/call`):
+
+```json
+{
+  "tool": "n2n-knowledge/query",
+  "arguments": {
+    "corpus_id": "knowledge:documents",
+    "query": "summarize the book's main topics and takeaways",
+    "k": 8
+  },
+  "request_id": "as65099-10.255.255.1:7"
+}
+```
+
+**Result** (grounded answer with provenance, FR-008):
+
+```json
+{
+  "answer": "Automate Your Network is ... (grounded summary)",
+  "provenance": {
+    "peer": "as65001-4.4.4.4",
+    "corpus_id": "knowledge:documents",
+    "citations": [
+      {"title": "Automate Your Network", "loc": "Preface p.13"},
+      {"title": "Automate Your Network", "loc": "Summary p.207"}
+    ]
+  }
+}
+```
+
+**Rules**
+- Default-deny + possession tier: a self-asserted (keyless) or ungranted peer is refused
+  with the standard NCFED authorization error and audited (FR-007; NCFED §6.4, §9.3).
+- `corpus_id` MUST be one the caller is authorized to see; an unknown/hidden id is answered
+  exactly as "no such corpus" (no existence oracle).
+- The callee runs `rag_search` against its **live** RAG; the answer is composed by the
+  owner's agent and returned with citations when the source provides them.
+- One audit record per call: `{peer_identity, corpus_id, request_id, decision, gait_ref}`.
+
+## 3. Routing behavior (agent/router, not a wire message)
+
+Before answering a knowledge/document question the agent MUST:
+1. Score the query against all visible advertised collection descriptions (local + peers).
+2. If a peer corpus is the best match above threshold → invoke contract #2 against that peer
+   and return its answer with provenance.
+3. Else if a local corpus matches → answer locally.
+4. Else → answer from the model; MUST NOT fabricate a federated source.
+Selection is repeatable (stable tiebreak by peer identity then corpus_id).

--- a/specs/064-knowledge-capability-cards/contracts/knowledge-card-and-retrieval.md
+++ b/specs/064-knowledge-capability-cards/contracts/knowledge-card-and-retrieval.md
@@ -1,11 +1,15 @@
-# Contract: Knowledge on the Capability Card + Retrieval Skill
+# Contract: Knowledge on the Capability Card + Retrieval Method
 
-Two wire contracts, both carried over the existing NCFED channel — no new methods.
+Two wire contracts over the existing NCFED channel. Advertisement rides the capability
+card; retrieval is a **dedicated NCFED method** `n2n/knowledge/query` (a method family
+alongside `n2n/tools/call` and `n2n/tasks/*`) — NOT the generic MCP `n2n/tools/call` proxy,
+which resolves `server_id/tool_name` against real registered MCP servers and cannot address
+a synthetic knowledge endpoint (analysis finding H1).
 
 ## 1. Capability card: `knowledge` array (via `n2n/inventory` / `n2n/inventory_get`)
 
 The card gains a `knowledge` array alongside `skills` / `mcp_servers`. Each element is the
-Knowledge Skill entity (data-model.md). Content-free; visibility-filtered per peer.
+Knowledge Entry (data-model.md). Content-free; visibility-filtered per peer.
 
 ```json
 {
@@ -15,14 +19,14 @@ Knowledge Skill entity (data-model.md). Content-free; visibility-filtered per pe
   "mcp_servers": [ ... ],
   "knowledge": [
     {
-      "id": "knowledge:documents",
+      "collection_id": "knowledge:documents",
       "name": "Knowledge: documents",
       "description": "Automate Your Network (John Capobianco) — network automation, Ansible, CI/CD NDLC, data models, templates, reconnaissance, automated documentation.",
       "tags": ["install-guide"],
       "doc_count": 1,
       "page_count": 212,
       "chunk_count": 389,
-      "retrieval": "n2n-knowledge/query"
+      "retrieval": "n2n/knowledge/query"
     }
   ],
   "badges": [ ... ],
@@ -32,36 +36,35 @@ Knowledge Skill entity (data-model.md). Content-free; visibility-filtered per pe
 ```
 
 **Rules**
-- A peer that does not understand `knowledge` MUST ignore it (backwards compatible, FR/Const XV).
-- `description` MAY omit document titles in topic-only mode (D5); everything else unchanged.
-- The card MUST still pass `_assert_no_secrets`; `id` is opaque and safe to expose.
+- A peer that does not understand `knowledge` MUST ignore it (backwards compatible, Const XV).
+- `description` MAY omit document titles in topic-only mode (research D5); everything else unchanged.
+- The card MUST still pass `_assert_no_secrets`; `collection_id` is opaque and safe to expose.
+- Card size grows only with the metadata summary, independent of collection size (SC-005).
 
-## 2. Retrieval: invocable knowledge-retrieval skill (via `n2n/tools/call`)
+## 2. Retrieval: `n2n/knowledge/query` (dedicated NCFED method)
 
-The `retrieval` name from the card entry is invoked with the advertised `id`.
+Registered in the service handler map like `n2n/tasks/*`. Invoked with the `collection_id`
+the card advertised.
 
-**Request** (`n2n/tools/call`):
+**Request** (`n2n/knowledge/query`):
 
 ```json
 {
-  "tool": "n2n-knowledge/query",
-  "arguments": {
-    "corpus_id": "knowledge:documents",
-    "query": "summarize the book's main topics and takeaways",
-    "k": 8
-  },
+  "collection_id": "knowledge:documents",
+  "query": "summarize the book's main topics and takeaways",
+  "k": 8,
   "request_id": "as65099-10.255.255.1:7"
 }
 ```
 
-**Result** (grounded answer with provenance, FR-008):
+**Result** (agent-composed, grounded answer with provenance — NOT raw chunks; FR-008):
 
 ```json
 {
   "answer": "Automate Your Network is ... (grounded summary)",
   "provenance": {
     "peer": "as65001-4.4.4.4",
-    "corpus_id": "knowledge:documents",
+    "collection_id": "knowledge:documents",
     "citations": [
       {"title": "Automate Your Network", "loc": "Preface p.13"},
       {"title": "Automate Your Network", "loc": "Summary p.207"}
@@ -72,19 +75,23 @@ The `retrieval` name from the card entry is invoked with the advertised `id`.
 
 **Rules**
 - Default-deny + possession tier: a self-asserted (keyless) or ungranted peer is refused
-  with the standard NCFED authorization error and audited (FR-007; NCFED §6.4, §9.3).
-- `corpus_id` MUST be one the caller is authorized to see; an unknown/hidden id is answered
-  exactly as "no such corpus" (no existence oracle).
-- The callee runs `rag_search` against its **live** RAG; the answer is composed by the
-  owner's agent and returned with citations when the source provides them.
-- One audit record per call: `{peer_identity, corpus_id, request_id, decision, gait_ref}`.
+  with the standard NCFED authorization error and audited (FR-007; NCFED §6.4, §9.3). The
+  per-peer grant is the Principle-XIV human-in-the-loop control point.
+- `collection_id` MUST be one the caller is authorized to see; an unknown/hidden id is
+  answered exactly as "no such collection" (no existence oracle).
+- The callee runs `rag_search` against its **live** RAG and the owner's **agent composes**
+  the answer (a local agent turn) with citations when the source provides them.
+- One audit record per call: `{peer_identity, collection_id, request_id, decision, gait_ref}`.
 
-## 3. Routing behavior (agent/router, not a wire message)
+## 3. Selection behavior (querying agent + `knowledge.py` helper, not a wire message)
 
-Before answering a knowledge/document question the agent MUST:
-1. Score the query against all visible advertised collection descriptions (local + peers).
-2. If a peer corpus is the best match above threshold → invoke contract #2 against that peer
-   and return its answer with provenance.
-3. Else if a local corpus matches → answer locally.
+Before answering a knowledge/document question the querying claw MUST:
+1. Embed the query with the local RAG embedder and compute cosine similarity against every
+   visible advertised collection description (local + peers' cached cards).
+2. If a **peer** collection scores highest and ≥ threshold (`N2N_KNOWLEDGE_MATCH_THRESHOLD`,
+   default 0.5) → invoke contract #2 against that peer and return its answer with provenance.
+3. Else if a **local** collection scores ≥ threshold → answer locally.
 4. Else → answer from the model; MUST NOT fabricate a federated source.
-Selection is repeatable (stable tiebreak by peer identity then corpus_id).
+Selection is deterministic (same embedder → same vectors → same scores); ties break by
+ascending peer identity then `collection_id`. This lives in an eN2N selection helper
+(`bgp/federation/knowledge.py`), NOT the iN2N `router.py` (finding H2).

--- a/specs/064-knowledge-capability-cards/data-model.md
+++ b/specs/064-knowledge-capability-cards/data-model.md
@@ -11,14 +11,14 @@ array (sibling of `skills`, `mcp_servers`). Content-free.
 
 | Field | Type | Source | Notes |
 |-------|------|--------|-------|
-| `id` | string | `"knowledge:" + collection` | Stable, addressable corpus id used by the retrieval skill (FR-004). |
+| `collection_id` | string | `"knowledge:" + collection` | Stable, addressable id passed to the retrieval method (FR-004). |
 | `name` | string | derived | Human label, e.g. "Knowledge: documents". |
-| `description` | string | from registry (titles/topics) | Semantic text used for routing (FR-005). Titles included unless topic-only mode (D5). |
+| `description` | string | from registry (titles/topics) | Text embedded for cosine selection (FR-005). Titles included unless topic-only mode (D5). |
 | `tags` | string[] | distinct `doc_type` values | Coarse classification (e.g. `install-guide`). |
 | `doc_count` | int | `COUNT(*)` over the collection | |
 | `page_count` | int | `SUM(page_count)` | |
 | `chunk_count` | int | `SUM(chunk_count)` | |
-| `retrieval` | string | fixed | The invocable retrieval skill/tool name to call with this `id` (FR-004). |
+| `retrieval` | string | fixed `"n2n/knowledge/query"` | The dedicated NCFED method to invoke with this `collection_id` (FR-004). |
 
 **Invariants**: MUST NOT contain chunk text, embeddings, `source_path`, `content_hash`,
 capture commands, or any secret; MUST pass `inventory._assert_no_secrets`. Only collections
@@ -34,22 +34,25 @@ documents are advertised). Never mutated by this feature. `source_path`, `conten
 
 ## Entity: Knowledge Route Decision (in-memory)
 
-Produced by the router when answering a knowledge query.
+Produced by the eN2N selection helper (`bgp/federation/knowledge.py`, **not** the iN2N
+`router.py`) when answering a knowledge query.
 
 | Field | Type | Notes |
 |-------|------|-------|
 | `query` | string | The knowledge question. |
 | `target` | enum | `local` \| `peer` \| `model`. |
 | `peer_identity` | string? | Set when `target == peer` (e.g. `as65099-10.255.255.1`). |
-| `corpus_id` | string? | The advertised `knowledge:<collection>` chosen. |
-| `score` | float | Semantic match score of the chosen corpus description. |
-| `rationale` | string | Why chosen (for audit); includes tiebreak note when applied. |
+| `collection_id` | string? | The advertised `knowledge:<collection>` chosen. |
+| `score` | float | Cosine similarity of query vs the chosen collection's description. |
+| `rationale` | string | Why chosen (for audit); includes tiebreak/threshold note. |
 
-**Selection rule (FR-005)**: score the query against every visible advertised collection
-description (local + federated peers); pick the highest; on a near-tie, break deterministically
-by ascending peer identity, then ascending `corpus_id`. Fallback order when no corpus clears
-the relevance threshold: authoritative **peer** corpus → **local** corpus → **model**
-(FR-006); never fabricate a federated source.
+**Selection rule (FR-005)**: embed the query with the local RAG embedder; compute cosine
+similarity against every visible advertised collection description (local + federated
+peers); pick the highest scoring at/above `N2N_KNOWLEDGE_MATCH_THRESHOLD` (default 0.5); on a
+tie (within a small epsilon) break deterministically by ascending peer identity then
+ascending `collection_id`. Deterministic because the same embedder yields the same vectors.
+Fallback order when no collection clears the threshold: authoritative **peer** collection →
+**local** collection → **model** (FR-006); never fabricate a federated source.
 
 ## State / lifecycle
 
@@ -58,5 +61,5 @@ the relevance threshold: authoritative **peer** corpus → **local** corpus → 
 - **Retrieval** always runs against the owner's **live** RAG (`rag_search`), so answers
   reflect current content even if an advertised summary lags (spec Edge Cases).
 - **Authorization/audit** reuse the existing per-peer grant + possession-tier gate + GAIT
-  audit; a retrieval decision emits one audit record with `peer_identity`, `corpus_id`, and a
-  GAIT reference (FR-007).
+  audit; a retrieval decision emits one audit record with `peer_identity`, `collection_id`,
+  and a GAIT reference (FR-007).

--- a/specs/064-knowledge-capability-cards/data-model.md
+++ b/specs/064-knowledge-capability-cards/data-model.md
@@ -1,0 +1,62 @@
+# Phase 1 Data Model: Knowledge Capability Cards & Knowledge-Aware Routing
+
+No new persistent store. This feature derives an on-wire structure from the existing RAG
+registry and adds an in-memory routing decision. Entities below are (1) the card knowledge
+skill (wire), (2) its source rows (read-only), and (3) the routing decision (in-memory).
+
+## Entity: Knowledge Skill (card entry — wire)
+
+One per advertised RAG collection, embedded in the capability card under a new `knowledge`
+array (sibling of `skills`, `mcp_servers`). Content-free.
+
+| Field | Type | Source | Notes |
+|-------|------|--------|-------|
+| `id` | string | `"knowledge:" + collection` | Stable, addressable corpus id used by the retrieval skill (FR-004). |
+| `name` | string | derived | Human label, e.g. "Knowledge: documents". |
+| `description` | string | from registry (titles/topics) | Semantic text used for routing (FR-005). Titles included unless topic-only mode (D5). |
+| `tags` | string[] | distinct `doc_type` values | Coarse classification (e.g. `install-guide`). |
+| `doc_count` | int | `COUNT(*)` over the collection | |
+| `page_count` | int | `SUM(page_count)` | |
+| `chunk_count` | int | `SUM(chunk_count)` | |
+| `retrieval` | string | fixed | The invocable retrieval skill/tool name to call with this `id` (FR-004). |
+
+**Invariants**: MUST NOT contain chunk text, embeddings, `source_path`, `content_hash`,
+capture commands, or any secret; MUST pass `inventory._assert_no_secrets`. Only collections
+visible to the requesting peer appear (FR-003). A claw with zero ready documents emits no
+`knowledge` array entries (absence, not empty).
+
+## Entity: RAG Document Registry row (source — read-only)
+
+Existing feature-062 `documents` table. Fields consumed for advertisement: `title`,
+`doc_type`, `collection`, `page_count`, `chunk_count`, `ingest_status` (only `ready`
+documents are advertised). Never mutated by this feature. `source_path`, `content_hash`,
+`capture_commands`, `redaction_counts` are explicitly NOT consumed (secret/PII surface).
+
+## Entity: Knowledge Route Decision (in-memory)
+
+Produced by the router when answering a knowledge query.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `query` | string | The knowledge question. |
+| `target` | enum | `local` \| `peer` \| `model`. |
+| `peer_identity` | string? | Set when `target == peer` (e.g. `as65099-10.255.255.1`). |
+| `corpus_id` | string? | The advertised `knowledge:<collection>` chosen. |
+| `score` | float | Semantic match score of the chosen corpus description. |
+| `rationale` | string | Why chosen (for audit); includes tiebreak note when applied. |
+
+**Selection rule (FR-005)**: score the query against every visible advertised collection
+description (local + federated peers); pick the highest; on a near-tie, break deterministically
+by ascending peer identity, then ascending `corpus_id`. Fallback order when no corpus clears
+the relevance threshold: authoritative **peer** corpus → **local** corpus → **model**
+(FR-006); never fabricate a federated source.
+
+## State / lifecycle
+
+- **Advertisement** refreshes with the card version (`inventory.build` increments `version`);
+  it is recomputed from `rag_list`, not per query (performance).
+- **Retrieval** always runs against the owner's **live** RAG (`rag_search`), so answers
+  reflect current content even if an advertised summary lags (spec Edge Cases).
+- **Authorization/audit** reuse the existing per-peer grant + possession-tier gate + GAIT
+  audit; a retrieval decision emits one audit record with `peer_identity`, `corpus_id`, and a
+  GAIT reference (FR-007).

--- a/specs/064-knowledge-capability-cards/plan.md
+++ b/specs/064-knowledge-capability-cards/plan.md
@@ -10,15 +10,17 @@ knowledge skills on the NCFED capability card, and route knowledge queries to th
 corpus is authoritative — generalizing the demonstrated Hermes↔NetClaw book-summary interop
 into deliberate, discoverable routing. The card gains one entry per RAG collection (from the
 `rag_list` registry: title/topics/doc_type/counts, no content); retrieval is a dedicated
-invocable knowledge-retrieval skill addressable from the card and fulfilled by the owner's
-local agent/RAG (`rag_search`); the agent/router selects the corpus by semantic match on the
-advertised description with a stable tiebreak. Reuses existing per-peer visibility, admission
-tiers, default-deny authorization, and audit/GAIT (057/060). No new MCP server.
+dedicated `n2n/knowledge/query` method addressable from the card and fulfilled by the owner's
+agent composing over local RAG (`rag_search`); a new `knowledge.py` helper selects the
+collection by embedding-cosine similarity (query vs advertised description) with a configurable
+threshold and stable tiebreak. Reuses existing per-peer visibility, admission tiers,
+default-deny authorization, and audit/GAIT (057/060). No new MCP server; iN2N `router.py`
+untouched.
 
 ## Technical Context
 
 **Language/Version**: Python 3.10+ (daemon + `bgp/federation/*`, matching 052–063); Markdown (SOUL/skill docs + NCFED draft §11 for -01)
-**Primary Dependencies**: Existing only — `bgp/federation/inventory.py` (card), `router.py` (selection), `invocation.py`/`gateway.py` (retrieval turn), the feature-062 rag-mcp (`rag_list`, `rag_search`). No new third-party packages.
+**Primary Dependencies**: Existing only — new `bgp/federation/knowledge.py` (advertisement builder + eN2N cosine selection), `inventory.py` (card), `invocation.py`/`gateway.py` (retrieval method + agent composition), the feature-062 rag-mcp (`rag_list`, `rag_search`, and its embedder for query vectors). No new third-party packages.
 **Storage**: Reuses `~/.openclaw/rag/rag.db` (documents registry, read-only for advertisement) and the issued capability card. Per-peer visibility reuses existing federation.db rows. No new store.
 **Testing**: pytest under `tests/n2n/` (card contents, no-secrets invariant, visibility filtering, deterministic selection, tier/authorization/audit on retrieval).
 **Target Platform**: Linux (systemd --user mesh/member services), consistent with the live deployment.
@@ -62,22 +64,25 @@ specs/064-knowledge-capability-cards/
 
 ```text
 mcp-servers/protocol-mcp/bgp/federation/
-├── inventory.py         # + build knowledge skills from rag_list; per-peer visibility; _assert_no_secrets covers them
-├── router.py            # + knowledge-aware selection: semantic match on advertised descriptions, stable tiebreak
-├── invocation.py        # + invocable knowledge-retrieval skill handler (default-deny, possession-tier, audited)
-└── gateway.py           # retrieval turn reuses rag_search (wiring only)
+├── knowledge.py         # NEW: build content-free collection entries from the RAG registry;
+│                        #      eN2N cosine selection (query vs advertised descriptions) + threshold
+├── inventory.py         # + call knowledge.build_entries() into the card; _assert_no_secrets covers them
+├── invocation.py        # + n2n/knowledge/query handler (default-deny, possession-tier, audited, agent-composed answer)
+├── gateway.py           # retrieval answer composition reuses the agent turn + rag_search (wiring only)
+└── router.py            # UNCHANGED — iN2N RiskRouter is not the eN2N knowledge selector (finding H2)
 
-workspace/skills/n2n-federation/SKILL.md   # + delegation guidance: prefer authoritative peer corpus; fallback peer→local→model; never fabricate a source
+workspace/skills/n2n-federation/SKILL.md   # + delegation guidance: prefer authoritative peer collection; fallback peer→local→model; never fabricate a source
 docs/ietf/draft-capobianco-ncfed-00.md     # §11 note staged for -01 (FR-010) — NOT the live -00 submission
 
 tests/n2n/
-├── test_knowledge_cards.py        # advertisement contents, no-secrets, visibility filtering, collection granularity
-└── test_knowledge_routing.py      # deterministic semantic selection, fallback order, tier/authorization/audit on retrieval
+├── test_knowledge_cards.py        # advertisement contents, no-secrets, visibility filtering, collection granularity, card-size independence (SC-005)
+└── test_knowledge_routing.py      # deterministic cosine selection, threshold fallback, tier/authorization/audit/no-oracle on n2n/knowledge/query
 ```
 
-**Structure Decision**: Single-project, in-repo extension of the existing federation package
-and RAG integration. No new package or service; the four `bgp/federation/*` files above are
-the code surface, plus the skill/SOUL doc and the (deferred) NCFED §11 update.
+**Structure Decision**: Single-project, in-repo extension. A new `bgp/federation/knowledge.py`
+holds the advertisement builder and the eN2N cosine selection helper; `inventory.py` and
+`invocation.py` wire it into the card and a dedicated `n2n/knowledge/query` method; `router.py`
+(the iN2N RiskRouter) is deliberately untouched. No new package, MCP server, or store.
 
 ## Complexity Tracking
 

--- a/specs/064-knowledge-capability-cards/plan.md
+++ b/specs/064-knowledge-capability-cards/plan.md
@@ -1,0 +1,84 @@
+# Implementation Plan: Knowledge Capability Cards & Knowledge-Aware Routing
+
+**Branch**: `064-knowledge-capability-cards` | **Date**: 2026-07-19 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/064-knowledge-capability-cards/spec.md`
+
+## Summary
+
+Advertise each claw's local RAG collections (feature 062) as content-free, A2A-style
+knowledge skills on the NCFED capability card, and route knowledge queries to the peer whose
+corpus is authoritative — generalizing the demonstrated Hermes↔NetClaw book-summary interop
+into deliberate, discoverable routing. The card gains one entry per RAG collection (from the
+`rag_list` registry: title/topics/doc_type/counts, no content); retrieval is a dedicated
+invocable knowledge-retrieval skill addressable from the card and fulfilled by the owner's
+local agent/RAG (`rag_search`); the agent/router selects the corpus by semantic match on the
+advertised description with a stable tiebreak. Reuses existing per-peer visibility, admission
+tiers, default-deny authorization, and audit/GAIT (057/060). No new MCP server.
+
+## Technical Context
+
+**Language/Version**: Python 3.10+ (daemon + `bgp/federation/*`, matching 052–063); Markdown (SOUL/skill docs + NCFED draft §11 for -01)
+**Primary Dependencies**: Existing only — `bgp/federation/inventory.py` (card), `router.py` (selection), `invocation.py`/`gateway.py` (retrieval turn), the feature-062 rag-mcp (`rag_list`, `rag_search`). No new third-party packages.
+**Storage**: Reuses `~/.openclaw/rag/rag.db` (documents registry, read-only for advertisement) and the issued capability card. Per-peer visibility reuses existing federation.db rows. No new store.
+**Testing**: pytest under `tests/n2n/` (card contents, no-secrets invariant, visibility filtering, deterministic selection, tier/authorization/audit on retrieval).
+**Target Platform**: Linux (systemd --user mesh/member services), consistent with the live deployment.
+**Project Type**: Extension of the existing NCFED daemon + capability card + RAG integration (single-project, in-repo).
+**Performance Goals**: Advertisement derived from `rag_list` cheaply and refreshed with the card version (not per query); card growth bounded by metadata only, independent of corpus size (SC-005).
+**Constraints**: Content-free card (no chunks/embeddings/source paths; passes `_assert_no_secrets`); retrieval possession-tier only + default-deny + audited; answers carry provenance.
+**Scale/Scope**: Small mesh of mutually-known operators (NCFED applicability); tens of collections per claw at most.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Assessment |
+|-----------|------------|
+| IV. Immutable Audit Trail | PASS — every federated retrieval audited with peer/corpus/GAIT (FR-007), reusing the existing trail. |
+| V. MCP-Native Integration | PASS — advertisement reads rag-mcp `rag_list`; retrieval uses `rag_search` via the agent turn; no bespoke data path. |
+| VI. Multi-Vendor / Agent Neutrality | PASS — knowledge advertised as an A2A-standard skill on the wire card; any implementation (Hermes, etc.) can consume it without shared code. |
+| VII. Skill Modularity | PASS — knowledge exposed as a discrete, self-describing skill entry; no coupling to the requester's internals. |
+| IX. Security by Default | PASS — content-free card, per-peer visibility, possession-tier + default-deny retrieval; sovereignty preserved (knowledge stays home). |
+| XV. Backwards Compatibility | PASS — additive card field; a peer that ignores `knowledge` is unaffected; chat retrieval path retained. |
+| XVI. Spec-Driven Development | PASS — this plan follows the spec; FR-010 keeps the NCFED draft §11 in sync. |
+| XI. Full-Stack Artifact Coherence | PASS — plan lists every touchpoint (card, router, SOUL/skill docs, NCFED draft, tests); no orphan surface. |
+
+No violations. Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/064-knowledge-capability-cards/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (card knowledge-skill + retrieval skill)
+└── tasks.md             # Phase 2 (/speckit.tasks — not created here)
+```
+
+### Source Code (repository root)
+
+```text
+mcp-servers/protocol-mcp/bgp/federation/
+├── inventory.py         # + build knowledge skills from rag_list; per-peer visibility; _assert_no_secrets covers them
+├── router.py            # + knowledge-aware selection: semantic match on advertised descriptions, stable tiebreak
+├── invocation.py        # + invocable knowledge-retrieval skill handler (default-deny, possession-tier, audited)
+└── gateway.py           # retrieval turn reuses rag_search (wiring only)
+
+workspace/skills/n2n-federation/SKILL.md   # + delegation guidance: prefer authoritative peer corpus; fallback peer→local→model; never fabricate a source
+docs/ietf/draft-capobianco-ncfed-00.md     # §11 note staged for -01 (FR-010) — NOT the live -00 submission
+
+tests/n2n/
+├── test_knowledge_cards.py        # advertisement contents, no-secrets, visibility filtering, collection granularity
+└── test_knowledge_routing.py      # deterministic semantic selection, fallback order, tier/authorization/audit on retrieval
+```
+
+**Structure Decision**: Single-project, in-repo extension of the existing federation package
+and RAG integration. No new package or service; the four `bgp/federation/*` files above are
+the code surface, plus the skill/SOUL doc and the (deferred) NCFED §11 update.
+
+## Complexity Tracking
+
+No constitution violations — section intentionally empty.

--- a/specs/064-knowledge-capability-cards/quickstart.md
+++ b/specs/064-knowledge-capability-cards/quickstart.md
@@ -11,10 +11,10 @@ Hermes↔NetClaw book summary), then the automated checks.
    `netclaw n2n inventory get as65001-4.4.4.4` → the card now contains a `knowledge` array
    with `knowledge:documents` (topics, tags, counts) and no document content.
 3. **Route to it.** Ask B a question answerable only by A's corpus. B semantically matches
-   the query to A's advertised `knowledge:documents`, invokes `n2n-knowledge/query` against
+   the query to A's advertised `knowledge:documents`, invokes `n2n/knowledge/query` against
    A, and returns A's grounded, cited answer — attributed to A.
 4. **Confirm sovereignty + audit.** Check that B never received chunks/embeddings (only the
-   answer), and that A's audit trail has one record `{peer=B, corpus_id, gait_ref}`.
+   answer), and that A's audit trail has one record `{peer=B, collection_id, gait_ref}`.
 5. **Confirm visibility.** Hide the collection from B (`n2n_set_visibility`); re-pull the
    card as B → `knowledge:documents` is gone; a permitted peer C still sees it.
 6. **Confirm fallback.** Ask B something no advertised corpus covers → B answers from its own
@@ -33,7 +33,7 @@ Expected coverage:
 - Hidden collection absent for the hidden peer, present for a permitted peer.
 - Deterministic selection: same query + same advertised set → same corpus; stable tiebreak.
 - Retrieval: possession-tier + granted peer succeeds and is audited; self-asserted or
-  ungranted peer refused; unknown/hidden `corpus_id` answered as "no such corpus".
+  ungranted peer refused; unknown/hidden `collection_id` answered as "no such corpus".
 - Fallback order peer → local → model; never fabricates a federated source.
 
 ## Success signals (from spec)

--- a/specs/064-knowledge-capability-cards/quickstart.md
+++ b/specs/064-knowledge-capability-cards/quickstart.md
@@ -1,0 +1,45 @@
+# Quickstart: Knowledge Capability Cards & Knowledge-Aware Routing
+
+Prove the feature end-to-end on the live mesh (the same setup that demonstrated the
+Hermes↔NetClaw book summary), then the automated checks.
+
+## Manual walkthrough
+
+1. **Have a corpus.** On claw A (e.g. AS 65001) ingest a document into RAG (feature 062):
+   `rag_list` shows the `documents` collection with page/chunk counts.
+2. **See it advertised.** From a federated peer B, pull A's card:
+   `netclaw n2n inventory get as65001-4.4.4.4` → the card now contains a `knowledge` array
+   with `knowledge:documents` (topics, tags, counts) and no document content.
+3. **Route to it.** Ask B a question answerable only by A's corpus. B semantically matches
+   the query to A's advertised `knowledge:documents`, invokes `n2n-knowledge/query` against
+   A, and returns A's grounded, cited answer — attributed to A.
+4. **Confirm sovereignty + audit.** Check that B never received chunks/embeddings (only the
+   answer), and that A's audit trail has one record `{peer=B, corpus_id, gait_ref}`.
+5. **Confirm visibility.** Hide the collection from B (`n2n_set_visibility`); re-pull the
+   card as B → `knowledge:documents` is gone; a permitted peer C still sees it.
+6. **Confirm fallback.** Ask B something no advertised corpus covers → B answers from its own
+   model and does not claim a federated source.
+
+## Automated checks (pytest)
+
+```bash
+cd ~/netclaw
+python3 -m pytest tests/n2n/test_knowledge_cards.py tests/n2n/test_knowledge_routing.py -q
+```
+
+Expected coverage:
+- Card lists one entry per ready collection; counts correct; **no** chunk text / source paths;
+  passes `_assert_no_secrets`.
+- Hidden collection absent for the hidden peer, present for a permitted peer.
+- Deterministic selection: same query + same advertised set → same corpus; stable tiebreak.
+- Retrieval: possession-tier + granted peer succeeds and is audited; self-asserted or
+  ungranted peer refused; unknown/hidden `corpus_id` answered as "no such corpus".
+- Fallback order peer → local → model; never fabricates a federated source.
+
+## Success signals (from spec)
+
+- SC-001 all authorized collections enumerable; 0% content on the card.
+- SC-002 ≥95% of peer-only questions delegated + answered with citations.
+- SC-003 selection deterministic.
+- SC-004 every retrieval audited; unauthorized fetch/retrieval refused 100%.
+- SC-005 card growth independent of corpus size.

--- a/specs/064-knowledge-capability-cards/research.md
+++ b/specs/064-knowledge-capability-cards/research.md
@@ -1,0 +1,63 @@
+# Phase 0 Research: Knowledge Capability Cards & Knowledge-Aware Routing
+
+All open decisions were resolved in the clarify session (2026-07-19); no `NEEDS
+CLARIFICATION` remain. This file records the decisions with rationale and rejected
+alternatives.
+
+## D1 — Advertisement granularity
+
+- **Decision**: One knowledge skill per RAG **collection**.
+- **Rationale**: Matches RAG's native grouping (the `collection` column in the documents
+  registry); keeps the card compact and its size independent of corpus size (SC-005);
+  limits title exposure vs. per-document.
+- **Alternatives rejected**: Per-document (card bloat, broad title exposure); single
+  rolled-up skill (too coarse for useful routing).
+
+## D2 — Retrieval invocation
+
+- **Decision**: A dedicated **invocable knowledge-retrieval skill**, addressable from the
+  corpus id the card advertises, invoked via `n2n/tools/call` and fulfilled by the owner's
+  local agent/RAG (`rag_search`). Free-form chat retained as a convenience.
+- **Rationale**: Deterministic and routable; A2A-clean (a skill with a stable id); no
+  out-of-band corpus ids. The chat path (proven Hermes↔NetClaw) stays for humans/ad-hoc.
+- **Alternatives rejected**: Chat-only (unstructured, non-deterministic to route); async A2A
+  task as the primary path (overhead for a fast lookup — remains available for long jobs).
+
+## D3 — Query → corpus selection
+
+- **Decision**: **Semantic match** of the query against each advertised collection's
+  description, over local + federated corpora, made **repeatable** by a stable tiebreak on
+  peer identity when scores are close.
+- **Rationale**: Mirrors how RAG already works (semantic), robust to paraphrase; determinism
+  requirement (FR-005) satisfied at the selection layer by the stable tiebreak, not by
+  forcing literal matching.
+- **Alternatives rejected**: Tag/keyword only (misses paraphrase); caller-names-corpus only
+  (pushes the burden to the requester, though it remains available as an explicit override).
+
+## D4 — Advertise posture
+
+- **Decision**: Collections advertised **by default** (as skills/MCP servers are today),
+  hidden per peer via the existing `n2n_set_visibility`.
+- **Rationale**: Consistent with existing card behavior and maximizes discoverability, which
+  is the point of the feature; sensitive corpora are hidden per peer, and a topic-only
+  description mode is available as a plan-time tunable (see D5).
+- **Alternatives rejected**: Opt-in per collection (safer but inconsistent with the current
+  card model and less discoverable; operator can still achieve opt-in behavior by hiding all
+  and un-hiding selectively).
+
+## D5 — Title exposure (deferred tunable)
+
+- **Decision**: Advertise document titles inside the collection description by default; make
+  a **topic-only** description mode (counts/tags, no titles) an available configuration.
+- **Rationale**: Titles aid routing precision; a minority of operators consider titles
+  sensitive and, under advertise-by-default (D4), need a way to suppress them without hiding
+  the whole collection. Not architecture-blocking → configuration, decided at implementation.
+
+## D6 — Reuse vs. new surface
+
+- **Decision**: Reuse `inventory.py` (card), `router.py` (selection), `invocation.py`/
+  `gateway.py` (retrieval turn via `rag_search`), and the existing visibility / admission
+  tier / default-deny / audit-GAIT machinery (057/060). No new MCP server or store.
+- **Rationale**: Constitution XI/XV — additive, coherent, backwards compatible.
+- **Alternatives rejected**: A standalone "knowledge federation" service (unjustified
+  complexity; duplicates card/auth/audit).

--- a/specs/064-knowledge-capability-cards/spec.md
+++ b/specs/064-knowledge-capability-cards/spec.md
@@ -13,20 +13,22 @@ claw knows**. The RAG knowledge base (feature 062) is invisible to peers, so the
 a remote claw discovers that another claw can answer questions about a corpus (e.g. John's
 book) is to ask it and see. The Hermes↔NetClaw book-summary interop proved the *retrieval*
 works over NCFED; this feature makes that knowledge **discoverable and routable** by
-advertising each claw's RAG corpora as A2A-style skills on the card, and by teaching the
-router/agent to prefer the authoritative peer KB for questions about that peer's domain.
+advertising each claw's RAG collections as A2A-style entries on the card, and by teaching
+the agent to prefer the authoritative peer KB for questions about that peer's domain.
 
-This is a lightweight feature: it extends the existing capability card, the existing
-router, and the delegation instructions. It adds **no new MCP server** and moves **no
-document content** across the federation — only content-free metadata (titles, topics,
-counts) that a peer is authorized to see.
+This is a lightweight feature: it extends the existing capability card, adds a small
+eN2N knowledge-selection helper and a dedicated `n2n/knowledge/query` method, and updates
+the delegation instructions. It adds **no new MCP server** and moves **no document
+content** across the federation — only content-free metadata (titles, topics, counts) that
+a peer is authorized to see. (The iN2N `router.py` is unchanged; peer selection is an eN2N
+concern handled separately.)
 
 ## Clarifications
 
 ### Session 2026-07-19
 
 - Q: At what granularity should a claw advertise its RAG knowledge on the card? → A: Per collection (one card skill per RAG collection).
-- Q: How should a remote claw invoke retrieval against an advertised corpus? → A: A dedicated invocable knowledge-retrieval skill, addressable from the card, invoked via `n2n/tools/call` and fulfilled by the local agent/RAG.
+- Q: How should a remote claw invoke retrieval against an advertised corpus? → A: A dedicated NCFED method `n2n/knowledge/query` (a method family alongside `n2n/tools/call` / `n2n/tasks/*`, not the MCP proxy), addressable by the advertised `collection_id`, fulfilled by the owner's local RAG composed by its agent. [Refined per analysis H1.]
 - Q: How should the querying claw choose which advertised corpus answers a question? → A: Semantic match of the query against each corpus's advertised description; deterministic given the advertised set plus a stable tiebreak.
 - Q: Should RAG collections be advertised by default or opt-in? → A: Advertised by default (consistent with skills/MCP servers), with per-peer visibility to hide a collection.
 
@@ -67,9 +69,9 @@ text, no source paths, and no secrets.
 
 When a claw is asked a question whose answer lives in a **federated peer's** advertised
 knowledge base rather than its own, it delegates the retrieval to that peer (the
-authoritative source) instead of answering from the model alone or declining. The Border's
-router and the agent's delegation instructions consult peers' advertised knowledge skills
-and select the peer whose corpus best matches the query.
+authoritative source) instead of answering from the model alone or declining. The agent's
+delegation instructions and an eN2N knowledge-selection helper consult peers' advertised
+knowledge entries and select the peer whose collection best matches the query.
 
 **Why this priority**: This is the payoff — it turns advertised knowledge into a working
 distributed-RAG answer with correct provenance. It is the generalization of the
@@ -84,9 +86,9 @@ B's grounded answer with B's citations, and does not fabricate an answer locally
 1. **Given** claw A federated with claw B, where B advertises a knowledge skill matching
    topic T and A has no local corpus on T, **When** A is asked a question about T, **Then**
    A routes the retrieval to B and returns B's cited answer attributed to B.
-2. **Given** both A and B advertise corpora matching T, **When** A must choose, **Then**
-   selection is deterministic (most-specific/topic-match first, then a stable tiebreak) and
-   documented.
+2. **Given** both A and B advertise collections matching T, **When** A must choose, **Then**
+   selection is deterministic (highest embedding-cosine score, then a stable tiebreak by
+   peer identity/collection id) and documented.
 3. **Given** no federated peer advertises a matching corpus, **When** A is asked about T,
    **Then** A answers from its own knowledge/model and does not invent a federated source.
 
@@ -156,27 +158,40 @@ restricted-tier peer sees knowledge advertisement but cannot invoke retrieval.
   visibility: an operator MUST be able to hide a collection from a given peer (reusing the
   existing `n2n_set_visibility` mechanism), and a hidden collection MUST NOT appear in that
   peer's card.
-- **FR-004**: Retrieval against a peer's advertised corpus MUST be exposed as a dedicated,
-  invocable **knowledge-retrieval skill**, addressable directly from the corpus id the card
-  advertises (a peer needs no out-of-band knowledge), invoked via `n2n/tools/call` and
-  fulfilled by the owner's local agent/RAG. The free-form chat path (proven in the
-  Hermes↔NetClaw interop) MAY remain as a convenience, but the invocable skill is the
-  normative, routable interface.
-- **FR-005**: The router/agent MUST select the corpus by **semantic match** of the query
-  against each advertised collection's description, considering both local and federated
-  peers' advertised knowledge. Selection MUST be repeatable: given the same query and the
-  same advertised set, the same corpus is chosen, using a stable, documented tiebreak by
-  peer identity when scores are close.
-- **FR-006**: When a matching **peer** corpus exists and the local claw lacks the knowledge,
-  the agent MUST prefer delegating retrieval to the authoritative peer over answering from
-  the model alone; when no matching peer corpus exists, it MUST NOT fabricate a federated
-  source.
+- **FR-004**: Retrieval against a peer's advertised collection MUST be exposed as a
+  **dedicated NCFED method** `n2n/knowledge/query` (a member of the method families
+  alongside `n2n/tools/call` and `n2n/tasks/*`), NOT the generic MCP `n2n/tools/call`
+  proxy — that proxy resolves `server_id/tool_name` against real registered MCP servers and
+  cannot address a synthetic knowledge endpoint. The method takes the `collection_id` the
+  card advertises (a peer needs no out-of-band knowledge) plus the query, and is fulfilled
+  by the owner's local RAG (`rag_search`) composed into an answer by the owner's agent. The
+  free-form chat path (proven in the Hermes↔NetClaw interop) MAY remain as a convenience,
+  but `n2n/knowledge/query` is the normative, routable interface. The card's `retrieval`
+  field names this method.
+- **FR-005**: The querying claw MUST select the collection by **embedding cosine
+  similarity** between the query and each advertised collection's description, computed with
+  the local RAG embedder (feature 062), over both local and federated peers' advertised
+  collections. Because the same embedder yields the same vectors, selection is deterministic:
+  given the same query and the same advertised set, the same collection is chosen; ties (or
+  scores within a small epsilon) break by ascending peer identity then ascending
+  `collection_id`. A configurable relevance threshold (env `N2N_KNOWLEDGE_MATCH_THRESHOLD`,
+  default `0.5`) gates whether any collection is considered a match.
+- **FR-006**: When a **peer** collection scores at or above the threshold and the local claw
+  has no local collection scoring higher, the agent MUST delegate retrieval to that
+  authoritative peer rather than answer from the model. Fallback order is peer collection →
+  local collection → model. When no collection meets the threshold, the claw answers from the
+  model and MUST NOT fabricate a federated source.
 - **FR-007**: Federated knowledge retrieval MUST be default-deny and authorized per peer,
   admitted only at the possession tier (not self-asserted), and MUST be audited with peer
-  identity, corpus, and a GAIT reference (consistent with {{NCFED}} §6.4 and feature 057).
-- **FR-008**: Returned federated answers MUST carry provenance — which peer and which corpus
-  produced them — so the requesting agent can attribute the source (and pass along the
-  owner's citations when present).
+  identity, collection, and a GAIT reference (consistent with {{NCFED}} §6.4 and feature
+  057). The per-peer grant is the human-in-the-loop control point for answering an external
+  peer from a local knowledge base (constitution Principle XIV) — no per-call approval is
+  required once granted.
+- **FR-008**: `n2n/knowledge/query` MUST return an **agent-composed, grounded answer** (not
+  raw chunks) carrying provenance — which peer and which collection produced it — and the
+  owner's source citations when present, so the requesting agent can attribute the source.
+  Composition requires a local agent turn; deployments accept its latency/cost as the price
+  of a cited, sovereignty-preserving answer.
 - **FR-009**: The delegation/SOUL instructions MUST be updated so a claw, before answering a
   document/factual question, checks whether a federated peer advertises a corpus matching the
   topic and routes accordingly; guidance MUST also cover the fallback order (matching peer →
@@ -187,15 +202,19 @@ restricted-tier peer sees knowledge advertisement but cannot invoke retrieval.
 
 ### Key Entities *(include if feature involves data)*
 
-- **Knowledge skill (card entry)**: The A2A-skill-shaped advertisement of one RAG collection
-  on the capability card. Attributes: stable id, name, semantic description (topics/titles),
-  tags (doc types), document/page/chunk counts. Content-free. Derived from the RAG registry;
-  filtered by per-peer visibility.
-- **RAG collection / corpus**: An existing feature-062 grouping of ingested documents in a
-  claw's local vector store. The authoritative source; never leaves the owner.
-- **Knowledge route decision**: The router's selection of which peer corpus (or the local
-  corpus, or the model) should answer a given knowledge query, with a deterministic rule and
-  a recorded rationale for audit.
+- **Knowledge entry (card advertisement)**: The A2A-skill-shaped advertisement of one RAG
+  collection on the capability card. Attributes: stable `collection_id`, name, semantic
+  description (topics/titles), tags (doc types), document/page/chunk counts, and the
+  `retrieval` method name (`n2n/knowledge/query`). Content-free. Derived from the RAG
+  registry; filtered by per-peer visibility. (Distinct from the **retrieval method**, the
+  invocable `n2n/knowledge/query` that returns answers.)
+- **RAG collection**: An existing feature-062 grouping of ingested documents in a claw's
+  local vector store. The authoritative source; never leaves the owner. ("Collection" is the
+  canonical term; earlier drafts also said "corpus".)
+- **Knowledge route decision**: The querying agent's selection (via the `knowledge.py`
+  selection helper, not the iN2N `router.py`) of which peer collection, local collection, or
+  the model should answer a query, with a deterministic embedding-cosine rule and a recorded
+  rationale for audit.
 
 ## Success Criteria *(mandatory)*
 

--- a/specs/064-knowledge-capability-cards/spec.md
+++ b/specs/064-knowledge-capability-cards/spec.md
@@ -21,6 +21,15 @@ router, and the delegation instructions. It adds **no new MCP server** and moves
 document content** across the federation — only content-free metadata (titles, topics,
 counts) that a peer is authorized to see.
 
+## Clarifications
+
+### Session 2026-07-19
+
+- Q: At what granularity should a claw advertise its RAG knowledge on the card? → A: Per collection (one card skill per RAG collection).
+- Q: How should a remote claw invoke retrieval against an advertised corpus? → A: A dedicated invocable knowledge-retrieval skill, addressable from the card, invoked via `n2n/tools/call` and fulfilled by the local agent/RAG.
+- Q: How should the querying claw choose which advertised corpus answers a question? → A: Semantic match of the query against each corpus's advertised description; deterministic given the advertised set plus a stable tiebreak.
+- Q: Should RAG collections be advertised by default or opt-in? → A: Advertised by default (consistent with skills/MCP servers), with per-peer visibility to hide a collection.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Advertise the knowledge base as an A2A skill on the card (Priority: P1)
@@ -124,28 +133,40 @@ restricted-tier peer sees knowledge advertisement but cannot invoke retrieval.
   treats it as "not available from that peer" and falls back (another peer, or local).
 - Empty/again: a claw with no RAG documents advertises no knowledge skill (absence, not an
   empty entry).
+- Title sensitivity: because collections are advertised by default (FR-003) and the
+  description may include document titles (FR-001), an operator who considers even titles
+  sensitive relies on per-peer visibility to hide the whole collection. A topic-only
+  description mode (counts/tags without titles) is a reasonable plan-time tunable if
+  needed — deferred to planning, not architecture-blocking.
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
-- **FR-001**: The capability card MUST include a content-free description of each advertised
-  RAG collection, shaped as an A2A-style skill (stable id, human-readable name, semantic
-  description of topics/titles, coarse tags, and document/page/chunk counts).
+- **FR-001**: The capability card MUST advertise knowledge at **collection granularity** —
+  one A2A-style skill entry per RAG collection — each carrying a stable id, human-readable
+  name, a semantic description of the collection's topics/titles, coarse tags, and
+  document/page/chunk counts. All content-free.
 - **FR-002**: The knowledge advertisement MUST be sourced from the feature-062 RAG document
   registry (title, doc_type, collection, page_count, chunk_count) and MUST NOT include chunk
   text, embeddings, `source_path`, capture commands, or any secret; it MUST pass the
   existing card `_assert_no_secrets` invariant.
-- **FR-003**: Knowledge advertisements MUST honor per-peer visibility: an operator MUST be
-  able to hide a collection from a given peer (reusing the existing `n2n_set_visibility`
-  mechanism), and a hidden collection MUST NOT appear in that peer's card.
-- **FR-004**: A claw MUST be able to invoke retrieval against a peer's advertised corpus over
-  NCFED (the retrieval path proven in the Hermes↔NetClaw interop), and the corpus MUST be
-  addressable from what the card advertises (a peer needs no out-of-band knowledge of the
-  corpus id).
-- **FR-005**: The router MUST consider federated peers' advertised knowledge when selecting
-  where to answer a knowledge query, selecting the best-matching corpus deterministically
-  (most-specific topic match first, then a stable, documented tiebreak by peer identity).
+- **FR-003**: RAG collections MUST be advertised **by default** (consistent with how skills
+  and MCP servers are advertised today). Knowledge advertisements MUST honor per-peer
+  visibility: an operator MUST be able to hide a collection from a given peer (reusing the
+  existing `n2n_set_visibility` mechanism), and a hidden collection MUST NOT appear in that
+  peer's card.
+- **FR-004**: Retrieval against a peer's advertised corpus MUST be exposed as a dedicated,
+  invocable **knowledge-retrieval skill**, addressable directly from the corpus id the card
+  advertises (a peer needs no out-of-band knowledge), invoked via `n2n/tools/call` and
+  fulfilled by the owner's local agent/RAG. The free-form chat path (proven in the
+  Hermes↔NetClaw interop) MAY remain as a convenience, but the invocable skill is the
+  normative, routable interface.
+- **FR-005**: The router/agent MUST select the corpus by **semantic match** of the query
+  against each advertised collection's description, considering both local and federated
+  peers' advertised knowledge. Selection MUST be repeatable: given the same query and the
+  same advertised set, the same corpus is chosen, using a stable, documented tiebreak by
+  peer identity when scores are close.
 - **FR-006**: When a matching **peer** corpus exists and the local claw lacks the knowledge,
   the agent MUST prefer delegating retrieval to the authoritative peer over answering from
   the model alone; when no matching peer corpus exists, it MUST NOT fabricate a federated
@@ -209,6 +230,16 @@ restricted-tier peer sees knowledge advertisement but cannot invoke retrieval.
   is slightly stale.
 - Cross-source reconciliation, ranking answers from multiple peers, and transitive knowledge
   delegation (A asks B who asks C) are out of scope for this lightweight feature.
+- **Knowledge replication (RAG2RAG) is explicitly out of scope and reserved for a future
+  spec (065).** This feature is *federated query* — knowledge stays home, only the answer
+  travels (sovereignty by default). Replicating vectors/chunks across the wire is the
+  opposite governance model (the data leaves; revocation becomes best-effort; embeddings are
+  effectively document sharing given inversion risk and embedding-model coupling). It has
+  real value for availability/offline, volume latency, blended retrieval, and deliberate
+  knowledge publishing, but carries a sync/versioning/consent burden this feature avoids.
+  064 is a prerequisite for it (discovery before replication). A lighter middle ground —
+  answer/chunk caching with TTL and provenance on the querying side — may be worth folding
+  in later without a full replication protocol.
 
 ## Dependencies
 

--- a/specs/064-knowledge-capability-cards/spec.md
+++ b/specs/064-knowledge-capability-cards/spec.md
@@ -1,0 +1,218 @@
+# Feature Specification: Knowledge Capability Cards & Knowledge-Aware Routing
+
+**Feature Branch**: `064-knowledge-capability-cards`
+**Created**: 2026-07-19
+**Status**: Draft
+**Input**: User description: "Adjust the A2A Agent Cards to include RAG capabilities (the knowledge base — the actual documents a NetClaw has in its local RAG) as a Skill (so it fits inside the A2A / NCFED capability card), plus instructional adjustments so routing considers remote claws' knowledge bases."
+
+## Overview
+
+Today a claw's A2A capability card ({{NCFED}} §11, built by `inventory.py`) advertises
+skills, MCP servers, badges, posture, and LLM tier — but it says nothing about **what a
+claw knows**. The RAG knowledge base (feature 062) is invisible to peers, so the only way
+a remote claw discovers that another claw can answer questions about a corpus (e.g. John's
+book) is to ask it and see. The Hermes↔NetClaw book-summary interop proved the *retrieval*
+works over NCFED; this feature makes that knowledge **discoverable and routable** by
+advertising each claw's RAG corpora as A2A-style skills on the card, and by teaching the
+router/agent to prefer the authoritative peer KB for questions about that peer's domain.
+
+This is a lightweight feature: it extends the existing capability card, the existing
+router, and the delegation instructions. It adds **no new MCP server** and moves **no
+document content** across the federation — only content-free metadata (titles, topics,
+counts) that a peer is authorized to see.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Advertise the knowledge base as an A2A skill on the card (Priority: P1)
+
+A NetClaw operator has documents in local RAG (feature 062). Their claw's capability card
+now includes a content-free description of each advertised RAG collection, shaped as an
+A2A skill: an id, a human/semantic description of the topics and document titles it covers,
+coarse tags (doc types), and document/page counts. A federated peer that pulls the card
+(`n2n/inventory_get`) can see *what this claw knows* without seeing the documents
+themselves.
+
+**Why this priority**: Discovery is the prerequisite for routing. Without the knowledge
+advertised on the card, a peer cannot reason about where to send a knowledge query. This
+story alone delivers value: operators and peer claws can enumerate federated knowledge.
+
+**Independent Test**: Ingest a document locally, pull the card as a peer, and confirm the
+card lists the collection with its topic description and counts — and contains no chunk
+text, no source paths, and no secrets.
+
+**Acceptance Scenarios**:
+
+1. **Given** a claw with a RAG collection containing "Automate Your Network", **When** a
+   federated peer fetches its capability card, **Then** the card includes a knowledge skill
+   whose description names the corpus topics/titles and reports document and page counts.
+2. **Given** the same claw, **When** the card is built, **Then** it contains no chunk
+   content, no embeddings, no `source_path`, and passes the existing `_assert_no_secrets`
+   check.
+3. **Given** a per-peer visibility policy that hides a collection from peer X, **When**
+   peer X fetches the card, **Then** that collection does not appear; a permitted peer Y
+   still sees it.
+
+---
+
+### User Story 2 - Knowledge-aware routing / delegation (Priority: P1)
+
+When a claw is asked a question whose answer lives in a **federated peer's** advertised
+knowledge base rather than its own, it delegates the retrieval to that peer (the
+authoritative source) instead of answering from the model alone or declining. The Border's
+router and the agent's delegation instructions consult peers' advertised knowledge skills
+and select the peer whose corpus best matches the query.
+
+**Why this priority**: This is the payoff — it turns advertised knowledge into a working
+distributed-RAG answer with correct provenance. It is the generalization of the
+Hermes↔NetClaw book demo into deliberate routing.
+
+**Independent Test**: On claw A (no local corpus on topic T) with a federated peer B that
+advertises a corpus on T, ask A a T-question; confirm A delegates retrieval to B, returns
+B's grounded answer with B's citations, and does not fabricate an answer locally.
+
+**Acceptance Scenarios**:
+
+1. **Given** claw A federated with claw B, where B advertises a knowledge skill matching
+   topic T and A has no local corpus on T, **When** A is asked a question about T, **Then**
+   A routes the retrieval to B and returns B's cited answer attributed to B.
+2. **Given** both A and B advertise corpora matching T, **When** A must choose, **Then**
+   selection is deterministic (most-specific/topic-match first, then a stable tiebreak) and
+   documented.
+3. **Given** no federated peer advertises a matching corpus, **When** A is asked about T,
+   **Then** A answers from its own knowledge/model and does not invent a federated source.
+
+---
+
+### User Story 3 - Provenance, privacy, and consent on federated knowledge (Priority: P2)
+
+Federated knowledge retrieval is subject to the same default-deny authorization, audit, and
+trust-tier rules as any other NCFED invocation. A peer only sees the collections it is
+authorized to see; a knowledge query is authorized per peer; every federated retrieval is
+audited; and answers carry provenance (which peer, which corpus).
+
+**Why this priority**: The whole value proposition is "knowledge stays home, only answers
+travel." That only holds if advertisement and retrieval respect visibility, authorization,
+and audit. P2 because P1 stories assume these controls exist (they largely do, via 057/060)
+and this story makes them explicit for the knowledge surface.
+
+**Independent Test**: Attempt to fetch a hidden collection and to query a non-granted
+corpus from an unauthorized peer; confirm both are refused and audited, and that a
+restricted-tier peer sees knowledge advertisement but cannot invoke retrieval.
+
+**Acceptance Scenarios**:
+
+1. **Given** a restricted (self-asserted tier) peer, **When** it fetches the card, **Then**
+   it may see authorized knowledge advertisements but any retrieval invocation is denied
+   (consistent with {{NCFED}} §6.4 admission tiers).
+2. **Given** a possession-tier peer without a grant for corpus C, **When** it requests a
+   retrieval against C, **Then** the request is refused (default-deny) and audited.
+3. **Given** a successful federated retrieval, **When** the answer is returned, **Then** the
+   invocation is recorded in the audit trail with the peer identity, corpus, and a GAIT
+   reference.
+
+### Edge Cases
+
+- What happens when a corpus is large or churns often? The advertised description/counts
+  must be derived cheaply and refreshed with the card version, not recomputed per query.
+- How is a stale card handled? A peer may route to a corpus that has since changed; the
+  authoritative retrieval always runs against the owner's live RAG, so the answer reflects
+  current content even if the advertised summary lags.
+- What if two peers advertise overlapping corpora with conflicting content? Selection is
+  deterministic; the answer is attributed to the chosen peer; the design does not attempt
+  cross-source reconciliation in this feature.
+- What if a peer advertises knowledge but denies the retrieval grant? The querying claw
+  treats it as "not available from that peer" and falls back (another peer, or local).
+- Empty/again: a claw with no RAG documents advertises no knowledge skill (absence, not an
+  empty entry).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The capability card MUST include a content-free description of each advertised
+  RAG collection, shaped as an A2A-style skill (stable id, human-readable name, semantic
+  description of topics/titles, coarse tags, and document/page/chunk counts).
+- **FR-002**: The knowledge advertisement MUST be sourced from the feature-062 RAG document
+  registry (title, doc_type, collection, page_count, chunk_count) and MUST NOT include chunk
+  text, embeddings, `source_path`, capture commands, or any secret; it MUST pass the
+  existing card `_assert_no_secrets` invariant.
+- **FR-003**: Knowledge advertisements MUST honor per-peer visibility: an operator MUST be
+  able to hide a collection from a given peer (reusing the existing `n2n_set_visibility`
+  mechanism), and a hidden collection MUST NOT appear in that peer's card.
+- **FR-004**: A claw MUST be able to invoke retrieval against a peer's advertised corpus over
+  NCFED (the retrieval path proven in the Hermes↔NetClaw interop), and the corpus MUST be
+  addressable from what the card advertises (a peer needs no out-of-band knowledge of the
+  corpus id).
+- **FR-005**: The router MUST consider federated peers' advertised knowledge when selecting
+  where to answer a knowledge query, selecting the best-matching corpus deterministically
+  (most-specific topic match first, then a stable, documented tiebreak by peer identity).
+- **FR-006**: When a matching **peer** corpus exists and the local claw lacks the knowledge,
+  the agent MUST prefer delegating retrieval to the authoritative peer over answering from
+  the model alone; when no matching peer corpus exists, it MUST NOT fabricate a federated
+  source.
+- **FR-007**: Federated knowledge retrieval MUST be default-deny and authorized per peer,
+  admitted only at the possession tier (not self-asserted), and MUST be audited with peer
+  identity, corpus, and a GAIT reference (consistent with {{NCFED}} §6.4 and feature 057).
+- **FR-008**: Returned federated answers MUST carry provenance — which peer and which corpus
+  produced them — so the requesting agent can attribute the source (and pass along the
+  owner's citations when present).
+- **FR-009**: The delegation/SOUL instructions MUST be updated so a claw, before answering a
+  document/factual question, checks whether a federated peer advertises a corpus matching the
+  topic and routes accordingly; guidance MUST also cover the fallback order (matching peer →
+  local corpus → model) and forbid inventing an authoritative source.
+- **FR-010**: The NCFED Internet-Draft capability-card section (§11) MUST be updated to
+  document the knowledge skill shape as part of the A2A card mapping, for the next draft
+  revision (-01), keeping the on-wire card and the spec in sync.
+
+### Key Entities *(include if feature involves data)*
+
+- **Knowledge skill (card entry)**: The A2A-skill-shaped advertisement of one RAG collection
+  on the capability card. Attributes: stable id, name, semantic description (topics/titles),
+  tags (doc types), document/page/chunk counts. Content-free. Derived from the RAG registry;
+  filtered by per-peer visibility.
+- **RAG collection / corpus**: An existing feature-062 grouping of ingested documents in a
+  claw's local vector store. The authoritative source; never leaves the owner.
+- **Knowledge route decision**: The router's selection of which peer corpus (or the local
+  corpus, or the model) should answer a given knowledge query, with a deterministic rule and
+  a recorded rationale for audit.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A peer fetching a claw's card can enumerate 100% of that claw's authorized RAG
+  collections with topic descriptions and counts, and 0% of document content / source paths
+  appear in the card.
+- **SC-002**: For a knowledge question answerable only by a federated peer's corpus, the
+  querying claw delegates to that peer and returns the peer's cited answer in ≥ 95% of trials
+  (no local fabrication), matching the Hermes↔NetClaw round-trip already demonstrated.
+- **SC-003**: Corpus selection is deterministic — the same query against the same advertised
+  set always routes to the same peer/corpus.
+- **SC-004**: Every federated retrieval appears in the audit trail with peer identity, corpus,
+  and a GAIT reference; unauthorized advertisement fetches and retrievals are refused 100% of
+  the time.
+- **SC-005**: Advertising knowledge adds no document content to the wire — card size grows
+  only by the metadata summary, independent of corpus size.
+
+## Assumptions
+
+- Feature 062 (rag-mcp) is the source of truth for local knowledge; this feature reads its
+  registry and reuses its retrieval, and does not change how documents are ingested or stored.
+- The NCFED capability card ({{NCFED}} §11, `inventory.py`) and its per-peer visibility,
+  admission tiers (§6.4), default-deny authorization, and audit/GAIT trail (features 057/060)
+  are reused as-is; this feature adds a knowledge surface on top, not a new trust model.
+- The federated retrieval transport already works (proven in the Hermes↔NetClaw book-summary
+  interop over the eN2N chat channel); this feature makes the corpus discoverable and the
+  routing deliberate rather than introducing a new invocation mechanism.
+- "Knowledge" advertised is descriptive metadata only; the owner's live RAG is always the
+  thing actually queried, so answers reflect current content even if the advertised summary
+  is slightly stale.
+- Cross-source reconciliation, ranking answers from multiple peers, and transitive knowledge
+  delegation (A asks B who asks C) are out of scope for this lightweight feature.
+
+## Dependencies
+
+- Feature 062 (rag-mcp) — local knowledge base and retrieval.
+- Feature 059 (NCFED Internet-Draft) — capability card (§11) and the A2A mapping the card
+  entry must fit; §11 update is a deliverable (FR-010).
+- Features 057/060 — admission tiers, per-peer authorization, audit/GAIT, card visibility.

--- a/specs/064-knowledge-capability-cards/tasks.md
+++ b/specs/064-knowledge-capability-cards/tasks.md
@@ -18,7 +18,7 @@ Tests: `tests/n2n/`. Skill docs: `workspace/skills/`. Draft: `docs/ietf/`.
 ## Phase 1: Setup
 
 - [X] T001 Confirm the feature-062 RAG surface is callable from the daemon env: `rag_list` (registry) and `rag_search` (retrieval) resolve and return expected shapes; note the exact call path (direct import vs. MCP stdio) to use from `bgp/federation/` in `specs/064-knowledge-capability-cards/research.md` (append a "D7 — RAG call path" note).
-- [ ] T002 [P] Create empty test modules `tests/n2n/test_knowledge_cards.py` and `tests/n2n/test_knowledge_routing.py` with the shared fixtures import (`conftest.py` manager fixture) so later test tasks just add cases.
+- [X] T002 [P] Create empty test modules `tests/n2n/test_knowledge_cards.py` and `tests/n2n/test_knowledge_routing.py` with the shared fixtures import (`conftest.py` manager fixture) so later test tasks just add cases.
 
 ---
 
@@ -55,14 +55,14 @@ Tests: `tests/n2n/`. Skill docs: `workspace/skills/`. Draft: `docs/ietf/`.
 **Goal**: A claw delegates a knowledge query to the peer whose corpus is authoritative and returns its cited answer.
 **Independent test**: On claw A with no local corpus on T but peer B advertising one, ask A about T → A routes to B, returns B's cited answer, does not fabricate.
 
-- [ ] T011 [US2] Implement the **dedicated NCFED method** `n2n/knowledge/query` handler in `mcp-servers/protocol-mcp/bgp/federation/invocation.py` and register it in the service handler map (alongside `n2n/tasks/*`, NOT via the MCP `tools/call` proxy — finding H1): accept `{collection_id, query, k}`, run `rag_search` against the **live** local RAG, and return `{answer, provenance:{peer, collection_id, citations}}` per `contracts/knowledge-card-and-retrieval.md`.
-- [ ] T012 [US2] Compose the retrieval answer via a local **agent turn** (`gateway.run_agent_turn` fed the `rag_search` hits) so the result is a grounded, cited answer (not raw chunks; FR-008), in `mcp-servers/protocol-mcp/bgp/federation/invocation.py`/`gateway.py`.
-- [ ] T013 [US2] Implement eN2N knowledge selection in **`mcp-servers/protocol-mcp/bgp/federation/knowledge.py`** (NOT `router.py` — finding H2): embed the query with the RAG embedder, compute cosine similarity against all visible advertised collection descriptions (local + federated peers' cached cards in `service.peer_caps`), pick the highest, deterministic tiebreak by ascending peer identity then `collection_id`; return a Knowledge Route Decision (`target`, `peer_identity`, `collection_id`, `score`, `rationale`) per `data-model.md`.
-- [ ] T014 [US2] Implement threshold + fallback in `knowledge.py`: a collection matches only at score ≥ `N2N_KNOWLEDGE_MATCH_THRESHOLD` (default 0.5); fallback order **peer → local → model**; MUST NOT emit `peer`/`collection_id` when nothing clears the threshold (no fabricated source, FR-006).
-- [ ] T015 [US2] Add delegation guidance to `workspace/skills/n2n-federation/SKILL.md`: before answering a document/factual question, consult peers' advertised knowledge and route to the authoritative collection via `n2n/knowledge/query`; state the peer→local→model fallback and the "never invent a federated source" rule.
-- [ ] T016 [P] [US2] Test in `tests/n2n/test_knowledge_routing.py`: deterministic cosine selection — same query + same advertised set → same collection (stub the embedder for fixed vectors); tiebreak applied and recorded in `rationale`.
-- [ ] T017 [P] [US2] Test in `tests/n2n/test_knowledge_routing.py`: peer-collection above threshold → decision targets that peer/collection; nothing above threshold → `target=model`, no `peer_identity`/`collection_id`.
-- [ ] T018 [P] [US2] Test in `tests/n2n/test_knowledge_routing.py`: `n2n/knowledge/query` against a granted, possession-tier peer returns an agent-composed answer with provenance and citations (stub `rag_search` + agent turn).
+- [X] T011 [US2] Implement the **dedicated NCFED method** `n2n/knowledge/query` handler in `mcp-servers/protocol-mcp/bgp/federation/invocation.py` and register it in the service handler map (alongside `n2n/tasks/*`, NOT via the MCP `tools/call` proxy — finding H1): accept `{collection_id, query, k}`, run `rag_search` against the **live** local RAG, and return `{answer, provenance:{peer, collection_id, citations}}` per `contracts/knowledge-card-and-retrieval.md`.
+- [X] T012 [US2] Compose the retrieval answer via a local **agent turn** (`gateway.run_agent_turn` fed the `rag_search` hits) so the result is a grounded, cited answer (not raw chunks; FR-008), in `mcp-servers/protocol-mcp/bgp/federation/invocation.py`/`gateway.py`.
+- [X] T013 [US2] Implement eN2N knowledge selection in **`mcp-servers/protocol-mcp/bgp/federation/knowledge.py`** (NOT `router.py` — finding H2): embed the query with the RAG embedder, compute cosine similarity against all visible advertised collection descriptions (local + federated peers' cached cards in `service.peer_caps`), pick the highest, deterministic tiebreak by ascending peer identity then `collection_id`; return a Knowledge Route Decision (`target`, `peer_identity`, `collection_id`, `score`, `rationale`) per `data-model.md`.
+- [X] T014 [US2] Implement threshold + fallback in `knowledge.py`: a collection matches only at score ≥ `N2N_KNOWLEDGE_MATCH_THRESHOLD` (default 0.5); fallback order **peer → local → model**; MUST NOT emit `peer`/`collection_id` when nothing clears the threshold (no fabricated source, FR-006).
+- [X] T015 [US2] Add delegation guidance to `workspace/skills/n2n-federation/SKILL.md`: before answering a document/factual question, consult peers' advertised knowledge and route to the authoritative collection via `n2n/knowledge/query`; state the peer→local→model fallback and the "never invent a federated source" rule.
+- [X] T016 [P] [US2] Test in `tests/n2n/test_knowledge_routing.py`: deterministic cosine selection — same query + same advertised set → same collection (stub the embedder for fixed vectors); tiebreak applied and recorded in `rationale`.
+- [X] T017 [P] [US2] Test in `tests/n2n/test_knowledge_routing.py`: peer-collection above threshold → decision targets that peer/collection; nothing above threshold → `target=model`, no `peer_identity`/`collection_id`.
+- [X] T018 [P] [US2] Test in `tests/n2n/test_knowledge_routing.py`: `n2n/knowledge/query` against a granted, possession-tier peer returns an agent-composed answer with provenance and citations (stub `rag_search` + agent turn).
 
 **Checkpoint**: US2 independently demonstrable — the Byrn book round-trip now happens by deliberate routing.
 
@@ -73,11 +73,11 @@ Tests: `tests/n2n/`. Skill docs: `workspace/skills/`. Draft: `docs/ietf/`.
 **Goal**: Federated knowledge respects visibility, per-peer authorization, admission tier, and audit.
 **Independent test**: unauthorized/ hidden-corpus/ restricted-tier attempts are all refused and audited; successful retrieval is audited with corpus + GAIT.
 
-- [ ] T019 [US3] Extend the **T011 handler** in `mcp-servers/protocol-mcp/bgp/federation/invocation.py` (edit it in place, not a parallel path — finding L1) to enforce default-deny + possession tier on `n2n/knowledge/query`: reuse `negotiate.allows` so a self-asserted (keyless) peer is denied, and require a per-peer grant for the collection (default-deny), reusing the authorizer path used by `tools/call`/`tasks/submit`. The grant is the Principle-XIV control point (FR-007).
-- [ ] T020 [US3] No existence oracle: an unknown or not-visible `collection_id` MUST be answered exactly as "no such collection" (same shape as a missing one), in `mcp-servers/protocol-mcp/bgp/federation/invocation.py`.
-- [ ] T021 [US3] Emit one audit record per retrieval in `invocation.py` via the existing `Auditor`: `{direction=inbound, peer_identity, target_type="knowledge", target_name=collection_id, decision, outcome, channel_kind, gait_ref}` (FR-007).
-- [ ] T022 [P] [US3] Test in `tests/n2n/test_knowledge_routing.py`: self-asserted (tier-0) peer denied retrieval but may still see authorized knowledge advertisements; possession-tier peer without a grant denied (default-deny); both audited.
-- [ ] T023 [P] [US3] Test in `tests/n2n/test_knowledge_routing.py`: hidden/unknown `collection_id` returns the missing-collection shape (no existence leak); successful retrieval produces exactly one audit record with collection + GAIT reference.
+- [X] T019 [US3] Extend the **T011 handler** in `mcp-servers/protocol-mcp/bgp/federation/invocation.py` (edit it in place, not a parallel path — finding L1) to enforce default-deny + possession tier on `n2n/knowledge/query`: reuse `negotiate.allows` so a self-asserted (keyless) peer is denied, and require a per-peer grant for the collection (default-deny), reusing the authorizer path used by `tools/call`/`tasks/submit`. The grant is the Principle-XIV control point (FR-007).
+- [X] T020 [US3] No existence oracle: an unknown or not-visible `collection_id` MUST be answered exactly as "no such collection" (same shape as a missing one), in `mcp-servers/protocol-mcp/bgp/federation/invocation.py`.
+- [X] T021 [US3] Emit one audit record per retrieval in `invocation.py` via the existing `Auditor`: `{direction=inbound, peer_identity, target_type="knowledge", target_name=collection_id, decision, outcome, channel_kind, gait_ref}` (FR-007).
+- [X] T022 [P] [US3] Test in `tests/n2n/test_knowledge_routing.py`: self-asserted (tier-0) peer denied retrieval but may still see authorized knowledge advertisements; possession-tier peer without a grant denied (default-deny); both audited.
+- [X] T023 [P] [US3] Test in `tests/n2n/test_knowledge_routing.py`: hidden/unknown `collection_id` returns the missing-collection shape (no existence leak); successful retrieval produces exactly one audit record with collection + GAIT reference.
 
 **Checkpoint**: US3 independently demonstrable — sovereignty/audit guarantees hold under adversarial peers.
 
@@ -85,9 +85,9 @@ Tests: `tests/n2n/`. Skill docs: `workspace/skills/`. Draft: `docs/ietf/`.
 
 ## Phase 6: Polish & Cross-Cutting
 
-- [ ] T024 [P] Update the NCFED draft §11 (Capability Cards) in `docs/ietf/draft-capobianco-ncfed-00.md` to document the `knowledge` skill shape as part of the A2A card mapping, staged for the **-01** revision (FR-010) — do NOT re-render/alter the live -00 submission.
+- [X] T024 [P] Update the NCFED draft §11 (Capability Cards) in `docs/ietf/draft-capobianco-ncfed-00.md` to document the `knowledge` skill shape as part of the A2A card mapping, staged for the **-01** revision (FR-010) — do NOT re-render/alter the live -00 submission.
 - [ ] T025 [P] Run the quickstart.md manual walkthrough on the live mesh (ingest → advertise → route → answer with citations → visibility → fallback) and record the result; correlate mesh audit + RAG retrieval_log as in the Byrn demo.
-- [ ] T026 Run the full n2n suite (`python3 -m pytest tests/n2n -q`) and confirm zero regressions; map passing tests to SC-001…SC-005.
+- [X] T026 Run the full n2n suite (`python3 -m pytest tests/n2n -q`) and confirm zero regressions; map passing tests to SC-001…SC-005.
 - [ ] T027 [P] Restart the live services (`systemctl --user restart netclaw-mesh.service` + members) to deploy, then confirm a real peer sees the `knowledge` array and a routed query answers with provenance.
 
 ---

--- a/specs/064-knowledge-capability-cards/tasks.md
+++ b/specs/064-knowledge-capability-cards/tasks.md
@@ -1,0 +1,111 @@
+# Tasks: Knowledge Capability Cards & Knowledge-Aware Routing
+
+**Input**: Design documents from `/specs/064-knowledge-capability-cards/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Included — the spec's Success Criteria and quickstart.md call for pytest coverage,
+and the repo is test-driven (`tests/n2n/`).
+
+**Organization**: By user story (US1/US2 = P1, US3 = P2), each independently testable.
+
+## Path Conventions
+
+Single project, in-repo. Federation code: `mcp-servers/protocol-mcp/bgp/federation/`.
+Tests: `tests/n2n/`. Skill docs: `workspace/skills/`. Draft: `docs/ietf/`.
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm the feature-062 RAG surface is callable from the daemon env: `rag_list` (registry) and `rag_search` (retrieval) resolve and return expected shapes; note the exact call path (direct import vs. MCP stdio) to use from `bgp/federation/` in `specs/064-knowledge-capability-cards/research.md` (append a "D7 — RAG call path" note).
+- [ ] T002 [P] Create empty test modules `tests/n2n/test_knowledge_cards.py` and `tests/n2n/test_knowledge_routing.py` with the shared fixtures import (`conftest.py` manager fixture) so later test tasks just add cases.
+
+---
+
+## Phase 2: Foundational (blocking prerequisites)
+
+**Purpose**: The content-free knowledge-entry builder that US1 advertises and US2/US3 depend on.
+
+- [ ] T003 Add a knowledge-advertisement builder in `mcp-servers/protocol-mcp/bgp/federation/inventory.py` that reads the RAG registry (via the T001 path) and returns one content-free entry per **ready** collection (`id`=`knowledge:<collection>`, `name`, `description` from titles/topics, `tags` from distinct `doc_type`, `doc_count`/`page_count`/`chunk_count`, `retrieval`=`n2n-knowledge/query`) per `data-model.md`. Never reads `source_path`/`content_hash`/`capture_*`.
+- [ ] T004 Extend `_assert_no_secrets` in `mcp-servers/protocol-mcp/bgp/federation/inventory.py` to also scan the `knowledge` array (reject any chunk text / path / hash / secret), so the invariant covers the new surface.
+- [ ] T005 [P] Add a `topic-only` description mode toggle (env/config, default off) in the T003 builder so titles can be suppressed without hiding the collection (research D5); default advertises titles.
+
+**Checkpoint**: Builder produces correct content-free entries and the no-secrets invariant covers them (unit-testable without a live peer).
+
+---
+
+## Phase 3: User Story 1 — Advertise the knowledge base as an A2A skill (Priority: P1)
+
+**Goal**: A peer pulling the card sees one content-free knowledge entry per authorized collection.
+**Independent test**: Ingest a doc, pull the card as a peer, confirm the collection is listed with counts and no content; hidden-for-peer filtering works.
+
+- [ ] T006 [US1] Wire the T003 builder into `InventoryBuilder.build` in `mcp-servers/protocol-mcp/bgp/federation/inventory.py`: add a `knowledge` array to the card (sibling of `skills`/`mcp_servers`), advertised **by default** (FR-003), filtered by the existing per-peer `_visibility` on `("knowledge", collection, peer_identity)`.
+- [ ] T007 [US1] Extend the visibility mechanism (`n2n_set_visibility` path) to accept a `knowledge` kind so an operator can hide a collection from a given peer; confirm hidden collections drop from that peer's card only.
+- [ ] T008 [P] [US1] Test in `tests/n2n/test_knowledge_cards.py`: card lists one entry per ready collection with correct counts; a claw with zero ready docs emits no `knowledge` entries (absence, not empty).
+- [ ] T009 [P] [US1] Test in `tests/n2n/test_knowledge_cards.py`: the card contains no chunk text, no `source_path`, no `content_hash`; `_assert_no_secrets` passes with knowledge present and fails if a secret is injected.
+- [ ] T010 [P] [US1] Test in `tests/n2n/test_knowledge_cards.py`: per-peer visibility — hidden collection absent for peer X, present for peer Y; topic-only mode omits titles but keeps counts/tags.
+
+**Checkpoint**: US1 independently demonstrable — card advertisement complete and secret-safe.
+
+---
+
+## Phase 4: User Story 2 — Knowledge-aware routing / delegation (Priority: P1)
+
+**Goal**: A claw delegates a knowledge query to the peer whose corpus is authoritative and returns its cited answer.
+**Independent test**: On claw A with no local corpus on T but peer B advertising one, ask A about T → A routes to B, returns B's cited answer, does not fabricate.
+
+- [ ] T011 [US2] Implement the invocable retrieval skill handler `n2n-knowledge/query` in `mcp-servers/protocol-mcp/bgp/federation/invocation.py`: accept `{corpus_id, query, k}`, run `rag_search` against the **live** local RAG, and return `{answer, provenance:{peer, corpus_id, citations}}` per `contracts/knowledge-card-and-retrieval.md`. Register it in the service handler map.
+- [ ] T012 [US2] Wire the retrieval answer composition through `gateway.run_agent_turn` (or direct `rag_search` + compose) so the returned answer is grounded and carries the source's citations when present, in `mcp-servers/protocol-mcp/bgp/federation/gateway.py`/`invocation.py`.
+- [ ] T013 [US2] Implement knowledge-aware selection in `mcp-servers/protocol-mcp/bgp/federation/router.py`: score a query against all visible advertised collection descriptions (local + federated peers' cached cards), pick the best, deterministic tiebreak by ascending peer identity then `corpus_id`; return a Knowledge Route Decision (`target`, `peer_identity`, `corpus_id`, `score`, `rationale`) per `data-model.md`.
+- [ ] T014 [US2] Implement the fallback order in the router/agent path: matching **peer** corpus → **local** corpus → **model**; MUST NOT emit a `peer`/`corpus_id` when no corpus clears the relevance threshold (no fabricated source), in `mcp-servers/protocol-mcp/bgp/federation/router.py`.
+- [ ] T015 [US2] Add delegation guidance to `workspace/skills/n2n-federation/SKILL.md`: before answering a document/factual question, check peers' advertised knowledge and route to the authoritative corpus; state the peer→local→model fallback and the "never invent a federated source" rule.
+- [ ] T016 [P] [US2] Test in `tests/n2n/test_knowledge_routing.py`: deterministic selection — same query + same advertised set → same corpus; tiebreak applied and recorded in `rationale`.
+- [ ] T017 [P] [US2] Test in `tests/n2n/test_knowledge_routing.py`: peer-corpus match → route decision targets that peer/corpus; no match → `target=model`, no `peer_identity`/`corpus_id`.
+- [ ] T018 [P] [US2] Test in `tests/n2n/test_knowledge_routing.py`: `n2n-knowledge/query` against a granted, possession-tier peer returns an answer with provenance and citations (stub `rag_search`).
+
+**Checkpoint**: US2 independently demonstrable — the Byrn book round-trip now happens by deliberate routing.
+
+---
+
+## Phase 5: User Story 3 — Provenance, privacy, and consent (Priority: P2)
+
+**Goal**: Federated knowledge respects visibility, per-peer authorization, admission tier, and audit.
+**Independent test**: unauthorized/ hidden-corpus/ restricted-tier attempts are all refused and audited; successful retrieval is audited with corpus + GAIT.
+
+- [ ] T019 [US3] Enforce default-deny + possession tier on `n2n-knowledge/query` in `mcp-servers/protocol-mcp/bgp/federation/invocation.py`: reuse `negotiate.allows` so a self-asserted (keyless) peer is denied, and require a per-peer grant for the corpus (default-deny) — reusing the authorizer path used by `tools/call`/`tasks/submit`.
+- [ ] T020 [US3] No existence oracle: an unknown or not-visible `corpus_id` MUST be answered exactly as "no such corpus" (same shape as a missing one), in `mcp-servers/protocol-mcp/bgp/federation/invocation.py`.
+- [ ] T021 [US3] Emit one audit record per retrieval in `invocation.py` via the existing `Auditor`: `{direction=inbound, peer_identity, target_type="knowledge", target_name=corpus_id, decision, outcome, channel_kind, gait_ref}` (FR-007).
+- [ ] T022 [P] [US3] Test in `tests/n2n/test_knowledge_routing.py`: self-asserted (tier-0) peer denied retrieval but may still see authorized knowledge advertisements; possession-tier peer without a grant denied (default-deny); both audited.
+- [ ] T023 [P] [US3] Test in `tests/n2n/test_knowledge_routing.py`: hidden/unknown `corpus_id` returns the missing-corpus shape (no existence leak); successful retrieval produces exactly one audit record with corpus + GAIT reference.
+
+**Checkpoint**: US3 independently demonstrable — sovereignty/audit guarantees hold under adversarial peers.
+
+---
+
+## Phase 6: Polish & Cross-Cutting
+
+- [ ] T024 [P] Update the NCFED draft §11 (Capability Cards) in `docs/ietf/draft-capobianco-ncfed-00.md` to document the `knowledge` skill shape as part of the A2A card mapping, staged for the **-01** revision (FR-010) — do NOT re-render/alter the live -00 submission.
+- [ ] T025 [P] Run the quickstart.md manual walkthrough on the live mesh (ingest → advertise → route → answer with citations → visibility → fallback) and record the result; correlate mesh audit + RAG retrieval_log as in the Byrn demo.
+- [ ] T026 Run the full n2n suite (`python3 -m pytest tests/n2n -q`) and confirm zero regressions; map passing tests to SC-001…SC-005.
+- [ ] T027 [P] Restart the live services (`systemctl --user restart netclaw-mesh.service` + members) to deploy, then confirm a real peer sees the `knowledge` array and a routed query answers with provenance.
+
+---
+
+## Dependencies & Execution Order
+
+- **Setup (T001–T002)** → **Foundational (T003–T005)** blocks everything.
+- **US1 (T006–T010)** depends on Foundational; is the discovery layer US2 routes against.
+- **US2 (T011–T018)** depends on US1 (needs advertised corpora to route to).
+- **US3 (T019–T023)** hardens US2's retrieval handler; depends on T011.
+- **Polish (T024–T027)** last.
+
+**MVP** = Setup + Foundational + **US1** (a claw's knowledge is discoverable on the card).
+Full value = + **US2** (deliberate distributed-RAG routing). **US3** makes it production-safe.
+
+## Parallel Opportunities
+
+- T002 ∥ T001-note; T005 ∥ T003/T004 review.
+- Within US1: T008/T009/T010 in parallel (all in one test file, independent cases).
+- Within US2: T016/T017/T018 in parallel after T011–T014.
+- Within US3: T022/T023 in parallel after T019–T021.
+- Polish: T024 (draft) ∥ T025 (walkthrough) ∥ T027 (deploy check); T026 after code tasks.

--- a/specs/064-knowledge-capability-cards/tasks.md
+++ b/specs/064-knowledge-capability-cards/tasks.md
@@ -26,9 +26,9 @@ Tests: `tests/n2n/`. Skill docs: `workspace/skills/`. Draft: `docs/ietf/`.
 
 **Purpose**: The content-free knowledge-entry builder that US1 advertises and US2/US3 depend on.
 
-- [ ] T003 Add a knowledge-advertisement builder in `mcp-servers/protocol-mcp/bgp/federation/inventory.py` that reads the RAG registry (via the T001 path) and returns one content-free entry per **ready** collection (`id`=`knowledge:<collection>`, `name`, `description` from titles/topics, `tags` from distinct `doc_type`, `doc_count`/`page_count`/`chunk_count`, `retrieval`=`n2n-knowledge/query`) per `data-model.md`. Never reads `source_path`/`content_hash`/`capture_*`.
+- [ ] T003 Create `mcp-servers/protocol-mcp/bgp/federation/knowledge.py` with a `build_entries()` that reads the RAG registry (via the T001 path) and returns one content-free entry per **ready** collection (`collection_id`=`knowledge:<collection>`, `name`, `description` from titles/topics, `tags` from distinct `doc_type`, `doc_count`/`page_count`/`chunk_count`, `retrieval`=`n2n/knowledge/query`) per `data-model.md`. Never reads `source_path`/`content_hash`/`capture_*`. (New module also hosts eN2N selection — T013/T014.)
 - [ ] T004 Extend `_assert_no_secrets` in `mcp-servers/protocol-mcp/bgp/federation/inventory.py` to also scan the `knowledge` array (reject any chunk text / path / hash / secret), so the invariant covers the new surface.
-- [ ] T005 [P] Add a `topic-only` description mode toggle (env/config, default off) in the T003 builder so titles can be suppressed without hiding the collection (research D5); default advertises titles.
+- [ ] T005 [P] Add a `topic-only` description mode toggle (env `N2N_KNOWLEDGE_TOPIC_ONLY`, default off) in `knowledge.build_entries()` so titles can be suppressed without hiding the collection (research D5); default advertises titles.
 
 **Checkpoint**: Builder produces correct content-free entries and the no-secrets invariant covers them (unit-testable without a live peer).
 
@@ -39,11 +39,12 @@ Tests: `tests/n2n/`. Skill docs: `workspace/skills/`. Draft: `docs/ietf/`.
 **Goal**: A peer pulling the card sees one content-free knowledge entry per authorized collection.
 **Independent test**: Ingest a doc, pull the card as a peer, confirm the collection is listed with counts and no content; hidden-for-peer filtering works.
 
-- [ ] T006 [US1] Wire the T003 builder into `InventoryBuilder.build` in `mcp-servers/protocol-mcp/bgp/federation/inventory.py`: add a `knowledge` array to the card (sibling of `skills`/`mcp_servers`), advertised **by default** (FR-003), filtered by the existing per-peer `_visibility` on `("knowledge", collection, peer_identity)`.
+- [ ] T006 [US1] Wire `knowledge.build_entries()` into `InventoryBuilder.build` in `mcp-servers/protocol-mcp/bgp/federation/inventory.py`: add a `knowledge` array to the card (sibling of `skills`/`mcp_servers`), advertised **by default** (FR-003), filtered by the existing per-peer `_visibility` on `("knowledge", collection, peer_identity)`.
 - [ ] T007 [US1] Extend the visibility mechanism (`n2n_set_visibility` path) to accept a `knowledge` kind so an operator can hide a collection from a given peer; confirm hidden collections drop from that peer's card only.
 - [ ] T008 [P] [US1] Test in `tests/n2n/test_knowledge_cards.py`: card lists one entry per ready collection with correct counts; a claw with zero ready docs emits no `knowledge` entries (absence, not empty).
 - [ ] T009 [P] [US1] Test in `tests/n2n/test_knowledge_cards.py`: the card contains no chunk text, no `source_path`, no `content_hash`; `_assert_no_secrets` passes with knowledge present and fails if a secret is injected.
 - [ ] T010 [P] [US1] Test in `tests/n2n/test_knowledge_cards.py`: per-peer visibility — hidden collection absent for peer X, present for peer Y; topic-only mode omits titles but keeps counts/tags.
+- [ ] T010a [P] [US1] Test in `tests/n2n/test_knowledge_cards.py` (SC-005): the serialized `knowledge` entry size is ~constant as document/chunk counts grow — build a card for a collection with N docs and 10×N docs and assert the entry byte size does not scale with corpus size.
 
 **Checkpoint**: US1 independently demonstrable — card advertisement complete and secret-safe.
 
@@ -54,14 +55,14 @@ Tests: `tests/n2n/`. Skill docs: `workspace/skills/`. Draft: `docs/ietf/`.
 **Goal**: A claw delegates a knowledge query to the peer whose corpus is authoritative and returns its cited answer.
 **Independent test**: On claw A with no local corpus on T but peer B advertising one, ask A about T → A routes to B, returns B's cited answer, does not fabricate.
 
-- [ ] T011 [US2] Implement the invocable retrieval skill handler `n2n-knowledge/query` in `mcp-servers/protocol-mcp/bgp/federation/invocation.py`: accept `{corpus_id, query, k}`, run `rag_search` against the **live** local RAG, and return `{answer, provenance:{peer, corpus_id, citations}}` per `contracts/knowledge-card-and-retrieval.md`. Register it in the service handler map.
-- [ ] T012 [US2] Wire the retrieval answer composition through `gateway.run_agent_turn` (or direct `rag_search` + compose) so the returned answer is grounded and carries the source's citations when present, in `mcp-servers/protocol-mcp/bgp/federation/gateway.py`/`invocation.py`.
-- [ ] T013 [US2] Implement knowledge-aware selection in `mcp-servers/protocol-mcp/bgp/federation/router.py`: score a query against all visible advertised collection descriptions (local + federated peers' cached cards), pick the best, deterministic tiebreak by ascending peer identity then `corpus_id`; return a Knowledge Route Decision (`target`, `peer_identity`, `corpus_id`, `score`, `rationale`) per `data-model.md`.
-- [ ] T014 [US2] Implement the fallback order in the router/agent path: matching **peer** corpus → **local** corpus → **model**; MUST NOT emit a `peer`/`corpus_id` when no corpus clears the relevance threshold (no fabricated source), in `mcp-servers/protocol-mcp/bgp/federation/router.py`.
-- [ ] T015 [US2] Add delegation guidance to `workspace/skills/n2n-federation/SKILL.md`: before answering a document/factual question, check peers' advertised knowledge and route to the authoritative corpus; state the peer→local→model fallback and the "never invent a federated source" rule.
-- [ ] T016 [P] [US2] Test in `tests/n2n/test_knowledge_routing.py`: deterministic selection — same query + same advertised set → same corpus; tiebreak applied and recorded in `rationale`.
-- [ ] T017 [P] [US2] Test in `tests/n2n/test_knowledge_routing.py`: peer-corpus match → route decision targets that peer/corpus; no match → `target=model`, no `peer_identity`/`corpus_id`.
-- [ ] T018 [P] [US2] Test in `tests/n2n/test_knowledge_routing.py`: `n2n-knowledge/query` against a granted, possession-tier peer returns an answer with provenance and citations (stub `rag_search`).
+- [ ] T011 [US2] Implement the **dedicated NCFED method** `n2n/knowledge/query` handler in `mcp-servers/protocol-mcp/bgp/federation/invocation.py` and register it in the service handler map (alongside `n2n/tasks/*`, NOT via the MCP `tools/call` proxy — finding H1): accept `{collection_id, query, k}`, run `rag_search` against the **live** local RAG, and return `{answer, provenance:{peer, collection_id, citations}}` per `contracts/knowledge-card-and-retrieval.md`.
+- [ ] T012 [US2] Compose the retrieval answer via a local **agent turn** (`gateway.run_agent_turn` fed the `rag_search` hits) so the result is a grounded, cited answer (not raw chunks; FR-008), in `mcp-servers/protocol-mcp/bgp/federation/invocation.py`/`gateway.py`.
+- [ ] T013 [US2] Implement eN2N knowledge selection in **`mcp-servers/protocol-mcp/bgp/federation/knowledge.py`** (NOT `router.py` — finding H2): embed the query with the RAG embedder, compute cosine similarity against all visible advertised collection descriptions (local + federated peers' cached cards in `service.peer_caps`), pick the highest, deterministic tiebreak by ascending peer identity then `collection_id`; return a Knowledge Route Decision (`target`, `peer_identity`, `collection_id`, `score`, `rationale`) per `data-model.md`.
+- [ ] T014 [US2] Implement threshold + fallback in `knowledge.py`: a collection matches only at score ≥ `N2N_KNOWLEDGE_MATCH_THRESHOLD` (default 0.5); fallback order **peer → local → model**; MUST NOT emit `peer`/`collection_id` when nothing clears the threshold (no fabricated source, FR-006).
+- [ ] T015 [US2] Add delegation guidance to `workspace/skills/n2n-federation/SKILL.md`: before answering a document/factual question, consult peers' advertised knowledge and route to the authoritative collection via `n2n/knowledge/query`; state the peer→local→model fallback and the "never invent a federated source" rule.
+- [ ] T016 [P] [US2] Test in `tests/n2n/test_knowledge_routing.py`: deterministic cosine selection — same query + same advertised set → same collection (stub the embedder for fixed vectors); tiebreak applied and recorded in `rationale`.
+- [ ] T017 [P] [US2] Test in `tests/n2n/test_knowledge_routing.py`: peer-collection above threshold → decision targets that peer/collection; nothing above threshold → `target=model`, no `peer_identity`/`collection_id`.
+- [ ] T018 [P] [US2] Test in `tests/n2n/test_knowledge_routing.py`: `n2n/knowledge/query` against a granted, possession-tier peer returns an agent-composed answer with provenance and citations (stub `rag_search` + agent turn).
 
 **Checkpoint**: US2 independently demonstrable — the Byrn book round-trip now happens by deliberate routing.
 
@@ -72,11 +73,11 @@ Tests: `tests/n2n/`. Skill docs: `workspace/skills/`. Draft: `docs/ietf/`.
 **Goal**: Federated knowledge respects visibility, per-peer authorization, admission tier, and audit.
 **Independent test**: unauthorized/ hidden-corpus/ restricted-tier attempts are all refused and audited; successful retrieval is audited with corpus + GAIT.
 
-- [ ] T019 [US3] Enforce default-deny + possession tier on `n2n-knowledge/query` in `mcp-servers/protocol-mcp/bgp/federation/invocation.py`: reuse `negotiate.allows` so a self-asserted (keyless) peer is denied, and require a per-peer grant for the corpus (default-deny) — reusing the authorizer path used by `tools/call`/`tasks/submit`.
-- [ ] T020 [US3] No existence oracle: an unknown or not-visible `corpus_id` MUST be answered exactly as "no such corpus" (same shape as a missing one), in `mcp-servers/protocol-mcp/bgp/federation/invocation.py`.
-- [ ] T021 [US3] Emit one audit record per retrieval in `invocation.py` via the existing `Auditor`: `{direction=inbound, peer_identity, target_type="knowledge", target_name=corpus_id, decision, outcome, channel_kind, gait_ref}` (FR-007).
+- [ ] T019 [US3] Extend the **T011 handler** in `mcp-servers/protocol-mcp/bgp/federation/invocation.py` (edit it in place, not a parallel path — finding L1) to enforce default-deny + possession tier on `n2n/knowledge/query`: reuse `negotiate.allows` so a self-asserted (keyless) peer is denied, and require a per-peer grant for the collection (default-deny), reusing the authorizer path used by `tools/call`/`tasks/submit`. The grant is the Principle-XIV control point (FR-007).
+- [ ] T020 [US3] No existence oracle: an unknown or not-visible `collection_id` MUST be answered exactly as "no such collection" (same shape as a missing one), in `mcp-servers/protocol-mcp/bgp/federation/invocation.py`.
+- [ ] T021 [US3] Emit one audit record per retrieval in `invocation.py` via the existing `Auditor`: `{direction=inbound, peer_identity, target_type="knowledge", target_name=collection_id, decision, outcome, channel_kind, gait_ref}` (FR-007).
 - [ ] T022 [P] [US3] Test in `tests/n2n/test_knowledge_routing.py`: self-asserted (tier-0) peer denied retrieval but may still see authorized knowledge advertisements; possession-tier peer without a grant denied (default-deny); both audited.
-- [ ] T023 [P] [US3] Test in `tests/n2n/test_knowledge_routing.py`: hidden/unknown `corpus_id` returns the missing-corpus shape (no existence leak); successful retrieval produces exactly one audit record with corpus + GAIT reference.
+- [ ] T023 [P] [US3] Test in `tests/n2n/test_knowledge_routing.py`: hidden/unknown `collection_id` returns the missing-collection shape (no existence leak); successful retrieval produces exactly one audit record with collection + GAIT reference.
 
 **Checkpoint**: US3 independently demonstrable — sovereignty/audit guarantees hold under adversarial peers.
 
@@ -105,7 +106,7 @@ Full value = + **US2** (deliberate distributed-RAG routing). **US3** makes it pr
 ## Parallel Opportunities
 
 - T002 ∥ T001-note; T005 ∥ T003/T004 review.
-- Within US1: T008/T009/T010 in parallel (all in one test file, independent cases).
+- Within US1: T008/T009/T010/T010a in parallel (all in one test file, independent cases).
 - Within US2: T016/T017/T018 in parallel after T011–T014.
 - Within US3: T022/T023 in parallel after T019–T021.
 - Polish: T024 (draft) ∥ T025 (walkthrough) ∥ T027 (deploy check); T026 after code tasks.

--- a/specs/064-knowledge-capability-cards/tasks.md
+++ b/specs/064-knowledge-capability-cards/tasks.md
@@ -17,7 +17,7 @@ Tests: `tests/n2n/`. Skill docs: `workspace/skills/`. Draft: `docs/ietf/`.
 
 ## Phase 1: Setup
 
-- [ ] T001 Confirm the feature-062 RAG surface is callable from the daemon env: `rag_list` (registry) and `rag_search` (retrieval) resolve and return expected shapes; note the exact call path (direct import vs. MCP stdio) to use from `bgp/federation/` in `specs/064-knowledge-capability-cards/research.md` (append a "D7 — RAG call path" note).
+- [X] T001 Confirm the feature-062 RAG surface is callable from the daemon env: `rag_list` (registry) and `rag_search` (retrieval) resolve and return expected shapes; note the exact call path (direct import vs. MCP stdio) to use from `bgp/federation/` in `specs/064-knowledge-capability-cards/research.md` (append a "D7 — RAG call path" note).
 - [ ] T002 [P] Create empty test modules `tests/n2n/test_knowledge_cards.py` and `tests/n2n/test_knowledge_routing.py` with the shared fixtures import (`conftest.py` manager fixture) so later test tasks just add cases.
 
 ---
@@ -26,9 +26,9 @@ Tests: `tests/n2n/`. Skill docs: `workspace/skills/`. Draft: `docs/ietf/`.
 
 **Purpose**: The content-free knowledge-entry builder that US1 advertises and US2/US3 depend on.
 
-- [ ] T003 Create `mcp-servers/protocol-mcp/bgp/federation/knowledge.py` with a `build_entries()` that reads the RAG registry (via the T001 path) and returns one content-free entry per **ready** collection (`collection_id`=`knowledge:<collection>`, `name`, `description` from titles/topics, `tags` from distinct `doc_type`, `doc_count`/`page_count`/`chunk_count`, `retrieval`=`n2n/knowledge/query`) per `data-model.md`. Never reads `source_path`/`content_hash`/`capture_*`. (New module also hosts eN2N selection — T013/T014.)
-- [ ] T004 Extend `_assert_no_secrets` in `mcp-servers/protocol-mcp/bgp/federation/inventory.py` to also scan the `knowledge` array (reject any chunk text / path / hash / secret), so the invariant covers the new surface.
-- [ ] T005 [P] Add a `topic-only` description mode toggle (env `N2N_KNOWLEDGE_TOPIC_ONLY`, default off) in `knowledge.build_entries()` so titles can be suppressed without hiding the collection (research D5); default advertises titles.
+- [X] T003 Create `mcp-servers/protocol-mcp/bgp/federation/knowledge.py` with a `build_entries()` that reads the RAG registry (via the T001 path) and returns one content-free entry per **ready** collection (`collection_id`=`knowledge:<collection>`, `name`, `description` from titles/topics, `tags` from distinct `doc_type`, `doc_count`/`page_count`/`chunk_count`, `retrieval`=`n2n/knowledge/query`) per `data-model.md`. Never reads `source_path`/`content_hash`/`capture_*`. (New module also hosts eN2N selection — T013/T014.)
+- [X] T004 Extend `_assert_no_secrets` in `mcp-servers/protocol-mcp/bgp/federation/inventory.py` to also scan the `knowledge` array (reject any chunk text / path / hash / secret), so the invariant covers the new surface.
+- [X] T005 [P] Add a `topic-only` description mode toggle (env `N2N_KNOWLEDGE_TOPIC_ONLY`, default off) in `knowledge.build_entries()` so titles can be suppressed without hiding the collection (research D5); default advertises titles.
 
 **Checkpoint**: Builder produces correct content-free entries and the no-secrets invariant covers them (unit-testable without a live peer).
 
@@ -39,12 +39,12 @@ Tests: `tests/n2n/`. Skill docs: `workspace/skills/`. Draft: `docs/ietf/`.
 **Goal**: A peer pulling the card sees one content-free knowledge entry per authorized collection.
 **Independent test**: Ingest a doc, pull the card as a peer, confirm the collection is listed with counts and no content; hidden-for-peer filtering works.
 
-- [ ] T006 [US1] Wire `knowledge.build_entries()` into `InventoryBuilder.build` in `mcp-servers/protocol-mcp/bgp/federation/inventory.py`: add a `knowledge` array to the card (sibling of `skills`/`mcp_servers`), advertised **by default** (FR-003), filtered by the existing per-peer `_visibility` on `("knowledge", collection, peer_identity)`.
-- [ ] T007 [US1] Extend the visibility mechanism (`n2n_set_visibility` path) to accept a `knowledge` kind so an operator can hide a collection from a given peer; confirm hidden collections drop from that peer's card only.
-- [ ] T008 [P] [US1] Test in `tests/n2n/test_knowledge_cards.py`: card lists one entry per ready collection with correct counts; a claw with zero ready docs emits no `knowledge` entries (absence, not empty).
-- [ ] T009 [P] [US1] Test in `tests/n2n/test_knowledge_cards.py`: the card contains no chunk text, no `source_path`, no `content_hash`; `_assert_no_secrets` passes with knowledge present and fails if a secret is injected.
-- [ ] T010 [P] [US1] Test in `tests/n2n/test_knowledge_cards.py`: per-peer visibility — hidden collection absent for peer X, present for peer Y; topic-only mode omits titles but keeps counts/tags.
-- [ ] T010a [P] [US1] Test in `tests/n2n/test_knowledge_cards.py` (SC-005): the serialized `knowledge` entry size is ~constant as document/chunk counts grow — build a card for a collection with N docs and 10×N docs and assert the entry byte size does not scale with corpus size.
+- [X] T006 [US1] Wire `knowledge.build_entries()` into `InventoryBuilder.build` in `mcp-servers/protocol-mcp/bgp/federation/inventory.py`: add a `knowledge` array to the card (sibling of `skills`/`mcp_servers`), advertised **by default** (FR-003), filtered by the existing per-peer `_visibility` on `("knowledge", collection, peer_identity)`.
+- [X] T007 [US1] Extend the visibility mechanism (`n2n_set_visibility` path) to accept a `knowledge` kind so an operator can hide a collection from a given peer; confirm hidden collections drop from that peer's card only.
+- [X] T008 [P] [US1] Test in `tests/n2n/test_knowledge_cards.py`: card lists one entry per ready collection with correct counts; a claw with zero ready docs emits no `knowledge` entries (absence, not empty).
+- [X] T009 [P] [US1] Test in `tests/n2n/test_knowledge_cards.py`: the card contains no chunk text, no `source_path`, no `content_hash`; `_assert_no_secrets` passes with knowledge present and fails if a secret is injected.
+- [X] T010 [P] [US1] Test in `tests/n2n/test_knowledge_cards.py`: per-peer visibility — hidden collection absent for peer X, present for peer Y; topic-only mode omits titles but keeps counts/tags.
+- [X] T010a [P] [US1] Test in `tests/n2n/test_knowledge_cards.py` (SC-005): the serialized `knowledge` entry size is ~constant as document/chunk counts grow — build a card for a collection with N docs and 10×N docs and assert the entry byte size does not scale with corpus size.
 
 **Checkpoint**: US1 independently demonstrable — card advertisement complete and secret-safe.
 

--- a/tests/n2n/test_knowledge_cards.py
+++ b/tests/n2n/test_knowledge_cards.py
@@ -1,0 +1,170 @@
+"""Feature 064 US1: knowledge advertised on the capability card.
+
+Covers T008 (per-collection entries + absence), T009 (content-free / no-secrets),
+T010 (per-peer visibility + topic-only), T010a (card size independent of corpus
+size, SC-005).
+"""
+
+import json
+import sqlite3
+
+import pytest
+
+from bgp.federation import knowledge as kn
+from bgp.federation.inventory import InventoryBuilder
+
+
+def _make_rag_db(dirpath, docs):
+    """Write a minimal feature-062 rag.db `documents` table. Each doc is a dict
+    with at least collection/title/doc_type/page_count/chunk_count; source_path
+    and content_hash are populated to prove they never reach the card."""
+    dirpath.mkdir(parents=True, exist_ok=True)
+    db = dirpath / "rag.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE documents (id TEXT, collection TEXT, title TEXT, doc_type TEXT, "
+        "page_count INT, chunk_count INT, ingest_status TEXT, source_path TEXT, "
+        "content_hash TEXT)")
+    for i, d in enumerate(docs):
+        conn.execute(
+            "INSERT INTO documents VALUES (?,?,?,?,?,?,?,?,?)",
+            (f"doc_{i}", d.get("collection", "documents"), d.get("title"),
+             d.get("doc_type"), d.get("page_count", 0), d.get("chunk_count", 0),
+             d.get("ingest_status", "ready"),
+             "/home/secret/path/original.pdf", "deadbeefcafe" * 4))
+    conn.commit()
+    conn.close()
+    return db
+
+
+def _repo(tmp_path):
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "openclaw.json").write_text(json.dumps({"mcpServers": {}}))
+    (tmp_path / "workspace" / "skills").mkdir(parents=True)
+    env = tmp_path / ".env"
+    env.write_text("SOME_SECRET=xyzzy-secret-123\n")
+    return tmp_path, str(env)
+
+
+def _builder(manager, tmp_path, rag_dir, monkeypatch):
+    monkeypatch.setenv("RAG_DATA_DIR", str(rag_dir))
+    monkeypatch.delenv("N2N_KNOWLEDGE_TOPIC_ONLY", raising=False)
+    repo, env = _repo(tmp_path)
+    return InventoryBuilder(manager, repo_root=str(repo),
+                            openclaw_config=str(repo / "config" / "openclaw.json"),
+                            env_path=env)
+
+
+# ---- T008 -----------------------------------------------------------------
+
+def test_one_entry_per_collection_with_counts(manager, tmp_path, monkeypatch):
+    _make_rag_db(tmp_path / "rag", [
+        {"collection": "documents", "title": "Automate Your Network",
+         "doc_type": "install-guide", "page_count": 212, "chunk_count": 389},
+        {"collection": "runbooks", "title": "BGP Runbook",
+         "doc_type": "runbook", "page_count": 10, "chunk_count": 20},
+    ])
+    b = _builder(manager, tmp_path, tmp_path / "rag", monkeypatch)
+    inv = b.build("as65007-7.7.7.7")
+    ids = {e["collection_id"]: e for e in inv["knowledge"]}
+    assert set(ids) == {"knowledge:documents", "knowledge:runbooks"}
+    docs = ids["knowledge:documents"]
+    assert docs["doc_count"] == 1 and docs["page_count"] == 212 and docs["chunk_count"] == 389
+    assert docs["retrieval"] == "n2n/knowledge/query"
+    assert "install-guide" in docs["tags"]
+
+
+def test_no_ready_docs_means_no_knowledge(manager, tmp_path, monkeypatch):
+    _make_rag_db(tmp_path / "rag", [
+        {"collection": "documents", "title": "Draft", "doc_type": "x",
+         "ingest_status": "pending"}])
+    b = _builder(manager, tmp_path, tmp_path / "rag", monkeypatch)
+    inv = b.build("as65007-7.7.7.7")
+    assert inv["knowledge"] == []
+
+
+def test_no_rag_db_means_no_knowledge(manager, tmp_path, monkeypatch):
+    b = _builder(manager, tmp_path, tmp_path / "empty", monkeypatch)  # no rag.db
+    inv = b.build("as65007-7.7.7.7")
+    assert inv["knowledge"] == []
+
+
+# ---- T009 -----------------------------------------------------------------
+
+def test_card_is_content_free(manager, tmp_path, monkeypatch):
+    _make_rag_db(tmp_path / "rag", [
+        {"collection": "documents", "title": "Automate Your Network",
+         "doc_type": "install-guide", "page_count": 212, "chunk_count": 389}])
+    b = _builder(manager, tmp_path, tmp_path / "rag", monkeypatch)
+    inv = b.build("as65007-7.7.7.7")
+    blob = json.dumps(inv["knowledge"])
+    assert "/home/secret/path" not in blob          # no source_path
+    assert "deadbeefcafe" not in blob               # no content_hash
+    # only the allowed keys are present
+    for e in inv["knowledge"]:
+        kn.assert_entry_clean(e)
+
+
+def test_no_secrets_guard_covers_knowledge(manager, tmp_path, monkeypatch):
+    # a secret value that leaks into a description must trip _assert_no_secrets
+    _make_rag_db(tmp_path / "rag", [
+        {"collection": "documents", "title": "xyzzy-secret-123 leak",
+         "doc_type": "x", "page_count": 1, "chunk_count": 1}])
+    b = _builder(manager, tmp_path, tmp_path / "rag", monkeypatch)
+    with pytest.raises(ValueError):
+        b.build("as65007-7.7.7.7")
+
+
+def test_assert_entry_clean_rejects_forbidden_key():
+    with pytest.raises(ValueError):
+        kn.assert_entry_clean({"collection_id": "knowledge:x", "source_path": "/etc/passwd"})
+
+
+# ---- T010 -----------------------------------------------------------------
+
+def test_per_peer_visibility(manager, tmp_path, monkeypatch):
+    _make_rag_db(tmp_path / "rag", [
+        {"collection": "documents", "title": "Book", "doc_type": "g",
+         "page_count": 1, "chunk_count": 1}])
+    b = _builder(manager, tmp_path, tmp_path / "rag", monkeypatch)
+    # hide 'documents' from peer X only
+    manager._conn.execute(
+        "INSERT OR REPLACE INTO visibility_setting (item_type,item_name,visibility,peer_list) "
+        "VALUES ('knowledge','documents','hidden',NULL)")
+    manager._conn.commit()
+    inv_x = b.build("as65099-9.9.9.9")
+    assert inv_x["knowledge"] == []
+    # a fresh collection visible to a permitted peer when not hidden
+    manager._conn.execute("DELETE FROM visibility_setting WHERE item_type='knowledge'")
+    manager._conn.commit()
+    inv_y = b.build("as65007-7.7.7.7")
+    assert any(e["collection_id"] == "knowledge:documents" for e in inv_y["knowledge"])
+
+
+def test_topic_only_omits_titles(manager, tmp_path, monkeypatch):
+    _make_rag_db(tmp_path / "rag", [
+        {"collection": "documents", "title": "Automate Your Network",
+         "doc_type": "install-guide", "page_count": 1, "chunk_count": 1}])
+    b = _builder(manager, tmp_path, tmp_path / "rag", monkeypatch)
+    monkeypatch.setenv("N2N_KNOWLEDGE_TOPIC_ONLY", "1")
+    inv = b.build("as65007-7.7.7.7")
+    e = inv["knowledge"][0]
+    assert "Automate Your Network" not in e["description"]   # title suppressed
+    assert "install-guide" in e["description"]               # tag/topic kept
+    assert e["doc_count"] == 1
+
+
+# ---- T010a (SC-005) -------------------------------------------------------
+
+def test_card_size_independent_of_corpus_size(manager, tmp_path, monkeypatch):
+    small = [{"collection": "documents", "title": "Automate Your Network",
+              "doc_type": "install-guide", "page_count": 212, "chunk_count": 389}]
+    # 10x the documents/pages/chunks in the SAME collection
+    big = [{"collection": "documents", "title": "Automate Your Network",
+            "doc_type": "install-guide", "page_count": 2120, "chunk_count": 3890}
+           for _ in range(10)]
+    e_small = kn.build_entries(db_path=_make_rag_db(tmp_path / "s", small))
+    e_big = kn.build_entries(db_path=_make_rag_db(tmp_path / "b", big))
+    assert len(e_small) == len(e_big) == 1
+    # entry byte size does not scale with corpus size (counts are ints; titles deduped)
+    assert abs(len(json.dumps(e_big[0])) - len(json.dumps(e_small[0]))) < 40

--- a/tests/n2n/test_knowledge_routing.py
+++ b/tests/n2n/test_knowledge_routing.py
@@ -1,0 +1,170 @@
+"""Feature 064 US2/US3: knowledge-aware routing + the n2n/knowledge/query method.
+
+Covers T016 (deterministic cosine selection + tiebreak), T017 (peer/local/model
+targets + threshold), T018 (granted possession-tier retrieval returns a composed
+cited answer), T022 (tier-0 + default-deny denials, audited), T023 (no existence
+oracle + one audit record on success).
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from bgp.federation import knowledge as kn
+
+
+# ---- fixtures -------------------------------------------------------------
+
+def _entry(cid, desc):
+    return {"collection_id": cid, "name": cid, "description": desc, "tags": [],
+            "doc_count": 1, "page_count": 1, "chunk_count": 1,
+            "retrieval": "n2n/knowledge/query"}
+
+
+@pytest.fixture
+def fixed_embedder(monkeypatch):
+    """Deterministic stand-in for the embedder: map known texts to fixed vectors
+    so cosine scores are stable and assertable (T016)."""
+    vecs = {
+        "book about network automation": [1.0, 0.0],
+        "Automate Your Network — network automation, Ansible": [0.98, 0.02],
+        "Kubernetes operations and Helm charts": [0.0, 1.0],
+    }
+    monkeypatch.setattr(kn, "_embed_texts",
+                        lambda texts: [vecs.get(t, [0.5, 0.5]) for t in texts])
+    return vecs
+
+
+# ---- T016 / T017: selection ----------------------------------------------
+
+def test_deterministic_selection_and_target(fixed_embedder):
+    sources = [
+        {"source": "as65099-9.9.9.9", "entries": [
+            _entry("knowledge:book", "Automate Your Network — network automation, Ansible")]},
+        {"source": "local", "entries": [
+            _entry("knowledge:k8s", "Kubernetes operations and Helm charts")]},
+    ]
+    d1 = kn.select_collection("book about network automation", sources, threshold=0.5)
+    d2 = kn.select_collection("book about network automation", sources, threshold=0.5)
+    assert d1 == d2                                   # deterministic
+    assert d1["target"] == "peer"
+    assert d1["peer_identity"] == "as65099-9.9.9.9"
+    assert d1["collection_id"] == "knowledge:book"
+    assert d1["score"] >= 0.5
+
+
+def test_local_wins_when_highest(fixed_embedder):
+    sources = [
+        {"source": "local", "entries": [
+            _entry("knowledge:book", "Automate Your Network — network automation, Ansible")]},
+        {"source": "as65099-9.9.9.9", "entries": [
+            _entry("knowledge:k8s", "Kubernetes operations and Helm charts")]},
+    ]
+    d = kn.select_collection("book about network automation", sources, threshold=0.5)
+    assert d["target"] == "local" and d["peer_identity"] is None
+
+
+def test_below_threshold_falls_back_to_model(fixed_embedder):
+    sources = [{"source": "as65099-9.9.9.9", "entries": [
+        _entry("knowledge:k8s", "Kubernetes operations and Helm charts")]}]
+    d = kn.select_collection("book about network automation", sources, threshold=0.5)
+    assert d["target"] == "model"
+    assert d["peer_identity"] is None and d["collection_id"] is None
+
+
+def test_tiebreak_is_stable(monkeypatch):
+    # identical scores → deterministic tiebreak by ascending source then id
+    monkeypatch.setattr(kn, "_embed_texts", lambda texts: [[1.0, 0.0] for _ in texts])
+    sources = [
+        {"source": "as65099-9.9.9.9", "entries": [_entry("knowledge:z", "same")]},
+        {"source": "as65007-7.7.7.7", "entries": [_entry("knowledge:a", "same")]},
+    ]
+    d = kn.select_collection("q", sources, threshold=0.0)
+    assert d["peer_identity"] == "as65007-7.7.7.7"     # lower source wins tie
+
+
+def test_lexical_fallback_when_no_embedder(monkeypatch):
+    monkeypatch.setattr(kn, "_embed_texts", lambda texts: None)   # embedder unavailable
+    sources = [{"source": "local", "entries": [
+        _entry("knowledge:book", "network automation ansible book guide")]}]
+    d = kn.select_collection("network automation book", sources, threshold=0.1)
+    assert d["target"] == "local" and d["score"] > 0.0
+
+
+# ---- handler tests (US2 T018 / US3 T022, T023) ----------------------------
+
+def _service(manager, monkeypatch, tmp_path):
+    """A FederationService wired enough to exercise handle_knowledge_query."""
+    from bgp.federation.service import FederationService
+    monkeypatch.setenv("RAG_DATA_DIR", str(tmp_path / "norag"))  # no real rag
+    svc = FederationService(local_as=65001, router_id="4.4.4.4", manager=manager)
+    # advertise one collection regardless of rag.db (visible-set source)
+    monkeypatch.setattr(kn, "build_entries",
+                        lambda *a, **k: [_entry("knowledge:documents", "the book")])
+    return svc
+
+
+class _Chan:
+    def __init__(self, peer, attestation="possession"):
+        self.peer_identity = peer
+        self.attestation = attestation
+
+
+def _federate(manager, peer_as=65099, rid="9.9.9.9"):
+    manager.local_consent(peer_as, rid)
+    manager.remote_consent(peer_as, rid)
+    return f"as{peer_as}-{rid}"
+
+
+def test_tier0_peer_denied(manager, monkeypatch, tmp_path):
+    svc = _service(manager, monkeypatch, tmp_path)
+    peer = _federate(manager)
+    from bgp.federation.channel import RpcError
+    with pytest.raises(RpcError):
+        asyncio.run(svc.invoker.handle_knowledge_query(
+            _Chan(peer, attestation="self-asserted"),
+            {"collection_id": "knowledge:documents", "query": "hi"}))
+
+
+def test_no_grant_denied_default_deny(manager, monkeypatch, tmp_path):
+    svc = _service(manager, monkeypatch, tmp_path)
+    peer = _federate(manager)
+    from bgp.federation.channel import RpcError
+    with pytest.raises(RpcError):   # possession tier but no grant → not_allowlisted
+        asyncio.run(svc.invoker.handle_knowledge_query(
+            _Chan(peer), {"collection_id": "knowledge:documents", "query": "hi"}))
+
+
+def test_unknown_collection_is_not_an_oracle(manager, monkeypatch, tmp_path):
+    svc = _service(manager, monkeypatch, tmp_path)
+    peer = _federate(manager)
+    svc.authz.grant(peer, "knowledge", "knowledge:documents")
+    # hidden/unknown id → not_found shape, identical whether it exists or not
+    res = asyncio.run(svc.invoker.handle_knowledge_query(
+        _Chan(peer), {"collection_id": "knowledge:secret", "query": "hi"}))
+    assert res["not_found"] is True and res["answer"] is None
+
+
+def test_granted_retrieval_returns_composed_answer(manager, monkeypatch, tmp_path):
+    svc = _service(manager, monkeypatch, tmp_path)
+    peer = _federate(manager)
+    svc.authz.grant(peer, "knowledge", "knowledge:documents")
+
+    async def fake_turn(prompt, **kw):
+        return ("Automate Your Network is about network automation (Preface p.13).", 42)
+    import bgp.federation.gateway as gw
+    monkeypatch.setattr(gw, "run_agent_turn", fake_turn)
+
+    res = asyncio.run(svc.invoker.handle_knowledge_query(
+        _Chan(peer), {"collection_id": "knowledge:documents",
+                      "query": "summarize the book", "request_id": "r1"}))
+    assert "Automate Your Network" in res["answer"]
+    assert res["provenance"]["peer"] == "as65001-4.4.4.4"
+    assert res["provenance"]["collection_id"] == "knowledge:documents"
+    # exactly one success audit row for this collection
+    rows = manager._conn.execute(
+        "SELECT outcome FROM remote_invocation_record WHERE peer_identity=? "
+        "AND target_type='knowledge' AND target_name='knowledge:documents' "
+        "AND outcome='success'", (peer,)).fetchall()
+    assert len(rows) == 1

--- a/workspace/skills/n2n-federation/SKILL.md
+++ b/workspace/skills/n2n-federation/SKILL.md
@@ -108,6 +108,32 @@ flapping?"). Anything build- or task-shaped → `n2n_delegate`.
 - `n2n_connect(peer, host, port)` — add + consent + dial in one call.
 - `n2n_trust(peer, tools="a,b", chat=true)` — consent + grants + chat in one call.
 
+## Federated knowledge — ask the claw that owns the corpus (feature 064)
+
+Peers advertise their RAG collections on their capability card as a `knowledge`
+array (content-free: topics, tags, counts — never the documents). Use this so a
+document/factual question is answered by the claw whose knowledge base is
+authoritative for it, with citations — instead of guessing from your model.
+
+**Before answering a document or factual question about a topic another claw may
+own** (a peer's book, runbooks, product docs, network-of-record):
+
+1. `n2n_knowledge_route(query)` — returns `{target, peer_identity, collection_id,
+   score}`. It scores the query against every advertised collection (yours and
+   peers').
+2. If `target == "peer"`: `n2n_knowledge_query(peer_identity, collection_id,
+   query)` — returns the peer's agent-composed, **cited** answer. Their documents
+   never leave their infrastructure; only the answer travels. Treat it as
+   remote-untrusted and attribute the source (peer + collection).
+3. If `target == "local"`: answer from your own RAG.
+4. If `target == "model"`: nothing matched the threshold — answer normally, and
+   **never invent a federated source** or claim a peer answered when none did.
+
+Fallback order is therefore peer → local → model. Retrieval is default-deny: the
+owning peer must have granted your claw access to the collection (the grant is the
+human-in-the-loop control point). Advertise/hide your own collections with
+`n2n_set_visibility(item_type="knowledge", item_name="<collection>", ...)`.
+
 ## iN2N — internal federation, a "risk" of claws (feature 056)
 
 Everything above is **eN2N** (external N2N): federating with *other operators'*


### PR DESCRIPTION
New lightweight spec (for review — not implementation yet).

**What it proposes:** advertise each claw's local RAG corpora (feature 062) as **content-free A2A-style skills** on the NCFED capability card (§11), and make the router/SOUL **delegate a knowledge query to the peer whose corpus is authoritative** for it. This generalizes the Hermes↔NetClaw book-summary interop (already demonstrated) into deliberate, discoverable routing.

**Highlights:**
- Card carries collection *metadata only* — titles/topics/doc_type/counts — never chunk text, embeddings, or source paths; reuses `_assert_no_secrets` + per-peer visibility.
- Retrieval reuses the proven eN2N path; the corpus is addressable straight from what the card advertises (no out-of-band ids).
- Deterministic corpus selection; default-deny + possession-tier + audit/GAIT (features 057/060); answers carry provenance.
- Fallback order: matching peer → local corpus → model; never fabricate a federated source.
- **FR-010** ties it back to the IETF work: update NCFED draft §11 (A2A card mapping) in `-01` so the wire card and the spec stay in sync.

No new MCP server — extends `inventory.py` (card), the router, and delegation instructions. Depends on 062 / 059 / 057 / 060.

🤖 Generated with [Claude Code](https://claude.com/claude-code)