### PR TITLE
fix(mobile): microphone unusable on Android 11+, add retry on failed turns

### DIFF
--- a/mobile/netclaw-mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/netclaw-mobile/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,12 @@
          dependency would have silently broken networking in release with no
          compile-time error. Declared explicitly here instead. -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <!-- Voice requests (feature 067, US4). speech_to_text declares nothing
+         itself; until now RECORD_AUDIO reached the merged manifest only as a
+         side-effect of camera_android_camerax, so dropping the camera
+         dependency would have silently broken the microphone. Same accidental
+         -dependency class as INTERNET above — declared explicitly. -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <application
         android:label="NetClaw"
         android:name="${applicationName}"
@@ -54,6 +60,16 @@
         <intent>
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
+        </intent>
+        <!-- REQUIRED for speech_to_text (voice requests, feature 067 US4).
+             speech_to_text 7.4.0 ships a deliberately EMPTY AndroidManifest and
+             its README requires the host app to declare this itself. Without it,
+             Android 11+ (API 30) package-visibility rules hide every
+             RecognitionService from us, so SpeechToText.initialize() returns
+             false and the mic button did nothing at all — no prompt, no error.
+             Reported by a real tester as "microphone option isn't working". -->
+        <intent>
+            <action android:name="android.speech.RecognitionService"/>
         </intent>
     </queries>
 </manifest>

--- a/mobile/netclaw-mobile/lib/ncfed/voice_transcription.dart
+++ b/mobile/netclaw-mobile/lib/ncfed/voice_transcription.dart
@@ -1,8 +1,45 @@
 import 'dart:async';
 
+import 'package:speech_to_text/speech_recognition_error.dart';
 import 'package:speech_to_text/speech_to_text.dart' as stt;
 
 import 'edge_ask_client.dart';
+
+/// Why a voice request produced nothing. Previously every failure — permission
+/// denied, no recognition engine, engine error, silence — collapsed into a bare
+/// `null`, so the mic button did nothing at all with no explanation. A real
+/// tester reported it simply as "microphone option isn't working", which is the
+/// only thing the UI could possibly have conveyed.
+enum VoiceFailure {
+  /// The plugin could not initialise. Overwhelmingly this is a missing
+  /// `android.speech.RecognitionService` query in the manifest (Android 11+
+  /// package visibility) or no speech engine installed on the device.
+  unavailable,
+
+  /// The operator declined the microphone permission, or it isn't granted.
+  permissionDenied,
+
+  /// Initialised and listened, but nothing intelligible was heard.
+  noSpeechDetected,
+
+  /// The recognition engine reported an error mid-session.
+  engineError,
+}
+
+/// Outcome of one voice capture: either transcribed [text], or a [failure]
+/// with an operator-facing [message]. Exactly one of the two is set.
+class VoiceResult {
+  final String? text;
+  final VoiceFailure? failure;
+  final String? message;
+
+  const VoiceResult.success(this.text)
+      : failure = null,
+        message = null;
+  const VoiceResult.failed(this.failure, this.message) : text = null;
+
+  bool get ok => text != null;
+}
 
 /// On-device speech-to-text for voice requests (feature 067, US4, research
 /// D7): transcribes before sending, so the wire protocol never differs
