### PR TITLE
fix(068): daemon-restart-orphaned tasks are now actually cancellable

### DIFF
--- a/mcp-servers/protocol-mcp/bgp-daemon-v2.py
+++ b/mcp-servers/protocol-mcp/bgp-daemon-v2.py
@@ -405,9 +405,22 @@ async def handle_n2n(method, path, body):
             return 200, {"tasks": fed.tasks.list_recent()}
 
         if len(parts) == 4 and parts[1] == "tasks" and parts[3] == "cancel" and method == "POST":
-            row = mgr._conn.execute("SELECT peer_identity FROM delegated_task WHERE task_id=?",
-                                    (parts[2],)).fetchone()
+            row = mgr._conn.execute(
+                "SELECT peer_identity, direction FROM delegated_task WHERE task_id=?",
+                (parts[2],)).fetchone()
             if row:
+                # An "inbound" task (a peer/edge-node asked the Border to run
+                # something, e.g. a phone's edge_ask) is executed BY this
+                # process -- there is no remote channel to ask, cancelling it
+                # is purely local, exactly like tasks.py's own no-live-worker
+                # fallback for a task orphaned by a daemon restart. Routing
+                # this through the outbound member/remote-channel branch
+                # below always failed with "member not connected" (edge
+                # nodes live in fed.edge_channels, never fed.member_channels,
+                # so the lookup could never succeed even when the phone
+                # itself was connected).
+                if row["direction"] == "inbound":
+                    return 200, {"task_id": parts[2], "cancelled": fed.tasks.cancel(parts[2])}
                 try:
                     if fed.is_member_task(row["peer_identity"]):
                         ch = fed.member_channels.get(row["peer_identity"])

--- a/mcp-servers/protocol-mcp/bgp/federation/invocation.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/invocation.py
@@ -231,8 +231,27 @@ class Invoker:
 
     async def handle_task_cancel(self, channel, params):
         task_id = params.get("task_id", "")
-        return {"task_id": task_id,
-                "cancelled": self.service.tasks.cancel(task_id, owner=channel.peer_identity)}
+        cancelled = self.service.tasks.cancel(task_id, owner=channel.peer_identity)
+        # The phone's own Cancel button (chat_screen.dart _cancel()) never
+        # reads this RPC's return value -- it waits for a pushed
+        # n2n/edge/ask_result, exactly like a normal completion (mirrors
+        # _edge_on_ask's _push_result_when_done). A task cancelled via the
+        # live-worker path already gets that push from there; a task
+        # cancelled via tasks.py's no-live-worker fallback (e.g. orphaned by
+        # a daemon restart) never goes through that code at all, so without
+        # this the phone would show the fixed-up task as "cancelled" server
+        # side while its UI stays stuck on "Working..." forever.
+        if cancelled and self.service.edge_channels.get(channel.peer_identity) is channel:
+            result = self.service.tasks.result(task_id)
+            if result.get("state") == "cancelled":
+                try:
+                    await channel.notify("n2n/edge/ask_result", {
+                        "task_id": task_id, "state": "cancelled",
+                        "output_text": None, "tokens_used": 0,
+                    })
+                except Exception:
+                    pass
+        return {"task_id": task_id, "cancelled": cancelled}
 
     # ---- feature 064: federated knowledge retrieval -------------------
 

--- a/mcp-servers/protocol-mcp/bgp/federation/tasks.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/tasks.py
@@ -87,6 +87,19 @@ class TaskManager:
         if w and not w.done():
             w.cancel()
             return True
+        # No live worker for this task_id in THIS process. Usually that just
+        # means it already reached a terminal state -- but if a daemon
+        # restart happened while the task was in flight, the in-memory
+        # asyncio.Task that would run OR cancel it was destroyed while the
+        # DB row is still stuck at "submitted"/"working" forever, with
+        # nothing left alive to ever finish or cancel it (found via a real
+        # stuck edge_ask task whose phone-side Cancel button silently did
+        # nothing). Only a task genuinely still open is fixed up here.
+        row = self.manager._conn.execute(
+            "SELECT state FROM delegated_task WHERE task_id=?", (task_id,)).fetchone()
+        if row and row["state"] in ("submitted", "working"):
+            self._set(task_id, state="cancelled", completed_at=_now())
+            return True
         return False
 
     # ---- queries -------------------------------------------------------

