### PR TITLE
070: RFC — ITSM provider abstraction for change gating (spec only; proposes a Constitution amendment)

### DIFF
--- a/specs/070-itsm-provider-abstraction/checklists/requirements.md
+++ b/specs/070-itsm-provider-abstraction/checklists/requirements.md
@@ -1,0 +1,120 @@
+# Requirements & Coherence Checklist — Feature 070
+
+**Status**: Phase 0 (specification) **COMPLETE**. All implementation items are **BLOCKED**
+pending maintainer ratification of the Constitution amendment (1.2.0 → 1.3.0) and answers to
+the 9 Open Questions in `spec.md`.
+
+Legend: `[x]` done · `[ ]` not started · `[—]` deliberately out of v1 scope
+
+---
+
+## A. Specification artifacts (this round)
+
+- [x] `spec.md` — template-conformant: 4 prioritized user stories with Given/When/Then, edge
+      cases, 17 FRs, key entities + current-state inventory, 7 success criteria, assumptions,
+      9 open questions, discovered defects
+- [x] `plan.md` — technical context, Constitution Check gate (5 rows marked AMENDED),
+      project structure, complexity tracking
+- [x] `research.md` — R1–R8 with Decision / Rationale / Alternatives, incl. R6 amendment scope
+      modeled on spec 049's R6
+- [x] `data-model.md` — `ItsmProvider`, `ProviderAdapter`, `ChangeRef`, `GateDecision`,
+      `GateConfig`, decision flow
+- [x] `contracts/itsm-gate-contract.md` — public API, envelope with back-compat vs additive
+      markings, provider table, shim contract, behavior table
+- [x] `contracts/constitution-amendment.md` — literal before/after for all 5 locations
+      (byte-verified against the live file) + proposed Sync Impact Report
+- [x] `quickstart.md` — maintainer review path + operator usage
+- [x] `tasks.md` — phased, characterization-tests-first, amendment as exactly 2 tasks,
+      nautobot fenced as follow-on
+- [x] `checklists/requirements.md` — this file
+- [x] `gait-session-log.md` — Principle IV audit trail of decisions and scope corrections
+
+## B. Ratification gate (blocks everything below)
+
+- [ ] Maintainers ratify the Constitution amendment across all 5 locations
+- [ ] **OQ2** answered — default provider when unset (`none` vs `servicenow`) — *changes API*
+- [ ] **OQ3** answered — fail-open vs opt-in strict mode — *changes API*
+- [ ] **OQ4** answered — adopt `attested_state`? — *changes API*
+- [ ] OQ1 answered — config mechanism and precedence
+- [ ] OQ5 answered — v1 adapter set
+- [ ] OQ6 answered — canonical vs provider-native state vocabulary
+- [ ] OQ7 answered — nautobot migration disposition
+- [ ] OQ8 answered — register `servicenow-mcp` in `config/openclaw.json`?
+- [ ] OQ9 answered — generalize Principle III's "Assess → Authorize → Implement → Review"?
+      (`contracts/constitution-amendment.md` offers a conservative and a generalized variant —
+      pick one)
+
+## C. Safety net before any refactor (FR-011)
+
+- [ ] Characterization tests written for the **current** gate behavior and passing against the
+      **unrefactored** code — coverage is **0** today, so this is the only way "no regression"
+      is verifiable rather than asserted
+- [ ] Characterization coverage includes the envelope Claroty publishes in tool output
+- [ ] Characterization coverage pins the two divergent operation-label message strings
+      (`"…for gNMI Set operations"` vs `"…for Claroty write operations"`) byte-for-byte
+
+## D. Implementation (v1 — 7 gated tools, 2 servers)
+
+- [ ] `src/netclaw_itsm/` shared module created, mirroring `src/netclaw_tokens/`
+- [ ] Provider adapters: `servicenow`, `halo`, `atlassian`, `none` (declarative only — no
+      transport, no credentials)
+- [ ] Thin shim at `mcp-servers/gnmi-mcp/itsm_gate.py` re-exporting from the shared module
+      (`sys.path` depth: `"..","..","src"`)
+- [ ] Thin shim at `mcp-servers/claroty-mcp/utils/itsm_gate.py` (`sys.path` depth:
+      `"..","..","..","src"`)
+- [ ] `gnmi_set` and the 6 Claroty write tools behave identically under the status-quo provider
+- [ ] No MCP tool parameter renamed or made newly required (SC-007)
+- [ ] Dead `GnmiSetRequest` validator removed (`mcp-servers/gnmi-mcp/models.py:186-207`)
+- [ ] GAIT emission for every gate decision (FR-013) — **note: net-new for the 6 Claroty tools**,
+      which emit no GAIT record today; only `gnmi-mcp` does
+
+## E. Constitution XI coherence (implementation round)
+
+- [ ] `.specify/memory/constitution.md` — 5 locations amended + Sync Impact Report + version
+      bump + `Last Amended` date
+- [ ] `config/openclaw.json` — `NETCLAW_ITSM_PROVIDER` added to **every** gated server's env
+      block, including `gnmi-mcp` (`:81-90`), which currently receives no ITSM variable
+- [ ] `.env.example` — new variable documented; the two existing ServiceNow-framed comments
+      (`:119`, `:397-398`) generalized
+- [ ] `SOUL.md` — the three ServiceNow-as-required lines (`:351`, `:408`, `:419`) generalized
+- [ ] `SOUL-SKILLS.md` — the ~20 "requires ServiceNow CR" skill lines generalized
+- [ ] `README.md` — ServiceNow-as-required lines generalized (`:265`, `:811`, `:812`, `:1589`,
+      `:2249`, and the per-skill descriptions); integration-listing mentions left as-is
+- [ ] `TOOLS.md` — ITSM provider selection documented alongside the ServiceNow credentials line
+- [ ] `AGENTS.md` — `:40`, `:64-65` generalized
+- [ ] Affected `workspace/skills/**/SKILL.md` — the hard-gated set updated to reference the
+      configured ITSM and its verification responsibility (see `spec.md` FR-007)
+- [ ] `ui/netclaw-visual/server.js` — ENV_MAP entries for gated servers include the new variable
+- [ ] `scripts/verify-catalog-coverage.py` passes with no new gaps
+- [ ] Milestone blog drafted (Principle XVII) — *only if* this ships as a merged feature
+
+## F. Follow-on phase (specified, NOT in v1)
+
+- [—] nautobot family migration: 3 servers, **35** gated tools, `_check_itsm() -> Optional[str]`
+      → shared gate, incl. reconciling `ITSM_ENABLED`/`ITSM_LAB_MODE` with
+      `NETCLAW_ITSM_PROVIDER`/`NETCLAW_LAB_MODE` while preserving today's gating-off default
+      and the **optional** `cr_number` parameter
+- [—] Memory MCP change-reference provenance (`validate_cr_number`, `^CHG\d+$`) generalized —
+      deferred with rationale (FR-016): provenance metadata, not a gate
+
+## G. Discovered defects (reported for maintainer triage, not fixed here)
+
+- [—] `config/openclaw.json:291-304` registers `aruba-cx-mcp` with ITSM variables, but
+      `mcp-servers/aruba-cx-mcp/` does not exist; its skills and contract spec document it as live
+- [—] `mcp-servers/gnmi-mcp` receives no ITSM env var, so its lab bypass depends on
+      parent-environment leakage
+- [—] `servicenow-mcp` is an install-time clone of a community repo, invoked by skills via
+      `$MCP_CALL`, and is not registered in `config/openclaw.json` (OQ8)
+
+---
+
+## Verification of this round
+
+- [x] Every artifact conforms to its `.specify/templates/` counterpart
+- [x] Canonical counts identical across all artifacts: **5 gate implementations · 5 servers ·
+      42 gated tools (7 v1 + 35 follow-on) · 4 `^CHG\d+$` regexes · 0 existing tests ·
+      5 Constitution locations · 1.2.0 → 1.3.0**
+- [x] Constitution current-text quotes byte-verified against `.specify/memory/constitution.md`
+- [x] No artifact treats feature 069 (`halo-mcp`, `halo-change-request`) as existing on this
+      branch — it is cited as an unmerged dependency (PR #167)
+- [x] `git status` shows changes only under `specs/070-itsm-provider-abstraction/`

--- a/specs/070-itsm-provider-abstraction/contracts/constitution-amendment.md
+++ b/specs/070-itsm-provider-abstraction/contracts/constitution-amendment.md
@@ -1,0 +1,243 @@
+# Contract — Constitution Amendment 1.2.0 → 1.3.0 (Provider-Agnostic ITSM Gating)
+
+**Feature**: 070-itsm-provider-abstraction
+**Target file**: `.specify/memory/constitution.md` (355 lines at time of writing)
+**Version change**: **1.2.0 → 1.3.0 (MINOR)**
+**Status**: PROPOSED — **not applied.** This is a reviewable diff for maintainers, produced to satisfy FR-017 and US4. Feature 070 MUST NOT be implemented before this amendment is ratified.
+
+The Constitution names ServiceNow in **five** locations. Amending Principle III alone would leave four references contradicting it, so this amendment is **all-or-nothing across all five** (US4 acceptance scenario 2). Every proposed replacement generalizes existing text to "the configured ITSM" / "a change record" while **preserving each principle's force** — MUST-language intact, lab mode still the sole bypass, bypasses still GAIT-logged. No principle is removed or redefined, which is why this is a MINOR bump under the Constitution's own semantic-versioning rule (`Governance`, lines 344-347: "MAJOR for removals/redefinitions, MINOR for additions, PATCH for clarifications") and per US4 acceptance scenario 3.
+
+Line wrapping in every proposed block follows the file's existing ~72-character convention.
+
+---
+
+### Location 1 — `.specify/memory/constitution.md:55-64` (Principle III: ITSM-Gated Changes)
+
+**Current text (verbatim):**
+
+```
+### III. ITSM-Gated Changes
+
+- All production changes MUST have an approved ServiceNow Change
+  Request (CR) before execution.
+- The CR lifecycle (Assess → Authorize → Implement → Review) MUST
+  be followed completely.
+- Lab mode is the sole exception — lab devices MAY be modified
+  without a CR, but MUST still be GAIT-logged.
+- If a CR is rejected or withdrawn mid-execution, the change MUST
+  halt immediately and rollback.
+```
+
+**Proposed replacement — Variant A (conservative: lifecycle wording kept verbatim):**
+
+```
+### III. ITSM-Gated Changes
+
+- All production changes MUST have an approved change record in the
+  configured ITSM before execution.
+- The configured ITSM is an operator choice (e.g. ServiceNow,
+  HaloPSA/HaloITSM, Jira); no specific vendor is mandated.
+- The CR lifecycle (Assess → Authorize → Implement → Review) MUST
+  be followed completely.
+- Lab mode is the sole exception — lab devices MAY be modified
+  without a change record, but MUST still be GAIT-logged.
+- If a change record is rejected or withdrawn mid-execution, the
+  change MUST halt immediately and rollback.
+```
+
+**Proposed replacement — Variant B (generalized: lifecycle line also generalized):**
+
+```
+### III. ITSM-Gated Changes
+
+- All production changes MUST have an approved change record in the
+  configured ITSM before execution.
+- The configured ITSM is an operator choice (e.g. ServiceNow,
+  HaloPSA/HaloITSM, Jira); no specific vendor is mandated.
+- The change record's approval lifecycle MUST be followed completely
+  through to its terminal state — in ServiceNow terms, Assess →
+  Authorize → Implement → Review.
+- Lab mode is the sole exception — lab devices MAY be modified
+  without a change record, but MUST still be GAIT-logged.
+- If a change record is rejected or withdrawn mid-execution, the
+  change MUST halt immediately and rollback.
+```
+
+**Rationale:** Generalizes the gating requirement from a ServiceNow CR to an approved change record in the operator's configured ITSM, and adds one bullet making the "no vendor is mandated" reading unambiguous (this is what SC-005 measures) — while keeping MUST-language, lab mode as the *sole* exception, the GAIT-logging obligation, and the halt-and-rollback rule exactly as forceful as before. **Open Question 9 for maintainers:** the "Assess → Authorize → Implement → Review" sequence is ServiceNow's own change-lifecycle vocabulary — HaloPSA and Jira use different state names — so whether to generalize that line is a maintainer decision, not an editorial one. Variant A leaves it untouched (smallest diff, but the line still reads as ServiceNow-specific inside an otherwise vendor-neutral principle); Variant B generalizes it while retaining the ServiceNow sequence as an illustrative example (fully consistent, but a slightly larger change to principle text). **Pick one; do not apply both.**
+
+---
+
+### Location 2 — `.specify/memory/constitution.md:113-114` (Principle VIII: Verify After Every Change)
+
+**Current text (verbatim):**
+
+```
+- If rollback fails, the system MUST halt, alert the operator, and
+  mark the ServiceNow CR as failed.
+```
+
+**Proposed replacement:**
+
+```
+- If rollback fails, the system MUST halt, alert the operator, and
+  mark the change record in the configured ITSM as failed.
+```
+
+**Rationale:** The failed-rollback escalation duty is unchanged in force (halt + alert + mark failed); only the record being marked becomes provider-agnostic, so the obligation is dischargeable in a Halo or Jira shop rather than being literally impossible there.
+
+---
+
+### Location 3 — `.specify/memory/constitution.md:200` (Principle XIV: Human-in-the-Loop for External Communications, inside the approval list)
+
+**Current text (verbatim):**
+
+```
+  - Creating, updating, or closing ServiceNow tickets
+```
+
+**Proposed replacement:**
+
+```
+  - Creating, updating, or closing tickets in the configured ITSM
+```
+
+**Rationale:** Keeps the human-approval requirement identical while making it bind for whichever ITSM is configured — otherwise a Halo or Jira deployment could read the list as not covering its own ticket writes, which would *narrow* a safety obligation rather than generalize it. The 2-space list indentation is preserved.
+
+---
+
+### Location 4 — `.specify/memory/constitution.md:260` (Operational Constraints → Technology Stack)
+
+**Current text (verbatim):**
+
+```
+- **ITSM**: ServiceNow (change management, incidents, CMDB)
+```
+
+**Proposed replacement:**
+
+```
+- **ITSM**: operator-selected — ServiceNow, HaloPSA/HaloITSM, or
+  Jira/Jira Service Management (change management, incidents, CMDB)
+```
+
+**Rationale:** The stack entry becomes a statement of choice rather than a mandate. ServiceNow is deliberately **retained as the first named example**, not deleted — it remains a fully supported provider, and removing it would misrepresent the stack for existing ServiceNow deployments. The parenthetical scope (change management, incidents, CMDB) is unchanged.
+
+---
+
+### Location 5 — `.specify/memory/constitution.md:269` (Forbidden Operations)
+
+**Current text (verbatim):**
+
+```
+- Bypassing ServiceNow CR approval for production changes
+```
+
+**Proposed replacement:**
+
+```
+- Bypassing configured ITSM change approval for production changes
+```
+
+**Rationale:** This is the prohibition that gives Principle III teeth; leaving it ServiceNow-specific would make it trivially non-binding for a non-ServiceNow deployment — a *loophole*, not a nuance. The replacement is a single line matching its sibling entries' one-line style, and the neighbouring `- Silent operations without GAIT logging` entry continues to cover the lab-mode bypass.
+
+---
+
+### Footer — `.specify/memory/constitution.md:355`
+
+**Current text (verbatim):**
+
+```
+**Version**: 1.2.0 | **Ratified**: 2026-03-26 | **Last Amended**: 2026-07-08
+```
+
+**Proposed replacement:**
+
+```
+**Version**: 1.3.0 | **Ratified**: 2026-03-26 | **Last Amended**: 2026-07-24
+```
+
+**Rationale:** MINOR bump per the Constitution's own versioning rule (generalizing clarification of existing principle text, no removal or redefinition); ratification date is unchanged; `Last Amended` advances to the amendment date.
+
+---
+
+## Proposed Sync Impact Report — replaces `.specify/memory/constitution.md:1-30`
+
+Lines 1-30 are the existing HTML-comment Sync Impact Report block (`<!--` on line 1 through `-->` on line 30). Replace the whole block with the following, which follows the established format and compresses prior versions into "Previous version history" (US4 acceptance scenario 4).
+
+```
+<!--
+  Sync Impact Report
+  ==================
+  Version change: 1.2.0 → 1.3.0 (MINOR — provider-agnostic ITSM gating)
+
+  Modified principles:
+    - Principle III: ITSM-Gated Changes — "approved ServiceNow Change
+      Request (CR)" generalized to an approved change record in the
+      configured ITSM, plus an explicit statement that the ITSM is an
+      operator choice and no vendor is mandated. Lab mode remains the
+      sole exception and is still GAIT-logged; the halt-and-rollback
+      rule is unchanged.
+    - Principle VIII: Verify After Every Change — the failed-rollback
+      escalation now marks the change record in the configured ITSM
+      rather than "the ServiceNow CR", so the duty is dischargeable on
+      any supported ITSM.
+    - Principle XIV: Human-in-the-Loop for External Communications —
+      the human-approval list now covers ticket writes in the
+      configured ITSM instead of ServiceNow tickets specifically, so
+      the obligation does not narrow on non-ServiceNow deployments.
+    - Operational Constraints → Technology Stack — the ITSM entry is
+      now operator-selected, naming ServiceNow, HaloPSA/HaloITSM, and
+      Jira/Jira Service Management; ServiceNow is retained as an
+      example, not removed.
+    - Forbidden Operations — "Bypassing ServiceNow CR approval" is now
+      "Bypassing configured ITSM change approval", closing the loophole
+      that made the prohibition non-binding for other ITSMs.
+
+  This is a generalizing clarification of existing principle text — no
+  principle is removed or redefined — hence MINOR, not MAJOR.
+
+  Added sections: None
+
+  Removed sections: None
+
+  Templates requiring updates:
+    - .specify/templates/plan-template.md — ✅ Compatible (no changes needed)
+    - .specify/templates/spec-template.md — ✅ Compatible (no changes needed)
+    - .specify/templates/tasks-template.md — ✅ Compatible (no changes needed)
+
+  Follow-up TODOs:
+    - Principle III's "Assess → Authorize → Implement → Review" wording
+      is ServiceNow's own lifecycle vocabulary; whether to generalize it
+      is Open Question 9 of spec 070 and is recorded as a maintainer
+      decision (both variants drafted in specs/
+      070-itsm-provider-abstraction/contracts/
+      constitution-amendment.md, Location 1).
+    - Memory MCP's change-reference provenance check remains
+      ServiceNow-shaped (^CHG\d+$) and will reject other providers'
+      reference formats — deferred, tracked as FR-016 of spec 070.
+    - The three nautobot servers (35 gated tools) still use a separate
+      gating contract with its own environment scheme; their migration
+      onto the shared gate is a specified follow-on phase (FR-014 and
+      Open Question 7 of spec 070).
+
+  Previous version history:
+    - 1.0.0 (2026-03-26): Initial ratification with 16 core principles
+    - 1.1.0 (2026-03-28): Added Principle XVII (Milestone Documentation via
+      WordPress)
+    - 1.2.0 (2026-07-08): Principle XI installer touchpoint clarification —
+      monolithic install script → modular catalog + per-component install
+      functions (spec 049)
+-->
+```
+
+**Note on "Templates requiring updates":** all three are marked `✅ Compatible (no changes needed)` on verified grounds — `.specify/templates/` contains **zero** occurrences of "ServiceNow", "servicenow", "ITSM", or "itsm" (case-insensitive search across the template directory returned no matches). No template asserts anything about the gating ITSM, so none is invalidated by this amendment.
+
+---
+
+## Ratification
+
+**This amendment requires maintainer ratification and MUST NOT be applied unilaterally.**
+
+The Constitution's own `Governance` section (lines 344-347) requires that amendments have (1) a documented rationale, (2) a review of impact on existing principles, and (3) a semantic version bump. This document supplies (1) per location and (3) with its reasoning; (2) is the maintainer review this document exists to enable — including the Variant A / Variant B choice at Location 1 (Open Question 9) and confirmation that all five locations are in scope (Open Question 9's first half).
+
+Sequencing: ratify this amendment first; the code changes of feature 070 land after. Applying any subset of the five locations is worse than applying none, because it leaves the Constitution internally contradictory about whether ServiceNow is mandatory.