@@ -12,33 +49,89 @@ import 'edge_ask_client.dart';
 /// `recordAndAsk`'s request-shape guarantee without a real microphone/STT
 /// platform channel.
 class VoiceTranscription {
-  final Future<String?> Function() _listenOnce;
+  /// How long to wait for a final result before giving up. Without a bound the
+  /// completer could wait forever if the engine ended its session without ever
+  /// firing `finalResult` — the mic button would hang with no way out.
+  static const listenTimeout = Duration(seconds: 30);
 
-  VoiceTranscription({Future<String?> Function()? listenOnce})
+  final Future<VoiceResult> Function() _listenOnce;
+
+  VoiceTranscription({Future<VoiceResult> Function()? listenOnce})
       : _listenOnce = listenOnce ?? _defaultListenOnce;
 
-  static Future<String?> _defaultListenOnce() async {
+  static Future<VoiceResult> _defaultListenOnce() async {
     final speech = stt.SpeechToText();
-    if (!await speech.initialize()) return null;
-    final completer = Completer<String?>();
-    await speech.listen(onResult: (result) {
-      if (result.finalResult && !completer.isCompleted) {
-        completer.complete(result.recognizedWords.isEmpty ? null : result.recognizedWords);
+    SpeechRecognitionError? lastError;
+
+    final available = await speech.initialize(onError: (e) => lastError = e);
+    if (!available) {
+      // Distinguish "you said no" from "this device can't do it at all" —
+      // those need completely different responses from the operator.
+      if (!await speech.hasPermission) {
+        return const VoiceResult.failed(VoiceFailure.permissionDenied,
+            'Microphone permission is needed for voice requests.');
       }
-    });
-    final text = await completer.future;
+      final why = lastError?.errorMsg;
+      return VoiceResult.failed(
+          VoiceFailure.unavailable,
+          why != null
+              ? 'Speech recognition unavailable: $why'
+              : 'Speech recognition is unavailable on this device.');
+    }
+
+    final completer = Completer<VoiceResult>();
+    void finish(VoiceResult r) {
+      if (!completer.isCompleted) completer.complete(r);
+    }
+
+    await speech.listen(
+      onResult: (result) {
+        if (!result.finalResult) return;
+        final words = result.recognizedWords.trim();
+        finish(words.isEmpty
+            ? const VoiceResult.failed(
+                VoiceFailure.noSpeechDetected, "Didn't catch that — try again.")
+            : VoiceResult.success(words));
+      },
+      listenOptions: stt.SpeechListenOptions(
+        partialResults: false,
+        cancelOnError: true,
+        listenFor: listenTimeout,
+      ),
+    );
+
+    // The engine can also end its session without ever producing a final
+    // result (pure silence, or an error raised after listen() returned).
+    // Both land here instead of hanging.
+    final result = await completer.future.timeout(
+      listenTimeout + const Duration(seconds: 2),
+      onTimeout: () {
+        final why = lastError?.errorMsg;
+        return why != null
+            ? VoiceResult.failed(
+                VoiceFailure.engineError, 'Speech recognition failed: $why')
+            : const VoiceResult.failed(VoiceFailure.noSpeechDetected,
+                "Didn't hear anything — try again.");
+      },
+    );
     await speech.stop();
-    return text;
+    return result;
   }
 
   /// Records, transcribes, and sends the result through the SAME `ask()`
   /// path a typed message uses. Returns the (task_id, transcribed text)
-  /// pair — the caller needs the text too, to show a pending conversation
-  /// turn exactly like a typed request gets — or `null` if nothing was
-  /// heard (never sends an empty request).
-  Future<(String taskId, String text)?> recordAndAsk(EdgeAskClient askClient) async {
-    final text = await _listenOnce();
-    if (text == null || text.trim().isEmpty) return null;
+  /// pair on success; on failure calls [onFailure] with the reason and returns
+  /// null. An empty request is never sent to the Border.
+  Future<(String taskId, String text)?> recordAndAsk(
+    EdgeAskClient askClient, {
+    void Function(VoiceResult failure)? onFailure,
+  }) async {
+    final result = await _listenOnce();
+    if (!result.ok) {
+      onFailure?.call(result);
+      return null;
+    }
+    final text = result.text!;
     final taskId = await askClient.ask(text);
     return (taskId, text);
   }

--- a/mobile/netclaw-mobile/lib/screens/chat_screen.dart
+++ b/mobile/netclaw-mobile/lib/screens/chat_screen.dart
@@ -29,6 +29,7 @@ class _ChatScreenState extends State<ChatScreen> {
   final _controller = TextEditingController();
   final _scroll = ScrollController();
   bool _loading = true;
+  bool _listening = false;
 
   @override
   void initState() {
@@ -128,9 +129,47 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   Future<void> _recordVoice() async {
-    final result = await widget.voiceTranscription.recordAndAsk(widget.askClient);
-    if (result == null) return; // nothing heard — no request sent
-    final (taskId, text) = result;
+    if (_listening) return; // already recording — ignore a double tap
+    setState(() => _listening = true);
+    try {
+      final result = await widget.voiceTranscription.recordAndAsk(
+        widget.askClient,
+        // Previously every voice failure was a silent no-op: the operator
+        // tapped the mic and nothing whatsoever happened. Always say why.
+        onFailure: (failure) {
+          if (!mounted) return;
+          ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+            content: Text(failure.message ?? 'Voice request failed.'),
+            duration: const Duration(seconds: 4),
+          ));
+        },
+      );
+      if (result == null) return; // nothing sent; the operator has been told why
+      final (taskId, text) = result;
+      await widget.store.addPending(taskId, text);
+      if (mounted) setState(() {});
+      _jumpToNewest(animate: true);
+    } finally {
+      if (mounted) setState(() => _listening = false);
+    }
+  }
+
+  /// Re-sends a turn's original request as a NEW turn, leaving the failed one
+  /// in place as a record. Requested by a tester: a failed turn was a dead end
+  /// with no way to try again short of retyping the whole thing.
+  Future<void> _retry(ConversationTurn turn) async {
+    final text = turn.requestText;
+    if (text.trim().isEmpty || text == '[Photo]') {
+      // A photo turn's bytes aren't retained locally, so there is nothing to
+      // resend — say so rather than silently doing nothing.
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+          content: Text('Take the photo again to retry.'),
+        ));
+      }
+      return;
+    }
+    final taskId = await widget.askClient.ask(text);
     await widget.store.addPending(taskId, text);
     if (mounted) setState(() {});
     _jumpToNewest(animate: true);
@@ -176,6 +215,7 @@ class _ChatScreenState extends State<ChatScreen> {
                   itemBuilder: (context, index) => _TurnTile(
                     turn: turns[index],
                     onCancel: () => _cancel(turns[index].taskId),
+                    onRetry: () => _retry(turns[index]),
                   ),
                 ),
         ),
@@ -192,7 +232,15 @@ class _ChatScreenState extends State<ChatScreen> {
                   ),
                 ),
                 IconButton(icon: const Icon(Icons.camera_alt), onPressed: _capturePhoto),