--- a/mobile/netclaw-mobile/MAC-IOS-HANDOFF.md
+++ b/mobile/netclaw-mobile/MAC-IOS-HANDOFF.md
@@ -1,0 +1,215 @@
+# NetClaw Mobile — Mac / iOS Handoff
+
+**Read this first on the Mac.** It replaces the throwaway kickoff prompt from the
+2026-07-23 Android session (which was written to a scratchpad and lost — hence
+this file lives in the repo now).
+
+Last updated: **2026-07-25**, at the end of the Android verification pass.
+
+---
+
+## Where things stand
+
+The Android/Dart/Python side of specs **066** (NCFED edge node), **067**
+(mobile command channel) and **068** (biometrics/capture) is done, merged, and
+— as of 2026-07-25 — **verified against the real production Border with a real
+round trip from an emulated phone**.
+
+Merged: **#159, #161, #162, #163** (the 066→067→068 stack), **#164**
+(branding/icon, persisted reconnect, first real end-to-end proof, HUD phone
+glyph), **#166** (heartbeat, stale-answer recovery, session-key fix, manual
+enrollment fallback, HUD edge-node liveness), **#170** (orphaned-task cancel).
+
+Pull `main` and confirm **#170** is merged before starting.
+
+### Proof the stack works end to end
+
+From 2026-07-25 13:04–13:06 local, a question typed on the emulated phone
+("check the CML lab R1 interfaces, test them and report back") produced:
+
+| Time | Event |
+|---|---|
+| 13:04:33 | Edge WS accepts the ask, capability negotiate (proto 053) |
+| 13:04:46 | `cml-lab-lifecycle` → member `johns-risk/cml` completed |
+| 13:04:59 | Router picks `pyats-health-check` → `johns-risk/pyats`, GAIT logged |
+| 13:06:10 | pyATS returns `in_scope/success` |
+| 13:06:46 | 1583-byte answer delivered to the handset — **2m13s end to end** |
+
+Enrollment, edge WS transport, delegation, routing, GAIT audit, and result
+delivery are all real. iOS is the only unproven platform.
+
+---
+
+## What's already built (verify/wire up on iOS — do not rebuild)
+
+Everything under `mobile/netclaw-mobile/`:
+
+- **`EdgeIdentity`** (`lib/ncfed/edge_identity.dart`) — platform-channel
+  interface. iOS native side is `ios/Runner/EdgeIdentityPlugin.swift` (Secure
+  Enclave keygen/signing) and `ios/Runner/X509SelfSigned.swift` (manual
+  self-signed cert builder — iOS has no equivalent of AndroidKeyStore's cert
+  convenience). **Both were written without a Mac and are entirely unverified.**
+  This is the actual iOS work: get them compiling, generate a real Secure
+  Enclave key, sign real challenge nonces, build a real X.509 cert from it.
+  The Secure Enclave does not exist on the Simulator — you need a real device
+  for keygen/signing. Simulator is fine for build + UI sanity.
+  - Android's working equivalent is
+    `android/app/src/main/kotlin/.../MainActivity.kt` — read it as the
+    reference implementation. It is confirmed to link and run on a real
+    emulator, so its shape is trustworthy.
+- **`AppDelegate`/`SceneDelegate`** — Android needed `FlutterActivity` →
+  `FlutterFragmentActivity` for `local_auth`. Confirm whether iOS needs an
+  analogous change (it likely does not).
+- **Everything else is pure Dart** and should behave identically on iOS:
+  enrollment (QR *and* manual), ask/chat, approvals, capture UI, capability
+  registration, heartbeat, persisted reconnect.
+- **App icon/splash** via `flutter_launcher_icons`/`flutter_native_splash` from
+  `assets/icon/icon.png`. The generator targets both platforms, but the iOS
+  icon has never been eyeballed on a device. See `ASSETS.md`.
+
+---
+
+## Corrections to the old draft — these are now FIXED, don't go hunting
+
+The 2026-07-23 prompt listed three gaps. Two are closed:
+
+1. ~~Session-key bug: `n2n-edge-{member_id}` breaks on `/`~~ — **FIXED.**
+   `bgp/federation/service.py:1289` now does
+   `"n2n-edge-" + member_id.replace("/", "_")`. Shipped in #166.
+2. ~~Enrollment is QR-scan-only with no manual fallback~~ — **FIXED.**
+   `lib/screens/manual_enrollment_screen.dart` exists; `enrollment_screen.dart`
+   offers "Can't scan? Enter manually" (domain/port/token fields). Shipped in
+   #166. **This matters for you specifically** — it's the clean way past
+   enrollment on the iOS Simulator, which has no usable camera. You no longer
+   need the `integration_test/enrollment_and_ask_test.dart` trick.
+3. **Face ID / `NSFaceIDUsageDescription`** — still open, still unverified.
+   The key is in `ios/Runner/Info.plist` but no real Face ID prompt has ever
+   fired. Confirm on a real device.
+
+---
+
+## Known defects — pre-existing, not yours
+
+If you hit these on iOS, they are not iOS bugs and not something you introduced.
+
+- **Empty result payloads survive a crash as a clean "completed".** Two
+  independent holes, both found 2026-07-25:
+  - `bgp/federation/audit.py:30-38` `store_result()` writes results
+    non-atomically (no temp+`os.replace`+`fsync`), and returns the path even
+    when the write raised. A host reboot inside the ext4 delayed-allocation
+    window leaves a **0-byte** result file. Confirmed twice on this box
+    (2026-07-24 14:14 and 2026-07-25 11:47, each ~12s before a reboot).
+  - `bgp/federation/tasks.py:139-146` `result()` swallows the resulting JSON
+    parse failure with a bare `except: pass`, returning
+    `{"state": "completed"}` with no `output_text`, no `error`, and no log
+    line. A lost payload is indistinguishable from a skill that returned
+    nothing. `service.py:1593` then re-caches that empty reply over the
+    Border's own good copy.
+  - Also on that line: `resp.get("completed_at")` is always `None` because
+    `TaskManager.result()` never returns the field — every outbound task row
+    has `completed_at=NULL`.
+  - Fourth path: `gateway.py:123-125` returns `("", 0)` when the agent CLI
+    emits no stdout at all, bypassing the `"(no reply text…)"` fallback at
+    `gateway.py:184`; `tasks.py:65-68` records that as `completed`.
+- **Operator-side cancel doesn't notify the phone.** #170 fixed the phone's own
+  Cancel button (`invocation.py:232-254` pushes `n2n/edge/ask_result` with
+  `state:"cancelled"`), but the HTTP route `bgp-daemon-v2.py:422-423` returns
+  `{"cancelled": …}` without the push. Cancel a stuck `edge_ask` from the
+  HUD/CLI and the phone sits on "Working…" forever.
+- **`ReconnectSupervisor` ignores revocation.** `reconnect_supervisor.dart:55`
+  is a bare `catch (_)` that backs off forever, so a device revoked *while
+  running* retries a dead enrollment indefinitely instead of returning to the
+  enrollment gate. `isRevokedByBorder()` (`edge_client.dart:22-31`, added in
+  #170) exists but is only consulted on cold-start reconnect.
+- **`NotificationDeepLink` is orphaned code.** `lib/ncfed/notification_deep_link.dart`
+  wires `onMessageOpenedApp` + `getInitialMessage()` to open the matching feed
+  message, but nothing ever instantiates it — repo-wide grep finds only its own
+  definition. **This bites APNs on iOS exactly as it bites FCM on Android**:
+  tapping a push notification will not deep-link. Fix it once, both platforms
+  benefit.
+
+---
+
+## Push notifications — read before doing APNs
+
+Push is **wired in Dart, dead at runtime, on both platforms**:
+
+- `firebase_messaging: ^16.4.3` + `firebase_core: ^4.12.1` are in `pubspec.yaml`.
+- `lib/ncfed/push_registration.dart` does `requestPermission()` → `getToken()` →
+  `n2n/edge/register_push` (`platform: 'apns'` on iOS).
+- `main.dart:272-279` `_tryRegisterPush()` wraps `Firebase.initializeApp()` in a
+  `try/catch` that **swallows failure to a `debugPrint`** — so a missing Firebase
+  config produces silence, not an error. Don't be fooled by "no crash".
+- Android has no `google-services.json` and no `com.google.gms.google-services`
+  Gradle plugin. iOS will need the equivalent `GoogleService-Info.plist`, an
+  APNs auth key uploaded to Firebase, and the Push Notifications + Background
+  Modes capabilities in Xcode.
+
+Treat push as a **separate work item**, not part of the iOS port. The core
+product (enrollment → ask → answer) works without it.
+
+---
+
+## How to verify for real
+
+Match the rigor of the Android pass — actually run it, don't just green the tests.
+
+1. `flutter analyze` / `flutter test` clean (platform-agnostic, should already pass).
+2. Xcode build → Simulator (UI/layout, manual enrollment path) → **real device**
+   (Secure Enclave, Face ID, camera).
+3. Enroll against the operator's real Border: **`N2N_EDGE_WS_PORT=8443` is
+   permanently live** and confirmed serving as of 2026-07-25 13:00
+   (`Edge WS listener on 0.0.0.0:8443`, risk `johns-risk`). You should not need
+   to enable anything. For an isolated run instead, follow the throwaway-Border
+   pattern in `specs/068-ncfed-mobile-biometrics-capture/quickstart.md`.
+4. Close out the two remaining manual-verification tasks if iOS is the platform
+   you do them on:
+   - `specs/066-netclaw-mobile-ncfed-edge/tasks.md:121` — **T045**, full
+     `quickstart.md` walkthrough steps 1–10 against a live Border.
+   - `specs/067-ncfed-mobile-command-channel/tasks.md:72` — **T017**, confirm a
+     federated-peer request is attributed to the external peer in the
+     conversation. Note: the three eN2N peers (`as65007`, `as65008`, `as65099`)
+     have been connection-refused all week — you need a reachable peer first.
+5. Update `README.md`'s iOS section and 066 T044's iOS note once verified. Be
+   honest about verified vs. still-assumed, the way the Android section is.
+
+---
+
+## Environment gotchas learned the hard way
+
+- **`JAVA_HOME` must point at JDK 17.** The Gradle/AGP/Kotlin combination in
+  this project (Gradle 9.1.0, AGP 9.0.1, Kotlin 2.3.20, `JvmTarget.JVM_17`)
+  fails confusingly on newer JDKs. On the Mac, expect the same class of
+  problem and pin JDK 17 for Android builds. (Irrelevant for the iOS target
+  itself, relevant the moment you build Android from the Mac.)
+- `mobile/netclaw-mobile/build` reaches **2.2 GB** and `.dart_tool` **334 MB**.
+  Both are gitignored; don't copy them to the Mac, just `flutter pub get`.
+- The repo is a **shared checkout** — other agents switch branches in it. Verify
+  the branch before committing.
+
+---
+
+## Store-release status (Android, applies to iOS App Store too)
+
+The user intends to publish. Current Android release config is **not
+shippable**, and the same discipline will apply to the App Store:
+
+- `android/app/build.gradle.kts:32` — release is **signed with the debug
+  keystore** (`signingConfig = signingConfigs.getByName("debug")`). Play rejects
+  this. No keystore exists in the repo (correctly gitignored).
+- **R8/minify is off** — no `isMinifyEnabled`, no ProGuard rules file.
+- Resolved SDK levels: `compileSdk 36`, `targetSdk 36`, `minSdk 24` (from the
+  Flutter SDK defaults). **API 36 is already correct** for Google's
+  2026-08-31 deadline — no change needed.
+- `pubspec.yaml:19` — `version: 1.0.0+1` → `versionName 1.0.0`, `versionCode 1`.
+- **`applicationId` is permanent once published.** See `PLAY-STORE-ROADMAP.md`.
+
+Full path to publication, timelines, and the account-type decision (which gates
+everything and cannot be changed later) are in
+[`PLAY-STORE-ROADMAP.md`](PLAY-STORE-ROADMAP.md).
+
+---
+
+Work through this the same way the Android pass did: implement, test for real,
+be honest in the docs about what's verified vs. still assumed, and open a PR
+when done.

--- a/mobile/netclaw-mobile/MOBILE-ONBOARDING.md
+++ b/mobile/netclaw-mobile/MOBILE-ONBOARDING.md
@@ -1,0 +1,188 @@
+# Securely onboarding a mobile Claw
+
+How to enroll a phone as an **NCFED edge node** against *your* Border Claw.
+
+NetClaw Mobile is a generic client for the NCFED Edge Node profile. It is not
+built for, tied to, or preconfigured with any particular Border — the app ships
+with no hostnames, no tokens, and no credentials. Every install starts unbound
+and is pointed at whichever Border enrolls it. `netclaw.automateyournetwork.ca`
+appears in this repo only as the maintainer's own test Border; substitute your
+own domain everywhere.
+
+Two sides, in order: **the Claw side** issues a single-use enrollment token,
+then **the phone side** consumes it. Neither works without the other.
+
+---
+
+## What the phone becomes
+
+An enrolled phone is a `node_type='edge'` member of your risk — a peer that can
+ask your Border questions and receive pushes, *not* an admin console. It gets
+no shell, no filesystem, and no ability to enroll anyone else. Everything it
+can do routes through your Border's existing authorization and audit path, so a
+phone is exactly as privileged as the scope you grant it and no more.
+
+---
+
+## Security model — what protects what
+
+| Concern | Mechanism |
+|---|---|
+| **Who may enroll** | A single-use enrollment token (`in2n_…`, 24 random bytes). The Border stores only its SHA-256 hash — the raw token exists once, in the output you hand over. |
+| **Replay of a token** | `consume_token()` marks the row `spent_at` / `spent_by_member_id` on first use. A second attempt with the same token is rejected. |
+| **Phone identity** | The app generates an EC P-256 keypair **inside the phone's hardware keystore** (Android Keystore / iOS Secure Enclave) at enrollment. The private key never leaves the device and is never transmitted — the app has no code path that can export it. |
+| **Impersonation after enrollment** | Trust-on-first-use pinning: the Border records the phone's public key and fingerprint on the member row at enrollment. Later connections must sign a challenge with that exact key. |
+| **Server impersonation** | The phone dials `wss://` and validates the Border's domain-verified TLS certificate. A phone enrolled for `border.example.com` will not complete a handshake against anything else. |
+| **Revocation** | Removing the member unpins the key. The Border then answers that device with `-32023` (not trusted), which drops the app back to its enrollment screen instead of retrying forever. |
+| **Audit** | Every request a phone originates is recorded in the Border's normal GAIT audit trail, attributed to that member ID. |
+
+**The enrollment token is the one genuinely sensitive artifact in this flow.**
+It is bearer credentials: anyone who has it before your tester does can enroll
+their own device in their place. Treat it like a password — see *Handing over
+the token* below.
+
+---
+
+## Claw side (Border operator)
+
+### 1. One-time: expose the edge listener
+
+The edge WebSocket listener is separate from the agent/service listeners. Two
+settings are required, in the runtime env the mesh daemon reads
+(`~/.openclaw/mesh.systemd.env` for the durable systemd units, or
+`~/.openclaw/.env`):
+
+```properties
+N2N_CLAW_DOMAIN=border.example.com   # must match your TLS certificate
+N2N_EDGE_WS_PORT=8443
+```
+
+Restart the daemon, then confirm the listener came up:
+
+```bash
+systemctl --user restart netclaw-mesh.service
+journalctl --user -u netclaw-mesh.service -n 50 --no-pager | grep -i "Edge"
+# → Edge (NetClaw Mobile) WS listener on 0.0.0.0:8443 (risk=<your-risk>)
+```
+
+`N2N_CLAW_DOMAIN` must resolve publicly and match the certificate the Border
+presents — phones validate it. A self-signed or mismatched cert fails the
+handshake with no override in the app, by design.
+
+Make sure the port is actually reachable from outside your network (firewall,
+NAT, security group). A phone on cellular is not on your LAN.
+
+### 2. Per device: issue an enrollment token
+
+One token per device. Label it so you can tell members apart later:
+
+```bash
+./scripts/netclaw risk token --edge alice-pixel8
+```
+
+This prints an ASCII QR code plus a raw JSON fallback:
+
+```json
+{"border_host":"border.example.com","border_port":8443,
+ "claw_domain":"border.example.com","enrollment_token":"in2n_…"}
+```
+
+The QR and the JSON carry identical data — the QR is only a transport for it.
+
+> **Tokens do not expire by default.** `issue_token()` sets `expires_at` only
+> when given an explicit TTL, and the CLI does not pass one. An unused token
+> stays valid indefinitely. Issue tokens close to when they'll be used, and
+> treat an unclaimed one as live credentials until it is spent or the member
+> is removed.
+
+### 3. Confirm and scope the device
+
+After the phone enrolls, it appears as a member:
+
+```bash
+./scripts/netclaw risk members
+```
+
+Verify the label and fingerprint match the device you expect **before** the
+phone is used for anything real — TOFU means the first key wins, so this is
+the moment to catch a wrong device having claimed the token.
+
+### 4. Revoke when needed
+
+```bash
+./scripts/netclaw risk remove <member_id>
+```
+
+Do this immediately for a lost or stolen phone, when a person leaves, or if a
+token may have been intercepted. Revocation is server-side and takes effect on
+the device's next connection attempt — you do not need access to the phone.
+
+---
+
+## Phone side (the person holding the device)
+
+### 1. Install the app
+
+Until it is published, install the APK directly (Android requires allowing
+installs from your file manager or browser). See the release instructions in
+[`README.md`](README.md) for producing a signed build, and
+[`PLAY-STORE-ROADMAP.md`](PLAY-STORE-ROADMAP.md) for the publication path.
+
+### 2. Enroll
+
+On first launch the app opens on the enrollment screen. Two equivalent paths:
+
+- **Scan the QR** — "Scan Border QR Code", point the camera at the QR the
+  operator issued. Grant the camera permission when prompted.
+- **Type it in** — "Can't scan? Enter manually", then fill in:
+
+  | Field | Value |
+  |---|---|
+  | Border domain | `border.example.com` (`claw_domain` from the payload) |
+  | Port | `8443` (`border_port`) |
+  | Enrollment token | `in2n_…` (`enrollment_token`) |
+
+  This builds exactly the payload a scan would produce, so it is a genuine
+  equivalent — useful on an emulator or any device whose camera can't focus on
+  a screen.
+
+Enrollment then happens without further input: the app generates its hardware
+keystore keypair, dials the Border over `wss://`, presents the token and its
+public key, and the Border pins that key to a new member row.
+
+### 3. After enrollment
+
+The token is now spent and worthless — it cannot be reused, including by the
+same device. Enrollment persists, so the app reconnects by itself on restart
+and after a dropped connection; the operator does not need to issue a second
+token.
+
+If the Border revokes the device, the app returns to the enrollment screen
+rather than retrying a dead identity. Re-enrolling requires a fresh token.
+
+---
+
+## Handing over the token
+
+The token is bearer credentials in transit. Send it over a channel you already
+trust for secrets — a password manager share, an encrypted DM, or in person.
+Avoid email and plaintext SMS.
+
+If the phone is in front of you, **displaying the QR on your screen and
+scanning it is the safest option**: the token never leaves your machine.
+
+If anything about a token's handling is uncertain, don't reuse it — revoke the
+member if it was already claimed, and issue a fresh one. Tokens are free.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `netclaw risk token --edge` exits with no output | `N2N_CLAW_DOMAIN` or `N2N_EDGE_WS_PORT` missing from the runtime env — see step 1. |
+| `qrcode not installed` | `pip install -r mcp-servers/protocol-mcp/requirements.txt`. The JSON fallback and manual entry still work without it. |
+| Phone times out connecting | Port not reachable from outside your network, or the daemon's edge listener never started — check the `journalctl` line in step 1. |
+| TLS / certificate error on the phone | `N2N_CLAW_DOMAIN` doesn't match the served certificate, or the cert isn't publicly trusted. There is no bypass in the app. |
+| "Token already used" | Tokens are single-use. Issue a new one. |
+| App drops back to the enrollment screen | The Border revoked this device (`-32023`). Issue a fresh token to re-enroll. |

--- a/mobile/netclaw-mobile/PLAY-STORE-ROADMAP.md
+++ b/mobile/netclaw-mobile/PLAY-STORE-ROADMAP.md
@@ -1,0 +1,163 @@
+# NetClaw Mobile — Google Play publication roadmap
+
+Captured 2026-07-25 so the plan survives the session. Sequenced against **this
+repo's actual build config**, not a generic checklist.
+
+> **Provenance:** the Google policy facts below (fees, deadlines, tester rules,
+> review windows) come from the operator's own research pass, not from
+> verification by this repo's tooling. Re-check them against Google's own docs
+> before acting — Play policy shifts year to year. Everything under "our
+> current state" *was* verified directly against the files cited.
+
+---
+
+## The deadline that shapes the schedule
+
+Per the operator's research: from **2026-08-31**, new apps and updates must
+target **Android 16 (API 36)** or higher to be submitted to Play. That is
+roughly five weeks out and shorter than the process below takes.
+
+**Good news — we already comply.** Flutter's SDK defaults resolve this project
+to `compileSdk 36` / `targetSdk 36` / `minSdk 24`
+(`android/app/build.gradle.kts:9,22-23` delegating to `flutter.*`, resolved in
+the Flutter SDK's `FlutterExtension.kt`). No migration work needed. Do **not**
+pin these lower.
+
+---
+
+## Phase 1 — Developer account (gates everything; start first)
+
+$25 USD one-time registration. The consequential part is the account type,
+**which cannot be changed later**:
+
+| | Personal | Organization |
+|---|---|---|
+| Extra prerequisite | none | D-U-N-S number (days–weeks to obtain) |
+| Closed-testing gate | **12 testers × 14 continuous days** | **exempt** |
+| Realistic time to live | ~4–6 weeks | ~1–3 weeks |
+
+Identity verification (document upload, sometimes a selfie) takes hours to two
+business days; the name on the ID must match the name on the payment card.
+
+**Recommendation:** if a business entity is available or obtainable, the
+organization route removes the single biggest schedule risk. Decide this before
+paying the fee.
+
+---
+
+## Phase 2 — Make the build shippable
+
+This is the part that is **our work**, and it is currently incomplete.
+
+| # | Item | Current state | File |
+|---|---|---|---|
+| 1 | **Final `applicationId`** | `ca.automateyournetwork.netclaw.netclaw_mobile` — raw Flutter template default (`<org>.<project>`), carries an underscore and an ugly suffix | `android/app/build.gradle.kts:19` (+ `namespace`, line 8) |
+| 2 | **Release signing key** | ❌ release signs with the **debug keystore** | `android/app/build.gradle.kts:30-32` |
+| 3 | **R8 / minify** | ❌ off; no `isMinifyEnabled`, no ProGuard rules file | `android/app/build.gradle.kts:29-33` |
+| 4 | **AAB not APK** | not yet produced — `./gradlew bundleRelease` | — |
+| 5 | **`INTERNET` permission** | ⚠️ absent from the release manifest; arrives only as a merge side-effect of `firebase_messaging` | `android/app/src/main/AndroidManifest.xml` |
+| 6 | **App description** | ❌ still `"A new Flutter project."` | `pubspec.yaml:2` |
+| 7 | **Version** | `1.0.0+1` | `pubspec.yaml:19` |
+
+### Item 1 is irreversible — decide it before the first upload
+
+`ca.automateyournetwork.netclaw.netclaw_mobile` is what the Flutter template
+generated. Once an AAB with a given `applicationId` is published, that string is
+permanent for the life of the listing; changing it means a brand-new listing
+with zero install base. Candidates: `ca.automateyournetwork.netclaw` or
+`ca.automateyournetwork.netclaw.mobile`.
+
+Changing it means updating `applicationId` **and** `namespace`
+(`build.gradle.kts:8,19`) and the Kotlin package path under
+`android/app/src/main/kotlin/`.
+
+### Item 2 — the biggest irreversible risk overall
+
+Losing the upload keystore means you can never update the app again, only
+publish a fresh listing. Generate it, then back it up in **two** places off this
+machine. `key.properties`, `*.jks` and `*.keystore` are already gitignored
+(`android/.gitignore:12-14`) — verified nothing of the sort is tracked. Enroll
+in Play App Signing.
+
+---
+
+## Phase 3 — Listing and compliance paperwork
+
+One sitting, but larger than people expect:
+
+- 512×512 icon, 1024×500 feature graphic, ≥2 screenshots per form factor
+  (we have brand assets already — see `ASSETS.md`)
+- Short description (80 chars), full description (4000 chars)
+- **Privacy policy at a public HTTPS URL** — mandatory, no exceptions
+- **Data safety form** — must match actual app behavior or it's a rejection
+- Content rating questionnaire (IARC)
+- Declarations: ads, target audience, government/financial/health flags
+
+### Where NetClaw Mobile specifically will draw scrutiny
+
+These are ours, and they are not the generic ones:
+
+- **Camera, microphone, and biometric** permissions (spec 068) all need
+  justification in the Data safety form. Biometric auth via `local_auth` is
+  local-only and never leaves the device — say so explicitly.
+- **Photo/video/audio capture** (068) is user-initiated and transmitted to the
+  operator's own Border. That is a data *transfer*, and must be declared.
+- The app is effectively a **remote-administration client for network
+  infrastructure**. Expect questions about target audience — it is unambiguously
+  not for children; answer the audience questions accordingly.
+- **Push**: if `firebase_messaging` ships (see below), FCM token collection is
+  declarable data collection even though the token is only sent to our Border.
+
+### Decide before submitting: does push ship in v1?
+
+Push is currently **dead code with live dependencies** — `firebase_messaging`
+and `firebase_core` are in `pubspec.yaml`, but there is no
+`google-services.json` and no Google Services Gradle plugin, so
+`Firebase.initializeApp()` throws into a swallowed `catch`
+(`lib/main.dart:272-279`). `NotificationDeepLink` is never instantiated at all.
+
+Shipping it in this state means declaring an FCM dependency that does nothing.
+Either finish it (Firebase project + config + wire the deep-link handler) or
+strip the dependencies for v1. Don't ship it half-wired.
+
+---
+
+## Phase 4 — The testing gate (personal accounts only)
+
+Closed test with **≥12 testers opted in continuously for 14 days**, then apply
+for production access.
+
+- The 14-day clock starts only once the release is approved **and** 12 testers
+  have actually opted in — not when you add their emails.
+- Testers must genuinely open and use the app; dropping below 12 can reset it.
+- **Emulators and fake accounts risk permanent account suspension.** Our
+  `netclaw_test` AVD is fine for our own verification; it must not be used to
+  pad the tester count.
+
+Use **internal testing** (up to 100 testers, no waiting period) first to shake
+out crashes, then start the closed-test clock with a build you trust.
+
+---
+
+## Phase 5 — Production review
+
+Typically ≤7 days, sometimes longer; first submissions from new accounts skew
+long.
+
+---
+
+## Suggested order of work
+
+1. **Now, before anything else:** decide the final `applicationId` and the
+   account type. Both are permanent.
+2. Generate and back up the release keystore; wire a real signing config.
+3. Enable R8, add a ProGuard rules file, declare `INTERNET` explicitly, fix the
+   `pubspec.yaml` description.
+4. Resolve the push question (finish or strip).
+5. Build a release AAB and smoke-test it on the emulator — a minified release
+   build is where reflection/serialization breakage surfaces, and we have never
+   built one.
+6. Register the developer account (in parallel with 2–5; if organization, start
+   the D-U-N-S request *first* since it's the long pole).
+7. Listing assets + compliance forms.
+8. Internal testing → closed testing (if personal) → production.

--- a/mobile/netclaw-mobile/README.md
+++ b/mobile/netclaw-mobile/README.md
@@ -24,9 +24,11 @@ lib/
     edge_client.dart          # WebSocket JSON-RPC client (mirrors edge.py's EdgeChannel)
     enrollment_flow.dart      # QR -> parse -> domain check -> dial -> outcome
     message_feed.dart         # local persisted store for Border-pushed messages (066)
-    reconnect_supervisor.dart # generic bounded-retry loop (ports _in2n_member_dialer)
+    enrollment_store.dart     # persisted enrollment, so a restart redials instead of re-enrolling
+    reconnect_supervisor.dart # bounded-retry loop; drives the app's auto-redial
+    heartbeat.dart            # answers the Border's n2n/edge/heartbeat + self_status probes
     push_registration.dart    # FCM/APNs token registration
-    notification_deep_link.dart
+    notification_deep_link.dart # notification tap -> jump to that message in the feed
     edge_ask_client.dart      # n2n/edge/ask + task status/result/cancel (067)
     conversation_store.dart   # per-device persisted chat history (067)
     voice_transcription.dart  # on-device speech-to-text -> ask() (067, US4)
@@ -35,7 +37,9 @@ lib/
     capability_registration.dart # advertises/toggles capture capabilities (068, US3)
     capture_client.dart       # phone-initiated attach + Border-requested capture handler (068, US2/US3)
   screens/
-    enrollment_screen.dart    # "Scan Border QR Code" (one-time, pre-enrollment)
+    enrollment_screen.dart    # "Scan Border QR Code" + "Can't scan? Enter manually"
+    manual_enrollment_screen.dart # domain/port/token typed by hand (no camera needed)
+    empty_state.dart          # shared illustrated empty state
     feed_screen.dart          # renders pushed messages (066)
     chat_screen.dart          # request/answer history, cancel, voice, camera (067/068)
     device_scan_screen.dart   # "Scan Device" -- any time, post-enrollment (067, US5)
@@ -54,11 +58,51 @@ ios/Runner/X509SelfSigned.swift                    # manual self-signed cert bui
    the daemon (`mcp-servers/protocol-mcp/bgp-daemon-v2.py`).
 2. Issue a QR: `netclaw risk token --edge [label]`.
 3. `flutter pub get`, then `flutter run` (Android) to launch the app and scan it.
+   No usable camera (emulator, Simulator)? Tap **"Can't scan? Enter manually"** on
+   the enrollment screen and type the domain, port, and token instead — it
+   synthesizes exactly the payload a scan would produce.
+
+Once enrolled, the app persists the enrollment (`enrollment_store.dart`) and
+redials automatically on restart or a dropped connection, so steps 2–3 are
+one-time. A Border that revokes the device returns `-32023`, which drops the app
+back to the enrollment screen rather than retrying forever.
 
 ```bash
 flutter analyze
 flutter test
 ```
+
+## Building a release
+
+`flutter build appbundle` reads signing material from `android/key.properties`:
+
+```properties
+storeFile=/absolute/path/to/upload-keystore.jks
+storePassword=…
+keyAlias=upload
+keyPassword=…
+```
+
+That file and any `*.jks`/`*.keystore` are gitignored and must never be
+committed. **If it's absent the build still succeeds but signs with the debug
+key** (Gradle prints a warning) — such an artifact cannot be uploaded to Play.
+The release build type has R8 minification and resource shrinking enabled; keep
+rules live in `android/app/proguard-rules.pro`.
+
+## Docs
+
+| Doc | What it covers |
+|---|---|
+| [`MOBILE-ONBOARDING.md`](MOBILE-ONBOARDING.md) | **How to securely enroll a phone against your own Border** — operator side (token/QR) and phone side, plus the security model. Start here. |
+| [`TESTER-INSTRUCTIONS.md`](TESTER-INSTRUCTIONS.md) | Copy-paste handout for sending a build to someone else to test. |
+| [`PLAY-STORE-ROADMAP.md`](PLAY-STORE-ROADMAP.md) | Google Play publication path, sequenced against this repo's build config. |
+| [`MAC-IOS-HANDOFF.md`](MAC-IOS-HANDOFF.md) | Read before starting iOS work on a Mac. |
+| [`ASSETS.md`](ASSETS.md) | Icon/splash regeneration and brand rationale. |
+
+The app ships with no hostnames or credentials — it is a generic NCFED edge
+client, bound to whichever Border enrolls it. Any reference to
+`netclaw.automateyournetwork.ca` in this repo is the maintainer's own test
+Border, not a dependency.
 
 ## Platform-specific notes
 
@@ -82,6 +126,11 @@ flutter test
   emulator has no provisioned fingerprint/Face-unlock enrollment and its virtual
   camera only produces a synthetic test pattern, not a real capture; both need
   either a real device or a properly provisioned emulator, done in a later pass.
+  **A full production round trip has since been verified** (2026-07-25): a question
+  asked from the emulated phone against the operator's real Border fanned out to
+  the `cml` and `pyats` risk members and returned a 1583-byte answer to the handset
+  in 2m13s, with GAIT audit records for each delegation. Enrollment, the edge WS
+  transport, delegation/routing, and result delivery are all proven end to end.
 - **iOS**: building, signing, and running the app — and exercising
   `EdgeIdentityPlugin.swift`'s Secure Enclave key generation — **requires Xcode,
   which only runs on macOS.** That code was written and reviewed without a Mac
@@ -95,15 +144,22 @@ flutter test
   Developer credentials configured on the Border (`.env.example`'s
   `FCM_SERVICE_ACCOUNT_JSON`/`APNS_*` vars) and a real `Firebase.initializeApp()`
   setup in the app (`google-services.json` / `GoogleService-Info.plist`) — neither
-  exists in this repo; wire them in with your own project's credentials.
+  exists in this repo; wire them in with your own project's credentials. Note that
+  `main.dart`'s `_tryRegisterPush()` swallows the resulting failure to a
+  `debugPrint`, so **push silently does nothing rather than erroring** until those
+  credentials exist. Notification-tap deep-linking is wired on the same success
+  path: it jumps to the Feed tab and highlights the referenced message.
 - Voice transcription (`speech_to_text`, feature 067 US4) and the device deep link
   (`app_links`, feature 067 US5) are wired in and pass their unit tests, but — like
   push notifications — haven't been exercised against a real microphone or a real
   tapped/scanned link on either platform.
 - Feature 068's `local_auth`/`camera` packages need no manual `AndroidManifest.xml`
   permission entries — both merge their own required permissions (`CAMERA`,
-  `RECORD_AUDIO`, `USE_BIOMETRIC`) in automatically via Gradle manifest merging;
-  `AndroidManifest.xml` itself declares zero `<uses-permission>` for either. On
+  `RECORD_AUDIO`, `USE_BIOMETRIC`) in automatically via Gradle manifest merging.
+  `INTERNET` is the exception and **is** declared explicitly in
+  `android/app/src/main/AndroidManifest.xml`: it previously reached release builds
+  only as a merge side-effect of `firebase_messaging`, so dropping that dependency
+  would have silently broken networking in release with no compile-time error. On
   iOS, `local_auth`'s Face ID needs `NSFaceIDUsageDescription` (Touch ID/Android's
   BiometricPrompt need no key at all) — added to `Info.plist` alongside the
   existing camera/microphone keys, which now also cover the `camera` package's

--- a/mobile/netclaw-mobile/TESTER-INSTRUCTIONS.md
+++ b/mobile/netclaw-mobile/TESTER-INSTRUCTIONS.md
@@ -1,0 +1,142 @@
+# NetClaw Mobile — Android tester instructions
+
+Copy the **"Send this to your tester"** section below verbatim. Do the
+operator steps first — the tester can't do anything without the QR.
+
+---
+
+## Operator steps (you, before sending anything)
+
+**1. Confirm the edge listener is up and reachable.**
+
+```bash
+journalctl --user -u netclaw-mesh.service -n 50 --no-pager | grep -i "Edge"
+# → Edge (NetClaw Mobile) WS listener on 0.0.0.0:8443 (risk=johns-risk)
+```
+
+Your tester will be on their own network or cellular, so port 8443 must be
+reachable from the public internet — not just your LAN. Verify from outside
+before blaming the app.
+
+**2. Issue a fresh single-use token, labelled for that person.**
+
+```bash
+./scripts/netclaw risk token --edge <their-name>-android
+```
+
+Screenshot the QR block it prints. Do **not** reuse a token from an earlier
+run — they are single-use, and any token that has been pasted into a chat log
+or terminal transcript should be considered spent.
+
+**3. Send them the APK and the QR** (see the handout below).
+
+**4. After they enroll, confirm the device is really theirs:**
+
+```bash
+./scripts/netclaw risk members
+```
+
+Check the label and key fingerprint before the device is used for anything
+real. Trust-on-first-use means whoever claims the token first wins the
+identity — this is the step that catches a wrong claim.
+
+**5. When testing is done, or immediately if the phone is lost:**
+
+```bash
+./scripts/netclaw risk remove <member_id>
+```
+
+Revocation is server-side; you don't need the phone back.
+
+> **The APK is signed with the Android debug key.** That's fine for sideloading
+> and expected at this stage, but it is not a Play-uploadable artifact and the
+> tester's phone will warn them it's from an unknown developer. See
+> `PLAY-STORE-ROADMAP.md`.
+
+---
+
+## Send this to your tester
+
+> **Testing NetClaw Mobile — about 5 minutes**
+>
+> This is an early Android build of NetClaw Mobile. It turns your phone into a
+> secure remote for my NetClaw network-automation agent — you ask it a question
+> in plain English, it does the work on my side and sends the answer back.
+>
+> You'll need the APK file and the QR code image I sent alongside this.
+>
+> **1. Install the app**
+>
+> - Tap the `app-release.apk` file I sent you.
+> - Android will say installs from this source aren't allowed — tap
+>   **Settings**, turn on **Allow from this source**, then go back and tap
+>   **Install**.
+> - You may get a "scan app / unsafe app blocked" warning from Play Protect.
+>   This is expected for an app that isn't on the Play Store yet — choose
+>   **Install anyway** / **More details → Install anyway**.
+> - Open **NetClaw** from your app drawer.
+>
+> **2. Enroll it against my server**
+>
+> The app opens on a screen with a **Scan Border QR Code** button.
+>
+> - Tap it and allow camera access when asked.
+> - Point the camera at the QR code image I sent. Displaying it full-screen on
+>   a computer monitor works best.
+>
+> If the camera won't focus or the scan doesn't catch, tap **"Can't scan? Enter
+> manually"** and type in the three values I sent with the QR (Border domain,
+> Port, Enrollment token). That does exactly the same thing.
+>
+> It should connect within a few seconds and take you to the main screen with
+> tabs along the bottom: **Chat**, **Feed**, **Approvals**, **Settings**.
+>
+> **3. Try it**
+>
+> On the **Chat** tab, send:
+>
+> ```
+> Check the CML lab R1 interfaces and report back
+> ```
+>
+> It takes about **2 minutes** — the request goes to my Border, which farms the
+> work out to the lab tooling and sends the answer back. You'll see it working
+> while it runs. You should get a table of interfaces and their status.
+>
+> Then try one of your own, anything about the network.
+>
+> **4. Tell me**
+>
+> - Did the install and QR scan work, or did you have to type it manually?
+> - Did the answer come back? Roughly how long?
+> - Anything confusing, ugly, or broken — including wording and layout.
+> - Phone model and Android version.
+>
+> **A few things to know**
+>
+> - The QR contains a **single-use token**. It only works once, so don't share
+>   it — if the install fails partway, tell me and I'll issue a new one.
+> - The app can only ask my agent questions. It has no access to your phone's
+>   files, contacts, or anything else, and it can't be used to reach anything
+>   other than my server.
+> - Push notifications aren't wired up yet, so answers only arrive while the
+>   app is open.
+> - I can cut this phone off from my end at any time — just say when you're
+>   done and I'll revoke it.
+
+---
+
+## Known rough edges (don't be surprised when they're reported)
+
+| Behavior | Status |
+|---|---|
+| Play Protect warns on install | Expected — unsigned-for-Play debug key |
+| No push notifications | Firebase not configured; `_tryRegisterPush()` fails silently by design |
+| Tapping a notification doesn't deep-link | Wired but inert until Firebase exists |
+| Biometric approval untested on real hardware | Never exercised outside an emulator without enrolled biometrics |
+| Camera capture untested on real hardware | Emulator only produced a synthetic test pattern |
+| Voice input untested on real hardware | Never exercised against a real microphone |
+
+A real device exercising biometrics, camera, and voice is the single most
+valuable thing this tester can give you — those are the three features with no
+real-hardware verification at all.

