### PR TITLE
fix(068): heartbeat, stale-answer recovery, session-key, HUD edge-node liveness

### DIFF
--- a/mcp-servers/protocol-mcp/bgp-daemon-v2.py
+++ b/mcp-servers/protocol-mcp/bgp-daemon-v2.py
@@ -624,9 +624,19 @@ async def handle_n2n(method, path, body):
                 {"member_id": m["member_id"], "display_name": m["display_name"],
                  "profile": m["profile"], "state": m["state"],
                  "transport_binding": m["transport_binding"],
+                 "node_type": m["node_type"],
                  "specialty_count": fed.risk.specialty_count(m["scope"]),
                  "skills": _spec_names(m["scope"]),
-                 "live": m["member_id"] in fed.member_channels}
+                 # An edge (phone) member's live connection lives in
+                 # edge_channels, never member_channels (agent members
+                 # only) -- checking only the latter meant every edge node
+                 # showed live=false forever regardless of actual
+                 # connection health, and the HUD's own edge-node panel
+                 # (node_type filter) silently rendered nothing since 066
+                 # first shipped, since node_type wasn't even in this
+                 # response at all until this fix.
+                 "live": m["member_id"] in fed.member_channels
+                         or m["member_id"] in fed.edge_channels}
                 for m in fed.risk.list_members()]}
 
         if path == "/n2n/members/health" and method == "GET":
@@ -639,7 +649,8 @@ async def handle_n2n(method, path, body):
                     health = {}
                 out.append({"member_id": m["member_id"], "state": m["state"],
                             "auth_failures": m["auth_failures"],
-                            "live": m["member_id"] in fed.member_channels,
+                            "live": m["member_id"] in fed.member_channels
+                                    or m["member_id"] in fed.edge_channels,
                             "health": health})
             return 200, {"members": out}
 

--- a/mcp-servers/protocol-mcp/bgp/federation/service.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/service.py
@@ -1281,8 +1281,14 @@ class FederationService:
                 with os.fdopen(fd, "w") as f:
                     f.write(f"{prompt}\n\n[Attached {content_type}, base64-encoded]\n{content}\n")
             try:
+                # openclaw agent's --session-id/--session-key rejects a
+                # value containing "/" ("Invalid session ID") -- every
+                # edge member_id is risk-scoped ("risk/<label>") and always
+                # contains one, so it must be sanitized here, unlike peer/
+                # skill identifiers elsewhere in this file which never do.
+                session_key = "n2n-edge-" + member_id.replace("/", "_")
                 output, tokens = await run_agent_turn(
-                    prompt, session_key=f"n2n-edge-{member_id}", untrusted=False,
+                    prompt, session_key=session_key, untrusted=False,
                     message_file=message_file)
             finally:
                 if message_file:

--- a/mobile/netclaw-mobile/lib/main.dart
+++ b/mobile/netclaw-mobile/lib/main.dart
@@ -13,6 +13,7 @@ import 'ncfed/edge_ask_client.dart';
 import 'ncfed/edge_client.dart';
 import 'ncfed/edge_identity.dart';
 import 'ncfed/enrollment_store.dart';
+import 'ncfed/heartbeat.dart';
 import 'ncfed/message_feed.dart';
 import 'ncfed/push_registration.dart';
 import 'ncfed/reconnect_supervisor.dart';