-                IconButton(icon: const Icon(Icons.mic), onPressed: _recordVoice),
+                IconButton(
+                  // Visible listening state — the mic previously gave no
+                  // indication it was live, so a working recording looked
+                  // identical to a broken one.
+                  icon: Icon(_listening ? Icons.mic : Icons.mic_none,
+                      color: _listening ? Theme.of(context).colorScheme.error : null),
+                  tooltip: _listening ? 'Listening…' : 'Voice request',
+                  onPressed: _listening ? null : _recordVoice,
+                ),
                 IconButton(icon: const Icon(Icons.send), onPressed: _send),
               ],
             ),
@@ -206,13 +254,43 @@ class _ChatScreenState extends State<ChatScreen> {
 class _TurnTile extends StatelessWidget {
   final ConversationTurn turn;
   final VoidCallback onCancel;
+  final VoidCallback onRetry;
 
-  const _TurnTile({required this.turn, required this.onCancel});
+  const _TurnTile({
+    required this.turn,
+    required this.onCancel,
+    required this.onRetry,
+  });
+
+  bool get _isRetryable => turn.state == 'failed' || turn.state == 'cancelled';
 
   bool get _inProgress => turn.state == 'pending' || turn.state == 'working';
 
   @override
   Widget build(BuildContext context) {
+    final card = _card(context);
+    // "Or if you click on fail it asks to retry" — make the whole tile a retry
+    // affordance, not just the button, so a failed turn is never a dead end.
+    if (!_isRetryable) return card;
+    return InkWell(onTap: () => _confirmRetry(context), child: card);
+  }
+
+  Future<void> _confirmRetry(BuildContext context) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Retry this request?'),
+        content: Text(turn.requestText),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
+          TextButton(onPressed: () => Navigator.pop(ctx, true), child: const Text('Retry')),
+        ],
+      ),
+    );
+    if (ok ?? false) onRetry();
+  }
+
+  Widget _card(BuildContext context) {
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
       child: Padding(
@@ -234,9 +312,26 @@ class _TurnTile extends StatelessWidget {
                 ],
               )
             else if (turn.state == 'cancelled')
-              const Text('Cancelled', style: TextStyle(color: Colors.grey))
+              Row(children: [
+                const Text('Cancelled', style: TextStyle(color: Colors.grey)),
+                const Spacer(),
+                TextButton.icon(
+                    onPressed: onRetry,
+                    icon: const Icon(Icons.refresh, size: 18),
+                    label: const Text('Retry')),
+              ])
             else if (turn.state == 'failed')
-              Text(turn.answerText ?? 'Failed', style: const TextStyle(color: Colors.red))
+              Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+                Text(turn.answerText ?? 'Failed',
+                    style: const TextStyle(color: Colors.red)),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: TextButton.icon(
+                      onPressed: onRetry,
+                      icon: const Icon(Icons.refresh, size: 18),
+                      label: const Text('Retry')),
+                ),
+              ])
             else
               Text(turn.answerText ?? ''),
           ],