--- a/mobile/netclaw-mobile/android/app/build.gradle.kts
+++ b/mobile/netclaw-mobile/android/app/build.gradle.kts
@@ -1,11 +1,25 @@
+import java.util.Properties
+
 plugins {
     id("com.android.application")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }
 
+// Release signing material lives outside git (android/.gitignore covers
+// key.properties, *.jks and *.keystore). When it is absent — CI, a fresh
+// clone, or anyone who only needs a debug build — the release build type
+// falls back to the debug key so `flutter run --release` still works, but
+// the resulting artifact is one Play will reject. See PLAY-STORE-ROADMAP.md
+// phase 2.
+val keystoreProperties = Properties().apply {
+    val f = rootProject.file("key.properties")
+    if (f.exists()) f.inputStream().use { load(it) }
+}
+val hasReleaseKeystore = keystoreProperties.getProperty("storeFile") != null
+
 android {
-    namespace = "ca.automateyournetwork.netclaw.netclaw_mobile"
+    namespace = "ca.automateyournetwork.netclaw.mobile"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -15,8 +29,8 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "ca.automateyournetwork.netclaw.netclaw_mobile"
+        // Permanent once published to Play — do not change. See PLAY-STORE-ROADMAP.md.
+        applicationId = "ca.automateyournetwork.netclaw.mobile"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
@@ -25,11 +39,34 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        if (hasReleaseKeystore) {
+            create("release") {
+                keyAlias = keystoreProperties.getProperty("keyAlias")
+                keyPassword = keystoreProperties.getProperty("keyPassword")
+                storeFile = rootProject.file(keystoreProperties.getProperty("storeFile"))
+                storePassword = keystoreProperties.getProperty("storePassword")
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = if (hasReleaseKeystore) {
+                signingConfigs.getByName("release")
+            } else {
+                logger.warn(
+                    "NetClaw: android/key.properties not found — signing the release " +
+                        "build with the DEBUG key. This artifact cannot be uploaded to Play."
+                )
+                signingConfigs.getByName("debug")
+            }
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
         }
     }
 }

