### PR TITLE
fix(036): honor the Retry-After value in the Auvik 429 backoff

### DIFF
--- a/mcp-servers/auvik-mcp/clients/auvik_client.py
+++ b/mcp-servers/auvik-mcp/clients/auvik_client.py
@@ -136,7 +136,9 @@ class AuvikClient:
                 attempt += 1
                 if attempt > _max_retries:
                     return self._rate_limited_error()
-                delay = parse_retry_after(dict(resp.headers)) or 1
+                # Pass the httpx Headers object directly: dict(resp.headers)
+                # lowercases header names, which loses the "Retry-After" lookup.
+                delay = parse_retry_after(resp.headers) or 1
                 await asyncio.sleep(delay)
                 # Re-acquire rate limiter slot after sleeping
                 if self._rate_limiter is not None:

--- a/mcp-servers/auvik-mcp/utils/rate_limiter.py
+++ b/mcp-servers/auvik-mcp/utils/rate_limiter.py
@@ -53,8 +53,13 @@ class SlidingWindowRateLimiter:
             self._timestamps.append(time.monotonic())
 
 
-def parse_retry_after(headers: dict) -> Optional[int]:
+def parse_retry_after(headers) -> Optional[int]:
     """Parse the Retry-After header value into integer seconds.
+
+    Accepts either an httpx ``Headers`` object (case-insensitive) or a plain
+    dict. The lookup is case-insensitive because ``dict(response.headers)``
+    lowercases header names, which would otherwise miss the canonical
+    ``Retry-After`` spelling and silently fall back to the caller's default.
 
     Returns:
         Integer seconds if the header is present and parsable as int.
@@ -62,6 +67,8 @@ def parse_retry_after(headers: dict) -> Optional[int]:
         (a warning is logged in the latter case).
     """
     value = headers.get("Retry-After")
+    if value is None:
+        value = headers.get("retry-after")
     if value is None:
         return None
     try:

--- a/tests/auvik-mcp/test_client_429.py
+++ b/tests/auvik-mcp/test_client_429.py
@@ -52,15 +52,30 @@ async def test_get_retries_once_on_429_then_200():
 # ---------------------------------------------------------------------------
 
 
-async def test_get_retry_uses_retry_after_value():
-    """Sleep delay is sourced from Retry-After: 0 (zero means instant retry)."""
+async def test_get_retry_uses_retry_after_value(monkeypatch):
+    """The server-supplied Retry-After value drives the backoff delay.
+
+    Uses a NON-ZERO value and asserts the observed sleep, so this can actually
+    distinguish "honored the header" from "fell back to the 1-second default".
+    A ``Retry-After: 0`` cannot: both paths sleep 1 second, because
+    ``0 or 1`` and ``None or 1`` are both 1.
+    """
+    import asyncio
+
+    sleep_calls = []
+
+    async def fake_sleep(delay):
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
     call_count = 0
 
     def handler(request: httpx.Request) -> httpx.Response:
         nonlocal call_count
         call_count += 1
         if call_count < 2:
-            return httpx.Response(429, headers={"Retry-After": "0"}, json={})
+            return httpx.Response(429, headers={"Retry-After": "7"}, json={})
         return httpx.Response(200, json={"data": []})
 
     mt = _make_transport(handler)
@@ -76,6 +91,9 @@ async def test_get_retry_uses_retry_after_value():
 
     assert result["success"] is True
     assert call_count == 2
+    assert sleep_calls == [7], (
+        "Retry-After: 7 must drive a 7-second backoff, not the 1s fallback"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/auvik-mcp/test_rate_limiter.py
+++ b/tests/auvik-mcp/test_rate_limiter.py
@@ -46,7 +46,10 @@ def test_parse_retry_after_zero():
 
 
 def test_parse_retry_after_case_insensitive_header():
-    # httpx headers are case-insensitive dicts, but dict keys are exact —
-    # the helper reads the exact key; test both variants are tolerated
-    # (the typical form is "Retry-After")
+    """Both header spellings resolve.
+
+    A plain ``dict(response.headers)`` lowercases header names, so the helper
+    must not depend on the canonical capitalization.
+    """
     assert parse_retry_after({"Retry-After": "10"}) == 10
+    assert parse_retry_after({"retry-after": "10"}) == 10


### PR DESCRIPTION
## Summary
`AuvikClient.get()` silently discarded the server's requested 429 backoff and always slept
**1 second**. It called `parse_retry_after(dict(resp.headers))`, but `dict(resp.headers)`
lowercases header names to `retry-after` while `parse_retry_after` looked up the canonical
`Retry-After` — so it always returned `None` and fell through to the `or 1` default.

An Auvik `Retry-After: 30` was thrown away: we retry 30× sooner than asked, which can prolong
our own rate limiting.

Reproducible in two lines:
```python
>>> r = httpx.Response(429, headers={"Retry-After": "30"})
>>> dict(r.headers).get("Retry-After")   # None  <-- the bug
>>> r.headers.get("Retry-After")         # '30'  <-- works
```

## The fix (both layers)
- **`clients/auvik_client.py`** — pass the httpx `Headers` object directly (it's
  case-insensitive) instead of flattening it to a dict.
- **`utils/rate_limiter.py`** — `parse_retry_after()` falls back to the lowercase spelling, so a
  plain dict from any caller works too. Type hint widened from `dict` to accept either.

Defense in depth: either change alone fixes it; together the helper is correct regardless of how
a future caller passes headers.

## Why the existing tests missed it
Both were misleading, and both are corrected here:

- **`test_get_retry_uses_retry_after_value`** claimed to "verify Retry-After is respected" but only
  asserted `success` and `call_count` — never the delay. It also used `Retry-After: 0`, which is
  **indistinguishable from the bug**, since `0 or 1` and `None or 1` are both `1`. It now patches
  `asyncio.sleep`, uses a **non-zero** `Retry-After: 7`, and asserts the observed sleep is `7`.
- **`test_parse_retry_after_case_insensitive_header`** was named for case-insensitivity but only
  tested the exact key, and its comment codified the bug as intended behavior. It now asserts
  both spellings resolve.

**Both updated tests fail against the unfixed code and pass after the fix.**

## Testing
- Full `tests/auvik-mcp` suite: **381 passing**, no regressions.
- Verified the pattern exists nowhere else: auvik was the only `parse_retry_after(dict(...))`
  caller, and `claroty-mcp` already reads `resp.headers.get("Retry-After")` off the
  case-insensitive object correctly.

## Notes
Found while building the Halo MCP server (#167), whose client was based on this one — the same
bug was caught there by TDD before it shipped. This is the corresponding fix for `main`, where
Auvik landed via #165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