--- a/mobile/netclaw-mobile/test/chat_retry_test.dart
+++ b/mobile/netclaw-mobile/test/chat_retry_test.dart
@@ -1,0 +1,153 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:netclaw_mobile/ncfed/conversation_store.dart';
+import 'package:netclaw_mobile/ncfed/edge_ask_client.dart';
+import 'package:netclaw_mobile/ncfed/edge_client.dart';
+import 'package:netclaw_mobile/screens/chat_screen.dart';
+
+/// Retry, requested by a tester: "Retry button would be useful / or if you
+/// click on fail it asks to retry". A failed turn was previously a dead end —
+/// the only way to try again was retyping the whole request.
+class _FakeRpc implements EdgeRpcSource {
+  final List<(String, Map<String, dynamic>)> calls = [];
+  int _n = 0;
+
+  @override
+  void on(String method, EdgeMethodHandler handler) {}
+
+  @override
+  Future<Map<String, dynamic>> call(String method, Map<String, dynamic> params,
+      {Duration timeout = const Duration(seconds: 30)}) async {
+    calls.add((method, params));
+    return {'task_id': 'retry-task-${++_n}'};
+  }
+}
+
+void main() {
+  late Directory dir;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp('ncfed_retry');
+  });
+
+  tearDown(() async {
+    if (await dir.exists()) await dir.delete(recursive: true);
+  });
+
+  /// `ConversationStore` writes real files, and `testWidgets` runs its body in a
+  /// FakeAsync zone where dart:io futures never complete — so setup I/O has to
+  /// go through `runAsync`.
+  Future<ConversationStore> storeWithFailedTurn(WidgetTester tester) async {
+    late ConversationStore store;
+    await tester.runAsync(() async {
+      store = ConversationStore(dir);
+      await store.addPending('t-failed', 'show me the BGP table');
+      await store.updateState('t-failed', 'failed', answerText: 'Border unreachable');
+    });
+    return store;
+  }
+
+  Future<void> pumpChat(WidgetTester tester, ConversationStore store, _FakeRpc rpc) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(body: ChatScreen(askClient: EdgeAskClient(rpc), store: store)),
+    ));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+
+  testWidgets('a failed turn offers a Retry action', (tester) async {
+    final store = await storeWithFailedTurn(tester);
+    await pumpChat(tester, store, _FakeRpc());
+
+    expect(find.text('Border unreachable'), findsOneWidget);
+    expect(find.text('Retry'), findsOneWidget,
+        reason: 'a failed turn must not be a dead end');
+  });
+
+  testWidgets('Retry resends the original text as a new turn', (tester) async {
+    final store = await storeWithFailedTurn(tester);
+    final rpc = _FakeRpc();
+    await pumpChat(tester, store, rpc);
+
+    await tester.tap(find.text('Retry'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final asks = rpc.calls.where((c) => c.$1 == 'n2n/edge/ask').toList();
+    expect(asks, hasLength(1));
+    expect(asks.single.$2, {'text': 'show me the BGP table'},
+        reason: 'retry must resend the ORIGINAL request verbatim');
+    expect(store.turns, hasLength(2),
+        reason: 'the failed turn stays as a record; retry is a new turn');
+    expect(store.turns.last.state, 'pending');
+  });
+
+  testWidgets('tapping the failed turn itself asks to retry', (tester) async {
+    final store = await storeWithFailedTurn(tester);
+    final rpc = _FakeRpc();
+    await pumpChat(tester, store, rpc);
+
+    // "Or if you click on fail it asks to retry" — the whole tile is tappable.
+    await tester.tap(find.text('show me the BGP table'));
+    await tester.pump();
+
+    expect(find.text('Retry this request?'), findsOneWidget);
+
+    // Scope to the dialog: the tile behind it has its own Retry button, so a
+    // bare widgetWithText finder matches two and tap() refuses.
+    await tester.tap(find.descendant(
+      of: find.byType(AlertDialog),
+      matching: find.widgetWithText(TextButton, 'Retry'),
+    ));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(rpc.calls.where((c) => c.$1 == 'n2n/edge/ask'), hasLength(1));
+  });
+
+  testWidgets('dismissing the retry dialog sends nothing', (tester) async {
+    final store = await storeWithFailedTurn(tester);
+    final rpc = _FakeRpc();
+    await pumpChat(tester, store, rpc);
+
+    await tester.tap(find.text('show me the BGP table'));
+    await tester.pump();
+    await tester.tap(find.descendant(
+      of: find.byType(AlertDialog),
+      matching: find.widgetWithText(TextButton, 'Cancel'),
+    ));
+    await tester.pump();
+
+    expect(rpc.calls, isEmpty, reason: 'declining must not resend');
+    expect(store.turns, hasLength(1));
+  });
+
+  testWidgets('a completed turn offers no Retry', (tester) async {
+    late ConversationStore store;
+    await tester.runAsync(() async {
+      store = ConversationStore(dir);
+      await store.addPending('t-ok', 'ping R1');
+      await store.updateState('t-ok', 'completed', answerText: 'R1 is up');
+    });
+    await pumpChat(tester, store, _FakeRpc());
+
+    expect(find.text('R1 is up'), findsOneWidget);
+    expect(find.text('Retry'), findsNothing,
+        reason: 'retry is only for turns that did not produce an answer');
+  });
+
+  testWidgets('a cancelled turn is also retryable', (tester) async {
+    late ConversationStore store;
+    await tester.runAsync(() async {
+      store = ConversationStore(dir);
+      await store.addPending('t-cancel', 'long running thing');
+      await store.updateState('t-cancel', 'cancelled');
+    });
+    await pumpChat(tester, store, _FakeRpc());
+
+    expect(find.text('Cancelled'), findsOneWidget);
+    expect(find.text('Retry'), findsOneWidget);
+  });
+}

--- a/mobile/netclaw-mobile/test/voice_transcription_test.dart
+++ b/mobile/netclaw-mobile/test/voice_transcription_test.dart
@@ -26,7 +26,8 @@ void main() {
     final source = _RecordingEdgeRpcSource();
     final askClient = EdgeAskClient(source);
     final voice = VoiceTranscription(
-      listenOnce: () async => 'check every core router for BGP problems',
+      listenOnce: () async =>
+          const VoiceResult.success('check every core router for BGP problems'),
     );
 
     final result = await voice.recordAndAsk(askClient);
@@ -45,7 +46,10 @@ void main() {
   test('nothing heard never sends an empty (or any) request', () async {
     final source = _RecordingEdgeRpcSource();
     final askClient = EdgeAskClient(source);
-    final voice = VoiceTranscription(listenOnce: () async => null);
+    final voice = VoiceTranscription(
+      listenOnce: () async => const VoiceResult.failed(
+          VoiceFailure.noSpeechDetected, "Didn't hear anything — try again."),
+    );
 
     final result = await voice.recordAndAsk(askClient);
 
@@ -53,14 +57,52 @@ void main() {
     expect(source.calls, isEmpty);
   });
 
-  test('whitespace-only transcription is treated as nothing heard', () async {
-    final source = _RecordingEdgeRpcSource();
-    final askClient = EdgeAskClient(source);
-    final voice = VoiceTranscription(listenOnce: () async => '   ');
+  // Every one of these used to collapse into a bare `null`, so the mic button
+  // did nothing at all and the operator had no idea why — reported by a real
+  // tester as simply "microphone option isn't working". Each failure mode must
+  // now surface a distinct, actionable reason.
+  group('failure reporting', () {
+    for (final (failure, label) in [
+      (VoiceFailure.permissionDenied, 'permission denied'),
+      (VoiceFailure.unavailable, 'no recognition engine'),
+      (VoiceFailure.noSpeechDetected, 'silence'),
+      (VoiceFailure.engineError, 'engine error'),
+    ]) {
+      test('$label is reported to the caller, and sends nothing', () async {
+        final source = _RecordingEdgeRpcSource();
+        final askClient = EdgeAskClient(source);
+        final voice = VoiceTranscription(
+          listenOnce: () async => VoiceResult.failed(failure, 'because $label'),
+        );
 
-    final result = await voice.recordAndAsk(askClient);
+        final reported = <VoiceResult>[];
+        final result =
+            await voice.recordAndAsk(askClient, onFailure: reported.add);
 
-    expect(result, isNull);
-    expect(source.calls, isEmpty);
+        expect(result, isNull);
+        expect(source.calls, isEmpty, reason: 'a failed capture must never ask');
+        expect(reported, hasLength(1), reason: 'the UI must be told why');
+        expect(reported.single.failure, failure);
+        expect(reported.single.message, 'because $label');
+        expect(reported.single.ok, isFalse);
+      });
+    }
+
+    test('a caller that passes no onFailure still just gets null, not a throw',
+        () async {
+      final source = _RecordingEdgeRpcSource();
+      final voice = VoiceTranscription(
+        listenOnce: () async =>
+            const VoiceResult.failed(VoiceFailure.unavailable, 'nope'),
+      );
+      expect(await voice.recordAndAsk(EdgeAskClient(source)), isNull);
+    });
+  });
+
+  test('VoiceResult.success reports ok and carries the text', () {
+    const r = VoiceResult.success('hello');
+    expect(r.ok, isTrue);
+    expect(r.text, 'hello');
+    expect(r.failure, isNull);
   });
 }


### PR DESCRIPTION
Both from tester feedback on a real device.

## Microphone — two bugs stacked

**1. The app was invisible to every speech engine.** `speech_to_text` 7.4.0 ships a deliberately **empty** `AndroidManifest.xml` and its README requires the host app to declare the `RecognitionService` query itself. We never did — so under Android 11+ package-visibility rules `initialize()` returned false and the mic button did **nothing at all**: no prompt, no error, no sign it had been pressed. Reported as "microphone option isn't working", which is all the UI could convey.

```xml
<intent><action android:name="android.speech.RecognitionService"/></intent>
```

Also declared `RECORD_AUDIO` explicitly — it previously reached the merged manifest only as a side-effect of `camera_android_camerax`, so dropping the camera dependency would have silently broken voice. Same accidental-dependency class as `INTERNET`.

**2. Every failure was silent.** Permission denied, no engine, engine error, and silence all collapsed into a bare `null` the caller discarded. Voice capture now returns a `VoiceResult` with a distinct `VoiceFailure` and an operator-facing message, shown as a snackbar — permission-denied distinguished from device-unsupported, because those need different responses.

Fixed alongside: the completer could **wait forever** if the engine ended without firing `finalResult` (silence, or an error after `listen()` returned) — now bounded. And the mic button shows live listening state; a working recording previously looked identical to a broken one.

## Retry

> "Retry button would be useful / or if you click on fail it asks to retry"

Failed and cancelled turns now carry a **Retry** action, and tapping the tile opens a confirm dialog. Retry resends the original text **verbatim as a new turn**, leaving the failed one as a record. A photo turn says to retake the photo rather than silently no-op'ing, since the bytes aren't retained locally.

Verified: **80 Dart tests** (13 new), `flutter analyze` clean. No `ios/`, `pubspec.yaml`, or `specs/` files touched — no conflict with concurrent iOS work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)