--- a/mobile/netclaw-mobile/android/app/proguard-rules.pro
+++ b/mobile/netclaw-mobile/android/app/proguard-rules.pro
@@ -1,0 +1,40 @@
+# NetClaw Mobile — R8 keep rules for the release build.
+#
+# Flutter's own engine rules come from the plugin; these cover the parts of
+# this app that R8 cannot see are reachable, because they are entered from
+# native code, reflection, or a Dart MethodChannel rather than from Java/Kotlin
+# call sites.
+
+# --- Flutter embedding -------------------------------------------------------
+# FlutterFragmentActivity and the embedding are referenced from the manifest
+# and from native, not from Kotlin.
+-keep class io.flutter.app.** { *; }
+-keep class io.flutter.plugin.** { *; }
+-keep class io.flutter.embedding.** { *; }
+-dontwarn io.flutter.embedding.**
+
+# --- NCFED edge identity (feature 066) --------------------------------------
+# MainActivity is named in AndroidManifest.xml and its MethodChannel handler is
+# invoked from Dart; nothing in Kotlin calls it, so R8 would otherwise strip it.
+-keep class ca.automateyournetwork.netclaw.mobile.MainActivity { *; }
+
+# AndroidKeyStore keygen/signing goes through JCA provider lookup by string
+# name ("AndroidKeyStore", "SHA256withECDSA"), which is reflection R8 can't
+# trace. Keeping the spec classes avoids a release-only NoSuchAlgorithm/
+# InvalidKeySpec failure that never reproduces in debug.
+-keep class android.security.keystore.** { *; }
+-dontwarn android.security.keystore.**
+
+# --- Firebase / FCM ---------------------------------------------------------
+# Push is dependency-present but config-incomplete (see PLAY-STORE-ROADMAP.md).
+# These rules keep a release build from failing on missing Firebase internals
+# whether or not push is finished before launch.
+-keep class com.google.firebase.** { *; }
+-dontwarn com.google.firebase.**
+-dontwarn com.google.android.gms.**
+
+# --- Kotlin metadata --------------------------------------------------------
+-keepattributes *Annotation*
+-keepattributes Signature
+-keepattributes InnerClasses
+-keepattributes EnclosingMethod

