### PR TITLE
fix(faults): health_report() reported connected phones as down

### DIFF
--- a/mcp-servers/protocol-mcp/bgp/federation/service.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/service.py
@@ -800,7 +800,14 @@ class FederationService:
         member_fault = backend_fault = False
         for m in self.risk.list_members():
             mid = m["member_id"]
-            live = mid in self.member_channels
+            # An edge (phone) member's live connection lives in edge_channels,
+            # never member_channels (agent members only) -- checking only the
+            # latter reported every connected phone as down, and since its DB
+            # row is `active` that also tripped member_fault, mislabelling the
+            # WHOLE risk fault_class="member" when nothing was wrong. Same bug
+            # class fixed in ec7acdd for GET /n2n/members and
+            # /n2n/members/health; this third call site was missed.
+            live = mid in self.member_channels or mid in self.edge_channels
             will_cold = (not live) and bool(m.get("launch_cmd")) and (
                 bool(m.get("on_demand")) or self.risk.managed_by(mid) == "service")
             members[mid] = {"state": "up" if live else "down", "will_cold_start": will_cold}

--- a/tests/n2n/test_faults_edge_liveness.py
+++ b/tests/n2n/test_faults_edge_liveness.py
@@ -1,0 +1,104 @@
+"""Regression: `health_report()` (the /n2n/faults source) computed member
+liveness only from `fed.member_channels`, the agent-member registry. An edge
+(phone) member's channel lives in `fed.edge_channels` instead, so a connected
+phone was reported `state: down` — and because the DB row is `active` while
+`live` was False, it also tripped `member_fault`, making the WHOLE risk report
+`fault_class: "member"` when nothing was wrong.
+
+This is the same bug class already fixed in commit ec7acdd for GET /n2n/members
+and GET /n2n/members/health (see test_members_endpoint_edge_liveness.py); the
+third call site, health_report(), was missed. Observed live on the production
+Border 2026-07-25: member_health reported the node active/live with a
+heartbeat seconds old while n2n_faults simultaneously reported it down.
+"""
+
+import asyncio
+import os
+import sys
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+PROTO = os.path.join(REPO, "mcp-servers", "protocol-mcp")
+
+
+def _service(tmp_path):
+    sys.path.insert(0, PROTO)
+    from bgp.federation.service import FederationService
+    from bgp.federation.manager import FederationManager
+    svc = FederationService(local_as=65001, router_id="4.4.4.4",
+                            manager=FederationManager(base_dir=str(tmp_path)))
+    svc.risk.set_role("border", risk_name="risk", enabled_stacks="in2n")
+    # health_report() gates daemon_up on the iN2N listener being bound.
+    svc._in2n_server = object()
+    return svc
+
+
+def _activate(svc, member_id):
+    """Drive the real lifecycle to STATE_ACTIVE: enrollment pins the key
+    (state=enrolled), then authentication marks it active -- which is the
+    state a live production phone actually sits in."""
+    fp = svc.risk.get_member(member_id)["key_fingerprint"]
+    assert svc.risk.verify_member(member_id, fp)
+    assert svc.risk.get_member(member_id)["state"] == "active"
+
+
+def _enroll_edge(svc, member_id="risk/phone1"):
+    from bgp.federation import certs
+    cert_pem, _ = certs.create_self_signed(member_id)
+    token = svc.risk.issue_token(label="phone1")["token"]
+    svc.risk.consume_token(token, member_id, cert_pem, scope=[],
+                           transport_binding="edge-ws", node_type="edge")
+    _activate(svc, member_id)
+    return member_id
+
+
+def test_connected_edge_node_is_not_a_member_fault(tmp_path):
+    asyncio.run(_connected_edge_node_is_not_a_member_fault(tmp_path))
+
+
+async def _connected_edge_node_is_not_a_member_fault(tmp_path):
+    svc = _service(tmp_path)
+    member_id = _enroll_edge(svc)
+
+    # Disconnected edge node: down, and a genuine member fault (DB says
+    # active, no channel) -- this half already behaved correctly.
+    rep = svc.health_report()
+    assert rep["members"][member_id]["state"] == "down"
+    assert rep["fault_class"] == "member"
+
+    # Now the phone is connected. Its channel lives in edge_channels --
+    # never member_channels. This is the exact distinction the bug missed.
+    svc.edge_channels[member_id] = object()
+
+    rep = svc.health_report()
+    assert rep["members"][member_id]["state"] == "up", (
+        "connected edge node reported down -- health_report() is reading only "
+        "member_channels and ignoring edge_channels")
+    assert rep["fault_class"] == "none", (
+        "a healthy connected phone tripped fault_class=%r for the whole risk"
+        % rep["fault_class"])
+
+
+def test_agent_member_liveness_unchanged(tmp_path):
+    asyncio.run(_agent_member_liveness_unchanged(tmp_path))
+
+
+async def _agent_member_liveness_unchanged(tmp_path):
+    """Guard the fix against over-reach: an agent member must still be judged
+    by member_channels alone, so a real agent-member outage is still reported."""
+    svc = _service(tmp_path)
+    from bgp.federation import certs
+    member_id = "risk/cml"
+    cert_pem, _ = certs.create_self_signed(member_id)
+    token = svc.risk.issue_token(label="cml")["token"]
+    svc.risk.consume_token(token, member_id, cert_pem, scope=[],
+                           transport_binding="distributed")
+    _activate(svc, member_id)
+
+    rep = svc.health_report()
+    assert rep["members"][member_id]["state"] == "down"
+    assert rep["fault_class"] == "member"
+
+    svc.member_channels[member_id] = object()
+    rep = svc.health_report()
+    assert rep["members"][member_id]["state"] == "up"
+    assert rep["fault_class"] == "none"


### PR DESCRIPTION
`health_report()` (the source for `GET /n2n/faults`) computed member liveness from `self.member_channels` only. An edge (phone) member's channel lives in `self.edge_channels`, so a **connected phone read as `state: "down"`** — and because its DB row is `active` while `live` was False, that also tripped `member_fault`, mislabelling the **whole risk** as `fault_class: "member"` when nothing was wrong.

Third call site of a bug already fixed twice in `ec7acdd` (`GET /n2n/members`, `GET /n2n/members/health`); this one was missed.

Observed live on the production Border 2026-07-25: `member_health` reported a node active with a heartbeat seconds old while `n2n_faults` simultaneously reported it down.

This was already sitting uncommitted in the shared checkout from an earlier session — shipping it on its own rather than folding it into an unrelated PR. 2 regression tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)