### PR TITLE
fix: mobile keepalive, chat scroll/state, clear actions, unread badge, DDNS

### DIFF
--- a/mcp-servers/protocol-mcp/bgp-daemon-v2.py
+++ b/mcp-servers/protocol-mcp/bgp-daemon-v2.py
@@ -43,6 +43,11 @@ BGP_PEERS   = json.loads(os.environ.get("NETCLAW_BGP_PEERS", "[]"))
 API_PORT    = int(os.environ.get("BGP_API_PORT", "8179"))
 BGP_LISTEN_PORT = int(os.environ.get("BGP_LISTEN_PORT", "1179"))
 MESH_OPEN   = os.environ.get("NETCLAW_MESH_OPEN", "true").lower() in ("true", "1", "yes")
+# feature 066 edge (phone) WebSocket keepalive — see _start_edge_ws_listener().
+# Overridable for operators whose carrier NAT is more aggressive than the
+# default 90s window.
+EDGE_WS_PING_INTERVAL = int(os.environ.get("N2N_EDGE_WS_PING_INTERVAL", "30"))
+EDGE_WS_PING_TIMEOUT  = int(os.environ.get("N2N_EDGE_WS_PING_TIMEOUT", "90"))
 MESH_ENDPOINT = os.environ.get("NETCLAW_MESH_ENDPOINT", "")
 LOCAL_IPV6  = os.environ.get("NETCLAW_LOCAL_IPV6", "")
 DRY_RUN     = os.environ.get("NETCLAW_DRY_RUN", "").lower() in ("true", "1", "yes")
@@ -856,7 +861,22 @@ async def _start_edge(fed):
             except Exception as e:
                 logger.warning("Edge WS accept failed: %s", e)
 
-        server = await websockets.serve(_on_ws, "0.0.0.0", port, ssl=ctx)
+        # Keepalive tuned for phones, not servers. The websockets defaults
+        # (ping_interval=20, ping_timeout=20) drop a peer that stays silent for
+        # ~20s — and Android suspends an app's Dart isolate the moment the
+        # screen locks, which stops the protocol-level pong. Observed with a
+        # real device: connections lived 25-32s while backgrounded (ping
+        # timeout + latency) vs 85-190s while actively used, reconnecting in a
+        # loop all day. A 90s timeout rides out brief suspensions.
+        #
+        # Liveness is NOT weakened by this: the Border tracks it separately via
+        # the application-level n2n/edge/heartbeat call, so a genuinely dead
+        # peer is still detected there rather than by the socket timeout.
+        server = await websockets.serve(
+            _on_ws, "0.0.0.0", port, ssl=ctx,
+            ping_interval=EDGE_WS_PING_INTERVAL,
+            ping_timeout=EDGE_WS_PING_TIMEOUT,
+        )
         fed._edge_server = server  # keep a ref
         logger.info("Edge (NetClaw Mobile) WS listener on 0.0.0.0:%d (risk=%s)",
                    port, fed.risk.get_risk().get("risk_name"))