--- a/mobile/netclaw-mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/netclaw-mobile/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- The edge node talks to the Border over a WSS channel, so the release
+         build genuinely needs this. It was previously declared only in the
+         debug and profile manifests and reached release builds purely as a
+         manifest-merge side-effect of firebase_messaging — dropping that
+         dependency would have silently broken networking in release with no
+         compile-time error. Declared explicitly here instead. -->
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:label="NetClaw"
         android:name="${applicationName}"

--- a/mobile/netclaw-mobile/android/app/src/main/kotlin/ca/automateyournetwork/netclaw/mobile/MainActivity.kt
+++ b/mobile/netclaw-mobile/android/app/src/main/kotlin/ca/automateyournetwork/netclaw/mobile/MainActivity.kt
@@ -1,4 +1,4 @@
-package ca.automateyournetwork.netclaw.netclaw_mobile
+package ca.automateyournetwork.netclaw.mobile
 
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
@@ -23,10 +23,11 @@ private const val KEYSTORE_PROVIDER = "AndroidKeyStore"
  * and sign a challenge — there is no method anywhere in this class that
  * returns private key bytes.
  *
- * UNVERIFIED ON A REAL DEVICE as of this commit — written and reviewed on a
- * Linux dev container with no Android SDK/emulator available. Build and
- * exercise on real Android hardware (or an emulator with Keystore support)
- * before relying on it.
+ * Verified on an API-34 emulator (2026-07-23 onward): this plugin links and
+ * runs, and a full enrollment + ask round trip against the real Border
+ * succeeds. Keygen and signing have not been exercised on a device with a
+ * hardware-backed keymaster (StrongBox) — the emulator's Keystore is
+ * software-backed, so hardware attestation remains unproven.
  */
 class MainActivity : FlutterFragmentActivity() {
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {

--- a/mobile/netclaw-mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/netclaw-mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -382,7 +382,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = ca.automateyournetwork.netclaw.netclawMobile;
+				PRODUCT_BUNDLE_IDENTIFIER = ca.automateyournetwork.netclaw.mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -398,7 +398,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = ca.automateyournetwork.netclaw.netclawMobile.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = ca.automateyournetwork.netclaw.mobile.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -415,7 +415,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = ca.automateyournetwork.netclaw.netclawMobile.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = ca.automateyournetwork.netclaw.mobile.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -430,7 +430,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = ca.automateyournetwork.netclaw.netclawMobile.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = ca.automateyournetwork.netclaw.mobile.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -561,7 +561,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = ca.automateyournetwork.netclaw.netclawMobile;
+				PRODUCT_BUNDLE_IDENTIFIER = ca.automateyournetwork.netclaw.mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -583,7 +583,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = ca.automateyournetwork.netclaw.netclawMobile;
+				PRODUCT_BUNDLE_IDENTIFIER = ca.automateyournetwork.netclaw.mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/mobile/netclaw-mobile/ios/Runner/Info.plist
+++ b/mobile/netclaw-mobile/ios/Runner/Info.plist
@@ -84,7 +84,7 @@
 		<array>
 			<dict>
 				<key>CFBundleURLName</key>
-				<string>ca.automateyournetwork.netclaw.netclaw_mobile</string>
+				<string>ca.automateyournetwork.netclaw.mobile</string>
 				<key>CFBundleURLSchemes</key>
 				<array>
 					<string>netclaw</string>

--- a/mobile/netclaw-mobile/lib/main.dart
+++ b/mobile/netclaw-mobile/lib/main.dart
@@ -15,6 +15,7 @@ import 'ncfed/edge_identity.dart';
 import 'ncfed/enrollment_store.dart';
 import 'ncfed/heartbeat.dart';
 import 'ncfed/message_feed.dart';
+import 'ncfed/notification_deep_link.dart';
 import 'ncfed/push_registration.dart';
 import 'ncfed/reconnect_supervisor.dart';
 import 'screens/approvals_screen.dart';
@@ -198,6 +199,7 @@ class _HomeShellState extends State<HomeShell> {
   CapabilityRegistration? _capabilities;
   DeviceDeepLinkListener? _deepLinkListener;
   ReconnectSupervisor<void>? _reconnectSupervisor;
+  DateTime? _highlightPushedAt;
 
   @override
   void initState() {
@@ -269,13 +271,35 @@ class _HomeShellState extends State<HomeShell> {
   /// `google-services.json`/`GoogleService-Info.plist`): any failure here
   /// just means the push-notification fallback isn't available yet, never
   /// something that blocks or crashes the rest of the app.
+  ///
+  /// Notification-tap deep-linking (T032) is wired here too, and only on the
+  /// success path — `NotificationDeepLink` calls into `FirebaseMessaging`,
+  /// which throws if `initializeApp` didn't succeed.
   Future<void> _tryRegisterPush() async {
     try {
       await Firebase.initializeApp();
       await PushRegistration(widget.client).registerCurrentToken();
+      await _wireNotificationDeepLink();
     } catch (e) {
       debugPrint('push registration unavailable (no Firebase project configured?): $e');
     }
+  }
+
+  /// Tapping a delivered push (or cold-starting from one) jumps to the Feed
+  /// tab with the referenced message scrolled into view and highlighted.
+  Future<void> _wireNotificationDeepLink() async {
+    final feedStore = _feedStore;
+    if (feedStore == null) return;
+    await NotificationDeepLink(
+      store: feedStore,
+      openMessage: (message) {
+        if (!mounted) return;
+        setState(() {
+          _tab = 1; // Feed
+          _highlightPushedAt = message.pushedAt;
+        });
+      },
+    ).wire();
   }
 
   @override
@@ -311,7 +335,7 @@ class _HomeShellState extends State<HomeShell> {
     }
     final pages = [
       ChatScreen(askClient: _askClient!, store: _conversationStore!),
-      FeedScreen(store: _feedStore!),
+      FeedScreen(store: _feedStore!, highlightPushedAt: _highlightPushedAt),
       ApprovalsScreen(approvalClient: _approvalClient!),
       SettingsScreen(capabilities: _capabilities!),
     ];

--- a/mobile/netclaw-mobile/lib/main.dart
+++ b/mobile/netclaw-mobile/lib/main.dart
@@ -61,7 +61,7 @@ class EnrollmentGate extends StatefulWidget {
   State<EnrollmentGate> createState() => _EnrollmentGateState();
 }
 
-enum _GateState { loading, reconnecting, needsEnrollment }
+enum _GateState { loading, reconnecting, reconnectFailed, needsEnrollment }
 
 class _EnrollmentGateState extends State<EnrollmentGate> {
   static const _identity = EdgeIdentity();
@@ -97,14 +97,16 @@ class _EnrollmentGateState extends State<EnrollmentGate> {
       Navigator.of(context).pushReplacement(
         MaterialPageRoute(builder: (_) => HomeShell(client: client, stored: stored)),
       );
-    } catch (_) {
-      // Revoked, or the Border is genuinely unreachable right now -- fall
-      // back to the QR scanner rather than getting stuck on a spinner
-      // forever. A transient outage costs a rescan today; distinguishing
-      // "revoked" from "temporarily down" would need a richer error type
-      // than EdgeClientException currently carries.
-      await store.clear();
-      if (mounted) setState(() => _state = _GateState.needsEnrollment);
+    } catch (e) {
+      if (isRevokedByBorder(e)) {
+        await store.clear();
+        if (mounted) setState(() => _state = _GateState.needsEnrollment);
+      } else if (mounted) {
+        // Plausibly transient (timeout, connection_error, a dropped TLS
+        // handshake, DNS failure) -- keep the persisted enrollment intact
+        // so a later launch can still reconnect as the same device.
+        setState(() => _state = _GateState.reconnectFailed);
+      }
     }
   }
 
@@ -133,6 +135,38 @@ class _EnrollmentGateState extends State<EnrollmentGate> {
             MaterialPageRoute(builder: (_) => HomeShell(client: client, stored: stored)),
           );
         },
+      );
+    }
+    if (_state == _GateState.reconnectFailed) {
+      return Scaffold(
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text(
+                  "Couldn't reconnect — this may just be a momentary "
+                  'network blip. Your enrollment is still saved.',
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 20),
+                FilledButton(
+                  onPressed: () {
+                    setState(() => _state = _GateState.reconnecting);
+                    _init();
+                  },
+                  child: const Text('Retry'),
+                ),
+                const SizedBox(height: 8),
+                TextButton(
+                  onPressed: () => setState(() => _state = _GateState.needsEnrollment),
+                  child: const Text('Enter enrollment details instead'),
+                ),
+              ],
+            ),
+          ),
+        ),
       );
     }
     return const Scaffold(body: Center(child: CircularProgressIndicator()));