@@ -174,6 +175,7 @@ class _HomeShellState extends State<HomeShell> {
       final approvalClient = ApprovalClient(widget.client);
       final capabilities = CapabilityRegistration(widget.client);
       wireMessageFeed(widget.client, feedStore, onApproval: approvalClient.receiveApproval);
+      wireHeartbeat(widget.client);
       CaptureClient(
         askClient: askClient,
         capture: (type) => CaptureScreen.capture(context, type),

--- a/mobile/netclaw-mobile/lib/ncfed/edge_ask_client.dart
+++ b/mobile/netclaw-mobile/lib/ncfed/edge_ask_client.dart
@@ -83,6 +83,19 @@ class EdgeAskClient {
     return TaskUpdate(taskId: taskId, state: _parseTaskState(result['state'] as String?));
   }
 
+  /// Fetches the full answer for a task that already finished — unlike
+  /// [status], which only reports state. Needed for recovery: a task that
+  /// completes while this device is disconnected (or its `ask_result` push
+  /// simply never arrives) has no other way to reach the phone, since the
+  /// Border never re-pushes a result spontaneously (contracts/
+  /// edge-ask-command-channel.md: "a disconnected phone recovers via
+  /// n2n/tasks/status|result on reconnect"). The response shape matches
+  /// `ask_result`'s exactly (`task_id`/`state`/`output_text`/`tokens_used`).
+  Future<TaskUpdate> result(String taskId) async {
+    final result = await client.call('n2n/tasks/result', {'task_id': taskId});
+    return TaskUpdate.fromAskResult(result);
+  }
+
   void dispose() {
     _updates.close();
   }

--- a/mobile/netclaw-mobile/lib/ncfed/heartbeat.dart
+++ b/mobile/netclaw-mobile/lib/ncfed/heartbeat.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+
+import 'edge_client.dart';
+
+/// Answers the Border's `n2n/edge/heartbeat`/`n2n/edge/self_status` calls
+/// (066, `_edge_heartbeat_once`/`edge_self_status`) — without this, the
+/// Border's periodic heartbeat call finds no handler registered, silently
+/// times out every interval, and the device is marked unreachable/`live:
+/// false` even while its WebSocket connection is perfectly healthy. Neither
+/// call's response body is validated by the Border beyond "did it reply at
+/// all" (heartbeat) or "store whatever came back" (self_status) — this is
+/// deliberately minimal, not a rich device-telemetry surface.
+void wireHeartbeat(EdgeMethodSource client) {
+  client.on('n2n/edge/heartbeat', (params) async => <String, dynamic>{});
+  client.on('n2n/edge/self_status', (params) async => <String, dynamic>{
+        'platform': Platform.operatingSystem,
+      });
+}

--- a/mobile/netclaw-mobile/lib/screens/chat_screen.dart
+++ b/mobile/netclaw-mobile/lib/screens/chat_screen.dart
@@ -32,20 +32,50 @@ class _ChatScreenState extends State<ChatScreen> {
   @override
   void initState() {
     super.initState();
-    widget.store.load().then((_) {
+    widget.store.load().then((_) async {
       if (mounted) setState(() => _loading = false);
+      await _reconcileStaleTurns();
     });
     widget.askClient.updates.listen((update) async {
-      final stateName = switch (update.state) {
-        TaskState.completed => 'completed',
-        TaskState.failed => 'failed',
-        TaskState.cancelled => 'cancelled',
-        TaskState.working => 'working',
-        _ => 'pending',
-      };
-      await widget.store.updateState(update.taskId, stateName, answerText: update.outputText);
-      if (mounted) setState(() {});
+      await _applyUpdate(update);
     });
+  }
+
+  Future<void> _applyUpdate(TaskUpdate update) async {
+    final stateName = switch (update.state) {
+      TaskState.completed => 'completed',
+      TaskState.failed => 'failed',
+      TaskState.cancelled => 'cancelled',
+      TaskState.working => 'working',
+      _ => 'pending',
+    };
+    await widget.store.updateState(update.taskId, stateName, answerText: update.outputText);
+    if (mounted) setState(() {});
+  }
+
+  /// A task that finishes while this device is disconnected (or whose
+  /// `ask_result` push simply never arrives — e.g. a connection already
+  /// going stale by the time the answer was ready) has no other way to
+  /// reach the phone; the Border never re-pushes a result spontaneously.
+  /// Called once after the store loads: for every turn still `pending`/
+  /// `working` locally, ask the Border directly whether it actually
+  /// finished already.
+  Future<void> _reconcileStaleTurns() async {
+    final staleTaskIds = widget.store.turns
+        .where((t) => t.state == 'pending' || t.state == 'working')
+        .map((t) => t.taskId)
+        .toList();
+    for (final taskId in staleTaskIds) {
+      try {
+        final update = await widget.askClient.result(taskId);
+        if (update.state != TaskState.pending && update.state != TaskState.unknown) {
+          await _applyUpdate(update);
+        }
+      } catch (_) {
+        // Still disconnected, or the Border is unreachable right now --
+        // the next reconnect will retry; never blocks the rest of the UI.
+      }
+    }
   }
 
   Future<void> _send() async {

--- a/mobile/netclaw-mobile/lib/screens/enrollment_screen.dart
+++ b/mobile/netclaw-mobile/lib/screens/enrollment_screen.dart
@@ -5,6 +5,7 @@ import '../ncfed/edge_client.dart';
 import '../ncfed/edge_identity.dart';
 import '../ncfed/enrollment_flow.dart';
 import '../ncfed/enrollment_qr_payload.dart';
+import 'manual_enrollment_screen.dart';
 
 /// "Scan Border QR Code" — feature 066, US1/T014. Explicit error states for
 /// domain-mismatch, expired/already-used tokens, and any other enrollment
@@ -61,6 +62,16 @@ class _EnrollmentScreenState extends State<EnrollmentScreen> {
     }
   }
 
+  Future<void> _enterManually() async {
+    await Navigator.of(context).push(MaterialPageRoute(
+      builder: (_) => ManualEnrollmentScreen(
+        memberId: widget.memberId,
+        identity: widget.identity,
+        onEnrolled: widget.onEnrolled,
+      ),
+    ));
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -68,6 +79,19 @@ class _EnrollmentScreenState extends State<EnrollmentScreen> {
       body: Stack(
         children: [
           MobileScanner(onDetect: _onDetect),
+          Positioned(
+            left: 16,
+            right: 16,
+            top: 16,
+            child: Center(
+              child: TextButton(
+                onPressed: _busy ? null : _enterManually,
+                style: TextButton.styleFrom(backgroundColor: Colors.black54),
+                child: const Text("Can't scan? Enter manually",
+                    style: TextStyle(color: Colors.white)),
+              ),
+            ),
+          ),
           if (_errorText != null)
             Positioned(
               left: 16,

--- a/mobile/netclaw-mobile/lib/screens/manual_enrollment_screen.dart
+++ b/mobile/netclaw-mobile/lib/screens/manual_enrollment_screen.dart
@@ -1,0 +1,166 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+
+import '../ncfed/edge_client.dart';
+import '../ncfed/edge_identity.dart';
+import '../ncfed/enrollment_flow.dart';
+import '../ncfed/enrollment_qr_payload.dart';
+
+/// Builds the exact same JSON shape a scanned QR would decode to — pulled
+/// out so the form's actual behavior is testable without a real network
+/// dial (mirrors `enrollment_flow.dart`'s own reason for existing).
+/// `border_host`/`claw_domain` are always the same value here since this
+/// app's own QR generation (`netclaw risk token --edge`) never produces a
+/// deliberate mismatch — a manually-entered one has no reason to either.
+String buildManualEnrollmentQr({
+  required String domain,
+  required int port,
+  required String token,
+}) =>
+    jsonEncode({
+      'border_host': domain,
+      'border_port': port,
+      'claw_domain': domain,
+      'enrollment_token': token,
+    });
+
+/// "Can't scan? Enter manually" — the fallback enrollment path alongside
+/// `EnrollmentScreen`'s QR scanner. Builds the exact same JSON payload a
+/// scanned QR would decode to and hands it to the SAME
+/// `attemptEnrollmentFromQr` — no separate enrollment logic, no protocol
+/// change, just a second way to produce the raw string. `border_host` and
+/// `claw_domain` are always the same value in this app's own QR generation
+/// (`netclaw risk token --edge`), so this form only asks for it once rather
+/// than exposing that redundancy.
+class ManualEnrollmentScreen extends StatefulWidget {
+  final String memberId;
+  final EdgeIdentity identity;
+  final void Function(EdgeClient client, EnrollmentQrPayload payload) onEnrolled;
+
+  const ManualEnrollmentScreen({
+    super.key,
+    required this.memberId,
+    required this.onEnrolled,
+    this.identity = const EdgeIdentity(),
+  });
+
+  @override
+  State<ManualEnrollmentScreen> createState() => _ManualEnrollmentScreenState();
+}
+
+class _ManualEnrollmentScreenState extends State<ManualEnrollmentScreen> {
+  final _domainController = TextEditingController();
+  final _portController = TextEditingController(text: '8443');
+  final _tokenController = TextEditingController();
+  bool _busy = false;
+  String? _errorText;
+
+  @override
+  void dispose() {
+    _domainController.dispose();
+    _portController.dispose();
+    _tokenController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    final domain = _domainController.text.trim();
+    final token = _tokenController.text.trim();
+    final port = int.tryParse(_portController.text.trim());
+    if (domain.isEmpty || token.isEmpty) {
+      setState(() => _errorText = 'Border domain and enrollment token are both required.');
+      return;
+    }
+    if (port == null) {
+      setState(() => _errorText = 'Port must be a number.');
+      return;
+    }
+    setState(() {
+      _busy = true;
+      _errorText = null;
+    });
+    final raw = buildManualEnrollmentQr(domain: domain, port: port, token: token);
+    final outcome = await attemptEnrollmentFromQr(
+      raw,
+      memberId: widget.memberId,
+      identity: widget.identity,
+    );
+    switch (outcome) {
+      case EnrollmentSuccess(client: final client, payload: final payload):
+        widget.onEnrolled(client, payload);
+      case EnrollmentFailure(message: final message):
+        setState(() {
+          _errorText = message;
+          _busy = false;
+        });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Enter Border Details')),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                'Ask your operator for these three values — the same ones '
+                'encoded in the QR code.',
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _domainController,
+                enabled: !_busy,
+                decoration: const InputDecoration(
+                  labelText: 'Border domain',
+                  hintText: 'e.g. netclaw.example.com or 10.0.2.2',
+                ),
+                keyboardType: TextInputType.url,
+                autocorrect: false,
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _portController,
+                enabled: !_busy,
+                decoration: const InputDecoration(labelText: 'Port'),
+                keyboardType: TextInputType.number,
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _tokenController,
+                enabled: !_busy,
+                decoration: const InputDecoration(
+                  labelText: 'Enrollment token',
+                  hintText: 'in2n_...',
+                ),
+                autocorrect: false,
+                minLines: 1,
+                maxLines: 3,
+              ),
+              const SizedBox(height: 20),
+              if (_errorText != null)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: Text(_errorText!, style: const TextStyle(color: Colors.red)),
+                ),
+              FilledButton(
+                onPressed: _busy ? null : _submit,
+                child: _busy
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Enroll'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/netclaw-mobile/test/chat_screen_test.dart
+++ b/mobile/netclaw-mobile/test/chat_screen_test.dart
@@ -12,6 +12,7 @@ import 'package:netclaw_mobile/screens/chat_screen.dart';
 /// WebSocketChannel) just to test the widget in isolation.
 class _FakeEdgeRpcSource implements EdgeRpcSource {
   final Map<String, EdgeMethodHandler> handlers = {};
+  Map<String, dynamic>? taskResultResponse;
 
   @override
   void on(String method, EdgeMethodHandler handler) {
@@ -21,6 +22,9 @@ class _FakeEdgeRpcSource implements EdgeRpcSource {
   @override
   Future<Map<String, dynamic>> call(String method, Map<String, dynamic> params,
       {Duration timeout = const Duration(seconds: 30)}) async {
+    if (method == 'n2n/tasks/result' && taskResultResponse != null) {
+      return taskResultResponse!;
+    }
     return {'task_id': 'task-1'};
   }
 }
@@ -29,7 +33,8 @@ class _FakeEdgeRpcSource implements EdgeRpcSource {
 /// Real dart:io (Directory/ConversationStore) is used, so setup runs inside
 /// `runAsync()` — testWidgets() runs in a fake-async zone where a plain
 /// await never lets real File I/O complete.
-Future<Widget> _buildChatScreen(WidgetTester tester, String state, {String? answerText}) async {
+Future<Widget> _buildChatScreen(WidgetTester tester, String state,
+    {String? answerText, _FakeEdgeRpcSource? source}) async {
   late Directory dir;
   late ConversationStore store;
   await tester.runAsync(() async {
@@ -42,7 +47,8 @@ Future<Widget> _buildChatScreen(WidgetTester tester, String state, {String? answ
   });
   addTearDown(() => dir.delete(recursive: true));
   return MaterialApp(
-    home: Scaffold(body: ChatScreen(askClient: EdgeAskClient(_FakeEdgeRpcSource()), store: store)),
+    home: Scaffold(
+        body: ChatScreen(askClient: EdgeAskClient(source ?? _FakeEdgeRpcSource()), store: store)),
   );
 }
 
@@ -74,5 +80,26 @@ void main() {
     expect(find.text('Cancelled'), findsOneWidget);
     expect(find.text('Working…'), findsNothing);
     expect(find.textContaining('Failed'), findsNothing);
+  });
+
+  testWidgets(
+      'a turn that finished while disconnected recovers via n2n/tasks/result on next load',
+      (tester) async {
+    // No push ever arrives on `updates` in this test -- reconciliation is
+    // the ONLY path that can surface the answer, exactly like a real
+    // device whose connection went stale before the Border's push landed.
+    final source = _FakeEdgeRpcSource()
+      ..taskResultResponse = {
+        'task_id': 'task-1',
+        'state': 'completed',
+        'output_text': 'Recovered answer.',
+        'tokens_used': 12,
+      };
+    await tester.pumpWidget(await _buildChatScreen(tester, 'pending', source: source));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Recovered answer.'), findsOneWidget);
+    expect(find.text('Working…'), findsNothing);
   });
 }

--- a/mobile/netclaw-mobile/test/heartbeat_test.dart
+++ b/mobile/netclaw-mobile/test/heartbeat_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:netclaw_mobile/ncfed/edge_client.dart';
+import 'package:netclaw_mobile/ncfed/heartbeat.dart';
+
+class _RecordingMethodSource implements EdgeMethodSource {
+  final _handlers = <String, EdgeMethodHandler>{};
+
+  @override
+  void on(String method, EdgeMethodHandler handler) {
+    _handlers[method] = handler;
+  }
+
+  Future<Map<String, dynamic>> invoke(String method) async {
+    final handler = _handlers[method];
+    if (handler == null) throw StateError('no handler registered for $method');
+    return await handler(const {});
+  }
+}
+
+void main() {
+  test('wireHeartbeat answers both n2n/edge/heartbeat and n2n/edge/self_status', () async {
+    final source = _RecordingMethodSource();
+    wireHeartbeat(source);
+
+    // Without this, the Border's periodic heartbeat call finds no handler
+    // and silently times out every interval -- the device gets marked
+    // unreachable/live:false even while its connection is perfectly
+    // healthy (confirmed against a real production Border, 068 polish).
+    final heartbeatReply = await source.invoke('n2n/edge/heartbeat');
+    expect(heartbeatReply, isA<Map<String, dynamic>>());
+
+    final statusReply = await source.invoke('n2n/edge/self_status');
+    expect(statusReply['platform'], isNotEmpty);
+  });
+}

--- a/mobile/netclaw-mobile/test/manual_enrollment_screen_test.dart
+++ b/mobile/netclaw-mobile/test/manual_enrollment_screen_test.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:netclaw_mobile/ncfed/edge_client.dart';
+import 'package:netclaw_mobile/ncfed/edge_identity.dart';
+import 'package:netclaw_mobile/ncfed/enrollment_qr_payload.dart';
+import 'package:netclaw_mobile/screens/manual_enrollment_screen.dart';
+
+void main() {
+  test('buildManualEnrollmentQr produces the exact shape a scanned QR would', () {
+    final raw = buildManualEnrollmentQr(
+      domain: 'netclaw.example.com',
+      port: 8443,
+      token: 'in2n_abc123',
+    );
+
+    final decoded = jsonDecode(raw) as Map<String, dynamic>;
+    expect(decoded['border_host'], 'netclaw.example.com');
+    expect(decoded['claw_domain'], 'netclaw.example.com'); // same value, D7 never violated
+    expect(decoded['border_port'], 8443);
+    expect(decoded['enrollment_token'], 'in2n_abc123');
+  });
+
+  Future<void> pump(WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: ManualEnrollmentScreen(
+        memberId: 'risk/test',
+        identity: const EdgeIdentity(),
+        onEnrolled: (EdgeClient client, EnrollmentQrPayload payload) {},
+      ),
+    ));
+  }
+
+  testWidgets('empty fields are refused before any enrollment attempt', (tester) async {
+    await pump(tester);
+    await tester.tap(find.text('Enroll'));
+    await tester.pump();
+
+    expect(find.textContaining('are both required'), findsOneWidget);
+  });
+
+  testWidgets('a non-numeric port is refused with a clear message', (tester) async {
+    await pump(tester);
+    await tester.enterText(find.widgetWithText(TextField, 'Border domain'), 'netclaw.example.com');
+    await tester.enterText(find.widgetWithText(TextField, 'Port'), 'not-a-number');
+    await tester.enterText(find.widgetWithText(TextField, 'Enrollment token'), 'in2n_abc123');
+    await tester.tap(find.text('Enroll'));
+    await tester.pump();
+
+    expect(find.text('Port must be a number.'), findsOneWidget);
+  });
+}

--- a/tests/n2n/test_edge_ask.py
+++ b/tests/n2n/test_edge_ask.py
@@ -350,3 +350,38 @@ async def _edge_ask_neither(tmp_path):
     finally:
         server.close()
     border.manager.close()
+
+
+def test_edge_ask_session_key_never_contains_a_slash(tmp_path, monkeypatch):
+    """Every edge member_id is risk-scoped ("risk/<label>") and openclaw
+    agent's --session-id/--session-key rejects a value containing "/" with
+    "Invalid session ID" -- confirmed via a real device against a real
+    Border (068 polish). session_key must be sanitized before reaching
+    run_agent_turn(), not just prefixed."""
+    asyncio.run(_edge_ask_session_key_sanitized(tmp_path, monkeypatch))
+
+
+async def _edge_ask_session_key_sanitized(tmp_path, monkeypatch):
+    seen_session_keys = []
+
+    async def _fake_run_agent_turn(prompt, session_key="n2n", **kwargs):
+        seen_session_keys.append(session_key)
+        return "ok", 0
+
+    monkeypatch.setattr(gateway, "run_agent_turn", _fake_run_agent_turn)
+
+    border = _border(tmp_path / "border")
+    server, port = await _serve(border)
+    try:
+        phone = await _enroll(border, port, member_id="risk/has-a-slash")
+        resp = await phone.call("n2n/edge/ask", {"text": "hello"})
+        result = await phone.wait_for_notification("n2n/edge/ask_result")
+        assert result["task_id"] == resp["task_id"]
+        await phone.close()
+    finally:
+        server.close()
+    border.manager.close()
+
+    assert seen_session_keys, "run_agent_turn was never called"
+    assert "/" not in seen_session_keys[0], seen_session_keys[0]
+    assert seen_session_keys[0] == "n2n-edge-risk_has-a-slash"

--- a/tests/n2n/test_members_endpoint_edge_liveness.py
+++ b/tests/n2n/test_members_endpoint_edge_liveness.py
@@ -1,0 +1,68 @@
+"""068 polish: GET /n2n/members omitted node_type entirely and computed
+`live` only from `fed.member_channels` (agent members) — an edge (phone)
+member's connection lives in `fed.edge_channels` instead, so every edge
+node showed `live=false` forever regardless of real connection health, and
+the HUD's own edge-node panel (which filters on `node_type == 'edge'`)
+silently rendered nothing since 066 first shipped, since `node_type` was
+never even in this response to filter on. Confirmed live against a real
+production Border before this fix."""
+
+import asyncio
+import importlib.util
+import os
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+PROTO = os.path.join(REPO, "mcp-servers", "protocol-mcp")
+
+
+def _load_daemon(tmp_path):
+    import sys
+    sys.path.insert(0, PROTO)
+    spec = importlib.util.spec_from_file_location(
+        "bgp_daemon_v2_edge_liveness", os.path.join(PROTO, "bgp-daemon-v2.py"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    from bgp.federation.service import FederationService
+    from bgp.federation.manager import FederationManager
+    mod._federation = FederationService(
+        local_as=65001, router_id="4.4.4.4",
+        manager=FederationManager(base_dir=str(tmp_path)))
+    mod._federation.risk.set_role("border", risk_name="risk", enabled_stacks="in2n")
+    mod._speaker = None
+    return mod
+
+
+def test_connected_edge_member_reports_node_type_and_live(tmp_path):
+    asyncio.run(_connected_edge_member(tmp_path))
+
+
+async def _connected_edge_member(tmp_path):
+    from bgp.federation import certs
+
+    mod = _load_daemon(tmp_path)
+    fed = mod._federation
+    member_id = "risk/phone1"
+    cert_pem, _ = certs.create_self_signed(member_id)
+    token = fed.risk.issue_token(label="phone1")["token"]
+    fed.risk.consume_token(token, member_id, cert_pem, scope=[],
+                          transport_binding="edge-ws", node_type="edge")
+
+    # Not connected yet -- live must be false, matching an agent member
+    # with no channel.
+    code, body = await mod.handle_n2n("GET", "/n2n/members", {})
+    assert code == 200
+    row = next(m for m in body["members"] if m["member_id"] == member_id)
+    assert row["node_type"] == "edge"
+    assert row["live"] is False
+
+    # A connected edge node lives in edge_channels, never member_channels --
+    # this is the exact distinction the bug missed.
+    fed.edge_channels[member_id] = object()
+    code, body = await mod.handle_n2n("GET", "/n2n/members", {})
+    row = next(m for m in body["members"] if m["member_id"] == member_id)
+    assert row["live"] is True
+
+    # /n2n/members/health must agree.
+    code, body = await mod.handle_n2n("GET", "/n2n/members/health", {})
+    health_row = next(m for m in body["members"] if m["member_id"] == member_id)
+    assert health_row["live"] is True

--- a/ui/netclaw-visual/src/main.js
+++ b/ui/netclaw-visual/src/main.js
@@ -577,6 +577,15 @@ const CORE_POSITIONS = {
   peer1: new THREE.Vector3(52, 0, -28),
   peer2: new THREE.Vector3(52, 0, 28),
   peer3: new THREE.Vector3(18, 0, -56),
+  // NetClaw Mobile edge nodes (068 polish): a close, prominent orbit near
+  // the centroid like peers get, mirroring peer3's radius but on the
+  // opposite (+Z) side so the two groups read as visually distinct
+  // clusters rather than overlapping -- deliberately NOT the far-south
+  // member-spoke fan every other iN2N member uses, since a phone is the
+  // one member type an operator actually wants to spot at a glance.
+  edge1: new THREE.Vector3(18, -6, 56),
+  edge2: new THREE.Vector3(52, -6, 84),
+  edge3: new THREE.Vector3(-14, -6, 84),
 };
 const CORE_CENTROID = new THREE.Vector3(12, 0, 0);
 
@@ -1218,6 +1227,57 @@ function deduplicatePeers(peers) {
 
 // 056: render this risk's member claws as spokes SOUTH of the Border, each a
 // core with its own orbiting skills, colored by class. Additive + guarded.
+// The per-member spoke itself is factored out into spawnMemberCore() so a
+// later-arriving member (e.g. a phone enrolling well after the HUD tab was
+// already open) can be added incrementally via refreshRiskMembers() without
+// re-running this whole function or touching any already-built spoke.
+function spawnMemberCore(m, i, n, C, R, col) {
+  const isEdge = m.node_type === 'edge';
+  const dead = (m.state === 'quarantined' || m.state === 'removed');
+  const cold = !m.live;
+  let pos, tint, name, speed;
+  if (isEdge) {
+    // NetClaw Mobile edge nodes get the same close, prominent orbit as
+    // peers instead of the far-south member fan -- an operator wants to
+    // spot their phone at a glance, not hunt for it among every other
+    // member. Cycles through 3 fixed slots by how many edge cores already
+    // exist (a 4th+ phone falls back to the last slot rather than
+    // colliding with anything -- good enough until this ever needs more).
+    const edgeSlots = [CORE_POSITIONS.edge1, CORE_POSITIONS.edge2, CORE_POSITIONS.edge3];
+    const edgeIndex = (state.memberCores || []).filter((c) => c.memberPayload?.node_type === 'edge').length;
+    pos = edgeSlots[Math.min(edgeIndex, edgeSlots.length - 1)].clone();
+    tint = dead ? (col.memberQuarantined || 0xff5d6c) : (cold ? 0x3a6ea5 : 0xe65733); // the mobile app's own brand orange
+    const label = String(m.member_id || 'phone').split('/').pop();
+    name = `PHONE ${label}`.trim();
+    speed = 0.0007;
+  } else {
+    const frac = n > 1 ? i / (n - 1) : 0.5;
+    const spread = (frac - 0.5) * Math.PI * 1.25;               // wide fan across the south
+    const px = C.x + Math.sin(spread) * R * 3.0;                // spread far out in X
+    const pz = C.z - (R + 40) - Math.abs(Math.cos(spread)) * R * 0.9; // push well south (-Z)
+    const py = -6 - (i % 5) * 7;                                // deeper vertical stagger
+    pos = new THREE.Vector3(px, py, pz);
+    tint = dead ? (col.memberQuarantined || 0xff5d6c) : (cold ? 0x3a6ea5 : (col.member || 0x68f5b2));
+    name = String(m.member_id || 'member').split('/').pop().toUpperCase();
+    speed = 0.0004;
+  }
+  const core = buildCore(state.graph.identity, pos, name, tint);
+  core.isMember = true;
+  core.memberPayload = m;
+  core.orbit = { center: C.clone(), radius: pos.distanceTo(C),
+    angle: Math.atan2(pos.z - C.z, pos.x - C.x), y: pos.y, speed };
+  // orbiting skills only for LIVE members (keep the scene light for cold ones)
+  const names = (m.live ? (m.skills || []) : []).slice(0, 12);
+  core.skillSprites = createSkillSprites(pos, names.map((s) => ({ name: s, id: s })), tint, pos);
+  // Show member tools by default (don't hide behind a click like integrations).
+  core.skillSprites.forEach((sp) => {
+    if (sp.mesh) sp.mesh.visible = true;
+    if (sp.wire) sp.wire.visible = true;
+  });
+  state.cores.push(core);
+  state.memberCores.push(core);
+}
+
 function buildRiskMembers() {
   try {
     const risk = state.n2n && state.n2n.risk;
@@ -1229,36 +1289,39 @@ function buildRiskMembers() {
     const R = (typeof RISK_LAYOUT !== 'undefined' && RISK_LAYOUT.tierRadius) || 46;
     const col = (typeof RISK_LAYOUT !== 'undefined' && RISK_LAYOUT.colors) || {};
     const n = members.length;
-    members.forEach((m, i) => {
-      const frac = n > 1 ? i / (n - 1) : 0.5;
-      const spread = (frac - 0.5) * Math.PI * 1.25;               // wide fan across the south
-      const px = C.x + Math.sin(spread) * R * 3.0;                // spread far out in X
-      const pz = C.z - (R + 40) - Math.abs(Math.cos(spread)) * R * 0.9; // push well south (-Z)
-      const py = -6 - (i % 5) * 7;                                // deeper vertical stagger
-      const pos = new THREE.Vector3(px, py, pz);
-      const dead = (m.state === 'quarantined' || m.state === 'removed');
-      const cold = !m.live;
-      const tint = dead ? (col.memberQuarantined || 0xff5d6c)
-                        : (cold ? 0x3a6ea5 : (col.member || 0x68f5b2));
-      const name = String(m.member_id || 'member').split('/').pop().toUpperCase();
-      const core = buildCore(state.graph.identity, pos, name, tint);
-      core.isMember = true;
-      core.memberPayload = m;
-      core.orbit = { center: C.clone(), radius: pos.distanceTo(C),
-        angle: Math.atan2(pos.z - C.z, pos.x - C.x), y: pos.y, speed: 0.0004 };
-      // orbiting skills only for LIVE members (keep the scene light for cold ones)
-      const names = (m.live ? (m.skills || []) : []).slice(0, 12);
-      core.skillSprites = createSkillSprites(pos, names.map((s) => ({ name: s, id: s })), tint, pos);
-      // Show member tools by default (don't hide behind a click like integrations).
-      core.skillSprites.forEach((sp) => {
-        if (sp.mesh) sp.mesh.visible = true;
-        if (sp.wire) sp.wire.visible = true;
-      });
-      state.cores.push(core);
-      state.memberCores.push(core);
-    });
+    members.forEach((m, i) => spawnMemberCore(m, i, n, C, R, col));
   } catch (e) {
     console.warn('buildRiskMembers failed (non-fatal):', e);
+  }
+}
+
+// Incremental counterpart to buildRiskMembers(), called on every state.n2n
+// poll (FR-026): a member that enrolls AFTER the HUD was already loaded
+// (the exact case that made a freshly-enrolled phone invisible until a full
+// page reload) gets its spoke added on the next poll, with no reload
+// needed. Deliberately additive-only, never removing/disposing a spoke for
+// a member that disappears -- a disconnected member already renders "cold"
+// (dim blue, no orbiting skills) via the same tint logic, which is the
+// right visual for that case anyway, and skips the real complexity/risk of
+// safely disposing a live THREE.js core (shaders, sprites, orbit state)
+// out from under an in-progress render loop.
+function refreshRiskMembers() {
+  try {
+    const risk = state.n2n && state.n2n.risk;
+    if (!risk || risk.role !== 'border') return;
+    const members = (state.n2n.members) || [];
+    if (!members.length) return;
+    state.memberCores = state.memberCores || [];
+    const known = new Set(state.memberCores.map((c) => c.memberPayload && c.memberPayload.member_id));
+    const arrivals = members.filter((m) => !known.has(m.member_id));
+    if (!arrivals.length) return;
+    const C = CORE_CENTROID;
+    const R = (typeof RISK_LAYOUT !== 'undefined' && RISK_LAYOUT.tierRadius) || 46;
+    const col = (typeof RISK_LAYOUT !== 'undefined' && RISK_LAYOUT.colors) || {};
+    const n = members.length;
+    arrivals.forEach((m) => spawnMemberCore(m, members.indexOf(m), n, C, R, col));
+  } catch (e) {
+    console.warn('refreshRiskMembers failed (non-fatal):', e);
   }
 }
 
@@ -3311,6 +3374,15 @@ async function boot() {
     // Refresh N2N federation state so claw nodes reflect consent/inventory/sever (FR-026)
     setInterval(async () => {
       try { state.n2n = await (await fetch('/api/n2n')).json(); } catch { /* keep last */ }
+      // The detail panel only renders on click (setDetail is never called
+      // again just because state.n2n refreshed) -- if "This NetClaw" is the
+      // panel currently open, re-render it in place so edge-node liveness/
+      // approvals/replication jobs don't require a manual re-click to see.
+      if (state.selected?.kind === 'local-core') setDetail('local-core');
+      // A member (e.g. a phone) that enrolls after this page already loaded
+      // never got a 3D spoke, since buildRiskMembers() only ran once at
+      // boot -- add spokes for any newly-arrived members on every poll.
+      refreshRiskMembers();
     }, 30000);
     animate();
 


### PR DESCRIPTION
## Summary

Real bugs found only by actually using NetClaw Mobile end-to-end against production, not by unit tests alone:

- **Missing heartbeat handler**: the app never answered `n2n/edge/heartbeat`/`n2n/edge/self_status` — every heartbeat silently timed out, so a connected edge node eventually got closed and marked unreachable regardless of real connection health.
- **No stale-answer recovery**: a completed `n2n/edge/ask` answer had no way back to the phone if its push was missed. `ChatScreen` now reconciles any turn still pending/working against `n2n/tasks/result` on load.
- **Session-key bug**: `gateway.run_agent_turn()`'s `session_key=f"n2n-edge-{member_id}"` breaks when `member_id` contains `/` (every `risk/`-scoped edge member_id does) — `openclaw agent`'s session-ID validation rejects the slash. Sanitized.
- **HUD edge-node liveness/visibility bug**: `GET /n2n/members` never included `node_type` at all, and computed `live` only from `member_channels` (agent members), never `edge_channels` (phone connections) — every edge node showed `live=false` forever, and the HUD's own edge-node panel (filters on `node_type=='edge'`) silently rendered nothing since **066 first shipped**.
- **Manual-entry enrollment fallback**: `EnrollmentScreen` gains "Can't scan? Enter manually" — builds the identical JSON payload a scan would produce, reuses `attemptEnrollmentFromQr` unchanged.
- **HUD 3D graph**: member spokes (and the detail panel) only rendered once at boot, so a phone enrolling after the HUD page was already open never got a spoke without a full reload. Both now refresh on the existing 30s poll. Edge (phone) members also get their own close, prominent orbit near the centroid (matching peers) instead of the far-south member fan, with the mobile app's own brand orange and a "PHONE `<id>`" label.

All verified against the operator's real production Border throughout (federation intact, real enrollment + real recovered answer + real HUD spoke, confirmed via direct in-page state inspection over CDP).

## Test plan
- [x] `flutter analyze` — clean
- [x] `flutter test` — 53 passed
- [x] `python3 -m pytest tests/n2n -q` — 268 passed, zero regressions
- [x] Verified live against production: heartbeat succeeding, stale answer recovered on phone, HUD spoke visible and positioned correctly (confirmed via CDP state inspection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)