--- a/mobile/netclaw-mobile/lib/main.dart
+++ b/mobile/netclaw-mobile/lib/main.dart
@@ -200,6 +200,7 @@ class _HomeShellState extends State<HomeShell> {
   DeviceDeepLinkListener? _deepLinkListener;
   ReconnectSupervisor<void>? _reconnectSupervisor;
   DateTime? _highlightPushedAt;
+  int _unreadFeed = 0;
 
   @override
   void initState() {
@@ -210,7 +211,16 @@ class _HomeShellState extends State<HomeShell> {
       final conversationStore = ConversationStore(dir);
       final approvalClient = ApprovalClient(widget.client);
       final capabilities = CapabilityRegistration(widget.client);
-      wireMessageFeed(widget.client, feedStore, onApproval: approvalClient.receiveApproval);
+      wireMessageFeed(
+        widget.client,
+        feedStore,
+        onApproval: approvalClient.receiveApproval,
+        onMessage: (_) {
+          if (!mounted) return;
+          // Don't badge the tab the operator is already looking at.
+          setState(() { if (_tab != 1) _unreadFeed++; });
+        },
+      );
       wireHeartbeat(widget.client);
       CaptureClient(
         askClient: askClient,
@@ -256,6 +266,11 @@ class _HomeShellState extends State<HomeShell> {
       onConnected: (_) {
         if (mounted) setState(() => _connected = true);
       },
+      // Revoked mid-session: the pinned identity is gone and no amount of
+      // retrying brings it back. Drop the persisted enrollment and return to
+      // the enrollment gate, matching what a cold start already does — rather
+      // than spinning on a dead identity forever.
+      onUnrecoverable: _handleRevoked,
       initiallyConnected: true,
     );
     widget.client.onDisconnected = () {
@@ -355,19 +370,130 @@ class _HomeShellState extends State<HomeShell> {
               ),
             ),
           IconButton(icon: const Icon(Icons.qr_code_scanner), onPressed: _scanDevice),
+          _buildOverflowMenu(),
         ],
       ),
-      body: pages[_tab],
+      // IndexedStack, not `pages[_tab]`. Indexing keeps only the selected page
+      // in the tree, so switching tabs DISPOSES the previous page's State —
+      // which reset the chat's scroll position (and re-ran its load + stale-turn
+      // reconciliation) every single time you came back to it. IndexedStack
+      // keeps all four mounted and just changes which is painted.
+      body: IndexedStack(index: _tab, children: pages),
       bottomNavigationBar: NavigationBar(
         selectedIndex: _tab,
-        onDestinationSelected: (i) => setState(() => _tab = i),
-        destinations: const [
-          NavigationDestination(icon: Icon(Icons.chat), label: 'Chat'),
-          NavigationDestination(icon: Icon(Icons.notifications), label: 'Feed'),
-          NavigationDestination(icon: Icon(Icons.verified_user), label: 'Approvals'),
-          NavigationDestination(icon: Icon(Icons.settings), label: 'Settings'),
+        onDestinationSelected: (i) => setState(() {
+          _tab = i;
+          // Opening the Feed is what marks it read; clear the badge and the
+          // one-shot notification highlight together.
+          if (i == 1) {
+            _unreadFeed = 0;
+            _highlightPushedAt = null;
+          }
+        }),
+        destinations: [
+          const NavigationDestination(icon: Icon(Icons.chat), label: 'Chat'),
+          NavigationDestination(
+            // Without this the operator has no way to know a Border push
+            // arrived — messages land silently in the Feed while they sit on
+            // Chat. Observed with a real tester: a push delivered successfully
+            // and went unnoticed entirely.
+            icon: Badge(
+              isLabelVisible: _unreadFeed > 0,
+              label: Text('$_unreadFeed'),
+              child: const Icon(Icons.notifications),
+            ),
+            label: 'Feed',
+          ),
+          const NavigationDestination(icon: Icon(Icons.verified_user), label: 'Approvals'),
+          const NavigationDestination(icon: Icon(Icons.settings), label: 'Settings'),
         ],
       ),
     );
+  }
+
+  /// The Border revoked this device while it was running. Clear the persisted
+  /// enrollment and send the operator back to the enrollment gate with an
+  /// explanation, so the state on screen matches reality.
+  Future<void> _handleRevoked() async {
+    final dir = await getApplicationDocumentsDirectory();
+    await EnrollmentStore(dir).clear();
+    if (!mounted) return;
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (_) => const EnrollmentGate()),
+    );
+    ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+      content: Text('This device was removed by your Border. Enroll again to reconnect.'),
+      duration: Duration(seconds: 6),
+    ));
+  }
+
+  /// Per-tab destructive actions, behind a confirmation. Both clears are
+  /// on-device only — the Border keeps its own GAIT audit trail either way.
+  Widget _buildOverflowMenu() {
+    return PopupMenuButton<String>(
+      onSelected: (v) {
+        if (v == 'clear_chat') _confirmClearChat();
+        if (v == 'clear_feed') _confirmClearFeed();
+      },
+      itemBuilder: (context) => [
+        if (_tab == 0)
+          const PopupMenuItem(value: 'clear_chat', child: Text('Clear chat history')),
+        if (_tab == 1)
+          const PopupMenuItem(value: 'clear_feed', child: Text('Clear all messages')),
+      ],
+    );
+  }
+
+  Future<bool> _confirm(String title, String body, String action) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(title),
+        content: Text(body),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
+          TextButton(onPressed: () => Navigator.pop(ctx, true), child: Text(action)),
+        ],
+      ),
+    );
+    return ok ?? false;
+  }
+
+  Future<void> _confirmClearChat() async {
+    final store = _conversationStore;
+    if (store == null) return;
+    // Warn specifically when something is still running — the Border keeps
+    // working on it, but a cleared turn has nothing left to reconcile into, so
+    // that answer will never appear on this device.
+    final extra = store.hasInProgressTurns
+        ? '\n\nA request is still in progress. The Border will finish it, but '
+            'the answer will no longer appear here.'
+        : '';
+    if (!await _confirm('Clear chat history?',
+        'Deletes this conversation from this phone. Your Border keeps its own '
+        'audit record.$extra',
+        'Clear')) {
+      return;
+    }
+    await store.clear();
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _confirmClearFeed() async {
+    final store = _feedStore;
+    if (store == null) return;
+    if (!await _confirm('Clear all messages?',
+        'Deletes every message your Border has pushed to this phone. They '
+        'cannot be retrieved again from here.',
+        'Clear')) {
+      return;
+    }
+    await store.clear();
+    if (mounted) {
+      setState(() {
+        _unreadFeed = 0;
+        _highlightPushedAt = null;
+      });
+    }
   }
 }