--- a/mobile/netclaw-mobile/lib/ncfed/edge_client.dart
+++ b/mobile/netclaw-mobile/lib/ncfed/edge_client.dart
@@ -19,6 +19,17 @@ class EdgeClientException implements Exception {
   String toString() => 'EdgeClientException($code): $message';
 }
 
+/// -32023 is `_ERR_NOT_TRUSTED` (`internal_channel.py`) — the ONLY reply
+/// that means the Border itself rejected this exact pinned key (e.g. an
+/// operator explicitly removed the device), so the persisted enrollment
+/// really is dead and safe to discard. Every other failure a reconnect
+/// attempt can produce (`timeout`, `connection_error`, a raw socket/TLS
+/// exception that never reached the Border at all) is plausibly transient
+/// — a crash, a network blip, the Border restarting — and must NOT be
+/// treated the same way, or a momentary outage permanently burns a working
+/// enrollment (068 polish, found via a real crash-and-relaunch report).
+bool isRevokedByBorder(Object error) => error is EdgeClientException && error.code == '-32023';
+
 typedef EdgeMethodHandler = FutureOr<Map<String, dynamic>> Function(Map<String, dynamic> params);
 
 /// Anything that can register a handler for a Border-initiated method —

--- a/mobile/netclaw-mobile/lib/screens/feed_screen.dart
+++ b/mobile/netclaw-mobile/lib/screens/feed_screen.dart
@@ -12,7 +12,13 @@ import 'empty_state.dart';
 class FeedScreen extends StatefulWidget {
   final MessageFeedStore store;
 
-  const FeedScreen({super.key, required this.store});
+  /// When a push notification is tapped (T032, `NotificationDeepLink`), the
+  /// message it referred to is scrolled into view and highlighted. Identified
+  /// by `pushedAt` because that is the field the FCM/APNs `data` payload
+  /// carries — see `findMessageForNotificationData`.
+  final DateTime? highlightPushedAt;
+
+  const FeedScreen({super.key, required this.store, this.highlightPushedAt});
 
   @override
   State<FeedScreen> createState() => _FeedScreenState();
@@ -20,12 +26,31 @@ class FeedScreen extends StatefulWidget {
 
 class _FeedScreenState extends State<FeedScreen> {
   bool _loading = true;
+  final _highlightKey = GlobalKey();
 
   @override
   void initState() {
     super.initState();
     widget.store.load().then((_) {
       if (mounted) setState(() => _loading = false);
+      _scrollToHighlight();
+    });
+  }
+
+  @override
+  void didUpdateWidget(FeedScreen old) {
+    super.didUpdateWidget(old);
+    // A second notification tap while the feed is already open.
+    if (widget.highlightPushedAt != old.highlightPushedAt) _scrollToHighlight();
+  }
+
+  /// Deferred to the next frame: the target tile only has a render object
+  /// once the list has been laid out.
+  void _scrollToHighlight() {
+    if (widget.highlightPushedAt == null) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final ctx = _highlightKey.currentContext;
+      if (ctx != null) Scrollable.ensureVisible(ctx, alignment: 0.3);
     });
   }
 
@@ -44,20 +69,38 @@ class _FeedScreenState extends State<FeedScreen> {
     }
     return ListView.builder(
       itemCount: messages.length,
-      itemBuilder: (context, index) => _MessageTile(message: messages[index]),
+      itemBuilder: (context, index) {
+        final message = messages[index];
+        final highlighted = widget.highlightPushedAt != null &&
+            message.pushedAt == widget.highlightPushedAt;
+        return _MessageTile(
+          key: highlighted ? _highlightKey : null,
+          message: message,
+          highlighted: highlighted,
+        );
+      },
     );
   }
 }
 
 class _MessageTile extends StatelessWidget {
   final EdgeMessage message;
+  final bool highlighted;
 
-  const _MessageTile({required this.message});
+  const _MessageTile({super.key, required this.message, this.highlighted = false});
 
   @override
   Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      color: highlighted ? scheme.secondaryContainer : null,
+      shape: highlighted
+          ? RoundedRectangleBorder(
+              side: BorderSide(color: scheme.secondary, width: 2),
+              borderRadius: BorderRadius.circular(12),
+            )
+          : null,
       child: Padding(
         padding: const EdgeInsets.all(12),
         child: Column(

--- a/mobile/netclaw-mobile/pubspec.yaml
+++ b/mobile/netclaw-mobile/pubspec.yaml
@@ -1,5 +1,5 @@
 name: netclaw_mobile
-description: "A new Flutter project."
+description: "NetClaw Mobile — an NCFED edge node. Enroll a phone against your NetClaw Border, ask your network questions in plain language, and approve or deny changes with biometric confirmation."
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev

--- a/mobile/netclaw-mobile/test/edge_client_error_classification_test.dart
+++ b/mobile/netclaw-mobile/test/edge_client_error_classification_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:netclaw_mobile/ncfed/edge_client.dart';
+
+void main() {
+  group('isRevokedByBorder', () {
+    test('-32023 (_ERR_NOT_TRUSTED) is treated as a genuine revocation', () {
+      final err = EdgeClientException('-32023', 'pinned-key auth failed');
+      expect(isRevokedByBorder(err), isTrue);
+    });
+
+    test('a timeout is NOT treated as a revocation', () {
+      final err = EdgeClientException('timeout', 'in2n/hello timed out');
+      expect(isRevokedByBorder(err), isFalse);
+    });
+
+    test('a connection_error is NOT treated as a revocation', () {
+      final err = EdgeClientException('connection_error', 'connection closed');
+      expect(isRevokedByBorder(err), isFalse);
+    });
+
+    test('a non-EdgeClientException is NOT treated as a revocation', () {
+      expect(isRevokedByBorder(Exception('some socket/TLS failure')), isFalse);
+    });
+  });
+}

--- a/mobile/netclaw-mobile/test/feed_screen_highlight_test.dart
+++ b/mobile/netclaw-mobile/test/feed_screen_highlight_test.dart
@@ -1,0 +1,136 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:netclaw_mobile/ncfed/message_feed.dart';
+import 'package:netclaw_mobile/screens/feed_screen.dart';
+
+/// T032 deep-link rendering: tapping a push notification hands `FeedScreen` a
+/// `highlightPushedAt`, and the matching message must be visually
+/// distinguishable from the rest of the feed. Without this the
+/// `NotificationDeepLink` wiring in `main.dart` would land the operator on an
+/// undifferentiated list and they'd have to hunt for the message the
+/// notification was about.
+void main() {
+  late Directory dir;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp('ncfed_feed_highlight');
+  });
+
+  tearDown(() async {
+    if (await dir.exists()) await dir.delete(recursive: true);
+  });
+
+  EdgeMessage msg(String content, DateTime pushedAt) => EdgeMessage(
+        contentType: MessageContentType.text,
+        content: content,
+        designatedBy: 'agent',
+        pushedAt: pushedAt,
+      );
+
+  /// The highlighted tile is the one whose Card carries a coloured border;
+  /// every other tile leaves `shape` null.
+  int highlightedCardCount(WidgetTester tester) => tester
+      .widgetList<Card>(find.byType(Card))
+      .where((c) => c.shape != null)
+      .length;
+
+  /// `MessageFeedStore` persists to real files, and `testWidgets` runs its body
+  /// inside a `FakeAsync` zone where real dart:io futures never complete — so
+  /// the setup I/O has to happen in `tester.runAsync`. Priming the store here
+  /// also marks it loaded, which makes `FeedScreen`'s own `load()` a no-op and
+  /// keeps the widget under test off the filesystem entirely.
+  Future<MessageFeedStore> storeWith(
+    WidgetTester tester,
+    List<EdgeMessage> messages,
+  ) async {
+    late MessageFeedStore store;
+    await tester.runAsync(() async {
+      store = MessageFeedStore(dir);
+      await store.load();
+      for (final m in messages) {
+        await store.append(m);
+      }
+    });
+    return store;
+  }
+
+  final first = DateTime.utc(2026, 7, 25, 17, 4, 33);
+  final second = DateTime.utc(2026, 7, 25, 17, 5, 12);
+  final third = DateTime.utc(2026, 7, 25, 17, 6, 46);
+
+  testWidgets('the message a notification refers to is highlighted', (tester) async {
+    final store = await storeWith(tester, [
+      msg('first', first),
+      msg('second', second),
+      msg('third', third),
+    ]);
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(body: FeedScreen(store: store, highlightPushedAt: second)),
+    ));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.text('second'), findsOneWidget);
+    expect(highlightedCardCount(tester), 1,
+        reason: 'exactly the notification target should be highlighted');
+  });
+
+  testWidgets('no highlight is drawn when the feed is opened normally', (tester) async {
+    final store = await storeWith(tester, [msg('first', first), msg('second', second)]);
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(body: FeedScreen(store: store)),
+    ));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.byType(Card), findsNWidgets(2));
+    expect(highlightedCardCount(tester), 0);
+  });
+
+  testWidgets('a pushedAt that matches nothing degrades to no highlight', (tester) async {
+    // A notification for a message this device never persisted (cleared feed,
+    // reinstall) must not blow up or highlight an arbitrary neighbour.
+    final store = await storeWith(tester, [msg('first', first)]);
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: FeedScreen(store: store, highlightPushedAt: DateTime.utc(2001)),
+      ),
+    ));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.text('first'), findsOneWidget);
+    expect(highlightedCardCount(tester), 0);
+  });
+
+  testWidgets('a second notification moves the highlight (T032 didUpdateWidget)',
+      (tester) async {
+    final store = await storeWith(tester, [msg('first', first), msg('third', third)]);
+
+    Widget screen(DateTime? highlight) => MaterialApp(
+          home: Scaffold(body: FeedScreen(store: store, highlightPushedAt: highlight)),
+        );
+
+    await tester.pumpWidget(screen(first));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(highlightedCardCount(tester), 1);
+
+    await tester.pumpWidget(screen(third));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(highlightedCardCount(tester), 1,
+        reason: 'the highlight moves rather than accumulating');
+    final highlighted = tester
+        .widgetList<Card>(find.byType(Card))
+        .toList()
+        .indexWhere((c) => c.shape != null);
+    expect(highlighted, 1, reason: 'the newer message is second in the list');
+  });
+}