--- a/specs/070-itsm-provider-abstraction/contracts/itsm-gate-contract.md
+++ b/specs/070-itsm-provider-abstraction/contracts/itsm-gate-contract.md
@@ -1,0 +1,262 @@
+# Contract — Shared ITSM Change Gate (`src/netclaw_itsm/`)
+
+**Feature**: 070-itsm-provider-abstraction
+**Status**: PROPOSED — contract for maintainer review. Not implemented. Blocked on the Constitution amendment (1.2.0 → 1.3.0, see `contracts/constitution-amendment.md`).
+
+This document is the interface contract for the single shared change gate that replaces the duplicated per-server gate logic (FR-001). It defines the public function signature, the returned `GateDecision` envelope and its back-compat guarantees, the per-provider adapter data, the shim contract that keeps existing import sites unchanged, and the full input → decision behavior table.
+
+**Scope of v1**: the two servers using the `validate_change_request()` contract — **7 gated tools** (`gnmi_set` plus the six Claroty write tools `acknowledge_alert`, `set_device_purdue_level`, `set_device_custom_attribute`, `set_vulnerability_relevance`, `label_alerts`, `assign_alerts`). The three nautobot servers (**35 gated tools**, `_check_itsm() -> Optional[str]`, `ITSM_ENABLED` + `ITSM_LAB_MODE`) are a specified follow-on and are **not** covered by this contract (FR-014). Current-state totals being consolidated: **5 gate implementations, 42 gated tools, 4 independent `^CHG\d+$` regexes, 0 existing tests.**
+
+---
+
+## 1. Public API
+
+The shared module lives at `src/netclaw_itsm/`, following the one working precedent for cross-server Python in this repo (`src/netclaw_tokens/`, imported via a `sys.path` insert anchored on `__file__`).
+
+### 1.1 Entry point
+
+```python
+def validate_change_request(
+    cr_number: str,
+    *,
+    operation_label: str = "write operations",
+    attested_state: str | None = None,
+) -> dict[str, Any]
+```
+
+**THE ENTRY POINT IS SYNCHRONOUS.** It is a plain `def`, not `async def`, and MUST remain so. This is not a style preference — it is a hard constraint from the call sites:
+
+- `gnmi_set` (`mcp-servers/gnmi-mcp/gnmi_mcp_server.py:196`) is a plain `def` tool and calls the gate at line 219 with no `await` available.
+- The six Claroty write tools are `async def` but call the gate **unawaited** (e.g. `mcp-servers/claroty-mcp/tools/alerts.py:180`, `gate = validate_change_request(cr_number)`).
+
+Making the gate `async` would be a breaking change at all seven call sites. This constraint is also why server-side ITSM HTTP verification was rejected in favor of skill-layer verification (see §7).
+
+**Parameters**
+
+| Parameter | Type | Required | Meaning |
+|---|---|---|---|
+| `cr_number` | `str` | yes, positional | The operator-supplied change reference (`ChangeRef`). Name retained from the pre-refactor signature — see §4. Format is provider-specific (§3). |
+| `operation_label` | `str` | keyword-only, defaulted | Human-readable label for the gated operation class, interpolated into the "reference is required" message. Bound by each shim (§4) so today's exact message strings are preserved byte-for-byte. **New in 070; additive.** |
+| `attested_state` | `str \| None` | keyword-only, defaulted `None` | **New in 070; additive (Open Question 4).** The change record's state as *actually observed* by the verifying skill immediately before the write, in the provider's native vocabulary (e.g. `"Implement"`, `"Approved"`). `None` means no skill verified the state — the gate MUST then report `verified: false` and MUST NOT claim verification (FR-008). |
+
+`attested_state` is the only mechanism by which a `GateDecision` may report `verified: true`. Absent it, every decision is honestly `unverified`.
+
+### 1.2 Supporting public surface
+
+```python
+SUPPORTED_PROVIDERS: tuple[str, ...]          # ("servicenow", "halo", "atlassian", "none")
+
+def resolve_config() -> GateConfig            # reads env; never raises
+def get_adapter(provider_id: str) -> ProviderAdapter | None
+```
+
+`GateConfig` carries the resolved active provider, the lab/bypass state, and (proposed, Open Question 3) the strict flag. `ProviderAdapter` is **pure declarative data** — reference pattern, display name, approved-state vocabulary, responsible verification skill — and contains no transport, credential, or HTTP logic whatsoever (FR-004, FR-006).
+
+### 1.3 Error discipline
+
+`validate_change_request()` **MUST NOT raise** for any input, including an unrecognized provider value. Neither `gnmi_set` nor any Claroty write tool wraps the gate call in `try`/`except`, so a raised exception would surface as an unhandled traceback rather than a gate denial. Configuration errors are therefore returned as a **deny decision** with `state: "config_error"` and a message naming the supported providers (FR-003 — explicit, loud, and never a silent vendor fallback). Exceptions remain reserved for genuine programming errors (e.g. a non-`str` `cr_number`).
+
+### 1.4 Configuration inputs
+
+| Variable | Values | Default | Notes |
+|---|---|---|---|
+| `NETCLAW_ITSM_PROVIDER` | `servicenow` \| `halo` \| `atlassian` \| `none` | **Open Question 2** — spec recommends `none` with a startup warning | Case-insensitive, whitespace-trimmed. Any other value → `config_error` deny. MUST be added to **every** gated server's `env` block in `config/openclaw.json` (FR-015), including `gnmi-mcp`, whose block (`config/openclaw.json:81-90`) currently passes **no** ITSM variable at all — its lab bypass works today only by parent-environment leakage. |
+| `NETCLAW_LAB_MODE` | `true` \| `1` \| `yes` (case-insensitive) enable; anything else disables | `false` | Existing variable, semantics unchanged. Present in `claroty-mcp`'s env block; absent from `gnmi-mcp`'s. |
+| `NETCLAW_ITSM_STRICT` | `true` \| `1` \| `yes` | `false` | **Proposed, opt-in (Open Question 3).** When enabled, a format-valid but unverified reference denies instead of permitting. Default `false` preserves today's fail-open behavior and SC-003. |
+
+---
+
+## 2. The `GateDecision` envelope
+
+The return value is a plain `dict`. It is a **public contract**, not an internal detail: Claroty publishes the whole dict inside its tool output as `{"itsm_gate": <GateDecision>, "applied": bool, "response": ...}` (see `tools/alerts.py:182,219,223` and the equivalent lines in `devices.py`, `user_actions.py`, `vulnerabilities.py`). Any consumer parsing Claroty tool output sees these keys.
+
+| Key | Type | Meaning | Compatibility |
+|---|---|---|---|
+| `valid` | `bool` | Whether the gated write may proceed. `False` = deny; the caller MUST NOT perform the write. | **BACK-COMPAT — unchanged.** Present pre-070, same type, same meaning. |
+| `message` | `str` | Human-readable explanation. Always present, never `None`, never empty. Surfaced verbatim to operators and into GAIT. | **BACK-COMPAT — key unchanged.** The *key* is contractual; the *text* is not (it necessarily changes per provider — that is the point of the feature, SC-002). The one exception: under provider `servicenow` the text MUST remain byte-identical to pre-070 (§4, SC-003). |
+| `cr_number` | `str` | The change reference that was evaluated, echoed back exactly as supplied (including invalid values, so the operator can see what was rejected). | **BACK-COMPAT — MUST NOT BE RENAMED.** Renaming this to `change_ref` or similar is a **breaking change** to Claroty's published tool output. It keeps the ServiceNow-flavored name deliberately; the name is frozen even for non-ServiceNow providers. |
+| `state` | `str \| None` | Canonical state of the decision/change record. `None` when no state could be determined (missing or malformed reference). Vocabulary in §2.1. | **BACK-COMPAT — key and existing values unchanged.** The vocabulary is **extended additively**; no pre-070 value changes meaning. |
+| `provider` | `str` | The active provider id that evaluated this decision (`servicenow` \| `halo` \| `atlassian` \| `none`), or the raw offending value on a `config_error`. | **ADDITIVE — new in 070.** Explicitly sanctioned by spec US2 acceptance scenario 3. |
+| `verified` | `bool` | Whether the change record's state was **actually verified by the skill layer** for this decision. `true` only when a non-`None` `attested_state` was supplied. Never `true` on the strength of format validation alone. | **ADDITIVE — new in 070.** This is the FR-008 "verification indicator" and the key an auditor reads for SC-006. |
+
+These six keys are the complete envelope. Implementations MUST populate all six on every return path.
+
+### 2.1 `state` vocabulary
+
+Canonical internally, provider-native in `message` (Open Question 6 recommendation).
+
+| Value | Meaning | Status |
+|---|---|---|
+| `None` | No state determined — reference missing or malformed. | Pre-070, unchanged. |
+| `"unverified"` | Reference format-valid; state not verified by anyone. **This is the status-quo happy path** — today every well-formed `CHG\d+` lands here. | Pre-070, unchanged. |
+| `"lab_mode"` | Lab bypass taken; format was still checked first. | Pre-070, unchanged. |
+| `"error"` | Verification attempt raised. **Retained in the vocabulary for envelope compatibility but unreachable in v1**, because the shared gate makes no network calls (§7). No characterization test can reach it; today it is equally unreachable, since `_check_servicenow_cr_state()` returns `None` unconditionally. | Pre-070, unchanged, dead. |
+| `"approved"` | Skill layer attested a state that is in the active provider's approved-for-implementation vocabulary. Paired with `verified: true`. | **Additive.** |
+| `"not_approved"` | Skill layer attested a state that is **not** in the approved vocabulary → deny. Paired with `verified: true`. | **Additive.** |
+| `"no_itsm"` | Provider `none`: no external change record is required. | **Additive.** |
+| `"config_error"` | `NETCLAW_ITSM_PROVIDER` holds an unrecognized value. | **Additive.** |
+
+Provider-native state strings (e.g. `"Implement"`) MUST NOT be placed in `state`; they belong in `message`. Pre-070 code would have returned raw provider states in `state` on a code path that has never executed, so nothing depends on it.
+
+---
+
+## 3. Provider adapters
+
+Declarative data only (FR-004). One active provider per deployment; multi-provider-simultaneous gating is a non-goal.
+
+| Provider id | Display name | Change-reference format | Valid example | Invalid example | Approved-state vocabulary | Verifying skill (FR-007) |
+|---|---|---|---|---|---|---|
+| `servicenow` | ServiceNow | `^CHG\d+$` — literal `CHG` + one or more digits | `CHG0012345` | `1084` (bare integer — a valid **Halo** ref, rejected here) | `Implement` → canonical `approved` | `servicenow-change-request`, calling the install-time ServiceNow clone via `$SERVICENOW_MCP_SCRIPT` / `$MCP_CALL`. **Caveat**: there is no `servicenow-mcp` registered in `config/openclaw.json`, so this path is reachable only as an unregistered clone — see Open Question 8. |
+| `halo` | HaloPSA / HaloITSM | **PROVISIONAL** `^\d+$` — a Halo change-ticket id (Halo ticket ids are integers; change tickets are a distinct ticket type) | `1084` | `CHG0012345` (ServiceNow-shaped — MUST be rejected with a Halo-specific message, US1 acceptance scenario 2) | Halo change-ticket status naming its post-approval/implementation state → canonical `approved`. **Requires confirmation against feature 069's ticket-type and status data.** | `halo-change-request` (feature 069, PR #167). **Feature 069 is an unmerged dependency: `halo-mcp` and this skill do not exist on this branch.** If 069 does not land, this adapter ships with its verification skill marked unavailable, per the spec's Assumptions. |
+| `atlassian` | Atlassian Jira / Jira Service Management | Jira issue key `^[A-Z][A-Z0-9]+-\d+$` | `CHG-482`, `NETOPS-1204` | `CHG0012345` (no hyphen — not a Jira key) | Workflow-dependent; the adapter declares the operator-configurable set (e.g. `Approved`, `Implementing`) → canonical `approved` | `atlassian-change-request`, via the registered `atlassian-mcp` |
+| `none` | *(no ITSM gating)* | Not validated. A reference MAY be supplied and is echoed in `cr_number`, but is neither required nor pattern-checked. | any value, including `""` | — (nothing is invalid) | n/a | none — the bypass itself is the audit record and MUST be GAIT-logged (FR-012) |
+
+**Format notes for maintainer review**
+
+- The bare-integer Halo pattern is flagged PROVISIONAL because it accepts any typo'd digit string and cannot be told apart from a mistyped ticket number. A prefixed operator-facing form (e.g. `HALO-1084`, normalized to the integer before use) would be unambiguous at the cost of not matching what Halo's own UI displays. This is a decision for the maintainers, related to Open Question 5.
+- Cross-provider references MUST NEVER be silently accepted. Under `halo`, `CHG0012345` is a denial, not a fallback (spec Edge Cases; a silent fallback would recreate the original bug).
+- Reference-format matching is the **only** validation the gate performs on the reference. It does not check existence, ownership, scheduling window, or CAB status — no gate code can, without network access.
+
+---
+
+## 4. Shim contract
+
+Thin per-server shims are retained at the two existing gate paths so that no import site or call site churns (FR-010, SC-007). Each shim MUST behave as an alias of the shared gate with its `operation_label` pre-bound.
+
+### 4.1 `mcp-servers/gnmi-mcp/itsm_gate.py`
+
+MUST continue to export:
+
+```python
+def validate_change_request(cr_number: str) -> dict[str, Any]
+```
+
+- Callable with **exactly one positional argument**. The sole importer is `mcp-servers/gnmi-mcp/gnmi_mcp_server.py:50` — `from itsm_gate import validate_change_request` — and the sole call site is line 219, `itsm_result = validate_change_request(change_request_number)`. Both MUST remain unchanged.
+- MUST bind `operation_label` such that the empty-reference message is byte-identical to today's: `"Change request number is required for gNMI Set operations"`.
+- MAY accept and forward `attested_state` as a keyword-only parameter (that is how a future gnmi skill would attest), but MUST NOT make it required.
+- MUST resolve `netclaw_itsm` itself via its own `sys.path` insert anchored on `__file__` (`os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "src")`), matching the `netclaw_tokens` precedent. It MUST NOT rely on the insert that `gnmi_mcp_server.py:31` happens to perform first, so that the module is importable standalone (which the characterization tests require).
+
+### 4.2 `mcp-servers/claroty-mcp/utils/itsm_gate.py`
+
+MUST continue to export the same one-positional-argument `validate_change_request(cr_number)`.
+
+- Four importers, all `from utils.itsm_gate import validate_change_request`: `tools/alerts.py:17`, `tools/devices.py:27`, `tools/user_actions.py:22`, `tools/vulnerabilities.py:17`. Six call sites: `alerts.py:180`, `devices.py:226`, `devices.py:282`, `user_actions.py:47`, `user_actions.py:109`, `vulnerabilities.py:209`. All MUST remain unchanged.
+- MUST bind `operation_label` such that the empty-reference message is byte-identical to today's: `"Change request number is required for Claroty write operations"`.
+- MUST resolve `netclaw_itsm` via its own `sys.path` insert of `os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..", "src")` — three levels up from `utils/`, exactly as `mcp-servers/claroty-mcp/utils/gcf_helper.py:8` already does. Claroty's server module (`claroty_mcp_server.py:25`) inserts only its own directory, so the shim cannot inherit a `src` path.
+
+### 4.3 Private names
+
+`_CR_PATTERN` and `_check_servicenow_cr_state()` are private and have **no importers anywhere in the repo**. The shared gate MUST NOT call `_check_servicenow_cr_state()` (it is a stub returning `None`, and the shared gate makes no network calls). Recommendation: the characterization suite (FR-011) MUST NOT monkeypatch either name, so both can be deleted with the shim rewrite. If any characterization test does depend on them, the shims MUST retain them as deprecated no-ops for exactly as long as that test does.
+
+### 4.4 Parameter names at the MCP boundary
+
+Untouched by this contract, and MUST stay untouched (FR-010, SC-007):
+
+| Server | MCP tool parameter | Requiredness |
+|---|---|---|
+| `gnmi-mcp` | `change_request_number` | required |
+| `claroty-mcp` | `cr_number` | required |
+| nautobot family (follow-on, not v1) | `cr_number` | **optional** |
+
+The shared gate's own first parameter is `cr_number`; the gnmi shim receives whatever `gnmi_set` passes positionally, so the tool-level name `change_request_number` needs no rename.
+
+---
+
+## 5. Behavior table
+
+Evaluation order is normative — it is what preserves status-quo behavior:
+
+1. resolve provider → unknown value denies immediately (a misconfiguration MUST NOT be maskable by lab mode);
+2. provider `none` → permit;
+3. reference presence;
+4. reference format;
+5. lab bypass;
+6. attestation;
+7. strict mode.
+
+Steps 3 → 4 → 5 reproduce today's ordering exactly: **format is checked before the lab bypass**, so a malformed reference is rejected even in lab mode.
+
+| # | Input condition | `valid` | `state` | `verified` | `provider` | Message names |
+|---|---|---|---|---|---|---|
+| 1 | Provider `servicenow`; `CHG0012345`; no attestation | `true` | `unverified` | `false` | `servicenow` | ServiceNow; verification unavailable |
+| 2 | Provider `halo`; valid Halo ref; no attestation | `true` | `unverified` | `false` | `halo` | Halo; verification unavailable |
+| 3 | Any provider; format-valid ref; `attested_state` in approved vocabulary | `true` | `approved` | `true` | as configured | provider + provider-native state |
+| 4 | Any provider; format-valid ref; `attested_state` **not** in approved vocabulary | `false` | `not_approved` | `true` | as configured | provider + observed state + required state(s) |
+| 5 | Provider `halo`; `CHG0012345` (**wrong-provider format**) | `false` | `None` | `false` | `halo` | Halo + Halo's expected format. Never accepted, never a fallback. |
+| 6 | Any real provider; malformed ref (e.g. `chg123`, `NET 482`) | `false` | `None` | `false` | as configured | provider + expected format |
+| 7 | Any real provider; `cr_number` empty / falsy | `false` | `None` | `false` | as configured | shim-bound `operation_label`; byte-identical to pre-070 under `servicenow` |
+| 8 | Lab mode on; provider `servicenow`; format-valid ref | `true` | `lab_mode` | `false` | `servicenow` | lab mode; state check skipped. **GAIT-logged bypass** (FR-012). |
+| 9 | Lab mode on; **malformed** ref | `false` | `None` | `false` | as configured | expected format. Lab mode does **not** waive format validation (preserves today's ordering). |
+| 10 | Provider `none` (with or without lab mode; `none` wins and reports `no_itsm`) | `true` | `no_itsm` | `false` | `none` | no ITSM configured; no change record required. **GAIT-logged bypass** (FR-012). |
+| 11 | Provider `none`; no ref supplied at all | `true` | `no_itsm` | `false` | `none` | as row 10 — no reference is required |
+| 12 | `NETCLAW_ITSM_PROVIDER` unrecognized (e.g. `jira`, `Servicenow!`, `remedy`) | `false` | `config_error` | `false` | the raw offending value | configuration error + the four supported ids. **Never falls back to ServiceNow** (FR-003). Not bypassable by lab mode. |
+| 13 | Strict mode on; format-valid ref; **no** attestation | `false` | `unverified` | `false` | as configured | strict mode requires verified state. **Opt-in only** (Open Question 3); default off preserves row 1. |
+| 14 | Strict mode on; format-valid ref; attested approved | `true` | `approved` | `true` | as configured | as row 3 |
+
+**Precedence resolutions this table settles** (both called out as undefined in the spec's Edge Cases):
+
+- **Unknown provider vs lab mode**: unknown provider wins (row 12). A misconfiguration must be loud even in a lab.
+- **Provider `none` vs lab mode**: `none` wins and reports `no_itsm` (row 10), because provider selection is explicit operator configuration while lab mode is ambient environment. The permit/deny outcome is identical either way; only `state` differs.
+
+**GAIT (FR-013)**: every decision — allow and deny — is recorded with the provider, the change reference, the verification status, and the outcome. The gate module itself does not write GAIT; the calling server does, as `gnmi_set` already does at `gnmi_mcp_server.py:221-227`. Servers MUST extend their existing GAIT calls with `provider` and `verified`.
+
+---
+
+## 6. Compatibility guarantees and breaking-change rules
+
+### Guaranteed (a conforming implementation MUST NOT break these)
+
+1. `validate_change_request()` stays **synchronous** and callable with one positional `str`.
+2. The two shim module paths stay importable at their current paths with their current export names.
+3. All six envelope keys are present on every return path; the four pre-070 keys keep their names, types, and meanings.
+4. `cr_number` keeps its name.
+5. Under provider `servicenow` with lab mode off and strict mode off, every decision — including `message` text, byte-for-byte — is identical to the pre-070 gate. This is what the characterization suite (FR-011) locks down and what SC-003 measures.
+6. No MCP tool parameter is renamed and none changes requiredness (SC-007).
+7. The four pre-070 `state` values keep their exact spellings.
+
+### A future change MAY
+
+- add new keys to the envelope (additive only);
+- add new `state` values;
+- add new providers to `SUPPORTED_PROVIDERS` and new adapters;
+- change `message` **text** for non-`servicenow` providers freely, and for `servicenow` only alongside an updated characterization baseline;
+- add new keyword-only parameters with defaults that preserve current behavior.
+
+### A future change MUST NOT (each is breaking; requires a new contract version and a coordinated consumer update)
+
+- rename or remove `valid`, `message`, `cr_number`, or `state`;
+- rename `cr_number` to a provider-neutral name — the ServiceNow-flavored name is deliberately frozen;
+- change the type of any existing key (e.g. `state` to a dict, `valid` to a tri-state);
+- repurpose an existing `state` value;
+- make the entry point `async`, or add a required positional/keyword parameter;
+- make `verified: true` reachable without a real skill-layer attestation (that would resurrect exactly the dishonesty this feature removes);
+- default `NETCLAW_ITSM_PROVIDER` to a vendor when it is unset or invalid;
+- move the shim module paths, or drop their one-positional-argument form, while the current call sites exist.
+
+---
+
+## 7. Explicit non-responsibilities
+
+This contract deliberately does **not** cover, and a conforming gate MUST NOT do, the following:
+
+| Not done here | Why | Who owns it |
+|---|---|---|
+| **Any network call to any ITSM** (FR-006) | NetClaw MCP servers cannot call other MCP servers — no MCP client exists anywhere under `mcp-servers/`; `scripts/mcp-call.py` is used only by skills, bash, and the UI. Server-side HTTP would also require per-ITSM credentials inside every gated server and an `async` gate, which §1.1 forbids. | The agent/skill layer, which can reach any ITSM's MCP tools |
+| **Credential handling** — no tokens, no API keys, no instance URLs | Nothing in the gate authenticates to anything. Adapters are data. | The provider's MCP server + its `config/openclaw.json` env block |
+| **Change-record state verification** | The gate can only *receive* an attested state; it cannot observe one. | The per-provider verifying skill named in §3 (FR-007) |
+| **Deciding *which* tools are gated / what counts as a write** | Unchanged by this feature (explicit non-goal). | Each server's own tool definitions |
+| **Writing GAIT records** | The gate returns a decision; the caller already owns its audit call. | The calling MCP server (FR-013) |
+| **nautobot's `_check_itsm()` contract** (35 tools, `Optional[str]`, `ITSM_ENABLED` + `ITSM_LAB_MODE`) | Different contract, different env scheme, gating currently defaults **off** — migrating it is a breaking env change needing its own compatibility analysis. | Follow-on phase (FR-014, Open Question 7) |
+| **Memory MCP change-reference provenance** (`memory-mcp/storage/sqlite_store.py:109`, `validate_cr_number()`, `^CHG\d+$`) | Provenance metadata for audit records, not a gate. | Deferred, documented as a known user-visible inconsistency: a Halo or Jira reference will fail it (FR-016) |
+
+**The honest consequence, stated plainly**: with skill-layer verification the server-side gate is **advisory**. A direct tool call can assert any reference. The real controls are the skill layer and the GAIT audit trail. This is not a regression — today's gate enforces nothing either (`_check_servicenow_cr_state()` returns `None`, so every well-formed reference passes as `unverified`). What this contract changes is that the boundary is now *stated and auditable* rather than implied by a docstring that promises a ServiceNow check the code never performs.
+
+---
+
+## 8. Test obligations
+
+Referenced here because they are part of the contract's acceptance, not merely of the plan:
+
+- **FR-011 / US2-1**: characterization tests capturing the **current** behavior MUST exist and pass against the **unrefactored** code before the shared module replaces it. There are **0 existing tests** across all five gate implementations, so this baseline is written from the code in `mcp-servers/gnmi-mcp/itsm_gate.py` and `mcp-servers/claroty-mcp/utils/itsm_gate.py`.
+- The suite MUST cover, at minimum: each provider's format validation (valid and invalid), wrong-provider references, the unknown-provider error, the lab and `none` bypasses, the verified/unverified distinction, and the exact Claroty `{"itsm_gate": ..., "applied": ...}` envelope shape (SC-004).
+- Rows 1, 7, 8, and 9 of §5 are the status-quo rows; their assertions MUST be identical before and after the refactor (SC-003).

--- a/specs/070-itsm-provider-abstraction/data-model.md
+++ b/specs/070-itsm-provider-abstraction/data-model.md
@@ -1,0 +1,279 @@
+# Phase 1 Data Model: ITSM Provider Abstraction for Change Gating
+
+**Feature**: 070-itsm-provider-abstraction
+**Date**: 2026-07-24
+
+No persistent store, no schema migration, no new database. Every entity here is
+in-process and resolved per gated call inside the new shared module
+`src/netclaw_itsm/` (home rationale: research R3), reached from two thin
+re-export shims at the existing gate paths:
+
+- `mcp-servers/gnmi-mcp/itsm_gate.py` — shim for `gnmi_set`
+- `mcp-servers/claroty-mcp/utils/itsm_gate.py` — shim for Claroty's six writes
+
+Two of the five entities cross a **public** boundary and are therefore
+compatibility-constrained: `GateDecision` (published verbatim in Claroty tool
+output at `mcp-servers/claroty-mcp/tools/alerts.py:178,182,219,223`) and
+`ChangeRef` (its parameter name is part of each MCP tool's schema).
+
+---
+
+## Entity: `ItsmProvider` (enum)
+
+The selected ITSM for change gating. Exactly one is active per deployment
+(spec Non-Goals: no multi-provider-simultaneous gating).
+
+| Value | Meaning | v1 status |
+|---|---|---|
+| `servicenow` | ServiceNow change management. Reproduces today's behavior exactly. | supported |
+| `halo` | HaloPSA / HaloITSM change tickets. | supported; verification skill depends on unmerged PR #167 |
+| `atlassian` | Atlassian Jira issues used as change records. | supported |
+| `none` | No external ITSM. Writes proceed ungated, every call GAIT-logged as a bypass. | supported |
+
+**Validation rules**
+
+- Resolved from `NETCLAW_ITSM_PROVIDER` (research R5), **trimmed** and
+  **lower-cased** before comparison.
+- An unrecognized non-empty value is a **loud configuration error** — the gate
+  MUST fail with a message naming the four supported values and MUST NOT fall
+  back to any vendor (FR-003). A silent fallback to `servicenow` would recreate
+  the original defect.
+- Unset → the documented default. **Recommended**: `none` plus a startup warning
+  (spec Open Question 2 — maintainer decision, not settled here).
+- The set is closed: it is a frozen table in code, so no adapter can be
+  constructed at runtime for a value not listed above.
+
+---
+
+## Entity: `ProviderAdapter`
+
+Declarative metadata for one provider. **Pure data plus a compiled regex.**
+
+| Field | Type | Notes |
+|---|---|---|
+| `provider` | `ItsmProvider` | Primary key of the adapter table. |
+| `display_name` | `str` | Human-readable ITSM name used in every message (FR-005). Never a hard-coded vendor string elsewhere. |
+| `ref_pattern` | `re.Pattern \| None` | Compiled at import. `None` only for `none`, which accepts any/no reference. |
+| `ref_example` | `str \| None` | Concrete example embedded in the rejection message. |
+| `ref_description` | `str \| None` | Human phrasing of the expected format ("CHG followed by digits"), so messages read naturally instead of printing a regex. |
+| `approved_states` | `frozenset[str]` | Provider-native state strings that mean "approved for implementation". Compared case-insensitively, matching today's `cr_state.lower() == "implement"` (`mcp-servers/gnmi-mcp/itsm_gate.py:95`). |
+| `canonical_approved_state` | `str` | Internal normalization (`approved_for_implementation`). Envelope/messages carry the **native** name (spec Open Question 6 recommendation: canonical internally, provider-native in messages). |
+| `verification_skill` | `str \| None` | Name of the skill responsible for verifying a change record's state before a gated write (FR-004, FR-007). |
+| `verification_available` | `bool` | `False` when the named skill or its dependency is not present in the deployment; drives documentation and the startup warning, never a silent pass. |
+
+**Invariants**
+
+- **No transport, no credentials, no HTTP client, no network call, no ITSM SDK
+  import.** An adapter cannot perform I/O; this is the mechanical guarantee
+  behind FR-006 (research R2).
+- The only environment variable the module reads is the gate configuration
+  itself (`GateConfig`); adapters read none.
+- Adapters are immutable after import and are not operator-editable data files
+  in v1 (a plugin/registry mechanism is out of scope).
+- Every message rendered from an adapter MUST derive its ITSM name from
+  `display_name`, which is what makes SC-002 ("no gate output contains
+  'ServiceNow' under a non-ServiceNow provider") checkable by grep.
+
+### Per-provider adapter table
+
+| Provider | `display_name` | Reference format (`ref_pattern`) | Example | `approved_states` | `verification_skill` |
+|---|---|---|---|---|---|
+| `servicenow` | ServiceNow | `^CHG\d+$` — verified as today's behavior at `mcp-servers/gnmi-mcp/itsm_gate.py:21` and `mcp-servers/claroty-mcp/utils/itsm_gate.py:27` | `CHG0012345` | `{"Implement"}` (case-insensitive) | `servicenow-change-workflow` — exists at `workspace/skills/servicenow-change-workflow/`, but reaches ServiceNow only via `$SERVICENOW_MCP_SCRIPT`, an unregistered install-time clone (spec Open Question 8), so `verification_available` is deployment-dependent |
+| `halo` | HaloPSA / HaloITSM | **Proposed, must be confirmed against feature 069 when it merges** — Halo change tickets are addressed by ticket id, so a numeric-id pattern (optionally accepting an operator-visible prefix). Recorded as *open* deliberately: FR-004 exists so this is data, not code | pending 069 | pending 069 (Halo change-ticket status vocabulary) | `halo-change-request` — **does NOT exist on this branch**; it and `halo-mcp` arrive with PR #167. Ships with `verification_available = False` if 069 does not land (spec Assumptions) |
+| `atlassian` | Atlassian Jira | Jira issue key, `^[A-Z][A-Z0-9]*-\d+$` — key shape confirmed from `workspace/skills/atlassian-itsm/SKILL.md:108` ("NET-1234") | `NET-1234` | **Operator-supplied.** Jira workflow statuses are per-project configurable, so a fixed default would be wrong for most tenants; the adapter needs an operator-configurable status list rather than a shipped constant | `atlassian-itsm` — exists at `workspace/skills/atlassian-itsm/`, uses `jira_get_issue` / `jira_get_transitions` / `jira_transition_issue`; `atlassian-mcp` is registered in `config/openclaw.json` |
+| `none` | no ITSM (ungated) | `None` — no reference required or validated | — | n/a | n/a — no verification occurs; every call is a GAIT-logged bypass (FR-012) |
+
+**Note on `halo`**: feature 069 is an unmerged dependency. Neither `halo-mcp`
+nor a Halo change skill exists in this worktree, so this row records what the
+adapter needs rather than asserting what it is. The `atlassian` row's
+operator-supplied state vocabulary and the `halo` row's pending reference format
+are the two adapter fields that cannot be finalized from this branch alone.
+
+---
+
+## Entity: `ChangeRef`
+
+The operator-supplied reference to a change record. Not a stored object — a
+validated view over the string a tool received.
+
+| Field | Type | Notes |
+|---|---|---|
+| `raw` | `str \| None` | Exactly what the tool passed in, echoed unmodified into the envelope's `cr_number`. |
+| `provider` | `ItsmProvider` | The provider the reference was evaluated against. |
+| `matches_format` | `bool` | Result of `adapter.ref_pattern` (always `True` for `none`). |
+| `param_name` | `str` | Which tool parameter carried it — informational, for the GAIT record only. |
+
+**Validation rules**
+
+- Presence is checked first: empty or `None` → invalid, with the calling
+  subsystem named in the message ("gNMI Set operations" / "Claroty write
+  operations"). These two strings are supplied by the **shim**, not by a tool
+  parameter (research R4), and are preserved byte-for-byte.
+- Format is checked against the **configured provider's** pattern only. A
+  `CHG0012345` reference under provider `halo` MUST be rejected with a message
+  naming Halo's expected format — never silently accepted (spec Edge Cases).
+- `raw` is echoed **verbatim** in the envelope, including when it is `""` or
+  malformed. This preserves observed behavior at
+  `mcp-servers/gnmi-mcp/itsm_gate.py:38-54`, where `cr_number` mirrors the input
+  on every rejection path.
+- **Requiredness is a property of the tool signature, not of `ChangeRef`**, and
+  FR-010/SC-007 freeze it:
+
+  | Server | Parameter | Requiredness |
+  |---|---|---|
+  | `gnmi-mcp` (`gnmi_set`) | `change_request_number` | required |
+  | `claroty-mcp` (6 write tools) | `cr_number` | required |
+  | nautobot family (35 tools, follow-on) | `cr_number` | **optional** |
+
+  No rename, no requiredness change, in v1 or in the follow-on phase.
+
+---
+
+## Entity: `GateDecision` (the envelope — public contract)
+
+The dict returned by `validate_change_request()`. Claroty publishes it whole to
+the model as `{"itsm_gate": <GateDecision>, "applied": <bool>, …}`, so its keys
+are a public contract: **additive changes only** (FR-009).
+
+| Key | Type | Status | Meaning |
+|---|---|---|---|
+| `valid` | `bool` | **pre-existing / back-compat** | Whether the write may proceed. Load-bearing: branched on at `mcp-servers/gnmi-mcp/gnmi_mcp_server.py:220` and at all six Claroty sites (`tools/alerts.py:181`, `tools/devices.py:227,283`, `tools/user_actions.py:48,110`, `tools/vulnerabilities.py:210`). |
+| `message` | `str` | **pre-existing / back-compat** | Always present. Operator-facing explanation; carries the provider's `display_name` and, on the two subsystem-specific paths, the shim's operation label. |
+| `cr_number` | `str \| None` | **pre-existing / back-compat — name retained** | The reference that was checked, echoed verbatim. The name is now provider-neutral in meaning but MUST NOT be renamed (renaming is breaking; `provider` supplies the missing context). |
+| `state` | `str \| None` | **pre-existing / back-compat** | Observed value domain today: `None` (format failure), `"lab_mode"`, `"unverified"`, `"error"`, or a provider-native state string. New values are additive members of this domain, e.g. `"none"` for the ungated provider. |
+| `provider` | `str` | **additive (new)** | The active `ItsmProvider` value (FR-002). Present on every decision, including bypasses. |
+| `verified` | `bool` | **additive (new)** | `True` only when a skill attested a state that the adapter counts as approved. MUST be `False` on every other path, including `state: "unverified"`, `"lab_mode"`, `"error"`, and `"none"` (FR-008). |
+| `attested_state` | `str \| None` | **additive (new, proposed)** | The provider-native state the verifying skill claims (spec Open Question 4). `None` when the caller supplied none. |
+
+**Invariants**
+
+- Additive only: no pre-existing key is ever removed, renamed, or retyped, and
+  the four back-compat keys keep their exact meanings.
+- `valid == False` ⇒ the calling tool MUST NOT perform the write. Both existing
+  servers already honor this; the shared gate does not change the contract.
+- `verified == True` requires an `attested_state` present **and** in
+  `adapter.approved_states`. The gate MUST NEVER report verification that did not
+  occur (FR-008) — this is the single most important invariant in the model,
+  because the pre-refactor code's docstrings implied verification it never
+  performed.
+- JSON/GCF-serializable: Claroty passes the envelope through `gcf_dumps()`
+  (`mcp-servers/claroty-mcp/utils/gcf_helper.py`) and `json.dumps(..., indent=2)`.
+  So: primitives only — no sets, no `datetime`, no dataclass instances, no
+  regex objects.
+- Under a non-ServiceNow provider, no rendered `message` may contain the string
+  "ServiceNow" (SC-002).
+
+---
+
+## Entity: `GateConfig`
+
+Resolved policy, computed once at module import and reused for every decision
+(no per-call environment reads).
+
+| Field | Type | Source | Default |
+|---|---|---|---|
+| `provider` | `ItsmProvider` | `NETCLAW_ITSM_PROVIDER` | recommended `none` + startup warning (Open Question 2) |
+| `lab_mode` | `bool` | `NETCLAW_LAB_MODE` | `false` — truthy set `("true", "1", "yes")`, case-insensitive, preserving `mcp-servers/gnmi-mcp/itsm_gate.py:57` exactly |
+| `strict` | `bool` | `NETCLAW_ITSM_STRICT` (**proposed**, Open Question 3) | `false` — v1 stays fail-open for compatibility |
+| `source` | `str` | which variable/default supplied `provider` | — |
+| `warnings` | `list[str]` | emitted at import (unset provider, unavailable verification skill) | `[]` |
+
+**Validation and precedence rules**
+
+- **Unknown provider is an error even in lab mode.** Lab mode must not mask a
+  misconfiguration — an operator who typo'd `serviccenow` needs to hear about it
+  in the lab, not in production.
+- **Bypass precedence**: `lab_mode == True` **or** `provider == none` ⇒ a single
+  bypass decision (`valid: True`, `verified: False`, `state: "lab_mode"` or
+  `"none"`), GAIT-logged as a bypass (FR-012). When both hold, one decision is
+  produced and the GAIT record names both reasons; there is no double bypass and
+  no ambiguity about which fired.
+- `strict` has no effect on a bypass path — bypass is a deliberate operator
+  choice, not an unverified accident.
+- Delivery (FR-015): `NETCLAW_ITSM_PROVIDER` must appear in the `env` block of
+  every gated server in `config/openclaw.json`. `gnmi-mcp`'s block
+  (`config/openclaw.json:81-90`) currently carries **no** ITSM variable at all,
+  so it must gain both `NETCLAW_ITSM_PROVIDER` and `NETCLAW_LAB_MODE`, or
+  provider selection silently no-ops there the same way lab mode does today.
+  `claroty-mcp` already receives `NETCLAW_LAB_MODE` at
+  `config/openclaw.json:557`.
+- **Not touched in v1**: the nautobot family's `ITSM_ENABLED` / `ITSM_LAB_MODE`
+  pair. When the follow-on phase migrates them, they map onto `GateConfig` with
+  defaults preserved — `ITSM_ENABLED=false` (default) behaves as
+  `provider = none`, and `ITSM_LAB_MODE=true` (default) behaves as
+  `lab_mode = True` — so that migration flips no deployment's posture.
+
+---
+
+## Decision flow (how a `GateDecision` is reached)
+
+Evaluation is a single synchronous pass with no I/O (research R2). Order matters:
+it is chosen so that every currently-reachable path produces byte-identical
+output under provider `servicenow` with no attestation (SC-003).
+
+1. **Resolve config** — `GateConfig` from import-time state. Unknown provider ⇒
+   configuration error, terminal.
+2. **Bypass check** — `lab_mode` or `provider == none` ⇒ `valid: True`,
+   `verified: False`, `state: "lab_mode"` / `"none"`; GAIT bypass record;
+   terminal. (Preserves today's lab-mode message and `state: "lab_mode"`.)
+3. **Presence check** — empty/missing `ChangeRef.raw` ⇒ `valid: False`,
+   `state: None`, message = shim's operation label ("Change request number is
+   required for … operations"); terminal.
+4. **Format check** — `adapter.ref_pattern` fails ⇒ `valid: False`,
+   `state: None`, message names `display_name` + `ref_description` +
+   `ref_example`; terminal (FR-005).
+5. **Verification classification** —
+   - `attested_state` present **and** in `adapter.approved_states` ⇒
+     `verified: True`, `state` = the native attested string, `valid: True`.
+   - `attested_state` present **and not** approved ⇒ `valid: False`, message in
+     the form "…is in '<state>' state, not '<approved>'…" plus the subsystem
+     clause — mirroring the pre-existing, currently unreachable branch at
+     `mcp-servers/gnmi-mcp/itsm_gate.py:102-111`.
+   - `attested_state` absent ⇒ `verified: False`, `state: "unverified"`.
+6. **Policy** — for the `unverified` outcome: `strict == False` (v1 default) ⇒
+   `valid: True` (status quo preserved); `strict == True` ⇒ `valid: False` with a
+   message stating that no skill verified the record.
+7. **GAIT record** — one entry per decision carrying provider, reference,
+   verification status, allow/deny outcome, and the operation label (FR-013).
+   Emitted from the shared gate so all 7 v1 tools are uniform: `gnmi-mcp`
+   already logs decisions (`gnmi_mcp_server.py:97-110`), `claroty-mcp` logs
+   nothing today.
+
+### Terminal outcomes
+
+| Condition | `valid` | `state` | `verified` |
+|---|---|---|---|
+| Unknown provider value | *error raised* | — | — |
+| Lab mode on | `True` | `"lab_mode"` | `False` |
+| Provider `none` | `True` | `"none"` | `False` |
+| Reference missing/empty | `False` | `None` | `False` |
+| Reference fails provider format | `False` | `None` | `False` |
+| Valid reference, no attestation, non-strict | `True` | `"unverified"` | `False` |
+| Valid reference, no attestation, strict | `False` | `"unverified"` | `False` |
+| Attested, state approved | `True` | native state | `True` |
+| Attested, state not approved | `False` | native state | `False` |
+| Internal error during evaluation | `True` | `"error"` | `False` |
+
+The last row preserves the existing fail-open exception path
+(`mcp-servers/gnmi-mcp/itsm_gate.py:113-123`).
+
+---
+
+## Not modeled here (explicitly out of this data model)
+
+- **`_check_itsm(cr_number: Optional[str]) -> Optional[str]`** — the nautobot
+  family's separate contract (`nautobot-mcp-v2/server.py:39`,
+  `nautobot-routing-mcp/server.py:57`,
+  `nautobot-golden-config-mcp/server.py:60`). Returns an error message or `None`,
+  performs **no** format validation, and gates 35 tools with gating **off** by
+  default. Follow-on phase (FR-014); its mapping onto `GateConfig` is sketched
+  above but not implemented in v1.
+- **`validate_cr_number(cr_number) -> Tuple[bool, str|None]`** —
+  `mcp-servers/memory-mcp/storage/sqlite_store.py:109`. Audit *provenance* for
+  `memory_record_decision`, not a gate. Stays `^CHG\d+$`, so a Halo or Jira
+  reference will be rejected there; documented as a known deferred
+  inconsistency (FR-016). It is also the only change-reference validator in the
+  repo that currently has tests (`tests/unit/test_sqlite_store.py:98-107`).
+- **`GnmiSetRequest`** — `mcp-servers/gnmi-mcp/models.py:186-207`, unreferenced
+  dead code carrying a second `^CHG\d+$` validator at `:198`. Deleted, not
+  modeled; its removal is what takes SC-001's validator count from 4 to 1.

--- a/specs/070-itsm-provider-abstraction/gait-session-log.md
+++ b/specs/070-itsm-provider-abstraction/gait-session-log.md
@@ -1,0 +1,160 @@
+# GAIT Session Log — Feature 070: ITSM Provider Abstraction
+
+**Principle IV — Immutable Audit Trail.** This log records the decisions and findings of the
+specification session. Entries are append-only; corrections are recorded as new turns that
+reference the original, never by rewriting history.
+
+**Branch**: `070-itsm-provider-abstraction` (from clean `origin/main` @ `12325d0`)
+**Date**: 2026-07-24
+**Deliverable**: specification artifacts only — **no code**
+**Outcome**: 10 SDD artifacts authored; implementation deliberately blocked pending maintainer
+ratification of a Constitution amendment.
+
+---
+
+## Turn 0 — Origin of the feature
+
+**Asked** (operator, during feature 069 review): *"Is there any way in the current ITSM gating to
+allow for the user to choose which ITSM tool should be used vs NetClaw always talking about
+ServiceNow?"*
+
+**Answered** No. Verified by grep: no `ITSM_PROVIDER` / `CHANGE_PROVIDER` / equivalent
+configuration knob exists anywhere in the repo. ServiceNow is hardwired at three layers — the
+Constitution (Principle III), the code (`itsm_gate.py`), and the skill layer
+(`servicenow-change-workflow`).
+
+**Decided** This warrants its own feature rather than being bolted onto 069, because it touches
+the Constitution. Operator direction: *"That's going to take some discussion with the netclaw
+maintainers, but I think it's good."* → the deliverable is a **proposal**, not an
+implementation.
+
+---
+
+## Turn 1 — Four scoping decisions
+
+**Q1 — What does this round deliver?**
+> **Decided: specification artifacts only.** Nothing is built on an unratified Constitution
+> amendment. The artifacts are a proposal to take to the @automateyournetwork maintainers.
+
+**Q2 — How much of the gate surface does v1 unify?**
+> **Decided: phase it.** v1 covers the two servers on the `validate_change_request()` contract
+> (`gnmi-mcp`, `claroty-mcp` — 7 gated tools). The nautobot family (3 servers, 35 gated tools,
+> a different contract and different env vars) is **specified** as a follow-on phase but not
+> implemented. Rationale: with zero existing test coverage, a 42-tool blast radius is
+> irresponsible; 7 tools is a complete, verifiable story.
+
+**Q3 — How wide is the Constitution amendment?**
+> **Decided: all five ServiceNow-naming locations** — Principle III (`:55-64`), Principle VIII
+> (`:114`), Principle XIV (`:200`), Technology Stack (`:260`), Forbidden Operations (`:269`).
+> Amending Principle III alone would leave four references contradicting it, which would fail
+> the comprehension test that spec 049's own amendment criterion established.
+
+**Q4 — How is a change record's state verified?**
+> **Decided: skill-layer verification.** The agent/skill verifies via the ITSM's own MCP tools;
+> the server-side shared gate enforces reference format + provider policy + envelope + GAIT and
+> makes **no** network calls.
+>
+> This overruled the initial recommendation of server-side HTTP adapters. The operator's choice
+> is the better fit, and the reasons are recorded in `research.md` R2: NetClaw MCP servers
+> cannot call other MCP servers (no MCP client exists under `mcp-servers/`), the gate must be
+> **synchronously** callable (`gnmi_set` is a plain `def`), and server-side verification would
+> require per-ITSM credentials and HTTP clients inside every gated server.
+>
+> **Consequence accepted and documented rather than hidden:** the server-side gate is
+> **advisory** — a direct tool call can assert any reference. This is not a regression;
+> `_check_servicenow_cr_state()` already returns `None`, so today every well-formed `CHG\d+`
+> passes as `unverified`. The feature makes the boundary honest and adds an optional
+> `attested_state` so skill verification becomes auditable.
+
+---
+
+## Turn 2 — Exploration corrected the scope (three material findings)
+
+The initial draft spec was written before codebase exploration and **understated the problem**.
+Superseded by these verified findings:
+
+1. **The gate surface is 4× larger than drafted.** Beyond the two `itsm_gate.py` copies there
+   are three more copies of a *different* gate — `_check_itsm()` in `nautobot-mcp-v2`,
+   `nautobot-routing-mcp`, `nautobot-golden-config-mcp` — with a different return type
+   (`Optional[str]`), a different env scheme (`ITSM_ENABLED`/`ITSM_LAB_MODE`), **no** reference
+   format validation, and an **optional** `cr_number`. Plus a ServiceNow-shaped provenance
+   validator in Memory MCP and a dead validator in `gnmi-mcp/models.py`.
+   → Canonical totals: **5 implementations · 5 servers · 42 gated tools · 4 independent
+   `^CHG\d+$` regexes.**
+2. **Zero test coverage on any gate.** `grep tests/` for itsm / `validate_change_request` /
+   `NETCLAW_LAB_MODE` returns nothing. → FR-011: characterization tests must exist and pass
+   against the *unrefactored* code before consolidation, or "no regression" is unfalsifiable.
+3. **The Constitution names ServiceNow in five places, not one.** → drove the Q3 decision above.
+
+**Also corrected:** the draft implied a server could verify a Halo ticket's status. It cannot
+(finding in Q4). The draft did not follow `.specify/templates/spec-template.md` (missing the
+mandatory User Scenarios, Given/When/Then, Edge Cases, Key Entities, Assumptions) and was
+therefore **rewritten**, not extended.
+
+---
+
+## Turn 3 — Artifacts authored
+
+Ten artifacts under `specs/070-itsm-provider-abstraction/`: `spec.md`, `plan.md`, `research.md`,
+`data-model.md`, `contracts/itsm-gate-contract.md`, `contracts/constitution-amendment.md`,
+`quickstart.md`, `tasks.md`, `checklists/requirements.md`, and this log.
+
+**Design recorded:**
+- Shared module at `src/netclaw_itsm/`, mirroring `src/netclaw_tokens/` — the only working
+  cross-server Python precedent (a `sys.path` insert anchored on `__file__`, used by 8 servers).
+  A root installable package was rejected for v1: no root packaging exists and the repo runs
+  mixed interpreters (nautobot servers use a venv python, others bare `python3`), so a package
+  installed into one would be invisible to the other.
+- Thin shims retained at both existing gate paths so no import site or call site churns.
+- Backwards compatibility as a hard requirement: the envelope keys `valid`/`message`/
+  `cr_number`/`state` are a **public contract** because Claroty returns the whole dict in its
+  tool output; changes are additive only, and no MCP tool parameter is renamed.
+- The amendment is structured on the **spec 049 precedent**: its own P3 user story, a dedicated
+  research item justifying the MINOR bump, exactly two tasks, a quickstart step, and a
+  comprehension-test success criterion. Constitution current text was **byte-verified** against
+  the live file before being quoted.
+
+**Verification performed:** template conformance; canonical counts cross-checked across all
+artifacts; Constitution quotes byte-verified; confirmed no artifact treats feature 069
+(`halo-mcp`, `halo-change-request`) as existing on this branch — it is cited as an unmerged
+dependency (PR #167); `git status` limited to the spec directory.
+
+**Line-number corrections found during verification** (recorded rather than silently fixed):
+`nautobot-golden-config-mcp/server.py:60` (not `:61`); Principle III's lifecycle line sits at
+constitution `:59-60`; Principle XIV's ServiceNow line is `:200` (an earlier note said `:201`,
+which is the GitHub line).
+
+---
+
+## Turn 4 — Findings surfaced during authoring that change requirements
+
+Recorded because they were discovered *after* the spec's first pass and alter its meaning:
+
+1. **`claroty-mcp` emits no GAIT record at all** (`grep -rn gait mcp-servers/claroty-mcp/` is
+   empty), whereas `gnmi-mcp` does. Therefore **FR-013 is net-new behavior for 6 of the 7 v1
+   tools**, not preservation of existing behavior — which strengthens the case for emitting GAIT
+   from inside the shared gate rather than leaving it to each caller.
+2. **The two gate copies differ in two user-visible message strings** (`"…for gNMI Set
+   operations"` vs `"…for Claroty write operations"`). To preserve them byte-for-byte, the
+   shared gate needs an operation label supplied by the **shim**, not by a tool parameter.
+   Otherwise the characterization tests would have to be authored already-failing.
+3. **The `sys.path` insert depth differs per shim** — `gnmi-mcp` needs two levels
+   (`"..","..","src"`), `claroty-mcp/utils/` needs three. A silent-fallback trap if copied.
+4. **Two adapter fields cannot be settled from this branch** and are marked open rather than
+   invented: Halo's reference format (feature 069 is unmerged) and Atlassian's approved-state
+   vocabulary (Jira statuses are per-project configurable, so any shipped constant would be
+   wrong — must be operator-supplied).
+
+---
+
+## Open at end of session
+
+Nine questions await maintainer decisions (`spec.md` → *Open Questions for Maintainer Review*).
+**Three change the module's public API** and therefore block implementation: OQ2 (default
+provider), OQ3 (fail-open vs strict mode), OQ4 (adopt `attested_state`).
+
+Three defects were discovered and reported for triage rather than fixed: the dangling
+`aruba-cx-mcp` entry in `config/openclaw.json:291-304` pointing at a server that does not exist;
+`gnmi-mcp` receiving no ITSM environment variable; and the dead `GnmiSetRequest` validator.
+
+**End of session log.**

--- a/specs/070-itsm-provider-abstraction/plan.md
+++ b/specs/070-itsm-provider-abstraction/plan.md
@@ -1,0 +1,178 @@
+# Implementation Plan: ITSM Provider Abstraction for Change Gating
+
+**Branch**: `070-itsm-provider-abstraction` | **Date**: 2026-07-24 | **Spec**: `specs/070-itsm-provider-abstraction/spec.md`
+**Input**: Feature specification from `/specs/070-itsm-provider-abstraction/spec.md`
+
+> **Status of this plan**: This round's deliverable is **documentation only** — the nine-artifact spec set (spec, plan, research, data-model, quickstart, two contracts, requirements checklist, tasks). **No code, config, or constitution file is modified by this feature branch yet.** Implementation requires a Constitution amendment (1.2.0 → 1.3.0) and **MUST NOT begin before that amendment is ratified by the maintainer** (spec.md Status; Constitution Governance). Every implementation task in `tasks.md` is marked BLOCKED accordingly.
+
+## Summary
+
+NetClaw's change gate is hardwired to ServiceNow in three layers — the Constitution, `itsm_gate.py`, and the skill layer — and the same gate logic exists **five times across five servers** behind **two incompatible contracts**, guarding **42 gated tools** with **four independent `^CHG\d+$` regexes** and **zero tests**. The gate also enforces nothing today: `_check_servicenow_cr_state()` unconditionally returns `None`, so every well-formed `CHG…` reference passes as `{valid: True, state: "unverified"}`, and no `servicenow-mcp` is registered in `config/openclaw.json`.
+
+This plan consolidates the two servers using the `validate_change_request()` dict-envelope contract onto **one shared, provider-agnostic module** at `src/netclaw_itsm/` — mirroring the `src/netclaw_tokens/` precedent (a `sys.path` insert anchored on `__file__`, already used by 8 servers) — and makes the active ITSM selectable via `NETCLAW_ITSM_PROVIDER` across `servicenow`, `halo`, `atlassian`, and `none`. **v1 covers 7 gated tools** (`gnmi_set` plus Claroty's 6 writes). The **three nautobot servers (35 gated tools, `_check_itsm() -> Optional[str]`, `ITSM_ENABLED`/`ITSM_LAB_MODE`, gating defaults OFF, `cr_number` optional) are specified but explicitly NOT implemented in v1** — they are a distinct follow-on phase with its own compatibility analysis. Memory MCP's `validate_cr_number()` is deferred (it is CR provenance metadata, not a gate); the dead `GnmiSetRequest` validator at `mcp-servers/gnmi-mcp/models.py:198` is removed.
+
+Two architectural facts shape everything below. First, **NetClaw MCP servers cannot call other MCP servers** — no MCP client exists anywhere under `mcp-servers/` — so verification of a change record's *state* can only happen at the agent/skill layer, and the shared gate makes **no network calls** and must be **synchronously** callable (`gnmi_set` at `mcp-servers/gnmi-mcp/gnmi_mcp_server.py:196` is a plain `def`). Second, **back-compat is a hard requirement**: the envelope keys `valid`, `message`, `cr_number`, `state` are a public contract because Claroty publishes the whole dict as `{"itsm_gate": …}` in tool output, and no MCP tool parameter may be renamed (gnmi's `change_request_number` and Claroty's `cr_number` both stay, both required). Thin shims are retained at both existing gate paths so no import or call site churns. Finally, the Constitution's **five ServiceNow-naming locations** are amended together as a MINOR bump — Principle III (`:55-64`), Principle VIII (`:114`), Principle XIV (`:200`), Technology Stack (`:260`), and Forbidden Operations (`:269`).
+
+## Technical Context
+
+**Language/Version**: Python 3.10+ (matches every gated server and the `src/netclaw_tokens/` precedent; `from __future__ import annotations` + `X | None` unions already in use in both existing gate files)
+**Primary Dependencies**: **None new — Python standard library only (`os`, `re`, `logging`, `typing`), deliberately.** The gate makes no HTTP calls by design (FR-006), so it needs no client library, no credentials, and no async runtime. This is not minimalism for its own sake: adding `httpx` would force an async surface that `gnmi_set`'s plain `def` cannot await, and would put per-ITSM credentials inside every gated server.
+**Storage**: N/A — the gate is stateless. Provider selection is resolved from the process environment on each call; no database, no cache, no file state. (Memory MCP's SQLite is read/written by Memory MCP alone and is explicitly out of scope, FR-016.)
+**Testing**: `pytest` — a **characterization suite where none exists today**. Coverage is currently 0 tests across all 5 gate implementations, so the suite is written **first**, against the **unrefactored** code, and must pass before the shared module replaces anything (FR-011, US2 acceptance 1, SC-003/SC-004). New suite lives at `tests/itsm-gate/` following the per-component convention (`tests/halo-mcp/` from feature 069, with its own `conftest.py` + `pytest.ini`).
+**Target Platform**: Linux, macOS, WSL2 — same as every NetClaw MCP server. Note the repo runs **mixed interpreters** (the nautobot servers use a venv python; gnmi/claroty use bare `python3`), which is a first-class constraint on how the shared module is delivered.
+**Project Type**: Shared in-process Python library plus a governance amendment. No new MCP server, no new transport, no new catalog component, no UI.
+**Performance Goals**: N/A in throughput terms. The relevant budget is that the gate must add negligible latency to a write path and must not block: **no network I/O, no git I/O, no disk I/O on the hot path** — a regex match plus an environment lookup.
+**Constraints** (all hard):
+- **Synchronously callable** — `gnmi_set` is a plain `def`; the gate cannot be a coroutine and cannot require an event loop.
+- **No network calls from the gate** — state verification belongs to the skill layer (FR-006/FR-007). MCP servers cannot call other MCP servers.
+- **No MCP tool parameter renames or requiredness changes** — `change_request_number` (gnmi, required), `cr_number` (claroty, required), `cr_number` (nautobot, optional) all survive verbatim (FR-010, SC-007).
+- **Envelope keys are a public contract** — `valid`, `message`, `cr_number`, `state` keep their names and meanings; `provider` and the verification indicator are **additive only** (FR-009), because Claroty emits the dict verbatim (`mcp-servers/claroty-mcp/tools/alerts.py:182`, `devices.py:228`/`:284`, plus the success paths).
+- **No silent vendor fallback** — an unrecognized provider is a loud configuration error, never a quiet default to ServiceNow (FR-003); that silent-default behavior is the bug being fixed.
+- **Zero behavior regression under the status-quo provider** — 100% of pre-refactor characterization assertions must pass after (SC-003).
+- **`NETCLAW_ITSM_PROVIDER` must reach every gated server through its `config/openclaw.json` env block** (FR-015) — `gnmi-mcp` at `config/openclaw.json:81-90` currently passes **no ITSM variable at all**, so its lab bypass works only by parent-environment leakage; miss this and the feature silently misconfigures.
+- **Implementation is gated on maintainer ratification** of the Constitution amendment (Principle XVI + Governance).
+
+**Scale/Scope**: **v1 = 7 gated tools** across 2 servers (`gnmi_set`; Claroty's 6 writes at `tools/alerts.py:180`, `tools/devices.py:226` and `:282`, `tools/user_actions.py:47` and `:109`, `tools/vulnerabilities.py:209`). **35 further gated tools across 3 nautobot servers are specified but not implemented** (follow-on phase). Consolidation: **5 gate implementations → 1** shared module plus 2 thin shims; **4 independent `^CHG\d+$` regexes → 1** (excluding the deferred Memory MCP provenance check). **4 provider adapters** (`servicenow`, `halo`, `atlassian`, `none`). **1 Constitution amendment across 5 locations**, 1.2.0 → 1.3.0 MINOR. **9 spec artifacts** in this directory. **0 → a full gate test suite.**
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Evaluated against `.specify/memory/constitution.md` **v1.2.0** (the version in force as this plan is written). Five rows are marked **AMENDED** because this feature's own deliverable is the change to that text — see the self-reference note below the table.
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Safety-First Operations (NON-NEGOTIABLE) | PASS | The gate sits in front of writes and this feature only strengthens it. No new bypass is introduced: the lab/no-ITSM path already exists and is preserved with its GAIT logging intact (FR-012). Device interaction itself is untouched. |
+| II. Read-Before-Write | N/A | No device configuration path changes. `observe → baseline → modify → verify` is unaffected. |
+| III. ITSM-Gated Changes | **AMENDED — this feature *is* the change to Principle III** | `:55-64` currently mandates "an approved **ServiceNow** Change Request". FR-017 generalizes that to "the configured ITSM". The *substance* of the principle is preserved exactly — changes still require an approved change record, lab mode remains the **sole** exception, and it remains GAIT-logged. Open Question 9 asks the maintainer whether the "Assess → Authorize → Implement → Review" lifecycle wording (which is ServiceNow's vocabulary) should also be generalized. This row cannot honestly be marked PASS against v1.2.0, because compliance with the amended text is what is being proposed, not asserted. |
+| IV. Immutable Audit Trail | PASS (strengthened) | FR-013 requires **every** gate decision to be GAIT-recorded with provider, change reference, verification status, and allow/deny outcome — strictly more audit than today, and the basis for SC-006. FR-012 keeps every lab bypass logged. **Design constraint to honor**: the gate cannot perform git I/O itself (sync + no-I/O-on-hot-path), so it emits a structured decision record that the session/skill layer commits to the GAIT trail; that split is a Phase 0 research item, not an assumption. |
+| V. MCP-Native Integration | PASS | No new MCP server, no new transport, no protocol change. A shared in-process Python library imported by existing FastMCP servers, exactly as `src/netclaw_tokens/` already is by 8 of them. Notably this feature *declines* to introduce server-to-server MCP calls — none exist in the repo, and inventing a bespoke one would violate this principle rather than satisfy it. |
+| VI. Multi-Vendor Neutrality | PASS (this feature's core subject) | This is Principle VI applied to ITSM. Vendor-specific facts (reference format, display name, approved-state vocabulary, responsible skill) move into declarative `ProviderAdapter` data (FR-004); the shared gate holds no vendor logic and no vendor default (FR-003). |
+| VII. Skill Modularity | PASS | US3 documents **one** verification skill per provider rather than growing any skill's charter. `workspace/skills/servicenow-change-workflow/SKILL.md` remains the ServiceNow verifier; Halo's counterpart is feature 069's `halo-change-request` skill, which **does not exist on this branch** (PR #167 unmerged) — so the `halo` adapter ships with its verification skill marked unavailable if 069 does not land. |
+| VIII. Verify After Every Change | PASS + **AMENDED (location 2 of 5)** | The verify workflow is unchanged. The amendment touches only `:114`'s "mark the **ServiceNow** CR as failed", which becomes provider-agnostic. Separately, US2's characterization-first sequencing is this principle applied to a refactor: capture the baseline, apply, verify against the baseline. |
+| IX. Security by Default | PASS | The gate holds **no credentials** and opens **no network path** by design (FR-006), so this adds zero credential surface and zero new privilege. It also improves honesty: today's code *implies* it verifies CR state and does not. Documenting the advisory boundary (spec Assumptions, FR-007/FR-008) is a security-posture improvement, not a weakening — nothing is being turned off that was ever on. |
+| X. Observability as a First-Class Citizen | PASS (adapted) | No new monitored system, so no new HUD node is required by this feature. Gate decisions do become observable with provider and verification status attached (SC-006). If a HUD posture line for the active ITSM provider is wanted, it is a Polish nicety, not a completion criterion. |
+| XI. Full-Stack Artifact Coherence (NON-NEGOTIABLE) | PASS **conditional on the Polish phase completing** | No new MCP server and no new installable component ⇒ `scripts/lib/catalog.sh`, `scripts/lib/install-steps.sh`, and `scripts/verify-catalog-coverage.py` are **not** touched. The touchpoints that **do** apply are blocking Polish tasks: `.env.example` (`NETCLAW_ITSM_PROVIDER`, no value), `config/openclaw.json` env blocks (FR-015 — `gnmi-mcp` `:81-90` and `claroty-mcp` `:551-558`), `SOUL.md`, `SOUL-SKILLS.md`, `README.md`, `TOOLS.md`, and the affected `SKILL.md` files. Pre-existing, **not** caused here: `config/openclaw.json:291-304` registers `aruba-cx-mcp` with ITSM variables while `mcp-servers/aruba-cx-mcp/` does not exist — reported for triage, not fixed by this feature. |
+| XII. Documentation-as-Code | PASS | FR-007 (per-provider verification skill) and FR-016 (Memory MCP's deferred ServiceNow-shaped provenance check) are **requirements**, not follow-ups, so docs land in the same PR as the code by construction. |
+| XIII. Credential Safety | PASS | Nothing secret is introduced. `NETCLAW_ITSM_PROVIDER` is non-secret configuration, documented in `.env.example` with a description and **no value**. The gate reads it from the environment at runtime, never from a config file baked with a value. |
+| XIV. Human-in-the-Loop for External Communications | PASS + **AMENDED (location 3 of 5)** | Substance holds — nothing here sends messages or writes tickets; the gate never mutates an ITSM record. The amendment touches only `:200`'s "Creating, updating, or closing **ServiceNow** tickets", which becomes provider-agnostic. This principle also governs the amendment itself: the maintainer, not this plan, ratifies it. |
+| XV. Backwards Compatibility | PASS (hard requirement, this feature's second core subject) | FR-009 (additive envelope keys only), FR-010 (no parameter renames), FR-011 (characterization tests before the refactor), SC-003 (100% of prior assertions pass), SC-007 (zero parameter changes), retained thin shims at both existing gate paths, nautobot left entirely alone in v1, and dual env schemes allowed to coexist. New dependency conflicts are impossible — there are no new dependencies. |
+| XVI. Spec-Driven Development | PASS | Full specify → plan → tasks before any code, which is precisely why this round ships documentation only. The sharper reading is deliberate: "no implementation work begins without a ratified spec" — and a spec whose completion **requires** a constitutional amendment is not ratified until that amendment is. |
+| XVII. Milestone Documentation via WordPress | DEFERRED | Applies post-implementation. Nothing shipped this round — a rejected-or-pending proposal is not a milestone. Recorded as a session-log note per the principle's own fallback clause, and carried as `tasks.md` T062. |
+| Operational Constraints → Technology Stack | **AMENDED (location 4 of 5)** | `:260` reads `**ITSM**: ServiceNow (change management, incidents, CMDB)`. Becomes provider-agnostic, naming ServiceNow, HaloPSA/HaloITSM, and Atlassian/Jira as supported options rather than mandating one. |
+| Operational Constraints → Forbidden Operations | **AMENDED (location 5 of 5)** | `:269` reads `Bypassing **ServiceNow** CR approval for production changes`. Becomes provider-agnostic; lab mode remains the sole sanctioned bypass and remains GAIT-logged. |
+| Operational Constraints → MCP Server Standards | PASS | "Write operations MUST be explicitly flagged and gated" — this feature is that gating, consolidated. No new MCP server, so the per-server `README.md` requirement is not triggered; the shared module gets its own docs instead. |
+| Governance → amendment process | PASS | All three required elements are produced: (1) documented rationale, (2) review of impact on existing principles (this table), (3) a semantic version bump. **MINOR, 1.2.0 → 1.3.0** — the amendment generalizes existing principle text and removes no principle and redefines none, the same reasoning the 1.1.0 → 1.2.0 amendment used for Principle XI. The Sync Impact Report is rewritten in the established format with prior versions compressed into "Previous version history" (US4 acceptance 4). |
+
+### Self-reference note (Principle III) — read this before treating the gate as passed
+
+Feature 049 hit this same shape with Principle XI and marked it `PASS (this feature's core subject)` because the artifact-coherence work *was* the amendment. Principle III is a harder case and is marked differently on purpose.
+
+Principle XI is a process rule about which files to touch; 049's amendment changed the file list and complied with the rule in the act of changing it. Principle III is a **safety** rule (and Forbidden Operations makes bypassing it a forbidden operation). A plan cannot mark a safety principle "PASS" by pointing at text it proposes to rewrite — that is circular, and circular reasoning is exactly how a gating feature ends up weakening the gate it claims to strengthen. So:
+
+- Against the **current** text (v1.2.0), this feature does **not** claim compliance for III. It claims that the proposal preserves the principle's substance — approved change record required, lab mode the sole exception, still GAIT-logged — while removing the vendor name.
+- Against the **amended** text (v1.3.0), the feature complies. That is why implementation is **BLOCKED pending ratification**: the maintainer's ratification is what converts this row from AMENDED to PASS, and nothing in `tasks.md` may proceed on the assumption that it will.
+- Because Principle VIII, Principle XIV, Technology Stack, and Forbidden Operations all restate the same ServiceNow assumption, amending III alone would leave **four contradicting references** in the same document. The amendment is therefore **all-or-nothing across all five locations** (US4, FR-017).
+
+**Gate verdict**: **PASS with one gate held open.** No principle is violated, no complexity requires waiving a rule, and every applicable coherence touchpoint is tracked. The single open gate is ratification of the 1.3.0 amendment; until it closes, this feature ships specification artifacts only.
+
+## Project Structure
+
+### Documentation (this feature)
+
+Ten artifacts: the set features 065/068 shipped, plus a second contract for the amendment itself and a GAIT session log (Principle IV):
+
+```text
+specs/070-itsm-provider-abstraction/
+├── spec.md                          # Feature specification — SOURCE OF TRUTH (DRAFT, awaiting ratification)
+├── plan.md                          # This file
+├── research.md                      # Phase 0 — the 5-implementation survey with file:line evidence,
+│                                    #   sync/no-network rationale, the src/netclaw_tokens/ precedent
+│                                    #   decision, GAIT emit/commit seam, the 9 open questions
+├── data-model.md                    # Phase 1 — ItsmProvider, ProviderAdapter, ChangeRef, GateDecision,
+│                                    #   GateConfig
+├── quickstart.md                    # Phase 1 — operator walkthrough: select a provider, run a gated write,
+│                                    #   read the GAIT record, switch providers, trip the unknown-provider error
+├── contracts/
+│   ├── itsm-gate-contract.md        # Phase 1 — validate_change_request(cr_number) ->
+│   │                                #   dict{valid,message,cr_number,state} plus the additive
+│   │                                #   provider/verification keys; the nautobot _check_itsm() ->
+│   │                                #   Optional[str] contract documented as the follow-on target
+│   └── constitution-amendment.md    # Phase 1 — the exact before/after text for all five ServiceNow-naming
+│                                    #   locations, so US4 is a reviewable diff rather than an intention
+├── checklists/
+│   └── requirements.md              # Requirements + Constitution XI coherence checklist
+├── gait-session-log.md              # Principle IV — append-only audit trail of the four scoping
+│                                    #   decisions, the exploration findings that corrected scope,
+│                                    #   and the line-number/GAIT-emission corrections
+└── tasks.md                         # Phase 2 output — every implementation task marked BLOCKED
+```
+
+### Source Code (repository root)
+
+Paths below are what implementation **will** touch once ratified. Nothing in this tree is modified by this documentation round.
+
+```text
+src/
+├── netclaw_tokens/                     # EXISTING precedent this feature copies (imported by 8 servers via
+│                                       #   sys.path insert anchored on __file__ — e.g. gnmi_mcp_server.py:31)
+└── netclaw_itsm/                       # NEW — the single shared, provider-agnostic gate (stdlib only)
+    ├── __init__.py                     #   public surface: validate_change_request(), provider registry
+    ├── config.py                       #   NETCLAW_ITSM_PROVIDER + lab/bypass resolution  (FR-002, FR-003, FR-015)
+    ├── providers.py                    #   declarative ProviderAdapter data: servicenow|halo|atlassian|none (FR-004)
+    ├── gate.py                         #   format + policy evaluation; NO network, sync-callable
+    │                                   #     (FR-005, FR-006, FR-008, FR-009)
+    └── audit.py                        #   structured gate-decision record for the GAIT trail (FR-012, FR-013)
+                                        #   NOTE: no requirements.txt — stdlib only, deliberately
+
+mcp-servers/gnmi-mcp/
+├── itsm_gate.py                        # RETAINED as a thin shim re-exporting src/netclaw_itsm  (FR-010, SC-007)
+├── gnmi_mcp_server.py                  # gnmi_set() at :196 — plain `def`, param `change_request_number`;
+│                                       #   import path and call site UNCHANGED
+└── models.py                           # DELETE dead GnmiSetRequest ^CHG\d+$ validator (:186-207, regex at :198)
+
+mcp-servers/claroty-mcp/
+├── utils/itsm_gate.py                  # RETAINED as a thin shim re-exporting src/netclaw_itsm
+└── tools/                              # 6 gated write call sites UNCHANGED; still publish {"itsm_gate": …}
+    ├── alerts.py                       #   :180 gate, :182/:219/:223 envelope publication
+    ├── devices.py                      #   :226 and :282 gates
+    ├── user_actions.py                 #   :47 and :109 gates
+    └── vulnerabilities.py              #   :209 gate
+
+mcp-servers/nautobot-mcp-v2/server.py            # UNTOUCHED in v1 — _check_itsm() at :39, 35-tool follow-on phase
+mcp-servers/nautobot-routing-mcp/server.py       # UNTOUCHED in v1 — _check_itsm() at :57
+mcp-servers/nautobot-golden-config-mcp/server.py # UNTOUCHED in v1 — _check_itsm() at :61
+mcp-servers/memory-mcp/storage/sqlite_store.py   # UNTOUCHED — validate_cr_number() at :109 deferred (FR-016)
+
+tests/itsm-gate/                        # NEW — the coverage that does not exist today (FR-011, SC-004)
+├── conftest.py                         #   env isolation for NETCLAW_ITSM_PROVIDER / NETCLAW_LAB_MODE
+├── pytest.ini                          #   per-component config, matching tests/halo-mcp/ (feature 069)
+├── test_characterization_gnmi.py       #   pins PRE-refactor gnmi validate_change_request() behavior
+├── test_characterization_claroty.py    #   pins PRE-refactor claroty behavior + the published envelope
+├── test_providers.py                   #   per-provider format validation; unknown-provider error (FR-003)
+└── test_gate_policy.py                 #   lab/none bypass precedence; verified-vs-unverified (FR-008)
+
+config/openclaw.json                    # + NETCLAW_ITSM_PROVIDER into every gated server's env block (FR-015):
+                                        #   gnmi-mcp   :81-90   — currently passes NO ITSM variable at all
+                                        #   claroty-mcp :551-558 — currently NETCLAW_LAB_MODE only (:557)
+.env.example                            # + NETCLAW_ITSM_PROVIDER documented, no value (Principle XIII)
+.specify/memory/constitution.md         # AMENDED 1.2.0 → 1.3.0 (MINOR) at five locations —
+                                        #   III :55-64 · VIII :114 · XIV :200 · Tech Stack :260 · Forbidden :269
+                                        #   plus a rewritten Sync Impact Report and footer version/date
+SOUL.md, SOUL-SKILLS.md, README.md, TOOLS.md     # Principle XI coherence updates (Polish phase)
+workspace/skills/servicenow-change-workflow/SKILL.md  # named as the `servicenow` provider's verification skill,
+                                        #   reframed as one provider among several (US3, FR-007)
+```
+
+**Structure Decision**: The shared module goes at `src/netclaw_itsm/`, deliberately copying the **one cross-server Python pattern that already works in this repo** — `src/netclaw_tokens/`, imported through a `sys.path` insert anchored on `__file__` (see `mcp-servers/gnmi-mcp/gnmi_mcp_server.py:31`), currently consumed by 8 servers. A root-level installable package was considered and rejected for v1: no root packaging exists, and the repo runs **mixed interpreters** (the nautobot servers use a venv python while gnmi/claroty use bare `python3`), so a package installed into one interpreter would be invisible to the other — the exact failure the follow-on nautobot phase would trip over. The two existing gate files are **kept as thin shims** rather than deleted, so `from itsm_gate import validate_change_request` and `from utils.itsm_gate import validate_change_request` keep working verbatim across all 7 v1 call sites; that is what makes FR-010 and SC-007 achievable without touching a single tool signature. `src/netclaw_itsm/` carries **no `requirements.txt`** because it has no dependencies, and that is a design property to protect, not an omission. Tests go in their own per-component directory (`tests/itsm-gate/`) following feature 069's `tests/halo-mcp/` layout rather than being scattered into `tests/unit/`, because the characterization suite must be runnable as a single pre/post-refactor gate. The nautobot trio and Memory MCP appear in the tree only as **explicitly untouched** paths, so a reader can see the v1 boundary rather than infer it.
+
+## Complexity Tracking
+
+No constitution violation requires a waiver. Four deliberate complexities are nonetheless worth justifying up front, because each one *is* a place where a simpler design was available and rejected.
+
+| Violation / Added Complexity | Why Needed | Simpler Alternative Rejected Because |
+|---|---|---|
+| **Two thin shims retained** (`mcp-servers/gnmi-mcp/itsm_gate.py`, `mcp-servers/claroty-mcp/utils/itsm_gate.py`) instead of deleting them and importing `netclaw_itsm` directly | They are what make "one implementation, zero call-site churn" simultaneously true. All 7 v1 call sites keep their existing import statements, so the characterization suite exercises unchanged code paths and SC-003 is a real test rather than a rewritten one. The shims also localize the `sys.path` insert per server, matching how `netclaw_tokens` is reached today. | Deleting them means editing 7 call sites in 6 files across 2 servers **in the same change** that swaps the gate implementation — mixing a behavioral refactor with an import refactor and destroying the ability to attribute any regression to one or the other. It would also put a `sys.path`-dependent import into tool modules that currently know nothing about `src/`. The residual cost is 2 files of ~5 lines each; the residual risk of the alternative is a silent gate regression on a write path. |
+| **Phasing the nautobot family out of v1** (35 of 42 gated tools deferred), leaving **two** gate contracts and **two** env schemes alive simultaneously | The nautobot servers use a different contract (`_check_itsm() -> Optional[str]`, no format check), a different env scheme (`ITSM_ENABLED` + `ITSM_LAB_MODE`), a different default (**gating OFF**), a different parameter requiredness (`cr_number` **optional**), and a different interpreter. Folding them in during v1 would make the change a breaking env-var migration across 35 tools whose gate is currently off — landing in the same PR that must prove zero regression on 7 tools whose gate is currently on. | "Migrate all five servers at once" was rejected because it makes SC-003 unfalsifiable: a 42-tool blast radius with two incompatible contracts and defaults that flip in opposite directions cannot be characterization-tested as one unit. The interim cost is real and named honestly — two contracts and two env schemes coexist until the follow-on phase, and the coexistence is documented rather than hidden. The follow-on phase carries its own compatibility analysis task specifically so the default-off → default-? decision is made deliberately (Open Question 7). |
+| **`ProviderAdapter` indirection for what is, in v1, four rows of static data** | FR-003 forbids a silent vendor default and FR-005 requires provider-named error messages, so provider facts (reference format, display name, approved-state vocabulary, responsible verification skill) must be addressable as data by the shared gate. Declaring them as data — with **no** transport or credential logic — is what keeps the gate vendor-neutral (Principle VI) and lets a fifth provider be one table entry rather than a fifth `if`. | Inline `if provider == "halo": …` branching in `gate.py` was rejected because it reproduces, at a smaller scale, the exact defect this feature exists to remove: vendor identity smeared across shared logic. The `halo` adapter's dangling verification-skill reference (feature 069 is unmerged, PR #167) is precisely the kind of fact that must live in data so it can be marked *unavailable* rather than crash a code path. |
+| **Gate decisions emitted as structured records rather than written to GAIT by the gate itself** | FR-013 demands every decision reach the GAIT trail, while the gate must stay synchronous and do no I/O on a write path. Splitting *emit* from *commit* satisfies both: the gate produces the record (provider, reference, verification status, outcome) and the session/skill layer commits it. | Having `gate.py` invoke git directly was rejected — it would put filesystem and subprocess work inside a synchronous pre-write check on every gated call, in a module whose entire architectural value is that it does nothing but match a regex and read the environment. Dropping the requirement instead was also rejected: SC-006 (an auditor can determine provider, reference, and whether state was actually verified) is the payoff for admitting the gate is advisory, and without it US3 is just a comment in a file. The exact emit/commit seam is a Phase 0 research item, flagged rather than assumed. |

--- a/specs/070-itsm-provider-abstraction/quickstart.md
+++ b/specs/070-itsm-provider-abstraction/quickstart.md
@@ -1,0 +1,125 @@
+# Quickstart — ITSM Provider Abstraction (Feature 070)
+
+**Status**: this feature is a **proposal**. Nothing below is implemented yet; implementation is
+blocked pending maintainer ratification of the Constitution amendment (1.2.0 → 1.3.0). This
+document serves two audiences: a **maintainer reviewing the proposal**, and an **operator** who
+will use the feature once it ships.
+
+---
+
+## Part 1 — For the maintainer reviewing this proposal
+
+### What to read, in order
+
+| # | File | Why |
+|---|------|-----|
+| 1 | `spec.md` | The problem, four user stories, 17 functional requirements, and the **9 Open Questions** that need your decisions |
+| 2 | `contracts/constitution-amendment.md` | The **literal before/after text** for all five ServiceNow-naming locations, plus the proposed Sync Impact Report. Review this as a diff |
+| 3 | `research.md` → R2, R3, R6 | Why the gate can't verify state itself (R2), where the shared module lives (R3), and the amendment's scope + bump justification (R6) |
+| 4 | `contracts/itsm-gate-contract.md` | The interface and its backwards-compatibility guarantees |
+| 5 | `plan.md` → Constitution Check | How this feature reconciles with the Constitution it proposes to amend |
+| 6 | `tasks.md` | The phased execution, with T010 as the single ratification gate |
+
+### The decisions we need from you
+
+All nine are listed in `spec.md` → *Open Questions for Maintainer Review*, each with a
+recommendation. **Three of them change the module's public API**, so they must be settled
+before implementation starts, not during:
+
+- **OQ2 — default provider when unset** (`none` vs `servicenow`)
+- **OQ3 — fail-open vs an opt-in strict mode**
+- **OQ4 — adopt the `attested_state` parameter?**
+
+The remaining six (config mechanism, adapter set, state vocabulary, nautobot migration,
+`servicenow-mcp` registration, amendment scope) can be settled in review comments.
+
+### The one thing to push back on hardest
+
+With skill-layer verification, **the server-side gate is advisory** — a direct tool call can
+assert any change reference. We chose this because NetClaw's MCP servers cannot call other MCP
+servers (`research.md` R2), and we documented it plainly rather than implying enforcement.
+
+If you want the gate to *actually* enforce, that is a different and larger feature: it means
+per-ITSM HTTP clients and credentials inside every gated server, plus resolving the
+sync-callability constraint. Worth deciding now, because it changes the architecture.
+
+Note the honest baseline: **today's gate enforces nothing either.**
+`_check_servicenow_cr_state()` returns `None`, so every well-formed `CHG\d+` already passes as
+`unverified`. This feature does not weaken the current posture; it makes it visible.
+
+### Verifying this proposal
+
+```bash
+# Nothing outside the spec directory should have changed
+git status --short          # expect only specs/070-itsm-provider-abstraction/
+
+# The current-state claims are checkable
+grep -rn "return None" mcp-servers/gnmi-mcp/itsm_gate.py          # the fail-open stub
+grep -rn "servicenow" config/openclaw.json                        # expect: no matches
+grep -rniE "itsm|validate_change_request" tests/                  # expect: no matches (0 tests)
+diff mcp-servers/gnmi-mcp/itsm_gate.py mcp-servers/claroty-mcp/utils/itsm_gate.py
+```
+
+---
+
+## Part 2 — For the operator, once this ships
+
+### Prerequisites
+
+- An ITSM that NetClaw can reach for change records: ServiceNow, HaloPSA/HaloITSM, or Jira —
+  or none, if you gate changes another way.
+- The corresponding integration configured (e.g. the Halo MCP server for `halo`, which
+  requires feature 069 / PR #167 to be merged).
+
+### Select your ITSM
+
+Set one variable in `~/.openclaw/.env`:
+
+```bash
+NETCLAW_ITSM_PROVIDER=halo        # servicenow | halo | atlassian | none
+```
+
+That's the whole configuration. Restart NetClaw so the gated MCP servers pick it up.
+
+### What changes for you
+
+| Before | After |
+|--------|-------|
+| Every gated write demanded a `CHG…` ServiceNow number | The gate expects **your** ITSM's change reference format |
+| Error messages named ServiceNow regardless of your stack | Messages name your configured ITSM |
+| `CHG\d+` format check, then fail open | Provider-appropriate format check, plus an explicit record of whether the change's state was verified |
+
+### A gated write, end to end
+
+Using Halo as the example:
+
+1. **Open the change** in your ITSM — via the provider's change skill
+   (`halo-change-request`, `servicenow-change-workflow`, or `atlassian-itsm`).
+2. **The skill verifies the change is approved** before proceeding. This is the real
+   verification step: the skill can reach your ITSM's MCP tools; the server-side gate cannot.
+3. **Call the gated tool**, passing the change reference in its existing parameter
+   (`cr_number`, or `change_request_number` for `gnmi_set` — these names do not change).
+4. **The gate checks** the reference against your provider's format and applies policy, then
+   returns its decision including which provider was used and whether the state was verified.
+5. **GAIT records** the provider, the reference, the verification status, and allow/deny.
+
+### Lab and no-ITSM operation
+
+Both remain supported and are unchanged in spirit:
+
+```bash
+NETCLAW_ITSM_PROVIDER=none        # no external change record required
+# or
+NETCLAW_LAB_MODE=true             # existing lab bypass
+```
+
+Every bypass is still GAIT-logged — that requirement does not relax.
+
+### Troubleshooting
+
+| Symptom | Cause |
+|---------|-------|
+| Gate rejects a reference that is valid in your ITSM | `NETCLAW_ITSM_PROVIDER` is set to a different provider than you think — check the `provider` field in the gate's response |
+| Configuration error naming the supported providers | Unrecognized `NETCLAW_ITSM_PROVIDER` value. This is deliberate: there is **no** silent fallback to ServiceNow |
+| Lab bypass not taking effect on gNMI writes | `gnmi-mcp`'s `config/openclaw.json` env block historically passed no ITSM variable (`config/openclaw.json:81-90`); confirm the variable reaches the server |
+| A Halo/Jira reference rejected by `memory_record_decision` | Known deferred inconsistency (FR-016): Memory MCP's change-reference provenance check is still ServiceNow-shaped |

--- a/specs/070-itsm-provider-abstraction/research.md
+++ b/specs/070-itsm-provider-abstraction/research.md
@@ -1,0 +1,506 @@
+# Phase 0 Research: ITSM Provider Abstraction for Change Gating
+
+**Feature**: 070-itsm-provider-abstraction
+**Date**: 2026-07-24
+**Status**: Research for a **DRAFT** spec. R6 (Constitution amendment) is a
+precondition for implementation, not a side effect of it.
+
+Every claim below was verified against the tree on this branch. Where a fact
+comes from an unmerged branch (feature 069 / PR #167) it is labelled as such.
+
+---
+
+## R1: Current-State Inventory — What Actually Exists to Consolidate
+
+**Finding**: Five change-gate implementations across five servers, **42 gated
+tools**, **4 independent `^CHG\d+$` regexes**, and **0 tests** exercising any
+gate.
+
+| Implementation | Where | Contract | Env scheme | Gated tools | v1? |
+|---|---|---|---|---|---|
+| `validate_change_request()` | `mcp-servers/gnmi-mcp/itsm_gate.py:24`; `mcp-servers/claroty-mcp/utils/itsm_gate.py:30` | dict envelope | `NETCLAW_LAB_MODE` | **7** (1 gnmi + 6 claroty) | **yes** |
+| `_check_itsm()` | `nautobot-mcp-v2/server.py:39`; `nautobot-routing-mcp/server.py:57`; `nautobot-golden-config-mcp/server.py:60` | `Optional[str]`, no format check | `ITSM_ENABLED` + `ITSM_LAB_MODE` | **35** | follow-on |
+| `validate_cr_number()` | `memory-mcp/storage/sqlite_store.py:109` | `Tuple[bool, str\|None]` — provenance, not a gate | — | 1 | deferred (FR-016) |
+| dead validator | `mcp-servers/gnmi-mcp/models.py:198` (`GnmiSetRequest`, unreferenced) | — | — | 0 | remove |
+
+Supporting measurements taken directly from the tree:
+
+- **The two v1 copies are effectively byte-identical.** `diff -u` between them
+  yields only: the module docstring, the logger name (`gnmi-mcp.itsm` vs
+  `claroty-mcp.itsm`), one whitespace-only comment difference, and **two**
+  message strings — `"Change request number is required for {gNMI Set|Claroty
+  write} operations"` and `"{gNMI Set|Claroty write} operations require the CR
+  to be in 'Implement' state."` Nothing else differs. Consolidation of these
+  two is mechanical, which is exactly why they are v1.
+- **The nautobot copies are a different function, not a divergent copy.**
+  `_check_itsm(cr_number: Optional[str]) -> Optional[str]` performs **no format
+  validation at all** — it only refuses a *missing* `cr_number`, and only when
+  `ITSM_ENABLED and not ITSM_LAB_MODE`. Both defaults ship gating **off**
+  (`ITSM_ENABLED` default `false`, `ITSM_LAB_MODE` default `true`), verified at
+  `nautobot-mcp-v2/server.py:35-36` and the identical pair in the other two.
+  Call-site count: 22 + 8 + 5 = **35**, matching the canonical total.
+- **GAIT coverage of gate decisions is already uneven.** `gnmi-mcp` records the
+  decision (`_gait_log()` at `gnmi_mcp_server.py:97-110`, called on rejection at
+  `gnmi_mcp_server.py:219-231`). `claroty-mcp` emits **no GAIT record anywhere** —
+  `grep -rn gait mcp-servers/claroty-mcp/` returns nothing. FR-013 is therefore
+  a *net-new* requirement for 6 of the 7 v1 tools, not preservation of existing
+  behavior.
+- **The only change-reference validator in the repo that has tests is the one
+  being deferred.** `tests/unit/test_sqlite_store.py:98-107` covers memory-mcp's
+  `validate_cr_number()`. No test anywhere imports `validate_change_request` or
+  `_check_itsm`.
+
+**Decision**: v1 consolidates only the two `validate_change_request()` copies
+(7 gated tools) behind one shared module; the three nautobot servers are left
+untouched and specified as a follow-on phase; the dead `GnmiSetRequest`
+validator is deleted outright.
+
+**Rationale**: The v1 pair shares one contract, one env var, and (per the diff)
+one implementation, so the refactor is provably behavior-preserving. The
+nautobot family shares neither contract, env scheme, requiredness (`cr_number`
+is `Optional` there), nor default posture — folding it in would turn a
+regression-free refactor into a semantic change across 35 tools whose gating is
+currently *off by default*. Splitting the phases keeps the blast radius of v1
+at 7 tools.
+
+**Alternatives considered**:
+- *All five in one pass* — rejected. It combines a mechanical dedup (7 tools)
+  with a behavior migration (35 tools, breaking env-var change, defaults flip),
+  making SC-003 ("100% of characterization assertions pass") impossible to
+  interpret: any failure could be either a bug or the intended migration.
+- *Leave the duplication and add provider support to both copies* — rejected.
+  That is two parallel implementations of the same abstraction, which is the
+  problem US2 exists to remove, and it leaves SC-001 (4 validators → 1) unmet.
+- *Keep the dead `GnmiSetRequest` validator "in case it gets wired up"* —
+  rejected. It is a fourth `^CHG\d+$` regex that no code path reaches, so it can
+  only ever drift from the real gate; leaving it defeats SC-001's count.
+
+---
+
+## R2: Why the Servers Cannot Verify ITSM State — Skill-Layer Verification
+
+**Finding**: A NetClaw MCP server has no route to another MCP server, and the
+gate's call sites forbid a coroutine.
+
+1. **No MCP client exists under `mcp-servers/`.** A grep for `ClientSession`,
+   `mcp.client`, and `stdio_client` across every `.py` under `mcp-servers/`
+   returns exactly one hit, and it is a false positive: the string
+   `"claroty-mcp.client"` in a `logging.getLogger()` call at
+   `mcp-servers/claroty-mcp/clients/claroty_client.py:29`. There is no MCP
+   client library usage anywhere in any server.
+2. **`scripts/mcp-call.py` is the only MCP client in the repo, and it is a
+   skill-side tool.** Its callers are skills (`$MCP_CALL` in
+   `workspace/skills/servicenow-change-workflow/SKILL.md:21,58,71,…`), bash, and
+   the UI — never a server.
+3. **The gate must be synchronously callable.** `gnmi_set` is a plain `def`
+   (`mcp-servers/gnmi-mcp/gnmi_mcp_server.py:196`) and calls the gate inline at
+   `:219`. Claroty's six write tools are `async def` but likewise call the gate
+   **synchronously** (e.g. `tools/alerts.py:180`, `tools/devices.py:226,282`,
+   `tools/user_actions.py:47,109`, `tools/vulnerabilities.py:209`) — no `await`.
+   A shared gate that needed to await anything would break `gnmi_set`, and
+   `asyncio.run()` inside claroty's already-running loop would raise.
+4. **The gate already performs no I/O.** `_check_servicenow_cr_state()`
+   (`itsm_gate.py:126-138`) is documented as the integration point and
+   unconditionally `return None` at `:138`, so every well-formed reference lands
+   in the `valid: True, state: "unverified"` branch.
+
+**Decision**: The shared gate makes **no network calls of any kind** (FR-006).
+It enforces reference format + provider policy, returns the envelope, and
+records the decision. Verification of a change record's *state* is the
+responsibility of the agent/skill layer, and each provider adapter names the
+skill that owns it (FR-004, FR-007).
+
+**Rationale**: This is the only architecture the call sites permit, and — given
+point 4 — it is not a capability regression. It is a correction of a false
+implication: the code currently *reads* as though it verifies ServiceNow state
+(docstring: "Be in 'Implement' state in ServiceNow") while verifying nothing.
+Moving the claim to where the capability actually lives makes the posture
+honest and auditable rather than implied.
+
+**Alternatives considered**:
+- *Server-side HTTP verification per ITSM* — rejected on four concrete counts:
+  (a) it needs ITSM credentials in the env block of **every** gated server, so a
+  Halo token would sit in `gnmi-mcp`'s environment purely to check a ticket;
+  (b) it needs an HTTP client and an auth flow per provider (ServiceNow basic/
+  OAuth, Halo OAuth client-credentials, Jira token) inside a function that must
+  stay synchronous, ruling out reuse of the repo's `httpx.AsyncClient` patterns;
+  (c) it converts a gate bug from "advisory decision is wrong" into "every write
+  tool is down when the ITSM is slow or unreachable"; (d) it duplicates logic
+  that `atlassian-mcp` and (per PR #167) `halo-mcp` already implement correctly.
+- *Read Memory MCP's SQLite file directly* — rejected. `memory-mcp` is
+  stdio-only, so a server could only reach it by opening
+  `~/.openclaw/memory/memory.db` behind its owner's back; that couples two
+  servers' storage, adds a file read to every gated write, and the database
+  holds change-reference *provenance*, not live ITSM state, so it could not
+  answer the question anyway.
+- *Have the gate subprocess out to `scripts/mcp-call.py`* — rejected. It pays a
+  full stdio server startup per gated write, still requires the ITSM
+  credentials in the gated server's environment, and gives the gate a way to
+  hang — strictly worse than an advisory decision made in microseconds.
+
+---
+
+## R3: Where the Shared Module Lives
+
+**Decision**: `src/netclaw_itsm/`, imported by each gated server through a
+`sys.path.insert` anchored on `__file__`, mirroring `src/netclaw_tokens/`.
+
+**Rationale**: `src/netclaw_tokens/` is the **only** working cross-server Python
+sharing precedent in the repo. It contains `__init__.py`, `counter.py`,
+`cost_calculator.py`, `footer.py`, `gcf_serializer.py`, `gcf_wrapper.py`,
+`session_ledger.py`, `requirements.txt`, and is consumed by **8 servers**
+(`azure-network-mcp`, `batfish-mcp`, `claroty-mcp`, `eve-ng-mcp-server`,
+`gnmi-mcp`, `n2n-mcp`, `protocol-mcp`, `suzieq-mcp`). The canonical consumer
+shim is 9 lines — `mcp-servers/claroty-mcp/utils/gcf_helper.py:8` does the path
+insert, imports, and falls back on exception. Reusing that shape means the new
+module needs no packaging work, no interpreter assumptions, and no new
+convention for a reviewer to learn.
+
+**Implementation trap to record**: the insert depth is per-file, not per-server.
+`gnmi-mcp/gnmi_mcp_server.py:31` uses `"..", "..", "src"` (module at server
+root); `claroty-mcp/utils/gcf_helper.py:8` uses `"..", "..", "..", "src"`
+(module one directory deeper). The gnmi shim lives at
+`mcp-servers/gnmi-mcp/itsm_gate.py` and the claroty shim at
+`mcp-servers/claroty-mcp/utils/itsm_gate.py`, so the two shims need **different**
+depths. Getting this wrong fails silently into the fallback path.
+
+**Alternatives considered**:
+- *A root-level installable package* (`pyproject.toml` + `pip install -e .`) —
+  rejected for v1 on two verified grounds. First, no root packaging exists to
+  extend. Second, the repo runs **mixed interpreters**: `gnmi-mcp` and
+  `claroty-mcp` are launched with bare `python3` and *relative* script paths
+  (`config/openclaw.json:76-79`, `:546-550`), while all three nautobot servers
+  are launched with `/home/ubuntu/netclaw/.venv/bin/python3` and *absolute*
+  script paths (`config/openclaw.json:308+`). A package installed into one
+  interpreter is invisible to the other, so the follow-on nautobot phase would
+  hit an import error that v1 could not have caught. Spec 035's research made
+  the same call for GCF ("we **do not** refactor GCF into a proper Python
+  package import in this PR"), and this feature is not the place to reverse it.
+- *`mcp-servers/_shared/`* — rejected. It invents a second sharing convention
+  with zero precedent, and `src/` is already the answer to "where does
+  cross-server Python live". Two conventions is worse than one imperfect one.
+- *Vendoring a third copy into a `common/` dir per server* — rejected outright;
+  that is the status quo with extra steps.
+
+---
+
+## R4: Backwards-Compatibility Constraints
+
+**Finding**: Three hard constraints, all verified in code.
+
+1. **The envelope is published in tool output.** `claroty-mcp` returns the whole
+   gate dict to the model: `{"itsm_gate": gate, "applied": False}` on rejection
+   (`tools/alerts.py:182`), `{"itsm_gate": gate, "applied": True, "response":
+   raw}` on success (`:219`), and again in the error path (`:223`) — and the
+   tool docstring advertises that shape at `:178`. So `valid`, `message`,
+   `cr_number`, and `state` are a **public contract**, not internals.
+2. **Parameter names diverge and cannot be reconciled.** `gnmi_set` takes
+   `change_request_number` (required, `gnmi_mcp_server.py:196+`); claroty's six
+   tools take `cr_number` (required); nautobot's 35 take `cr_number`
+   (**`Optional`**). FR-010/SC-007 forbid touching any of them.
+3. **Two message strings are server-specific.** Per R1's diff, the
+   missing-reference message and the not-approved message each name the calling
+   subsystem ("gNMI Set operations" / "Claroty write operations").
+
+**Decision**: Retain thin shims at the existing paths —
+`mcp-servers/gnmi-mcp/itsm_gate.py` and
+`mcp-servers/claroty-mcp/utils/itsm_gate.py` — each re-exporting
+`validate_change_request` from `src/netclaw_itsm/`. All 7 call sites and both
+import statements (`from itsm_gate import validate_change_request`,
+`from utils.itsm_gate import validate_change_request`) stay exactly as they are.
+The two divergent strings are preserved by having each **shim** supply an
+operation label to the shared function; the label is never a tool parameter.
+Envelope changes are strictly additive: `provider` and a verification indicator
+are added, no existing key is renamed, removed, or retyped.
+
+**Rationale**: The shim is what makes FR-010 and SC-007 achievable without
+touching a single tool signature, and it keeps the diff of v1 confined to
+`src/netclaw_itsm/` plus two small files. Passing the operation label from the
+shim rather than the caller means the label cannot be forgotten at a call site
+and cannot leak into an MCP tool schema.
+
+**Alternatives considered**:
+- *Re-point the 7 call sites directly at the shared module* — rejected for v1.
+  It churns 5 files across 2 servers for zero behavioral gain and widens the
+  surface that SC-003 must prove unchanged. The shims can be removed later as
+  pure cleanup once the suite exists.
+- *Normalize the two divergent messages to one generic string* — rejected. It
+  is a user-visible message change that would force the characterization tests
+  (FR-011) to be authored already-failing, destroying their value as a
+  regression net. Provider-neutral wording is fine; *subsystem*-neutral wording
+  is a behavior change.
+- *Rename `cr_number` to `change_ref` in the envelope* — rejected. Claroty
+  publishes it; renaming is breaking (FR-009 states this explicitly). The name
+  is now slightly wrong for a Halo or Jira reference; that is a cheaper cost
+  than a broken contract, and the `provider` key supplies the missing context.
+
+---
+
+## R5: Provider Selection and Configuration Mechanism
+
+**Finding**: Existing gating configuration is 100% environment variables, and
+the delivery of those variables is already broken for one v1 server.
+
+- `NETCLAW_LAB_MODE` — read by both v1 gates (`itsm_gate.py:57` / `:63`),
+  truthy set `("true", "1", "yes")`, case-insensitive, default `false`.
+  Delivered to `claroty-mcp` at `config/openclaw.json:557`
+  (`"NETCLAW_LAB_MODE": "${NETCLAW_LAB_MODE:-false}"`) and documented at
+  `.env.example:119`.
+- `ITSM_ENABLED` / `ITSM_LAB_MODE` — nautobot family only, delivered in all
+  three env blocks, documented at `.env.example:397-398`.
+- **`gnmi-mcp` receives no ITSM variable at all.** Its env block
+  (`config/openclaw.json:81-90`) contains eight `GNMI_*` variables and nothing
+  else, so its lab-mode bypass works **only** if `NETCLAW_LAB_MODE` happens to
+  be exported in the parent process that launches OpenClaw.
+
+**Decision**: Provider selection is a single environment variable,
+`NETCLAW_ITSM_PROVIDER`, resolved once at module import, case-insensitive and
+trimmed, with an unrecognized value raising a loud configuration error and no
+vendor fallback (FR-003). It MUST be added to the `env` block of **every** gated
+server in `config/openclaw.json` (FR-015) — and `gnmi-mcp`'s block must gain
+both `NETCLAW_ITSM_PROVIDER` **and** `NETCLAW_LAB_MODE`, otherwise provider
+selection silently no-ops there exactly the way lab mode does today.
+Recommended default when unset: `none` with a startup warning (spec Open
+Question 2).
+
+**Rationale**: Env vars are how every server in this repo receives every piece
+of configuration, the two existing gate schemes are both env vars, and an env
+var is the only mechanism that is unambiguous at gate-evaluation time (no file
+resolution, no I/O, no failure mode). Defaulting to `none` rather than
+`servicenow` is deliberate: the current default enforces nothing anyway (R2
+point 4), and a silent ServiceNow default is precisely the mechanism that
+produced this bug.
+
+**Alternatives considered**:
+- *A setting in `config/openclaw.json`* — rejected for v1. Servers do not
+  receive this file; they receive its `env` block. The only runtime readers of
+  an `openclaw.json` under `mcp-servers/` are `protocol-mcp`'s federation
+  modules, and they demonstrate the problem rather than a precedent: across
+  `federation/controls.py:45`, `inventory.py:58`, `inventory.py:253`,
+  `invocation.py:46-57`, and `posture.py:135` they probe **three different
+  paths** (`<repo>/config/openclaw.json`,
+  `~/.openclaw/config/openclaw.json`, `~/.openclaw/openclaw.json`). A gate
+  would have to pick a winner among those on every write. Env vars have no such
+  ambiguity.
+- *A Memory MCP fact* — rejected. `memory-mcp` is stdio-only; a server could
+  only read `~/.openclaw/memory/memory.db` directly (see R2). Operator
+  ergonomics do not justify a cross-server storage dependency on the write path.
+- *Per-server variables (`GNMI_ITSM_PROVIDER`, `CLAROTY_ITSM_PROVIDER`)* —
+  rejected. The spec's Non-Goals fix one active provider per deployment, so
+  per-server names would only create drift; spec 035's research made the same
+  call when it declined to add a `CLAROTY_LAB_MODE`.
+- *Reusing `ITSM_ENABLED` as the on/off switch* — rejected for v1. It belongs
+  to the nautobot contract, its default (`false`) means "gating off", and
+  overloading it would couple the two phases the whole plan separates.
+
+---
+
+## R6: Constitution Amendment Scope
+
+**Decision**: Amend all **five** ServiceNow-naming locations in
+`.specify/memory/constitution.md` in a single, all-or-nothing amendment, and
+bump the version **1.2.0 → 1.3.0 (MINOR)**:
+
+| # | Location | Current text (verified) | Amendment |
+|---|---|---|---|
+| 1 | Principle III "ITSM-Gated Changes", `:55-64` (specifically `:57`) | "All production changes MUST have an approved **ServiceNow** Change Request (CR) before execution." | "…an approved change record in **the configured ITSM** before execution", with the configurable-provider set named once. |
+| 2 | Principle VIII "Verify After Every Change", `:114` | "…mark the **ServiceNow** CR as failed." | "…mark the change record as failed in the configured ITSM." |
+| 3 | Principle XIV "Human-in-the-Loop…", `:200` | "Creating, updating, or closing **ServiceNow** tickets" | "Creating, updating, or closing tickets in the configured ITSM" |
+| 4 | Technology Stack, `:260` | "**ITSM**: ServiceNow (change management, incidents, CMDB)" | "**ITSM**: operator-selected — ServiceNow, HaloPSA/HaloITSM, Atlassian/Jira, or none (change management, incidents, CMDB)" |
+| 5 | Forbidden Operations, `:269` | "Bypassing **ServiceNow** CR approval for production changes" | "Bypassing change-record approval in the configured ITSM for production changes" |
+
+Lab mode must remain, verbatim in substance, the **sole** exception and must
+remain GAIT-logged (`:61-62`); the amendment generalizes the vendor, never the
+control.
+
+**Rationale for MINOR**: This clarifies and generalizes existing principle text.
+No principle is removed, no principle is redefined, and no requirement is
+relaxed — gating stays mandatory and lab mode stays the only bypass; only the
+*vendor* becomes configurable. That is precisely the class of change the
+Constitution's own Governance versioning rule reserves for MINOR, and it is the
+same class as the 1.1.0 → 1.2.0 bump, whose Sync Impact Report describes
+updating "which concrete files satisfy the principle, not a redefinition of what
+artifact coherence means."
+
+**Rationale for all-or-nothing**: Amending Principle III alone would leave four
+locations still naming ServiceNow, i.e. the exact internal contradiction this
+feature exists to remove, and would fail SC-005 (a contributor reading only the
+Constitution must be able to state that the ITSM is configurable).
+
+**Sync Impact Report commitment**: The amendment MUST reproduce the established
+format — the HTML comment block at `.specify/memory/constitution.md:1-30` — with
+the same section order and headings:
+
+```
+  Sync Impact Report
+  ==================
+  Version change: 1.2.0 → 1.3.0 (MINOR — principle clarification)
+
+  Modified principles: <III, VIII, XIV + Technology Stack + Forbidden Operations>
+  Added sections: …
+  Removed sections: …
+  Templates requiring updates:
+    - .specify/templates/plan-template.md — ✅ Compatible / <change>
+    - .specify/templates/spec-template.md — …
+    - .specify/templates/tasks-template.md — …
+  Follow-up TODOs: …
+  Previous version history:
+    - 1.0.0 (2026-03-26): Initial ratification with 16 core principles
+    - 1.1.0 (2026-03-28): Added Principle XVII (Milestone Documentation via WordPress)
+    - 1.2.0 (2026-07-08): Principle XI — modular installer catalog (spec 049)
+```
+
+Prior versions compress into "Previous version history" (1.2.0's own entry gets
+added there), and the footer at `:355` — `**Version**: 1.2.0 | **Ratified**:
+2026-03-26 | **Last Amended**: 2026-07-08` — is updated to `1.3.0` with the new
+amendment date, leaving the ratification date untouched.
+
+**Open item surfaced for the maintainer (spec Open Question 9)**: two fragments
+encode ServiceNow's *state machine*, not just its name — Principle III's
+lifecycle "(Assess → Authorize → Implement → Review)" at `:59-60`, and
+Principle VIII's pairing with the `"Implement"` state that the code checks
+literally (`itsm_gate.py:95`, `cr_state.lower() == "implement"`). Recommend
+generalizing the lifecycle to provider-neutral phases and letting each
+provider's native state vocabulary live in its adapter (FR-004), so the
+Constitution stops hard-coding one vendor's workflow. Flagged rather than
+assumed, because it widens the amendment beyond a name substitution.
+
+**Alternatives considered**:
+- *MAJOR bump (2.0.0)* — rejected. Nothing is removed or redefined; gating
+  remains mandatory and lab mode remains the only exception. Reserving MAJOR for
+  actual redefinition is what keeps the version signal meaningful.
+- *PATCH bump* — rejected. This is not wording/typo cleanup: after the
+  amendment, a deployment gated by Halo is *compliant* where before it was not,
+  which is a change in normative meaning.
+- *Amend Principle III only, leave the rest as "obviously implied"* — rejected;
+  see all-or-nothing above.
+- *Implement first, amend later* — rejected. Principle III as written makes a
+  Halo-gated deployment non-compliant, so shipping the code first would put the
+  implementation in violation of the governing document. Hence the spec's DRAFT
+  status and the ratification precondition.
+
+---
+
+## R7: Zero Test Coverage — Characterization Tests First
+
+**Finding**: No test in the repo exercises any gate. The change-reference tests
+that exist (`tests/unit/test_sqlite_store.py:98-107`) cover memory-mcp's
+**deferred** provenance validator — the one implementation this feature does not
+touch. Test layout available to copy: `tests/unit/`, `tests/contract/`,
+`tests/integration/`, plain pytest classes, stdlib-only assertions.
+
+**Decision**: Author the characterization suite **against the unrefactored
+gate** and land it before `src/netclaw_itsm/` exists (FR-011), in `tests/unit/`
+alongside the existing unit tests. Behaviors to pin, taken from reading the
+current code rather than from intent:
+
+| # | Input / state | Expected today |
+|---|---|---|
+| 1 | `""` / `None` reference | `valid: False`, `state: None`, message names the calling subsystem ("gNMI Set operations" / "Claroty write operations") |
+| 2 | `"INC0012345"`, `"chg123"`, `"CHG"`, `"CHG12 "` | `valid: False`, `state: None`, message `Invalid CR format: '<x>'. Expected format: CHG followed by digits (e.g. CHG0012345)` |
+| 3 | `NETCLAW_LAB_MODE` ∈ {`true`,`1`,`yes`} any case | `valid: True`, `state: "lab_mode"`, message ends `(lab mode — ServiceNow check skipped)` |
+| 4 | `NETCLAW_LAB_MODE` unset / `"false"` / `"0"` / garbage | lab bypass **not** taken |
+| 5 | valid ref, default path | `valid: True`, `state: "unverified"`, "ServiceNow verification unavailable" message (the `_check_servicenow_cr_state() -> None` branch) |
+| 6 | `_check_servicenow_cr_state` patched to raise | `valid: True`, `state: "error"` |
+| 7 | patched to `"Implement"` / `"implement"` | `valid: True`, `state` echoes the native string |
+| 8 | patched to `"New"` | `valid: False`, message `…is in 'New' state, not 'Implement'…` + subsystem clause |
+| 9 | every return path | envelope has **exactly** the keys `{valid, message, cr_number, state}`, and `cr_number` echoes the raw input verbatim (including for `""`) |
+| 10 | claroty rejection wrapper | output JSON is `{"itsm_gate": <envelope>, "applied": false}` |
+
+**Rationale**: With zero coverage there is no way to distinguish an intended
+change from a regression, and SC-003 ("100% of the characterization assertions
+captured before the refactor pass after it") is literally unverifiable without
+this step. Rows 7 and 8 matter even though they are unreachable in production —
+they are the behavior the provider abstraction must reproduce once attestation
+(R8) makes them reachable again. Rows 1 and 8 are what prove the shim-supplied
+operation label (R4) preserves the divergent strings.
+
+**Alternatives considered**:
+- *Refactor first, add tests after* — rejected; that is the failure mode this
+  item exists to prevent, and it makes SC-003 meaningless.
+- *Live/manual verification only*, as used for feature-specific MCP work
+  elsewhere in the repo — rejected. There is no external system to verify
+  against (the gate makes no calls), and lab mode makes manual verification
+  tautological: everything well-formed passes.
+- *Golden-file snapshots of the envelope* — rejected as the primary form.
+  Explicit per-branch assertions document *why* each value is what it is; a
+  snapshot would freeze the message strings without recording that two of them
+  are deliberately subsystem-specific.
+
+---
+
+## R8: The Trust Boundary, Stated Honestly, and Attestation
+
+**Finding**: The current gate does not merely fail open — it *reads* as if it
+verifies. `itsm_gate.py:1-9` states the CR must "Be in 'Implement' state in
+ServiceNow"; `:67-78` documents a four-step verification flow; `:126-138`
+declares the integration point and then `return None`. Consequently every
+well-formed `CHG\d+` reference produces `{valid: True, state: "unverified"}`,
+and no `servicenow-mcp` is registered in `config/openclaw.json` for it to have
+called (verified: zero keys matching `servicenow`).
+
+**Decision**: State the boundary plainly and make it auditable rather than
+pretend to close it.
+
+1. The server-side gate is **advisory**: with skill-layer verification (R2), a
+   direct MCP tool call can assert any well-formed reference. Documentation MUST
+   say so (FR-007), per provider, naming the responsible skill.
+2. Add an `attested_state` that the verifying skill passes into the gate, plus a
+   verification indicator in the envelope — both **additive** (FR-008, FR-009).
+   The gate classifies: attested and in the adapter's approved-state vocabulary
+   → verified; absent → `unverified`; attested but **not** approved → deny,
+   mirroring the pre-existing (currently unreachable) not-approved branch at
+   `itsm_gate.py:102-111`.
+3. Every decision emits one GAIT record carrying provider, reference,
+   verification status, and allow/deny outcome (FR-013). Emitting it from the
+   shared gate is the cheapest way to get all 7 tools uniform, and it closes the
+   gap R1 found: claroty currently GAIT-logs nothing.
+
+**Why attestation is a precondition for strict mode**: without it, a strict mode
+could only fail closed on *reference format*, which adds no safety — a
+well-formed but entirely fictional reference still passes. With attestation,
+`NETCLAW_ITSM_STRICT` has a meaning worth having ("deny unless a skill attested
+an approved state"), and it can be introduced opt-in without breaking any
+currently-working call (spec Open Question 3).
+
+**Rationale**: An attested state is a *claim by the caller*, not a proof. That
+is a real limitation and must be documented, not papered over. What it buys is
+the difference between unknowable and recorded: the GAIT trail moves from "a
+reference was supplied" to "a reference was supplied, and here is whether
+anything checked it" — which is exactly what SC-006 asks an auditor to be able
+to determine.
+
+**Alternatives considered**:
+- *Cryptographic attestation / signed change tokens* — rejected. No ITSM in
+  scope issues an offline-verifiable claim about a change record's state, and
+  inventing a signing authority for CRs is a far larger feature than this one.
+- *Honor system with no attestation field* — rejected. It leaves US3 and SC-006
+  unmet and keeps the gate's audit record indistinguishable between "verified"
+  and "nobody looked".
+- *Fail closed by default whenever a state is unverified* — rejected for v1. It
+  would deny **every** currently-working gated call (all of which are
+  `unverified`), the precise regression FR-010/SC-003 forbid. Offered instead as
+  opt-in strict mode.
+- *Trust the skill layer implicitly and drop the server gate entirely* —
+  rejected. The format check and the GAIT record are cheap, are the only
+  server-side evidence that a change reference was ever demanded, and removing
+  the gate would mean removing Principle III's only mechanical enforcement point.
+
+---
+
+## What this feature does NOT change
+
+- The `_check_itsm()` contract or any of the 35 nautobot gated tools (follow-on
+  phase; env-var defaults preserved when it happens).
+- `memory-mcp`'s `validate_cr_number()` — stays `^CHG\d+$`, so
+  `memory_record_decision(cr_number=…)` will still reject a Halo or Jira
+  reference. Documented as a known deferred inconsistency (FR-016).
+- Which tools are gated, or what counts as a write.
+- Any MCP tool parameter name, type, or requiredness.
+- `src/netclaw_tokens/` (the module it is modelled on is not touched).
+- The absent `servicenow-mcp` registration, or the fact that ServiceNow is
+  reachable only as an unregistered install-time clone via
+  `$SERVICENOW_MCP_SCRIPT` (spec Open Question 8).
+- The discovered defect that `config/openclaw.json` registers `aruba-cx-mcp`
+  with ITSM variables for a server directory that does not exist — reported for
+  triage, out of scope.

--- a/specs/070-itsm-provider-abstraction/spec.md
+++ b/specs/070-itsm-provider-abstraction/spec.md
@@ -1,0 +1,214 @@
+# Feature Specification: ITSM Provider Abstraction for Change Gating
+
+**Feature Branch**: `070-itsm-provider-abstraction`
+**Created**: 2026-07-24
+**Status**: DRAFT — proposal for maintainer review. **Requires a Constitution amendment (1.2.0 → 1.3.0) and MUST NOT be implemented before that amendment is ratified.**
+**Input**: Let the operator choose which ITSM system provides the change record that gates NetClaw's write operations, instead of NetClaw hard-assuming ServiceNow everywhere.
+
+---
+
+## Problem
+
+NetClaw's change gating is hardwired to **ServiceNow** at three layers — the governance layer (Constitution), the code layer (`itsm_gate.py`), and the skill layer — so NetClaw "always talks about ServiceNow" even for organizations that run a different ITSM.
+
+This is now a concrete friction point, because two NetClaw integrations **are themselves ITSMs** with native change management: **HaloPSA/HaloITSM** (feature 069, PR #167) and **Atlassian/Jira** (`atlassian-mcp`). For a Halo shop, the change record *is* the Halo change ticket; requiring a separate ServiceNow CR is redundant and wrong.
+
+Two further facts make this more than cosmetic:
+
+1. **The gate currently enforces nothing.** `_check_servicenow_cr_state()` unconditionally returns `None`, so every well-formed `CHG\d+` yields `{valid: True, state: "unverified"}`. There is no `servicenow-mcp` registered in `config/openclaw.json`. The gate is format-only and fails open.
+2. **The gate logic is duplicated five times with two incompatible contracts** (see Key Entities → *Current-state inventory*), so any change to gating behavior today must be made in five places, and **no test anywhere exercises any of them**.
+
+## Goals / Non-Goals
+
+**Goals**
+- An operator can select the ITSM that gates writes (`servicenow`, `halo`, `atlassian`, `none`), and NetClaw's gate messages, ref formats, and skill routing follow that selection.
+- One shared, provider-agnostic gate module replaces the duplicated copies, with **no behavior regression** for currently-gated tools.
+- The trust boundary is stated honestly: verification of a change record's *state* happens at the skill/agent layer; the server-side gate enforces ref format + provider policy and records the decision.
+- The Constitution describes provider-agnostic ITSM gating consistently.
+
+**Non-Goals (this feature)**
+- Building a `servicenow-mcp` server, or fixing the fact that ServiceNow is only reachable as an unregistered install-time clone.
+- Making the server-side gate call any ITSM API (explicitly rejected — see Assumptions).
+- Changing *which* tools are gated, or what counts as a write.
+- Multi-provider-simultaneous gating. One active provider per deployment.
+- Migrating the nautobot family in v1 (specified as a follow-on phase — see US2 and FR-014).
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — An operator gates changes with their own ITSM (Priority: P1)
+
+An operator runs HaloPSA, not ServiceNow. They set the ITSM provider to `halo`. When they attempt a gated write, NetClaw expects a **Halo** change-ticket reference, validates it against Halo's ref format, and every message, prompt, and error names **Halo** — never ServiceNow. The same deployment switched to `servicenow` behaves exactly as NetClaw does today.
+
+**Why this priority**: This is the entire point of the feature. Without it a Halo or Jira shop is told to produce a ServiceNow CR that does not and will never exist in their environment.
+
+**Independent Test**: Configure `NETCLAW_ITSM_PROVIDER=halo`, call a gated tool with a Halo change-ticket id, and confirm it is accepted and that no output string contains "ServiceNow". Repeat with a `CHG0012345` ref and confirm it is rejected with a message naming Halo's expected format.
+
+**Acceptance Scenarios**:
+
+1. **Given** provider `halo`, **When** a gated tool is called with a valid Halo change-ticket reference, **Then** the gate returns `valid: true` with `provider: "halo"` and no ServiceNow terminology.
+2. **Given** provider `halo`, **When** a gated tool is called with `CHG0012345`, **Then** the gate returns `valid: false` with a message stating the expected Halo reference format.
+3. **Given** provider `servicenow`, **When** a gated tool is called with `CHG0012345`, **Then** behavior is identical to the pre-refactor gate (format accepted; `state` reported honestly).
+4. **Given** provider `none` (or `NETCLAW_LAB_MODE=true`), **When** a gated tool is called, **Then** the write proceeds without an external change record and the bypass is GAIT-logged.
+5. **Given** an unrecognized provider value, **When** any gated tool is called, **Then** the gate fails with a clear configuration error naming the supported providers, and does **not** silently fall back to ServiceNow.
+
+---
+
+### User Story 2 — One gate implementation instead of five (Priority: P1)
+
+A maintainer changing gating behavior edits **one** module and every gated server picks it up. Today the same logic exists in five places with two different contracts and two different environment-variable schemes, and a sixth ServiceNow-shaped CR regex lives in Memory MCP.
+
+**Why this priority**: Provider selection (US1) is unbuildable on five divergent copies — it would mean five parallel implementations of the same abstraction. Consolidation is the prerequisite, and it must be provably regression-free.
+
+**Independent Test**: With provider `servicenow` (status-quo config), run the characterization test suite captured before the refactor against the refactored gate; every assertion passes unchanged. Confirm `gnmi_set` and the six Claroty write tools behave identically, including the envelope Claroty publishes in its tool output.
+
+**Acceptance Scenarios**:
+
+1. **Given** zero existing test coverage of the gate, **When** the refactor begins, **Then** characterization tests capturing the *current* behavior already exist and pass against the *unrefactored* code.
+2. **Given** the shared module, **When** `gnmi-mcp` and `claroty-mcp` are re-pointed at it, **Then** their existing import paths and call sites are unchanged (thin shims re-export), and the characterization suite still passes.
+3. **Given** Claroty publishes the gate envelope as `{"itsm_gate": {...}}` in tool output, **When** the envelope gains a `provider` key, **Then** all previously-present keys (`valid`, `message`, `cr_number`, `state`) remain with unchanged meaning.
+4. **Given** the two servers use different parameter names (`change_request_number` vs `cr_number`), **When** the shared gate is adopted, **Then** both continue to work without renaming any MCP tool parameter.
+5. **Given** the nautobot family's separate `_check_itsm()` contract, **When** v1 ships, **Then** the nautobot servers are untouched and their migration is specified as a distinct later phase with its own compatibility analysis.
+
+---
+
+### User Story 3 — Skill-layer verification is documented and auditable (Priority: P2)
+
+Because NetClaw's MCP servers cannot call other MCP servers, the *state* of a change record ("is this CR approved?") can only be verified by the agent/skill layer, which can reach any ITSM's MCP tools. An operator and an auditor can both see exactly who verified what: the responsible skill per provider is documented, and the skill records its verification result so the gate decision and the GAIT trail show whether the state was actually checked or merely asserted.
+
+**Why this priority**: This makes the safety posture honest. Today the code *implies* it verifies CR state and does not — the worst of both worlds. Documenting the real boundary, plus an attestation the skill can pass, is what turns "advisory" into "advisory and auditable".
+
+**Independent Test**: Run a gated write through the provider's change skill and confirm the GAIT record shows the change reference, the provider, and whether the state was verified (attested) or unverified. Then call the gated tool directly without attestation and confirm the decision is recorded as unverified rather than reported as verified.
+
+**Acceptance Scenarios**:
+
+1. **Given** any provider, **When** the gate returns a decision, **Then** the decision distinguishes "state verified by the skill" from "state not verified" and never reports verification that did not occur.
+2. **Given** provider `halo`, **When** the change skill verifies the ticket's status before the write, **Then** the verified state is carried into the gate decision and the GAIT record.
+3. **Given** a gated tool called with no attestation, **When** the gate evaluates it, **Then** the write is permitted or denied per the configured policy, and the decision records that the state was unverified.
+4. **Given** documentation, **When** an operator asks "who checks that my change is approved?", **Then** the answer is stated explicitly per provider, naming the responsible skill.
+
+---
+
+### User Story 4 — The Constitution describes provider-agnostic gating (Priority: P3)
+
+A contributor reading the Constitution learns that changes require an approved change record in **the configured ITSM**, and cannot come away believing ServiceNow is the only supported system. All five ServiceNow-naming locations are consistent with each other and with the code.
+
+**Why this priority**: Governance should follow the implementation, not block it, so this is sequenced last — but it is **required for completion**, and it is the part that needs maintainer ratification. Amending Principle III alone would leave four contradicting references, so the amendment is all-or-nothing across the five locations.
+
+**Independent Test**: A contributor who has read only the amended Constitution can correctly state (a) that the gating ITSM is configurable, (b) that lab mode remains the sole bypass and is still GAIT-logged, and (c) that no specific vendor is mandated.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Constitution's own amendment process (documented rationale, impact review, semantic version bump), **When** this amendment is made, **Then** that process is followed and recorded exactly as prior amendments were.
+2. **Given** the five ServiceNow-naming locations, **When** the amendment lands, **Then** all five are provider-agnostic and mutually consistent.
+3. **Given** the amendment generalizes existing principle text rather than removing or redefining a principle, **When** the version is bumped, **Then** it is a MINOR bump (1.2.0 → 1.3.0) with that reasoning stated.
+4. **Given** the top-of-file Sync Impact Report, **When** the amendment lands, **Then** the report is rewritten in the established format and prior versions are compressed into "Previous version history".
+
+---
+
+### Edge Cases
+
+- **Provider/ref mismatch**: a `CHG\d+` ref supplied while provider is `halo` — must be rejected with a provider-specific message, never silently accepted.
+- **Unknown provider value**: must be a loud configuration error, never a silent fallback to ServiceNow (a silent fallback would recreate the bug).
+- **Provider configured but its ITSM is unreachable**: the skill cannot verify state. The gate must report the decision honestly per the configured policy — see Open Question 3 (fail-open today).
+- **Missing provider configuration entirely**: needs a documented default — see Open Question 2.
+- **`gnmi-mcp` receives no ITSM environment variable** from `config/openclaw.json:81-90` today, so its lab bypass works only by parent-environment leakage. Any new variable must be added to every gated server's env block or the feature silently misconfigures.
+- **Claroty's published envelope**: it returns the whole gate dict inside tool output, so envelope keys are a public contract. Additive changes only; renaming `cr_number` is breaking.
+- **Parameter-name divergence**: `gnmi_set` uses `change_request_number` (required); Claroty uses `cr_number` (required); nautobot uses `cr_number` (**optional**). A shared gate must not force a rename.
+- **Divergent operation-label messages**: the two gate copies emit different user-visible strings (`"…for gNMI Set operations"` vs `"…for Claroty write operations"`). Preserving them byte-for-byte requires the label to come from the **shim**, not from a tool parameter — otherwise the characterization tests of FR-011 would have to be authored already-failing.
+- **Provider-adapter fields that cannot be fixed on this branch**: Halo's change-reference format depends on unmerged feature 069, and Jira statuses are configurable per project, so Atlassian's approved-state vocabulary cannot ship as a constant — it must be operator-supplied. Both must be marked provisional rather than invented.
+- **Lab mode interaction**: `NETCLAW_LAB_MODE` (gnmi/claroty) and `ITSM_ENABLED`/`ITSM_LAB_MODE` (nautobot) coexist with different defaults. Provider `none` and lab mode overlap and must have defined precedence.
+- **Attestation spoofing**: an attested state is only as trustworthy as the caller. With skill-layer verification the server boundary is advisory by construction; this must be documented, not papered over.
+- **Memory MCP CR provenance**: `memory_record_decision(cr_number=...)` validates `^CHG\d+$` for audit metadata. A Halo shop's change reference will fail that validation — deferred, but it is a user-visible inconsistency (FR-016).
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a single shared, provider-agnostic change-gate module that all gated MCP servers use, replacing per-server copies of the gate logic.
+- **FR-002**: The gate MUST resolve an active ITSM provider from configuration, supporting at minimum `servicenow`, `halo`, `atlassian`, and `none`.
+- **FR-003**: The gate MUST reject an unrecognized provider value with an explicit configuration error and MUST NOT fall back to any vendor default.
+- **FR-004**: Each provider MUST declare, as data: its change-reference format, its human-readable ITSM name, its "approved for implementation" state vocabulary, and the skill responsible for verifying a change record's state.
+- **FR-005**: The gate MUST validate a supplied change reference against the **configured provider's** format and, on failure, return a message naming that provider and its expected format.
+- **FR-006**: The gate MUST NOT make network calls to any ITSM. State verification is the responsibility of the agent/skill layer (see FR-007).
+- **FR-007**: Documentation MUST state, per provider, which skill verifies the change record's state before a gated write, and MUST describe the server-side gate as enforcing format and policy rather than verifying state.
+- **FR-008**: The gate decision MUST distinguish a state that was verified by the skill layer from one that was not, and MUST NOT report verification that did not occur.
+- **FR-009**: The gate MUST preserve its existing return-envelope keys (`valid`, `message`, `cr_number`, `state`) with unchanged meaning, adding new keys additively, because at least one server publishes the envelope in its tool output.
+- **FR-010**: The refactor MUST NOT rename or change the requiredness of any existing MCP tool parameter, including the divergent `change_request_number` and `cr_number` names.
+- **FR-011**: Characterization tests capturing the current gate behavior MUST exist and pass against the pre-refactor code before the shared module replaces it, since no test coverage exists today.
+- **FR-012**: The gate MUST preserve a lab/no-ITSM path that permits writes without an external change record, and every such bypass MUST be GAIT-logged.
+- **FR-013**: Every gate decision MUST be recorded to the GAIT audit trail with the provider, the change reference, the verification status, and the allow/deny outcome. **Note**: this is *net-new* behavior for 6 of the 7 v1-gated tools — `claroty-mcp` emits no GAIT record today (only `gnmi-mcp` does), so this requirement closes an existing Principle IV gap rather than preserving current behavior, and argues for emitting from inside the shared gate rather than per caller.
+- **FR-014**: v1 MUST cover the two servers using the `validate_change_request()` contract (7 gated tools) and MUST specify — without implementing — the migration of the three nautobot servers (35 gated tools) that use the separate `_check_itsm()` contract.
+- **FR-015**: The provider configuration variable MUST be delivered to every gated server through its `config/openclaw.json` environment block, including servers that currently receive no ITSM variable.
+- **FR-016**: The system MUST document, as a known deferred inconsistency, that Memory MCP's change-reference provenance validation remains ServiceNow-shaped and will reject other providers' reference formats.
+- **FR-017**: The Constitution MUST be amended, following its own documented amendment process, so that all five of its ServiceNow-naming locations describe a configurable ITSM.
+
+### Key Entities
+
+- **ItsmProvider** — the selected ITSM for change gating. One of `servicenow`, `halo`, `atlassian`, `none`. Resolved from configuration; invalid values are an error.
+- **ProviderAdapter** — declarative metadata for one provider: reference format, display name, approved-state vocabulary, responsible verification skill. Contains **no** transport or credential logic.
+- **ChangeRef** — the operator-supplied reference to a change record (a ServiceNow `CHG…` number, a Halo change-ticket id, a Jira issue key). Format is provider-specific.
+- **GateDecision** — the returned envelope: `valid`, `message`, `cr_number` (retained name), `state`, plus additively `provider` and a verification indicator. Published in at least one server's tool output, so it is a public contract.
+- **GateConfig** — resolved policy: active provider, lab/bypass state, and (proposed) strictness.
+
+**Current-state inventory** *(the surface this feature consolidates — canonical counts used across all artifacts)*:
+
+| Implementation | Where | Contract | Env scheme | Gated tools | v1? |
+|---|---|---|---|---|---|
+| `validate_change_request()` | `mcp-servers/gnmi-mcp/itsm_gate.py`; `mcp-servers/claroty-mcp/utils/itsm_gate.py` | dict envelope | `NETCLAW_LAB_MODE` | **7** (1 gnmi + 6 claroty) | **yes** |
+| `_check_itsm()` | `nautobot-mcp-v2/server.py:39`; `nautobot-routing-mcp/server.py:57`; `nautobot-golden-config-mcp/server.py:61` | `Optional[str]`, no format check | `ITSM_ENABLED` + `ITSM_LAB_MODE` | **35** | follow-on |
+| `validate_cr_number()` | `memory-mcp/storage/sqlite_store.py:109` | `Tuple[bool, str\|None]` — provenance, not a gate | — | 1 | deferred (FR-016) |
+| dead validator | `mcp-servers/gnmi-mcp/models.py:198` (`GnmiSetRequest` unreferenced) | — | — | 0 | remove |
+
+Totals: **5 gate implementations across 5 servers · 42 gated tools · 4 independent `^CHG\d+$` regexes · 0 existing tests.**
+
+---
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A single gate implementation serves all v1-gated tools; the number of independent change-reference format validators drops from 4 to 1 (excluding the deferred Memory MCP provenance check).
+- **SC-002**: With a non-ServiceNow provider configured, no gate output, error message, or prompt for a gated write contains the word "ServiceNow".
+- **SC-003**: With the status-quo provider configured, 100% of the characterization assertions captured before the refactor pass after it — including the envelope Claroty publishes.
+- **SC-004**: Gate behavior is covered by tests where it previously had none (from 0 tests to a suite covering: each provider's format validation, unknown-provider error, lab/none bypass, and the verified/unverified distinction).
+- **SC-005**: A contributor who has read only the amended Constitution can correctly state that the gating ITSM is configurable, that lab mode is the sole bypass and is still GAIT-logged, and that no vendor is mandated.
+- **SC-006**: An auditor reading a GAIT record for a gated write can determine the provider, the change reference, and whether the change record's state was actually verified.
+- **SC-007**: Zero currently-gated tools change their parameter names or requiredness.
+
+---
+
+## Assumptions
+
+- **Skill-layer verification is the chosen architecture.** NetClaw MCP servers cannot call other MCP servers (no MCP client exists anywhere under `mcp-servers/`; `scripts/mcp-call.py` is used only by skills, bash, and the UI). Server-side HTTP verification was considered and rejected: it would require per-ITSM credentials and HTTP clients inside every gated server, and the gate must be **synchronously** callable (`gnmi_set` is a plain `def`), which rules out reusing the async client patterns the rest of the repo uses.
+- **Consequence, stated plainly**: with skill-layer verification the server-side gate is **advisory** — a direct tool call can assert any reference. The real controls are the skill layer and the GAIT audit trail. This is not a regression; today's gate already enforces nothing (`_check_servicenow_cr_state()` returns `None`, so every well-formed reference passes as `unverified`). This feature makes that boundary honest and auditable instead of implied.
+- **The shared module follows the one working precedent for cross-server Python**: `src/netclaw_tokens/`, imported via a `sys.path` insert anchored on `__file__`, used by 8 servers. A root-level installable package was considered and rejected for v1 because no root packaging exists and the repo runs mixed interpreters (the nautobot servers use a venv python; others use bare `python3`), so a package installed into one interpreter would be invisible to the other.
+- **Thin per-server shims are retained** at the existing gate paths so that existing import sites and call sites do not churn; this is what makes FR-010 and SC-007 achievable.
+- **The amendment is a clarifying/generalizing change to existing principle text** — not the removal or redefinition of a principle — and therefore a MINOR bump (1.2.0 → 1.3.0) under the Constitution's own semantic-versioning rule.
+- **Feature 069 (Halo MCP) is a dependency, not a given.** It is unmerged (PR #167); `halo-mcp` and the `halo-change-request` skill do not exist on this branch. The `halo` provider adapter's verification-skill reference assumes 069 lands; if it does not, the adapter ships with its verification skill marked unavailable.
+- **ServiceNow remains reachable only as an unregistered install-time clone** (`$SERVICENOW_MCP_SCRIPT`, invoked by skills via `$MCP_CALL`). Fixing that is out of scope but affects how the ServiceNow adapter's verification skill is documented (Open Question 8).
+
+---
+
+## Open Questions for Maintainer Review
+
+This specification exists to frame these decisions, not to presume them. Each carries a recommendation.
+
+1. **Config mechanism and precedence** — environment variable only, a `config/openclaw.json` setting, or a Memory MCP fact? *Recommend*: environment variable (`NETCLAW_ITSM_PROVIDER`) for v1, matching the existing `NETCLAW_LAB_MODE` / `ITSM_ENABLED` precedent; a Memory fact is reachable from a server only by reading its SQLite file directly, which is not worth it.
+2. **Default provider when unset** — `none` (safe, opt-in) or `servicenow` (preserves the nominal status quo)? *Recommend*: `none` with a startup warning, because the current default enforces nothing anyway and a silent ServiceNow default is what produced this problem.
+3. **Fail-open vs fail-closed** — should a configured provider plus an unverified reference ever fail *closed*? Today everything fails open. *Recommend*: keep fail-open in v1 for compatibility, and add an opt-in strict mode (`NETCLAW_ITSM_STRICT`) so operators who want real enforcement can have it.
+4. **Attestation** — adopt an `attested_state` the verifying skill passes into the gate, or leave verification purely honor-system? *Recommend*: adopt it; it is what makes US3/SC-006 auditable and is a precondition for any future strict mode.
+5. **v1 adapter set** — `servicenow`, `halo`, `atlassian`, `none`. Any others (Freshservice, Jira Service Management as distinct from Jira)?
+6. **State vocabulary** — normalize each ITSM's "ready to implement" state to one canonical value, or keep provider-native names in the envelope? *Recommend*: canonical internally, provider-native in messages.
+7. **nautobot migration** — fold the three nautobot servers onto the shared gate (a breaking env-var change affecting 35 tools, currently defaulting to gating *off*), or leave them? *Recommend*: migrate in a follow-on phase, defaults preserved.
+8. **`servicenow-mcp` registration** — should the community clone finally be registered in `config/openclaw.json`, given that gating documentation depends on it?
+9. **Amendment scope confirmation** — all five locations (recommended), and does Principle III's "Assess → Authorize → Implement → Review" lifecycle wording also need generalizing, since that sequence is ServiceNow's?
+
+### Discovered defects (out of scope, reported for triage)
+
+- `config/openclaw.json:291-304` registers `aruba-cx-mcp` with ITSM variables, but `mcp-servers/aruba-cx-mcp/` **does not exist**; its skills and contract spec document it as live.
+- `config/openclaw.json:81-90` (`gnmi-mcp`) passes no ITSM environment variable, so its lab bypass depends on environment leakage.
+- `mcp-servers/gnmi-mcp/models.py:186-207` (`GnmiSetRequest`) is dead code carrying a second `^CHG\d+$` validator.

--- a/specs/070-itsm-provider-abstraction/tasks.md
+++ b/specs/070-itsm-provider-abstraction/tasks.md
@@ -1,0 +1,327 @@
+# Tasks: ITSM Provider Abstraction for Change Gating
+
+**Input**: Design documents from `/specs/070-itsm-provider-abstraction/`
+**Prerequisites**: `spec.md` (required — source of truth), `plan.md` (required), `research.md`, `data-model.md`, `contracts/itsm-gate-contract.md`, `contracts/constitution-amendment.md`, `quickstart.md`, `checklists/requirements.md`
+
+---
+
+## ⛔ IMPLEMENTATION IS BLOCKED PENDING MAINTAINER RATIFICATION
+
+**This round's deliverable is documentation only — the spec set.** Phase 0 below is complete. **Every task from Phase 1 onward is BLOCKED** and must not be started until **T010** records the maintainer's ratification of the Constitution amendment (**1.2.0 → 1.3.0**) plus written answers to `spec.md`'s nine Open Questions.
+
+Why the block is real and not ceremonial:
+
+- Constitution **Principle XVI**: "No implementation work begins without a ratified spec." This spec's own completion criterion (**FR-017**) is a constitutional amendment, so the spec is not ratified until the amendment is.
+- Constitution **Governance**: amendments require a documented rationale, an impact review, and a semantic version bump — and the maintainer performs the ratification, not this plan.
+- The amendment touches **Principle III**, a safety principle, and **Forbidden Operations**, which makes bypassing it a forbidden operation. `plan.md`'s Constitution Check marks Principle III **AMENDED**, not PASS, precisely so nothing here can proceed on the assumption that ratification will happen.
+- Three Open Questions change the module's **API shape**, not just its defaults: Q2 (default provider when unset), Q3 (fail-open vs. an opt-in strict mode), Q4 (whether an `attested_state` is adopted). Writing `src/netclaw_itsm/` before those are answered means writing it twice.
+
+**Legend**
+
+- `[X]` — **documentation-only, already done this round** (Phase 0)
+- `[ ]` — **implementation, BLOCKED** (Phase 1 onward)
+- **NOT IN v1** — Phase 7 only; specified deliberately, implemented deliberately later
+
+---
+
+**Tests**: Explicitly requested by the spec. **FR-011** makes characterization tests a *blocking prerequisite*, not an optional extra: coverage across all five gate implementations is **zero** today, so the current behavior must be pinned **before** any refactor touches it (`SC-003`, `SC-004`, US2 acceptance 1).
+
+**Organization**: Grouped by user story per `spec.md`'s priorities, with one deliberate inversion — **Phase 3 implements US2 (consolidation) and Phase 4 implements US1 (provider selection)**, even though US1 has the lower story number. This follows `spec.md` US2 verbatim: *"Provider selection (US1) is unbuildable on five divergent copies — it would mean five parallel implementations of the same abstraction. Consolidation is the prerequisite."* Both are P1; the phases are ordered by dependency, not by number.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3, US4, or FOLLOW-ON)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Shared library**: `src/netclaw_itsm/` at repository root (mirroring the existing `src/netclaw_tokens/`, reached by a `sys.path` insert anchored on `__file__` — see `mcp-servers/gnmi-mcp/gnmi_mcp_server.py:31`)
+- **Gated servers**: `mcp-servers/gnmi-mcp/`, `mcp-servers/claroty-mcp/` (v1); `mcp-servers/nautobot-mcp-v2/`, `mcp-servers/nautobot-routing-mcp/`, `mcp-servers/nautobot-golden-config-mcp/` (follow-on)
+- **Tests**: `tests/itsm-gate/` — its own per-component directory with `pytest.ini` + `conftest.py`, following `tests/halo-mcp/` (feature 069)
+- **Governance**: `.specify/memory/constitution.md`
+- **Config**: `config/openclaw.json`, `.env.example`
+- **Docs**: `SOUL.md`, `SOUL-SKILLS.md`, `README.md`, `TOOLS.md`, `workspace/skills/<name>/SKILL.md`
+
+---
+
+## Phase 0: Specification (THIS ROUND — documentation only, COMPLETE)
+
+**Purpose**: Produce the nine-artifact spec set so the maintainer has something concrete to ratify or reject. **No code, config, or constitution file is modified by this phase.**
+
+- [X] T001 Write `specs/070-itsm-provider-abstraction/spec.md` — problem, goals/non-goals, 4 user stories, edge cases, FR-001…FR-017, key entities, the current-state inventory table (5 implementations · 42 gated tools · 4 `^CHG\d+$` regexes · 0 tests), SC-001…SC-007, assumptions, 9 Open Questions, 3 discovered defects
+- [X] T002 [P] Write `research.md` — Phase 0 evidence: the five-implementation survey with file:line citations, why the gate must be sync and network-free, the `src/netclaw_tokens/` vs. installable-package decision, the mixed-interpreter constraint, the GAIT emit/commit seam, and a landing place for the maintainer's Open Question answers
+- [X] T003 [P] Write `data-model.md` — `ItsmProvider`, `ProviderAdapter`, `ChangeRef`, `GateDecision`, `GateConfig`
+- [X] T004 [P] Write `contracts/itsm-gate-contract.md` — `validate_change_request(cr_number) -> dict{valid, message, cr_number, state}` plus the additive `provider`/verification keys, and the nautobot `_check_itsm() -> Optional[str]` contract documented as the follow-on target
+- [X] T005 [P] Write `contracts/constitution-amendment.md` — the exact before/after text for all five ServiceNow-naming locations, so US4 is a reviewable diff the maintainer can ratify rather than an intention they must trust
+- [X] T006 [P] Write `quickstart.md` — operator walkthrough: select a provider, run a gated write, read the GAIT record, switch providers, trip the unknown-provider error
+- [X] T007 [P] Write `checklists/requirements.md` — requirements-quality checklist for `spec.md`
+- [X] T008 Write `plan.md` — technical context, the Constitution Check gate table with the honest Principle III self-reference note, project structure, and Complexity Tracking
+- [X] T009 Write `tasks.md` (this file)
+- [X] T009a Write `gait-session-log.md` — Principle IV append-only audit trail: the four scoping decisions, the exploration findings that corrected the scope, and the corrections surfaced during authoring (Claroty emits no GAIT today; the two divergent operation-label strings; per-shim `sys.path` depth; two adapter fields that cannot be settled on this branch)
+
+**Checkpoint**: Ten artifacts exist in `specs/070-itsm-provider-abstraction/`. The proposal is reviewable. **Nothing is implemented, and nothing may be.** (Principle IV's session record is `gait-session-log.md`, written at T009a. Principle XVII's milestone post is deferred to T062, once there is a shipped milestone to record — a specification round is not one.)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure) — ⛔ BLOCKED
+
+**Purpose**: Unblock the feature, then stand up the two containers (test directory, package skeleton) that everything else fills in.
+
+- [ ] T010 **🔓 UNBLOCKING GATE — nothing below may start until this task is recorded.** Obtain the maintainer's ratification of the Constitution amendment (1.2.0 → 1.3.0, MINOR) **and** written answers to all nine Open Questions in `spec.md`, recording them verbatim in `research.md`. The three that change the module's API: **Q2** default provider when unset (`none` + startup warning is the recommendation), **Q3** fail-open vs. an opt-in `NETCLAW_ITSM_STRICT` mode, **Q4** whether an `attested_state` is adopted. Also required before Phase 6: **Q9** (whether Principle III's "Assess → Authorize → Implement → Review" lifecycle wording, which is ServiceNow's vocabulary, is also generalized). If ratification is declined, this feature stops here and the spec set stands as a rejected proposal — which is a valid outcome, not a failure.
+- [ ] T011 [P] Create `tests/itsm-gate/pytest.ini` and `tests/itsm-gate/conftest.py` with fixtures that isolate **all four** relevant environment variables per test — `NETCLAW_ITSM_PROVIDER`, `NETCLAW_LAB_MODE`, `ITSM_ENABLED`, `ITSM_LAB_MODE` — so no test inherits operator environment leakage (the same leakage that currently makes `gnmi-mcp`'s lab bypass work by accident)
+- [ ] T012 [P] Create the `src/netclaw_itsm/` package skeleton (`__init__.py` only, **no logic yet**) and prove the `sys.path` insert pattern from `mcp-servers/gnmi-mcp/gnmi_mcp_server.py:31` resolves it under **both** interpreters the repo actually uses — bare `python3` (gnmi, claroty) and the nautobot venv python — since a package invisible to one of them is the exact failure the follow-on phase would hit
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites) — ⛔ BLOCKED
+
+**Purpose**: Pin the current behavior of the gate **before** anything refactors it. This is **FR-011** and it is blocking because coverage is currently **zero** — there is no existing suite to fall back on, so the safety net has to be built first.
+
+**⚠️ CRITICAL**: No user story work may begin until **T015** passes. Characterization tests must be written against, and pass against, the **UNREFACTORED** code. A suite that only ever ran after the refactor proves nothing.
+
+- [ ] T013 [P] Write `tests/itsm-gate/test_characterization_gnmi.py` against the **unrefactored** `mcp-servers/gnmi-mcp/itsm_gate.py`, pinning every branch of today's `validate_change_request()`: empty/`None` reference → `valid: False` with the exact "Change request number is required for gNMI Set operations" message; malformed reference → `valid: False` with the exact "Invalid CR format… Expected format: CHG followed by digits (e.g. CHG0012345)" message; well-formed reference with lab mode off → `valid: True, state: "unverified"` (because `_check_servicenow_cr_state()` returns `None` unconditionally); lab mode on → `valid: True, state: "lab_mode"`; and in every case assert **exactly** the four envelope keys `valid`, `message`, `cr_number`, `state`
+- [ ] T014 [P] Write `tests/itsm-gate/test_characterization_claroty.py` against the **unrefactored** `mcp-servers/claroty-mcp/utils/itsm_gate.py`: the same branch matrix, plus its Claroty-specific wording ("Change request number is required for Claroty write operations"), plus the **published envelope shape** `{"itsm_gate": …, "applied": bool, …}` as emitted at `mcp-servers/claroty-mcp/tools/alerts.py:182` (deny), `:219` (allow), `:223` (error) and `tools/devices.py:228`/`:284` — this is the public contract FR-009 protects
+- [ ] T015 **🚧 BLOCKING GATE** — Run `tests/itsm-gate/` against the **unrefactored** code and confirm **100% pass** (FR-011, US2 acceptance 1, baseline for SC-003). If an assertion fails, the **test** is wrong and gets corrected; the code must not be touched to make a characterization test pass, because the whole point is that it characterizes what exists
+- [ ] T016 [P] Snapshot the SC-007 baseline into `contracts/itsm-gate-contract.md`: all **7 v1 gated call sites** with file:line — `mcp-servers/gnmi-mcp/gnmi_mcp_server.py:196` (`gnmi_set`, plain `def`, param `change_request_number`, **required**) and Claroty's six (`tools/alerts.py:180`, `tools/devices.py:226`, `tools/devices.py:282`, `tools/user_actions.py:47`, `tools/user_actions.py:109`, `tools/vulnerabilities.py:209` — param `cr_number`, **required**) — plus the nautobot contrast (`cr_number`, **optional**) so no later task can rename anything without a visible diff against this list
+- [ ] T017 [P] Snapshot the SC-001 baseline: the **four** independent `^CHG\d+$` regex locations — `mcp-servers/gnmi-mcp/itsm_gate.py`, `mcp-servers/claroty-mcp/utils/itsm_gate.py`, `mcp-servers/gnmi-mcp/models.py:198` (dead), `mcp-servers/memory-mcp/storage/sqlite_store.py:109` (deferred provenance, FR-016) — so the 4 → 1 reduction is measurable rather than asserted
+
+**Checkpoint**: A passing characterization suite exists against code nobody has touched yet. **Only now** can consolidation begin, and any regression it causes will be visible immediately.
+
+---
+
+## Phase 3: User Story 2 — One Gate Implementation Instead of Five (Priority: P1) 🎯 MVP FOUNDATION — ⛔ BLOCKED
+
+**Goal**: Collapse the two `validate_change_request()` copies onto one shared module behind thin shims, with **zero** behavior change and **zero** call-site churn. Nautobot stays untouched.
+
+**Independent Test**: With provider `servicenow` (status-quo config), the Phase 2 characterization suite passes **unchanged** against the refactored gate — including Claroty's published envelope — and `git diff` shows no change to any MCP tool signature.
+
+*Sequenced before US1 per `spec.md` US2: consolidation is the prerequisite for provider selection.*
+
+### Implementation for User Story 2
+
+- [ ] T018 [US2] Implement `src/netclaw_itsm/gate.py` — port today's `validate_change_request()` logic as the `servicenow` provider's behavior, **verbatim in effect**: a plain synchronous `def` (never a coroutine — `gnmi_set` cannot await), stdlib only, **no network calls**, all four envelope keys preserved with unchanged meaning, and today's exact message strings preserved for the status-quo provider (FR-001, FR-006, FR-009)
+- [ ] T019 [US2] Implement `src/netclaw_itsm/config.py` — resolve `NETCLAW_ITSM_PROVIDER` and the lab/bypass state, with the default and precedence exactly as answered in T010 (Q2, Q3). `NETCLAW_LAB_MODE` keeps its current truthiness parsing (`true`/`1`/`yes`, case-insensitive) so lab behavior does not shift under operators who never touch the new variable
+- [ ] T020 [US2] Replace the body of `mcp-servers/gnmi-mcp/itsm_gate.py` with a **thin shim** that re-exports `validate_change_request` from `netclaw_itsm` via a `sys.path` insert anchored on `__file__`. The module path and the symbol name are unchanged, so `gnmi_mcp_server.py`'s import and its `gnmi_set` call site are not edited at all (FR-010, SC-007)
+- [ ] T021 [US2] Replace `mcp-servers/claroty-mcp/utils/itsm_gate.py` with the same thin shim. Preserve Claroty's distinct "required for Claroty write operations" wording by passing a **caller context** into the shared gate — **not** by keeping a second copy of the logic, which would defeat FR-001
+- [ ] T022 [US2] Re-run the Phase 2 characterization suite **unchanged** against the refactored code; 100% pass required (**SC-003**). Editing an assertion at this step is a regression being covered up, not a fix — if an assertion fails, the refactor is wrong
+- [ ] T023 [US2] Verify against T016's snapshot that all 7 v1 call sites and both parameter names (`change_request_number`, `cr_number`) are byte-identical, and that neither requiredness changed (**SC-007**, US2 acceptance 4)
+- [ ] T024 [US2] Verify Claroty's published envelope is still consumable: `{"itsm_gate": …}` continues to carry `valid`, `message`, `cr_number`, `state` at `tools/alerts.py:182`/`:219`/`:223` and `tools/devices.py:228`/`:284` (FR-009, US2 acceptance 3)
+- [ ] T025 [US2] Delete the dead validator `GnmiSetRequest` at `mcp-servers/gnmi-mcp/models.py:186-207` (its `^CHG\d+$` regex is at `:198`), first proving it is unreferenced (`grep -rn GnmiSetRequest`). Regex count: 4 → 3
+- [ ] T026 [US2] Confirm the nautobot trio is entirely untouched — `git diff --stat` empty for `mcp-servers/nautobot-mcp-v2/server.py`, `mcp-servers/nautobot-routing-mcp/server.py`, `mcp-servers/nautobot-golden-config-mcp/server.py` — and that their `_check_itsm()` definitions still sit at `:39`, `:57`, `:61` respectively (US2 acceptance 5, FR-014)
+
+**Checkpoint**: 5 implementations → 1 shared module + 2 thin shims. Regex count 4 → 2 (shared gate + the deferred Memory MCP provenance check). Zero regression **proven**, not assumed. This state is independently valuable and mergeable even if US1 never lands: it removes the five-way duplication that made the real bug unfixable.
+
+---
+
+## Phase 4: User Story 1 — An Operator Gates Changes With Their Own ITSM (Priority: P1) 🎯 MVP — ⛔ BLOCKED
+
+**Goal**: Make the gating ITSM selectable, so a Halo or Jira shop is never told to produce a ServiceNow CR that will never exist in their environment.
+
+**Independent Test**: Set `NETCLAW_ITSM_PROVIDER=halo`, call a gated tool with a Halo change-ticket id → accepted, and **no** output string contains "ServiceNow". Repeat with `CHG0012345` → rejected, with a message naming Halo's expected format.
+
+### Implementation for User Story 1
+
+- [ ] T027 [US1] Implement `src/netclaw_itsm/providers.py` — four declarative `ProviderAdapter` entries (`servicenow`, `halo`, `atlassian`, `none`), each declaring **only data**: change-reference format, human-readable ITSM name, "approved for implementation" state vocabulary, and the responsible verification skill. **No transport, no credentials, no HTTP** (FR-004). The `halo` adapter's verification-skill reference points at feature 069's `halo-change-request` skill, which **does not exist on this branch** (PR #167 unmerged) — so the adapter must be able to declare that skill **unavailable** rather than dangle a broken reference
+- [ ] T028 [US1] Wire provider resolution into `src/netclaw_itsm/gate.py`: validate the supplied reference against the **configured** provider's format, and on failure return a message naming **that** provider and **its** expected format (FR-005, US1 acceptance 1 & 2)
+- [ ] T029 [US1] Implement the unknown-provider hard failure: an explicit configuration error naming the supported providers, with **no** fallback to any vendor default (FR-003, US1 acceptance 5). A silent fallback to ServiceNow would recreate the exact bug this feature exists to fix, so this path must be tested, not just written
+- [ ] T030 [US1] Add the **additive** `provider` key to the returned envelope while leaving `valid`, `message`, `cr_number`, `state` untouched in name and meaning (FR-009, US2 acceptance 3). `cr_number` keeps its ServiceNow-flavored name on purpose — renaming it is a breaking change to Claroty's published output
+- [ ] T031 [US1] Implement the `none` provider and its precedence relative to `NETCLAW_LAB_MODE` per the Q3/Q2 answers recorded in T010 — the two overlap and the spec requires defined precedence. Every bypass is GAIT-logged (FR-012, US1 acceptance 4)
+- [ ] T032 [US1] Add `NETCLAW_ITSM_PROVIDER` to **every** gated server's env block in `config/openclaw.json` (FR-015): `gnmi-mcp` at `:81-90`, which today passes **no ITSM variable at all** (its lab bypass currently works only by parent-environment leakage), and `claroty-mcp` at `:551-558`, which today passes only `NETCLAW_LAB_MODE` (`:557`). Miss either and the feature silently misconfigures
+- [ ] T033 [P] [US1] Write `tests/itsm-gate/test_providers.py` — per-provider accept/reject format matrix; `provider=halo` + `CHG0012345` → rejected with a **Halo-named** message (US1 acceptance 2); unknown provider → configuration error, never a fallback (FR-003)
+- [ ] T034 [P] [US1] Write `tests/itsm-gate/test_gate_policy.py` — `none`/lab bypass precedence (US1 acceptance 4); `provider=servicenow` produces behavior identical to the Phase 2 baseline (US1 acceptance 3); the verified/unverified distinction placeholder that T036 fills in
+- [ ] T035 [US1] **SC-002 check**: with a non-ServiceNow provider configured, assert that no gate output, error message, or prompt emitted on a gated-write path contains the string "ServiceNow" — as an automated test, not a manual read
+
+**Checkpoint**: US1 + US2 both hold. An operator can pick their ITSM; a maintainer changing gate behavior edits one module. Regex count 4 → 1 for gating (**SC-001**), plus the one deferred provenance check.
+
+---
+
+## Phase 5: User Story 3 — Skill-Layer Verification Is Documented and Auditable (Priority: P2) — ⛔ BLOCKED
+
+**Goal**: Make the safety posture honest. The server-side gate enforces **format + policy**; the **skill layer** verifies a change record's **state**; the GAIT trail shows which of the two actually happened.
+
+**Independent Test**: Run a gated write through the provider's change skill and confirm the GAIT record shows the reference, the provider, and that state was **verified**. Then call the gated tool directly with no attestation and confirm the decision is recorded as **unverified** — never reported as verified.
+
+### Implementation for User Story 3
+
+- [ ] T036 [US3] Implement the verified/unverified distinction in the `GateDecision` (FR-008): the envelope must be able to say "state verified by the skill layer" versus "state not verified", and must **never** report verification that did not occur (US3 acceptance 1 & 3). Today's code implies verification it does not perform — this task is what stops that
+- [ ] T037 [US3] Implement the attestation input per the Q4 answer — the value a verifying skill passes into the gate — defaulting to **unattested** for any direct tool call. Attestation is a precondition for any future strict mode (Q3)
+- [ ] T038 [US3] Implement `src/netclaw_itsm/audit.py` — emit a structured gate-decision record carrying provider, change reference, verification status, and allow/deny outcome (FR-013), using the emit/commit seam recorded in `research.md`. The gate **emits**; the session/skill layer **commits** to GAIT — the gate itself must do no git, subprocess, or filesystem work on a synchronous write path
+- [ ] T039 [P] [US3] Document, per provider, **which skill verifies state** before a gated write (FR-007, US3 acceptance 4): `servicenow` → `workspace/skills/servicenow-change-workflow/SKILL.md`; `halo` → feature 069's `halo-change-request` skill, marked **unavailable on this branch** (PR #167 unmerged); `atlassian` → the `atlassian-mcp`-backed change skill; `none` → no verification by definition. Also note (per Open Question 8) that ServiceNow is reachable only as an **unregistered install-time clone** (`$SERVICENOW_MCP_SCRIPT` via `$MCP_CALL`), which constrains how its verification skill can honestly be described
+- [ ] T040 [P] [US3] Document the advisory boundary explicitly, without softening it: MCP servers cannot call other MCP servers, so the server-side gate is advisory **by construction** — a direct tool call can assert any reference, and an attested state is only as trustworthy as the caller. State plainly that this is **not a regression** (today's `_check_servicenow_cr_state()` returns `None`, so nothing is enforced now either); the change is that the boundary becomes honest and auditable instead of implied
+- [ ] T041 [P] [US3] Document FR-016 as a **known deferred inconsistency**: `memory_record_decision(cr_number=…)` validates `^CHG\d+$` at `mcp-servers/memory-mcp/storage/sqlite_store.py:109` for audit provenance, so a Halo or Jira shop's change reference will fail that validation. It is provenance metadata, not a gate — deferred on purpose, but user-visible and therefore documented rather than discovered
+- [ ] T042 [US3] **SC-006 check**: confirm an auditor reading a single GAIT record for a gated write can determine the provider, the change reference, and whether the change record's state was actually verified
+
+**Checkpoint**: "Advisory" has become "advisory **and** auditable". The gate no longer claims verification it cannot perform.
+
+---
+
+## Phase 6: User Story 4 — The Constitution Describes Provider-Agnostic Gating (Priority: P3) — ⛔ BLOCKED
+
+**Goal**: Amend all five ServiceNow-naming locations together, so no contributor can read the Constitution and conclude ServiceNow is the only supported ITSM.
+
+**Independent Test**: A contributor who has read **only** the amended Constitution can correctly state (a) the gating ITSM is configurable, (b) lab mode remains the sole bypass and is still GAIT-logged, and (c) no specific vendor is mandated (**SC-005**).
+
+**Exactly two tasks**, mirroring feature 049's T022/T023 — the text edit, then the Sync Impact Report and version bump. Amending Principle III alone would leave **four contradicting references** in the same document, so this is **all-or-nothing across the five locations**.
+
+### Implementation for User Story 4
+
+- [ ] T043 [US4] In `.specify/memory/constitution.md`, edit all **five** ServiceNow-naming locations so each describes **the configured ITSM**: **Principle III — ITSM-Gated Changes** (`:55-64`, "an approved ServiceNow Change Request (CR)"); **Principle VIII — Verify After Every Change** (`:114`, "mark the ServiceNow CR as failed"); **Principle XIV — Human-in-the-Loop** (`:200`, "Creating, updating, or closing ServiceNow tickets"); **Operational Constraints → Technology Stack** (`:260`, "**ITSM**: ServiceNow (change management, incidents, CMDB)"); **Operational Constraints → Forbidden Operations** (`:269`, "Bypassing ServiceNow CR approval for production changes"). Preserve each principle's substance exactly — an approved change record is still required, lab mode is still the **sole** exception, bypasses are still GAIT-logged, and bypassing approval is still forbidden. Apply the T010/Q9 decision on whether Principle III's "Assess → Authorize → Implement → Review" lifecycle wording (ServiceNow's own vocabulary) is also generalized
+- [ ] T044 [US4] Rewrite the top-of-file **Sync Impact Report** comment block in the established format (matching the existing 1.1.0 → 1.2.0 block): version-change line stating **1.2.0 → 1.3.0 (MINOR — principle generalization)** with the reasoning that this generalizes existing principle text and neither removes nor redefines a principle; the five modified locations listed; added/removed sections (**None**/**None**); the templates-requiring-updates checklist; follow-up TODOs (carry FR-016's deferred Memory MCP inconsistency and the nautobot follow-on phase); and prior versions compressed into **"Previous version history"** including 1.2.0. Then bump the footer to `**Version**: 1.3.0 | **Ratified**: 2026-03-26 | **Last Amended**: <amendment date>` (US4 acceptance 1, 3 & 4)
+
+**Checkpoint**: Governance and code agree. Principle III's Constitution Check row in `plan.md` can now honestly move from **AMENDED** to **PASS**.
+
+---
+
+## Phase 7: Follow-On — Nautobot Migration (35 Gated Tools) — **NOT IN v1** 🚫
+
+**Purpose**: Fold the three nautobot servers onto the shared gate. **This phase is specified, not implemented** (FR-014, `spec.md` Non-Goals, US2 acceptance 5). It is a **separate feature branch and a separate PR**, and none of it may be pulled forward into v1 — doing so is what makes SC-003 unfalsifiable, because a 42-tool blast radius with two incompatible contracts and defaults that flip in opposite directions cannot be characterization-tested as one unit.
+
+Scope: `mcp-servers/nautobot-mcp-v2/server.py` (`_check_itsm()` at `:39`), `mcp-servers/nautobot-routing-mcp/server.py` (`:57`), `mcp-servers/nautobot-golden-config-mcp/server.py` (`:61`) — **35 gated tools**, contract `_check_itsm() -> Optional[str]`, env `ITSM_ENABLED` + `ITSM_LAB_MODE`, gating currently defaults **OFF**, `cr_number` **optional**, venv interpreter.
+
+- [ ] T045 [FOLLOW-ON] **Compatibility analysis (gates the whole phase)** — document the complete delta between `_check_itsm() -> Optional[str]` and `validate_change_request() -> dict`, item by item, and decide for each one: *preserve*, *migrate*, or *break with a documented migration path* per Constitution **Principle XV**. The items: return type (`Optional[str]` vs. dict envelope); **absence of any format check** in `_check_itsm()`; env scheme (`ITSM_ENABLED` + `ITSM_LAB_MODE` vs. `NETCLAW_ITSM_PROVIDER` + `NETCLAW_LAB_MODE`); default posture (gating **OFF** vs. **ON**); `cr_number` **optional** vs. **required**; and the venv interpreter vs. bare `python3` (the reason `src/netclaw_itsm/` is a `sys.path` insert and not an installed package). Resolve Open Question 7 here
+- [ ] T046 [FOLLOW-ON] Write characterization tests for all three `_check_itsm()` implementations **before** touching them — same discipline as Phase 2, and equally non-negotiable given the 35-tool surface
+- [ ] T047 [FOLLOW-ON] Add an `_check_itsm()`-shaped adapter over the shared gate that keeps the `Optional[str]` return and the **optional** `cr_number`, so no nautobot tool signature changes (FR-010 applies to this phase too)
+- [ ] T048 [FOLLOW-ON] Re-point the three servers at the adapter; all 35 call sites unchanged; re-run T046's suite with zero assertion edits
+- [ ] T049 [FOLLOW-ON] Env compatibility: honor `ITSM_ENABLED`/`ITSM_LAB_MODE` with **defaults preserved** — gating stays **OFF** unless T045 explicitly decides otherwise and documents the migration. Silently flipping 35 tools from ungated to gated is a breaking change dressed as a refactor
+- [ ] T050 [FOLLOW-ON] Add `NETCLAW_ITSM_PROVIDER` to all three nautobot env blocks in `config/openclaw.json` (FR-015), and reconcile it with the `ITSM_*` variables they already receive
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns — ⛔ BLOCKED
+
+**Purpose**: Constitution **Principle XI** artifact coherence (**NON-NEGOTIABLE** — a PR missing these must not merge) plus triage of the three defects this feature discovered but did not cause.
+
+### Constitution XI coherence updates
+
+- [ ] T051 [P] `.env.example` — add `NETCLAW_ITSM_PROVIDER` with a description and **no value** (Principle XIII), noting the supported values and that it coexists with `NETCLAW_LAB_MODE` (`:119`) and the nautobot pair `ITSM_ENABLED`/`ITSM_LAB_MODE` (`:397-398`) until Phase 7 lands
+- [ ] T052 [P] `SOUL.md` — replace ServiceNow-as-the-ITSM framing in the capability summary and identity references with the configurable-provider model; name the per-provider verification skills
+- [ ] T053 [P] `SOUL-SKILLS.md` — same reframing for the skill index, including which skill verifies change state per provider
+- [ ] T054 [P] `README.md` — describe ITSM gating as provider-selectable; document `NETCLAW_ITSM_PROVIDER`; state the v1 boundary honestly (7 tools now, 35 in a follow-on phase)
+- [ ] T055 [P] `TOOLS.md` — update the infrastructure reference so ITSM is listed as configurable rather than as ServiceNow
+- [ ] T056 `config/openclaw.json` — full env-block sweep confirming **every** gated server receives `NETCLAW_ITSM_PROVIDER` (FR-015); this is the task that catches the `gnmi-mcp` `:81-90` omission if T032 missed it
+- [ ] T057 [P] `SKILL.md` sweep — **66** `SKILL.md` files under `workspace/skills/` currently mention ServiceNow. Update the ones on a v1 gated-write path first (`workspace/skills/servicenow-change-workflow/`, the Claroty skills, `gnmi-telemetry`), and leave an explicit, enumerated list of the remainder as a documented follow-up rather than silently touching or silently skipping all 66
+
+### Discovered-defect triage (found by this feature, out of its scope)
+
+- [ ] T058 [P] **Dangling config entry** — `config/openclaw.json:291-304` registers `aruba-cx-mcp` with `ITSM_ENABLED`/`ITSM_LAB_MODE`, but `mcp-servers/aruba-cx-mcp/` **does not exist**, while its skills and contract spec document it as live. File for triage as its own fix (it is a coverage/registration defect, not a gating defect) — do not quietly delete a registration whose docs claim it works
+- [ ] T059 [P] **`gnmi-mcp` receives no ITSM env var** — `config/openclaw.json:81-90`; its lab bypass depends on parent-environment leakage. Closed by T032; confirm and record the closure here so the defect is not double-reported
+- [ ] T060 [P] **Dead `GnmiSetRequest` validator** — `mcp-servers/gnmi-mcp/models.py:186-207`, carrying a second `^CHG\d+$` regex at `:198`. Closed by T025; confirm and record
+
+### Final validation
+
+- [ ] T061 Run `quickstart.md` end to end against a real deployment: select each provider in turn, run a gated write, read the GAIT record, and trip the unknown-provider error deliberately
+- [ ] T062 Verify all seven success criteria are met — **SC-001** (4 format validators → 1), **SC-002** (no "ServiceNow" leakage under another provider), **SC-003** (100% of pre-refactor assertions pass), **SC-004** (0 tests → a suite covering per-provider formats, unknown-provider error, lab/none bypass, verified/unverified), **SC-005** (Constitution reads provider-agnostic), **SC-006** (auditable GAIT record), **SC-007** (zero parameter changes) — then record the GAIT session log and draft the Principle XVII milestone blog post
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 0 (Specification)**: Complete. No dependencies. Documentation only.
+- **Phase 1 (Setup)**: **Blocked by T010** (maintainer ratification + Open Question answers). T011 and T012 may then run in parallel.
+- **Phase 2 (Foundational)**: Depends on Phase 1. **BLOCKS every user story** — T015 is the hard gate, because there is no pre-existing test coverage to fall back on.
+- **Phase 3 (US2 — consolidation)**: Depends on Phase 2. **BLOCKS Phase 4** — provider selection cannot be built on five divergent copies (`spec.md` US2).
+- **Phase 4 (US1 — provider selection)**: Depends on Phase 3.
+- **Phase 5 (US3 — verification honesty)**: Depends on Phase 4 (T036's verified/unverified distinction extends the envelope T030 established). T039–T041 are pure documentation and can start as soon as T027 fixes the adapter set.
+- **Phase 6 (US4 — the amendment)**: Depends only on **T010**, not on any code. It can be done in parallel with Phases 3–5 by a different contributor — the constitution file is touched by nothing else. Sequenced last because governance should follow the implementation, but it is **required for completion** (FR-017).
+- **Phase 7 (Follow-on nautobot)**: **NOT IN v1.** Depends on all of v1 having shipped and settled. Separate branch, separate PR.
+- **Phase 8 (Polish)**: Depends on Phases 3–6 being complete. **Principle XI is NON-NEGOTIABLE** — T051–T057 are merge blockers, not nice-to-haves.
+
+### User Story Dependencies
+
+- **US2 (P1)** — no dependencies beyond Phase 2. Independently mergeable and independently valuable: it removes the five-way duplication even if nothing else lands.
+- **US1 (P1)** — depends on US2. This is the one real cross-story dependency and it is stated in `spec.md` rather than inferred here.
+- **US3 (P2)** — depends on US1's envelope work; its documentation tasks are independent.
+- **US4 (P3)** — fully independent of US1/US2/US3 at the file level.
+
+### Within Each User Story
+
+- Characterization tests before **any** refactor (Phase 2 before Phase 3) — non-negotiable
+- Data (`providers.py`) before logic that reads it (`gate.py` provider wiring)
+- Shared module before shims before call-site verification
+- Envelope shape (T030) before the verification indicator that extends it (T036)
+- Every phase's own verification task runs before its checkpoint is claimed
+
+### Parallel Opportunities
+
+- Phase 0: T002–T007 were parallel (different artifacts)
+- Phase 1: T011 and T012 (different trees)
+- Phase 2: T013, T014, T016, T017 all parallel (different files); **T015 is a serialization point**
+- Phase 4: T033 and T034 (different test files)
+- Phase 5: T039, T040, T041 (documentation, different targets)
+- **Phase 6 in parallel with Phases 3–5** — `.specify/memory/constitution.md` is touched by nothing else in this feature
+- Phase 8: T051–T055 and T057–T060 all parallel (different files); T056 and T061–T062 serialize at the end
+
+Caution: T018–T021 all converge on the same two shim files and the same shared module. They are logically ordered, not parallel — implement them in one working session to avoid edit conflicts.
+
+---
+
+## Parallel Example: Phase 2 (Foundational)
+
+```bash
+# Launch the characterization tests together — different files, no shared state:
+Task: "Write tests/itsm-gate/test_characterization_gnmi.py against the unrefactored mcp-servers/gnmi-mcp/itsm_gate.py"
+Task: "Write tests/itsm-gate/test_characterization_claroty.py against the unrefactored mcp-servers/claroty-mcp/utils/itsm_gate.py"
+
+# And the two baseline snapshots, also in parallel:
+Task: "Snapshot the 7 v1 call sites + parameter names/requiredness into contracts/itsm-gate-contract.md (SC-007 baseline)"
+Task: "Snapshot the 4 ^CHG\\d+$ regex locations (SC-001 baseline)"
+
+# Then SERIALIZE on the gate — nothing in Phase 3 starts until this passes:
+Task: "Run tests/itsm-gate/ against the UNREFACTORED code; require 100% pass (T015)"
+```
+
+---
+
+## Implementation Strategy
+
+### Step 0: Decide whether to implement at all
+
+`plan.md`'s Constitution Check marks Principle III **AMENDED, not PASS** — this feature *is* the proposed change to a safety principle, so compliance cannot be self-asserted. **T010 is the only task that may be started.** If the maintainer declines ratification, the nine spec artifacts stand as a documented, rejected proposal with a full current-state inventory — a legitimate outcome that still leaves the repo better understood than it was.
+
+### MVP First (US2 → US1)
+
+1. Phase 1: Setup (T010–T012)
+2. Phase 2: Foundational (T013–T017) — **the characterization suite must pass against unrefactored code**
+3. Phase 3: US2 — consolidation (T018–T026)
+4. **STOP and VALIDATE**: the characterization suite passes unchanged; `git diff` shows zero tool-signature changes; Claroty's published envelope still carries all four keys
+5. Phase 4: US1 — provider selection (T027–T035)
+6. **STOP and VALIDATE**: SC-002 (no "ServiceNow" leakage) and US1's five acceptance scenarios
+
+### Incremental Delivery
+
+1. Phases 1–2 → a safety net exists where there was none (0 → a real suite). Valuable on its own: the gate becomes changeable.
+2. + US2 → 5 implementations become 1; zero regression proven. Mergeable alone.
+3. + US1 → the actual feature; a Halo shop stops being asked for a ServiceNow CR.
+4. + US3 → the posture becomes honest and auditable.
+5. + US4 → governance matches the code; Principle III's row moves to PASS.
+6. + Phase 8 → Principle XI satisfied; merge becomes permissible.
+7. **Later, separately**: Phase 7 brings the remaining 35 tools across.
+
+### Suggested MVP Scope
+
+**US2 is the true MVP**, even though US1 is the headline. US2 is what converts "a bug that must be fixed in five places with no tests" into "a bug that can be fixed in one place with a safety net". US1 is the visible payoff, but shipping US1 without US2 would mean four more copies of the same abstraction — the failure mode this feature exists to end.
+
+### Parallel Team Strategy
+
+With multiple contributors, after **T010**:
+
+- Contributor A: Phases 1–2 (setup + characterization), then Phase 3 (US2)
+- Contributor B: Phase 6 (US4, the amendment) — no file overlap with anyone, can start immediately after T010
+- Contributor C: Phase 5's documentation tasks (T039–T041) and Phase 8's doc sweep (T051–T055, T057), drafted against `spec.md` and reconciled once T027 fixes the adapter set
+- Then A + C converge on Phase 4 (US1)
+
+---
+
+## Notes
+
+- **`[P]`** = different files, no dependencies. **`[Story]`** maps a task to a user story for traceability.
+- **Do not adjust a characterization assertion to make a refactor pass.** That inverts the entire purpose of Phase 2. If T022 fails, the refactor is wrong.
+- **`cr_number` keeps its ServiceNow-flavored name forever.** It is a published envelope key (Claroty emits the dict verbatim) and an MCP tool parameter on six tools. Renaming it is breaking; living with the name is not (FR-009, FR-010, SC-007).
+- **No new third-party dependency, in any phase.** The shared gate is stdlib-only by design, because the gate must be synchronous (`gnmi_set` is a plain `def`) and must make no network calls. Introducing `httpx` here would force an async surface `gnmi_set` cannot await and would place per-ITSM credentials inside every gated server.
+- **MCP servers cannot call other MCP servers** — no MCP client exists anywhere under `mcp-servers/`. Any task that seems to require one is misspecified; the answer is skill-layer verification plus attestation.
+- **Feature 069 (Halo MCP) is an unmerged dependency** (PR #167). `halo-mcp` and the `halo-change-request` skill **do not exist on this branch**. The `halo` adapter must ship with its verification skill marked *unavailable* if 069 does not land — a dangling reference to a nonexistent skill would be worse than the ServiceNow hardcoding this feature removes.
+- **Phase 7 is a fence, not a suggestion.** 35 tools, a different contract, a different env scheme, a different default, a different requiredness, and a different interpreter. Pulling any of it into v1 destroys SC-003's falsifiability.
+- Commit after each task or logical group; stop at any checkpoint to validate a story independently.


### PR DESCRIPTION
> **Draft — request for comment. Specification only; no code changes.**
> This proposes a **Constitution amendment (1.2.0 → 1.3.0)**, so it needs maintainer
> ratification before any implementation. I've deliberately built nothing.

## The ask

Let operators choose **which ITSM provides the change record that gates writes**, instead of
ServiceNow being hardwired. This became concrete because two NetClaw integrations *are*
ITSMs with native change management — **HaloPSA/HaloITSM** (#167) and **Atlassian/Jira**. For a
Halo shop, the change record *is* the Halo change ticket; a separate ServiceNow CR is redundant.

## What the survey turned up

Worth reading even if the proposal is rejected:

- **The gate enforces nothing today.** `_check_servicenow_cr_state()` unconditionally returns
  `None`, so every well-formed `CHG\d+` passes as `{valid: true, state: "unverified"}`. And
  **no `servicenow-mcp` is registered in `config/openclaw.json`** — it's an install-time clone of
  a community repo that skills invoke via `$MCP_CALL`.
- **The gate logic exists 5 times across 5 servers, with 2 incompatible contracts.** Beyond the
  two `itsm_gate.py` copies (`gnmi-mcp`, `claroty-mcp`), the nautobot family has three copies of
  a *different* gate (`_check_itsm() -> Optional[str]`, env `ITSM_ENABLED`/`ITSM_LAB_MODE`, **no**
  format validation, `cr_number` **optional**). Totals: **42 gated tools · 4 independent
  `^CHG\d+$` regexes · 0 tests on any of them.**
- **The Constitution hard-names ServiceNow in 5 places**, not one: Principle III `:55-64`,
  Principle VIII `:114`, Principle XIV `:200`, Technology Stack `:260`, Forbidden Operations
  `:269`. Amending III alone would leave four references contradicting it.
- **`claroty-mcp` emits no GAIT record at all** for its 6 gated writes (only `gnmi-mcp` does) —
  an existing Principle IV gap.

## Proposed design

- **One shared gate** at `src/netclaw_itsm/`, mirroring `src/netclaw_tokens/` (the only working
  cross-server Python precedent — a `sys.path` insert used by 8 servers). **Thin shims stay** at
  both existing gate paths so no import site or call site churns.
- **Declarative provider adapters** (`servicenow`, `halo`, `atlassian`, `none`): reference
  format, display name, approved-state vocabulary, and the skill responsible for verification.
  **No transport, no credentials.**
- **Skill-layer state verification.** NetClaw MCP servers cannot call other MCP servers, and the
  gate must be **synchronously** callable (`gnmi_set` is a plain `def`) — so the gate enforces
  *format + policy* and the skill verifies *state*.
  **The honest consequence, stated in the spec rather than implied: the server-side gate is
  advisory.** That's not a regression — today's gate already enforces nothing — and an optional
  `attested_state` makes skill verification auditable, which is the precondition for any future
  real enforcement.
- **Backwards compatibility as a hard requirement.** The gate envelope is a *public contract*
  (Claroty returns the whole dict in its tool output), so changes are additive only, `cr_number`
  is frozen by name, and **no MCP tool parameter is renamed** (`gnmi_set` keeps
  `change_request_number`; Claroty keeps `cr_number`).
- **Phased.** v1 = `gnmi-mcp` + `claroty-mcp` (**7 tools**). The nautobot family (**35 tools**)
  is *specified, not implemented* — a 42-tool blast radius against zero test coverage isn't
  responsible.
- **Characterization tests first** (FR-011): capture current behavior and prove it passes against
  the *unrefactored* code, so "no regression" is verifiable rather than asserted.

## The amendment

`contracts/constitution-amendment.md` carries **byte-verified before/after text for all five
locations** plus the complete replacement Sync Impact Report — review it as a diff, not a
description. It follows the **spec 049** precedent (its own P3 user story, a research item
justifying the MINOR bump, exactly 2 tasks, a comprehension-test success criterion). Principle
III's `Assess → Authorize → Implement → Review` lifecycle is ServiceNow vocabulary, so that line
is offered in a **conservative** and a **generalized** variant — see Q9.

## Nine questions for you

Each has a recommendation in `spec.md`. **The first three change the module's public API**, so
they block implementation:

| # | Question | Recommendation |
|---|---|---|
| **1** | Default provider when unset: `none` or `servicenow`? | `none` + startup warning — the current default enforces nothing anyway, and a silent ServiceNow default is what caused this |
| **2** | Fail-open, or an opt-in strict mode? | Keep fail-open in v1; add opt-in `NETCLAW_ITSM_STRICT` |
| **3** | Adopt the `attested_state` parameter? | Yes — it's what makes verification auditable |
| 4 | Config mechanism + precedence | Env var `NETCLAW_ITSM_PROVIDER`, matching the `NETCLAW_LAB_MODE` precedent |
| 5 | v1 adapter set | `servicenow`, `halo`, `atlassian`, `none` — others? |
| 6 | Canonical vs provider-native state vocabulary | Canonical internally, provider-native in messages |
| 7 | Migrate the nautobot family? | Follow-on phase, defaults preserved |
| 8 | Register `servicenow-mcp` in `config/openclaw.json`? | Open — gating docs already depend on it |
| 9 | Generalize Principle III's CR lifecycle wording? | Open — two variants provided |

**Also worth deciding up front:** if you'd rather the gate *genuinely* enforce, that's a larger
feature — per-ITSM HTTP clients and credentials inside every gated server, plus resolving the
sync-callability constraint. Better to know now, since it changes the architecture.

## Three unrelated defects found while surveying

Reported for triage, not fixed here:

1. `config/openclaw.json:291-304` registers **`aruba-cx-mcp` with ITSM variables, but
   `mcp-servers/aruba-cx-mcp/` does not exist** — while its skills and contract spec document it
   as live.
2. `config/openclaw.json:81-90` — **`gnmi-mcp` receives no ITSM environment variable**, so its
   lab bypass works only by parent-environment leakage.
3. `mcp-servers/gnmi-mcp/models.py:186-207` — `GnmiSetRequest` is **dead code** carrying a second
   `^CHG\d+$` validator.

## Dependency

The `halo` adapter assumes **#167** (feature 069, Halo MCP) lands. `halo-mcp` and
`halo-change-request` do not exist on this branch, and no artifact pretends otherwise — Halo's
reference format is marked **provisional** for that reason. Jira's approved-state vocabulary is
likewise operator-supplied, since Jira statuses are configurable per project.

## Not in this PR

No code. No `servicenow-mcp` server. No change to which tools are gated. No multi-provider
simultaneous gating. The nautobot migration is specified only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