--- a/mobile/netclaw-mobile/lib/ncfed/conversation_store.dart
+++ b/mobile/netclaw-mobile/lib/ncfed/conversation_store.dart
@@ -69,6 +69,26 @@ class ConversationStore {
     await _file().writeAsString(jsonEncode(_turns.map((t) => t.toJson()).toList()));
   }
 
+  /// Deletes the local conversation history. On-device only — the Border keeps
+  /// its own audit trail (GAIT) and this does not and must not touch it, so
+  /// clearing here is a display convenience, never an audit-evasion path.
+  ///
+  /// In-progress turns go too. That's deliberate: the Border keeps working and
+  /// `_reconcileStaleTurns()` no longer has a local row to reconcile against,
+  /// so a cleared in-flight answer simply never appears. Callers should warn
+  /// when anything is still running — see the confirmation in `main.dart`.
+  Future<void> clear() async {
+    await load();
+    _turns.clear();
+    final file = _file();
+    if (await file.exists()) await file.delete();
+  }
+
+  /// True when at least one turn is still awaiting an answer — lets the UI warn
+  /// before [clear] discards it.
+  bool get hasInProgressTurns =>
+      _turns.any((t) => t.state == 'pending' || t.state == 'working');
+
   Future<void> addPending(String taskId, String requestText) async {
     await load();
     _turns.add(ConversationTurn(

--- a/mobile/netclaw-mobile/lib/ncfed/message_feed.dart
+++ b/mobile/netclaw-mobile/lib/ncfed/message_feed.dart
@@ -82,6 +82,17 @@ class MessageFeedStore {
       flush: true,
     );
   }
+
+  /// Deletes every Border-pushed message held on this device. On-device only —
+  /// the Border's own audit trail is untouched, and a message cleared here
+  /// cannot be re-fetched (the Border never re-pushes spontaneously), so this
+  /// is destructive from the phone's point of view and should be confirmed.
+  Future<void> clear() async {
+    await load();
+    _messages.clear();
+    final file = _file();
+    if (await file.exists()) await file.delete();
+  }
 }
 
 /// Registers the SINGLE `n2n/edge/message` handler for the whole app —
@@ -91,17 +102,25 @@ class MessageFeedStore {
 /// text/voice/image is appended to `store` (066, contracts/
 /// edge-enrollment-and-push.md §3); a push with `content_type='approval'`
 /// (068, research D5) is instead handed to `onApproval` — never both.
+/// [onMessage] fires after a non-approval push has been persisted, so the UI
+/// can surface that something arrived (unread badge, repaint). Without it a
+/// push lands silently in the feed and the operator has no way to know —
+/// observed with a real tester, where a successfully delivered push went
+/// completely unnoticed because they were sitting on the Chat tab.
 void wireMessageFeed(
   EdgeMethodSource client,
   MessageFeedStore store, {
   void Function(Map<String, dynamic> params)? onApproval,
+  void Function(EdgeMessage message)? onMessage,
 }) {
   client.on('n2n/edge/message', (params) async {
     if (params['content_type'] == 'approval') {
       onApproval?.call(params);
       return {'received': true};
     }
-    await store.append(EdgeMessage.fromWire(params));
+    final message = EdgeMessage.fromWire(params);
+    await store.append(message);
+    onMessage?.call(message);
     return {'received': true};
   });
 }

--- a/mobile/netclaw-mobile/lib/ncfed/reconnect_supervisor.dart
+++ b/mobile/netclaw-mobile/lib/ncfed/reconnect_supervisor.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'edge_client.dart' show isRevokedByBorder;
+
 /// Ports `_in2n_member_dialer`'s exact backoff bounds (`bgp-daemon-v2.py`,
 /// research D4) to Dart: there is no missing Python reconnect capability to
 /// build here, only a port, since Dart and Python code cannot literally be
@@ -29,9 +31,17 @@ class ReconnectSupervisor<T> {
   bool _stopped = false;
   bool _connected;
 
+  /// Called instead of retrying when a dial fails in a way that retrying can
+  /// never fix — currently only a Border revocation (`-32023`). Without this
+  /// the loop treated revocation as a transient error and re-dialled a dead
+  /// enrollment forever, at a 60s ceiling, with the operator seeing nothing but
+  /// a permanent spinner.
+  final void Function()? onUnrecoverable;
+
   ReconnectSupervisor({
     required this.dial,
     required this.onConnected,
+    this.onUnrecoverable,
     Future<void> Function(Duration duration)? sleep,
     bool initiallyConnected = false,
   })  : _sleep = sleep ?? Future.delayed,
@@ -52,7 +62,14 @@ class ReconnectSupervisor<T> {
           _connected = true;
           _backoff = initialBackoff; // reset on success (T034)
           onConnected(client);
-        } catch (_) {
+        } catch (e) {
+          if (isRevokedByBorder(e)) {
+            // Terminal: this identity is gone. Stop the loop and hand control
+            // back so the app can return to enrollment.
+            _stopped = true;
+            onUnrecoverable?.call();
+            return;
+          }
           final doubled = _backoff * 2;
           _backoff = doubled > maxBackoff ? maxBackoff : doubled;
         }

--- a/mobile/netclaw-mobile/lib/screens/chat_screen.dart
+++ b/mobile/netclaw-mobile/lib/screens/chat_screen.dart
@@ -27,6 +27,7 @@ class ChatScreen extends StatefulWidget {
 
 class _ChatScreenState extends State<ChatScreen> {
   final _controller = TextEditingController();
+  final _scroll = ScrollController();
   bool _loading = true;
 
   @override
@@ -34,11 +35,47 @@ class _ChatScreenState extends State<ChatScreen> {
     super.initState();
     widget.store.load().then((_) async {
       if (mounted) setState(() => _loading = false);
+      _jumpToNewest();
       await _reconcileStaleTurns();
     });
     widget.askClient.updates.listen((update) async {
       await _applyUpdate(update);
     });
+  }
+
+  @override
+  void dispose() {
+    _scroll.dispose();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  /// Turns are rendered oldest-first, so offset 0 is the OLDEST message —
+  /// opening the chat there means scrolling all the way down to find what you
+  /// were just reading. A chat should open on the newest message, so jump to
+  /// the bottom once the list has been laid out.
+  ///
+  /// Deferred to the next frame because `maxScrollExtent` is meaningless until
+  /// the ListView has measured its children.
+  void _jumpToNewest({bool animate = false}) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_scroll.hasClients) return;
+      final target = _scroll.position.maxScrollExtent;
+      if (animate) {
+        _scroll.animateTo(target,
+            duration: const Duration(milliseconds: 250), curve: Curves.easeOut);
+      } else {
+        _scroll.jumpTo(target);
+      }
+    });
+  }
+
+  /// Only follow the newest message when the operator is already at (or near)
+  /// the bottom. Yanking the view down while they're reading back through
+  /// history is worse than not following at all.
+  bool get _isNearBottom {
+    if (!_scroll.hasClients) return true;
+    return _scroll.position.maxScrollExtent - _scroll.position.pixels < 120;
   }
 
   Future<void> _applyUpdate(TaskUpdate update) async {
@@ -49,8 +86,10 @@ class _ChatScreenState extends State<ChatScreen> {
       TaskState.working => 'working',
       _ => 'pending',
     };
+    final follow = _isNearBottom;
     await widget.store.updateState(update.taskId, stateName, answerText: update.outputText);
     if (mounted) setState(() {});
+    if (follow) _jumpToNewest(animate: true);
   }
 
   /// A task that finishes while this device is disconnected (or whose
@@ -85,6 +124,7 @@ class _ChatScreenState extends State<ChatScreen> {
     final taskId = await widget.askClient.ask(text);
     await widget.store.addPending(taskId, text);
     setState(() {});
+    _jumpToNewest(animate: true);
   }
 
   Future<void> _recordVoice() async {
@@ -93,6 +133,7 @@ class _ChatScreenState extends State<ChatScreen> {
     final (taskId, text) = result;
     await widget.store.addPending(taskId, text);
     if (mounted) setState(() {});
+    _jumpToNewest(animate: true);
   }
 
   Future<void> _capturePhoto() async {
@@ -107,6 +148,7 @@ class _ChatScreenState extends State<ChatScreen> {
     if (taskId == null) return;
     await widget.store.addPending(taskId, '[Photo]');
     if (mounted) setState(() {});
+    _jumpToNewest(animate: true);
   }
 
   Future<void> _cancel(String taskId) async {
@@ -129,6 +171,7 @@ class _ChatScreenState extends State<ChatScreen> {
           child: turns.isEmpty
               ? const Center(child: Text('Ask your Border something.'))
               : ListView.builder(
+                  controller: _scroll,
                   itemCount: turns.length,
                   itemBuilder: (context, index) => _TurnTile(
                     turn: turns[index],

--- a/mobile/netclaw-mobile/test/clear_and_revocation_test.dart
+++ b/mobile/netclaw-mobile/test/clear_and_revocation_test.dart
@@ -1,0 +1,140 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:netclaw_mobile/ncfed/conversation_store.dart';
+import 'package:netclaw_mobile/ncfed/edge_client.dart';
+import 'package:netclaw_mobile/ncfed/message_feed.dart';
+import 'package:netclaw_mobile/ncfed/reconnect_supervisor.dart';
+
+void main() {
+  late Directory dir;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp('ncfed_clear');
+  });
+
+  tearDown(() async {
+    if (await dir.exists()) await dir.delete(recursive: true);
+  });
+
+  group('ConversationStore.clear', () {
+    test('removes every turn and the backing file', () async {
+      final store = ConversationStore(dir);
+      await store.addPending('t1', 'first');
+      await store.addPending('t2', 'second');
+      expect(store.turns, hasLength(2));
+
+      await store.clear();
+
+      expect(store.turns, isEmpty);
+      expect(File('${dir.path}/ncfed_conversation.json').existsSync(), isFalse);
+    });
+
+    test('a cleared store stays empty across a simulated restart', () async {
+      final store = ConversationStore(dir);
+      await store.addPending('t1', 'first');
+      await store.clear();
+
+      // Fresh instance = cold start reading the same directory.
+      final reopened = ConversationStore(dir);
+      await reopened.load();
+      expect(reopened.turns, isEmpty);
+    });
+
+    test('clearing an already-empty store is a no-op, not an error', () async {
+      final store = ConversationStore(dir);
+      await store.clear();
+      await store.clear();
+      expect(store.turns, isEmpty);
+    });
+
+    test('hasInProgressTurns drives the extra warning in the confirm dialog', () async {
+      final store = ConversationStore(dir);
+      expect(store.hasInProgressTurns, isFalse, reason: 'empty store has nothing running');
+
+      await store.addPending('t1', 'ask');
+      expect(store.hasInProgressTurns, isTrue, reason: 'a pending turn is in progress');
+
+      await store.updateState('t1', 'completed', answerText: 'done');
+      expect(store.hasInProgressTurns, isFalse, reason: 'terminal turns are not in progress');
+    });
+  });
+
+  group('MessageFeedStore.clear', () {
+    EdgeMessage msg(String content) => EdgeMessage(
+          contentType: MessageContentType.text,
+          content: content,
+          designatedBy: 'agent',
+          pushedAt: DateTime.now().toUtc(),
+        );
+
+    test('removes every message and the backing file', () async {
+      final store = MessageFeedStore(dir);
+      await store.append(msg('one'));
+      await store.append(msg('two'));
+      expect(store.messages, hasLength(2));
+
+      await store.clear();
+
+      expect(store.messages, isEmpty);
+      expect(File('${dir.path}/ncfed_message_feed.jsonl').existsSync(), isFalse);
+    });
+
+    test('append still works after a clear (file is recreated)', () async {
+      final store = MessageFeedStore(dir);
+      await store.append(msg('one'));
+      await store.clear();
+      await store.append(msg('after'));
+
+      expect(store.messages.map((m) => m.content), ['after']);
+      final reopened = MessageFeedStore(dir);
+      await reopened.load();
+      expect(reopened.messages.map((m) => m.content), ['after'],
+          reason: 'the post-clear append must survive a restart');
+    });
+  });
+
+  group('ReconnectSupervisor revocation', () {
+    test('stops the loop and reports unrecoverable when the Border revokes', () async {
+      var dials = 0;
+      var unrecoverable = 0;
+      final supervisor = ReconnectSupervisor<void>(
+        dial: () async {
+          dials++;
+          throw EdgeClientException('-32023', 'not trusted');
+        },
+        onConnected: (_) {},
+        onUnrecoverable: () => unrecoverable++,
+        sleep: (_) async {},
+      );
+
+      await supervisor.run().timeout(const Duration(seconds: 5));
+
+      expect(dials, 1, reason: 'a revoked identity must not be retried at all');
+      expect(unrecoverable, 1);
+    });
+
+    test('a transient failure still retries and backs off', () async {
+      var dials = 0;
+      var unrecoverable = 0;
+      late ReconnectSupervisor<void> supervisor;
+      supervisor = ReconnectSupervisor<void>(
+        dial: () async {
+          dials++;
+          if (dials < 3) throw Exception('connection_error');
+          return;
+        },
+        onConnected: (_) => supervisor.stop(),
+        onUnrecoverable: () => unrecoverable++,
+        sleep: (_) async {},
+      );
+
+      await supervisor.run().timeout(const Duration(seconds: 5));
+
+      expect(dials, 3, reason: 'transient errors retry until success');
+      expect(unrecoverable, 0, reason: 'a timeout is not a revocation');
+      expect(supervisor.currentBackoff, ReconnectSupervisor.initialBackoff,
+          reason: 'backoff resets once connected');
+    });
+  });
+}

--- a/scripts/godaddy-ddns.sh
+++ b/scripts/godaddy-ddns.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Keeps a GoDaddy A record pointing at this host's current public IP.
+#
+# Why this exists: the NCFED edge (phone) listener is reached by domain name,
+# and enrolled phones store that name — so on a residential connection, an ISP
+# IP rotation silently breaks every enrolled device. The failure surfaces on the
+# phone as "Failed host lookup"/timeout with nothing wrong on the Border, which
+# is genuinely hard to diagnose from the app side.
+#
+# Only rewrites the record when the IP actually differs, so the normal case
+# costs one HTTPS GET and touches nothing.
+#
+#   GODADDY_PAT   required   gd_pat_… token (Bearer auth, same one the ACME
+#                            DNS-01 hook uses — see scripts/lib/godaddy-acme-hook.sh)
+#   DDNS_DOMAIN   required   registered domain, e.g. example.com
+#   DDNS_NAME     required   record name, e.g. netclaw  ("@" for the apex)
+#   DDNS_TTL      optional   default 600
+#
+# Exit 0 = record correct (changed or already fine). Exit non-zero = could not
+# determine the IP or the API rejected the update.
+set -uo pipefail
+
+API="https://api.godaddy.com/v1"
+TTL="${DDNS_TTL:-600}"
+: "${GODADDY_PAT:?set GODADDY_PAT}"
+: "${DDNS_DOMAIN:?set DDNS_DOMAIN}"
+: "${DDNS_NAME:?set DDNS_NAME}"
+
+log() { printf '%s ddns: %s\n' "$(date -Is)" "$*"; }
+
+# Several providers, because a single one being down or rate-limiting shouldn't
+# look like an IP change. Anything that isn't a plausible IPv4 is discarded.
+current_ip() {
+    local ip
+    for url in https://api.ipify.org https://ifconfig.me/ip https://icanhazip.com; do
+        ip="$(curl -fsS --max-time 10 "$url" 2>/dev/null | tr -d '[:space:]')"
+        if [[ "$ip" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+            printf '%s' "$ip"; return 0
+        fi
+    done
+    return 1
+}
+
+published_ip() {
+    curl -fsS --max-time 15 \
+        -H "Authorization: Bearer ${GODADDY_PAT}" -H "Accept: application/json" \
+        "$API/domains/${DDNS_DOMAIN}/records/A/${DDNS_NAME}" 2>/dev/null \
+      | python3 -c 'import json,sys
+try:
+    r=json.load(sys.stdin)
+    print(r[0]["data"] if isinstance(r,list) and r else "")
+except Exception:
+    print("")'
+}
+
+wanted="$(current_ip)" || { log "ERROR could not determine public IP from any provider"; exit 1; }
+have="$(published_ip)"
+
+if [ "$wanted" = "$have" ]; then
+    log "ok ${DDNS_NAME}.${DDNS_DOMAIN} already = ${wanted}"
+    exit 0
+fi
+
+log "updating ${DDNS_NAME}.${DDNS_DOMAIN}: '${have:-<unset>}' -> ${wanted}"
+code="$(curl -fsS --max-time 20 -o /dev/null -w '%{http_code}' \
+    -H "Authorization: Bearer ${GODADDY_PAT}" -H "Content-Type: application/json" \
+    -X PUT "$API/domains/${DDNS_DOMAIN}/records/A/${DDNS_NAME}" \
+    -d "[{\"data\":\"${wanted}\",\"ttl\":${TTL}}]" 2>/dev/null)" || code="000"
+
+case "$code" in
+    2*) log "updated ${DDNS_NAME}.${DDNS_DOMAIN} -> ${wanted} (ttl ${TTL})" ;;
+    *)  log "ERROR GoDaddy PUT returned HTTP ${code}"; exit 1 ;;
+esac


### PR DESCRIPTION
Six fixes, every one from a problem observed on a real device with a real tester.

**No conflict with concurrent iOS work** — nothing here touches `ios/`, `pubspec.yaml`, `README.md`, or `specs/`.

| # | Problem | Fix |
|---|---|---|
| 1 | Phone reconnected in a loop all day | Edge WS `ping_timeout` 20s → 90s |
| 2 | Leaving a tab and returning reset it | `pages[_tab]` → `IndexedStack` |
| 3 | Chat opened on the oldest message | `ScrollController` pinned to newest |
| 4 | No way to clear chats or messages | `clear()` on both stores + confirmed menu actions |
| 5 | Border pushes arrived invisibly | Unread badge on the Feed tab |
| 6 | Revoked device retried forever | `-32023` treated as terminal → back to enrollment |

### 1. Keepalive — the big one
`websockets` defaults to `ping_interval=20`/`ping_timeout=20`. Android suspends the Dart isolate when the screen locks, killing the protocol-level pong, so the server culled the phone seconds after screen-off. Measured on a real device: **25–32s sessions backgrounded vs 85–190s in active use**, reconnecting continuously.

Verified a socket now holds **41s of app-level silence** where the old default dropped at ~20s. Liveness detection is unaffected — the Border tracks it via the application-level `n2n/edge/heartbeat`, not the socket timeout.

### 5. The invisible push
A tester received a push that the Border logged as `pushed/success` and never saw it — it landed in Feed while he sat on Chat, with no indicator anywhere. `wireMessageFeed()` gained an `onMessage` hook that badges the tab.

### 4. Clear actions
Both clears are **on-device only** — the Border's GAIT audit trail is untouched, so this is a display convenience, never an audit-evasion path. Clearing chat warns specifically when a turn is still in flight: the Border keeps working, but the answer will have no local row to land in.

### Also: DDNS
`scripts/godaddy-ddns.sh` + a systemd timer (installed under `~/.config/systemd/user`, not in-repo). Re-PUTs the A record only when the public IP actually changes. On residential service an ISP rotation silently breaks every enrolled phone, and the on-device symptom (`Failed host lookup`) looks nothing like DNS from the app side.

Verified: 69 Dart tests, 272 Python tests, `flutter analyze` clean, daemon restarted and keepalive confirmed against the live public endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)