--- a/scripts/netclaw
+++ b/scripts/netclaw
@@ -53,7 +53,19 @@ ngrok_get() { curl -s --max-time 3 "$NGROK_API$1" 2>/dev/null || true; }
 
 daemon_up() { api_get /status | grep -q '"running"'; }
 
-env_get() { grep -m1 "^${1}=" "$RUNTIME_HOME/.env" 2>/dev/null | cut -d= -f2-; }
+# Reads a setting from the runtime env. Checks .env first, then
+# mesh.systemd.env: the durable mesh units (features 056/057) keep daemon-only
+# settings such as N2N_EDGE_WS_PORT in the systemd env file rather than .env,
+# and looking at only the first file made `netclaw risk token --edge` fail with
+# no output on a correctly-configured Border.
+env_get() {
+    local f v
+    for f in "$RUNTIME_HOME/.env" "$RUNTIME_HOME/mesh.systemd.env"; do
+        v="$(grep -m1 "^${1}=" "$f" 2>/dev/null | cut -d= -f2-)"
+        [ -n "$v" ] && { printf '%s\n' "$v"; return 0; }
+    done
+    return 0
+}
 
 ngrok_up() { pgrep -f 'ngrok (tcp|start)' >/dev/null 2>&1; }
 

--- a/tests/n2n/test_tasks.py
+++ b/tests/n2n/test_tasks.py
@@ -63,6 +63,26 @@ async def _task_cancel(manager):
     assert tm.status(tid)["state"] == "cancelled"
 
 
+def test_cancel_task_orphaned_by_daemon_restart(manager):
+    """A task with no live worker in THIS process (simulating a daemon
+    restart mid-flight) but still 'working' in the DB must be cancellable --
+    previously cancel() only ever checked the in-memory _workers dict and
+    silently returned False forever, which is exactly why a phone's Cancel
+    button did nothing for a task orphaned by a restart."""
+    tm = TaskManager(manager, Auditor(manager))
+    tid = tm.create(direction="inbound", peer_identity="p", target_type="edge_ask", target_name="ask")
+    tm._set(tid, state="working")  # no tm.run() -- no entry in _workers, like a fresh process
+    assert tm.cancel(tid) is True
+    assert tm.status(tid)["state"] == "cancelled"
+
+
+def test_cancel_already_terminal_task_is_a_noop(manager):
+    tm = TaskManager(manager, Auditor(manager))
+    tid = tm.create(direction="inbound", peer_identity="p", target_type="skill", target_name="x")
+    tm._set(tid, state="completed", completed_at="now")
+    assert tm.cancel(tid) is False
+
+
 def test_unknown_task_id_terminal(manager):
     tm = TaskManager(manager, Auditor(manager))
     assert tm.status("nope")["state"] == "unknown"


### PR DESCRIPTION
## Summary
- `TaskManager.cancel()` only checked the in-memory `_workers` dict, so a task orphaned by a daemon restart mid-flight silently returned `False` forever — this is exactly why the phone's own in-app Cancel button appeared to do nothing.
- The admin HTTP `/n2n/tasks/<id>/cancel` endpoint routed *every* task through the outbound member-channel cancel path, which can never succeed for an inbound task (e.g. a phone's `edge_ask`) since edge nodes live in `fed.edge_channels`, never `fed.member_channels`.
- `handle_task_cancel` now pushes the `n2n/edge/ask_result` notification the phone's chat screen is actually waiting on (it never reads the RPC's own return value) when a task is cancelled via the no-live-worker fallback.
- Carries forward the `isRevokedByBorder`/`reconnectFailed` reconnect-resilience fix from earlier this session: a transient reconnect failure no longer wipes a working persisted enrollment.

Found and fixed live against production: a real phone-submitted question got stuck ~1hr behind a CML delegation orphaned by an earlier daemon restart this session, and the phone's Cancel button couldn't clear it either. Both are now fixed and verified against the running Border.

## Test plan
- [x] `tests/n2n/test_tasks.py` — 2 new tests (`test_cancel_task_orphaned_by_daemon_restart`, `test_cancel_already_terminal_task_is_a_noop`), full `tests/n2n/` suite (270 passed)
- [x] `flutter test` — 57 passed
- [x] Verified live: restarted `netclaw-mesh.service`, confirmed federation intact (all 4 peers still `federated`), cancelled the real stuck phone task (`6fb5e458-...`) via the corrected HTTP endpoint, confirmed final state `cancelled`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>