### PR TITLE
fix(edge): phone requests were killed while their own delegation still ran

### DIFF
--- a/mcp-servers/protocol-mcp/bgp/federation/edge.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/edge.py
@@ -55,6 +55,12 @@ EDGE_METHODS = (
     # result/cancel) -- reused as-is, not reimplemented, per research D4.
     "n2n/edge/ask",
     "n2n/edge/ask_result",
+    # Border-initiated, best-effort, fire-and-forget: a turn that is still
+    # alive at the stall checkpoint says so rather than leaving the phone on a
+    # silent spinner for the whole (now much longer) budget. An app build with
+    # no handler for it drops the notification silently on both sides, so this
+    # is safe against version skew in either direction.
+    "n2n/edge/task_progress",
     "n2n/tasks/status",
     "n2n/tasks/result",
     "n2n/tasks/cancel",

--- a/mcp-servers/protocol-mcp/bgp/federation/service.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/service.py
@@ -997,6 +997,45 @@ class FederationService:
     # §2) — only consume_token()'s new node_type="edge" argument (T006) and a
     # separate registry (self.edge_channels, T008) distinguish it.
 
+    # ---- edge (phone) agent-turn budget --------------------------------
+
+    def _edge_ask_timeout(self) -> int:
+        """Wall-clock budget for one phone request's agent turn.
+
+        MUST be >= the member `skill_timeout` this turn may delegate into,
+        otherwise the parent dies while its own child is still running (see
+        _edge_on_ask). Defaults to the member budget plus headroom for the
+        Border's own reasoning either side of the delegation.
+        """
+        override = os.environ.get("N2N_EDGE_ASK_TIMEOUT_S")
+        if override:
+            try:
+                return max(60, int(override))
+            except ValueError:
+                logger.warning("N2N_EDGE_ASK_TIMEOUT_S=%r is not an int — ignoring", override)
+        member_budget = getattr(self.invoker, "skill_timeout", 600)
+        return int(member_budget) + self._edge_ask_stall_extension()
+
+    def _edge_ask_stall_extension(self) -> int:
+        """Extra seconds granted when a turn is still alive at the stall
+        checkpoint. Also the headroom added on top of the member budget."""
+        try:
+            return max(30, int(os.environ.get("N2N_EDGE_ASK_STALL_EXTENSION_S", "180")))
+        except ValueError:
+            return 180
+
+    async def _edge_notify_progress(self, member_id: str, task_id: str, text: str):
+        """Best-effort progress ping to a phone mid-turn. Never raises: a
+        disconnected phone just doesn't get it, and the turn continues."""
+        ch = self.edge_channels.get(member_id)
+        if not ch:
+            return
+        try:
+            await ch.notify("n2n/edge/task_progress",
+                            {"task_id": task_id, "detail": text})
+        except Exception as e:
+            logger.debug("edge progress notify to %s failed: %s", member_id, e)
+
     def _register_edge_channel(self, member_id, ch):
         """Track an edge node's channel; deregister on close and start its
         Border-driven heartbeat loop (T011) — the BASE_FLOOR-equivalent
@@ -1294,9 +1333,41 @@ class FederationService:
                 # contains one, so it must be sanitized here, unlike peer/
                 # skill identifiers elsewhere in this file which never do.
                 session_key = "n2n-edge-" + member_id.replace("/", "_")
+
+                # A phone request routinely delegates to an in-risk member,
+                # and that member's own agent turn gets `skill_timeout`
+                # (default 600s). Passing no timeout here inherited
+                # run_agent_turn's 300s default, so the INNER budget was twice
+                # the OUTER one: a delegating request was allowed to outlive
+                # the request that started it, and the phone's turn was killed
+                # while its own delegation was still legitimately running.
+                #
+                # Observed twice on a real device (2026-07-26): identical CML
+                # questions failed at exactly 300s while their `cml-node-
+                # operations` delegation completed *afterwards* — the work
+                # succeeded and the answer had nowhere to land. A third,
+                # warm-cache run finished in 114s and looked fine, which is the
+                # worst failure profile: it passes on a retry and fails cold.
+                #
+                # The phone's budget must therefore always be >= the member
+                # budget it may have to wait on.
+                timeout_s = self._edge_ask_timeout()
+
+                def on_stall(waited_s):
+                    # The turn is alive but slow. Tell the phone rather than
+                    # leaving it on a silent spinner, and extend instead of
+                    # dying on a blind deadline. Scheduled, not awaited:
+                    # run_agent_turn calls on_stall synchronously.
+                    self.tasks._set(task_id, progress="still working…")
+                    asyncio.create_task(self._edge_notify_progress(
+                        member_id, task_id,
+                        f"Still working on this — {int(waited_s)}s so far."))
+                    return self._edge_ask_stall_extension()
+
                 output, tokens = await run_agent_turn(
                     prompt, session_key=session_key, untrusted=False,
-                    message_file=message_file)
+                    message_file=message_file,
+                    timeout_s=timeout_s, on_stall=on_stall)
             finally:
                 if message_file:
                     try:

--- a/mobile/netclaw-mobile/lib/ncfed/edge_ask_client.dart
+++ b/mobile/netclaw-mobile/lib/ncfed/edge_ask_client.dart
@@ -27,18 +27,33 @@ class TaskUpdate {
   final String? outputText;
   final int? tokensUsed;
 
+  /// Set only by an `n2n/edge/task_progress` notification — a still-alive turn
+  /// reporting in. Never persisted; purely a live hint for the UI.
+  final String? progressDetail;
+
   const TaskUpdate({
     required this.taskId,
     required this.state,
     this.outputText,
     this.tokensUsed,
+    this.progressDetail,
   });
 
   factory TaskUpdate.fromAskResult(Map<String, dynamic> params) => TaskUpdate(
         taskId: params['task_id'] as String,
         state: _parseTaskState(params['state'] as String?),
-        outputText: params['output_text'] as String?,
+        // A failed task carries its reason under `error`, not `output_text`
+        // (TaskManager.run stores {"error": ...} on exception). Reading only
+        // output_text dropped every failure explanation on the floor, so a
+        // timeout showed as a bare "Failed" with no text at all.
+        outputText: (params['output_text'] ?? params['error']) as String?,
         tokensUsed: params['tokens_used'] as int?,
+      );
+
+  factory TaskUpdate.fromProgress(Map<String, dynamic> params) => TaskUpdate(
+        taskId: params['task_id'] as String,
+        state: TaskState.working,
+        progressDetail: params['detail'] as String?,
       );
 }
 
@@ -53,6 +68,12 @@ class EdgeAskClient {
   EdgeAskClient(this.client) {
     client.on('n2n/edge/ask_result', (params) {
       _updates.add(TaskUpdate.fromAskResult(params));
+      return <String, dynamic>{};
+    });
+    // Best-effort liveness for a long turn. A Border that never sends this
+    // (older build) simply produces no progress updates — nothing breaks.
+    client.on('n2n/edge/task_progress', (params) {
+      _updates.add(TaskUpdate.fromProgress(params));
       return <String, dynamic>{};
     });
   }

--- a/mobile/netclaw-mobile/lib/screens/chat_screen.dart
+++ b/mobile/netclaw-mobile/lib/screens/chat_screen.dart
@@ -30,6 +30,8 @@ class _ChatScreenState extends State<ChatScreen> {
   final _scroll = ScrollController();
   bool _loading = true;
   bool _listening = false;
+  /// taskId -> latest progress detail from n2n/edge/task_progress.
+  final Map<String, String> _progress = {};
 
   @override
   void initState() {
@@ -80,6 +82,14 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   Future<void> _applyUpdate(TaskUpdate update) async {
+    // A progress ping is a liveness hint, not a state change — record the
+    // detail and repaint, but don't touch the persisted turn.
+    if (update.progressDetail != null) {
+      _progress[update.taskId] = update.progressDetail!;
+      if (mounted) setState(() {});
+      return;
+    }
+    _progress.remove(update.taskId); // terminal update supersedes any hint
     final stateName = switch (update.state) {
       TaskState.completed => 'completed',
       TaskState.failed => 'failed',
@@ -214,6 +224,7 @@ class _ChatScreenState extends State<ChatScreen> {
                   itemCount: turns.length,
                   itemBuilder: (context, index) => _TurnTile(
                     turn: turns[index],
+                    progressDetail: _progress[turns[index].taskId],
                     onCancel: () => _cancel(turns[index].taskId),
                     onRetry: () => _retry(turns[index]),
                   ),
@@ -256,10 +267,16 @@ class _TurnTile extends StatelessWidget {
   final VoidCallback onCancel;
   final VoidCallback onRetry;
 
+  /// Live detail from the Border for an in-progress turn (e.g. "Still working
+  /// on this — 120s so far"). Null when there's nothing to add beyond
+  /// "Working…".
+  final String? progressDetail;
+
   const _TurnTile({
     required this.turn,
     required this.onCancel,
     required this.onRetry,
+    this.progressDetail,
   });
 
   bool get _isRetryable => turn.state == 'failed' || turn.state == 'cancelled';
@@ -306,8 +323,7 @@ class _TurnTile extends StatelessWidget {
                   const SizedBox(
                       width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2)),
                   const SizedBox(width: 8),
-                  const Text('Working…'),
-                  const Spacer(),
+                  Expanded(child: Text(progressDetail ?? 'Working…')),
                   TextButton(onPressed: onCancel, child: const Text('Cancel')),
                 ],
               )

--- a/tests/n2n/test_edge_ask_timeout.py
+++ b/tests/n2n/test_edge_ask_timeout.py
@@ -1,0 +1,104 @@
+"""Regression: a phone request must never be killed while its own delegation
+is still legitimately running.
+
+`_edge_on_ask` called `gateway.run_agent_turn()` without `timeout_s`, so it
+inherited the 300s default — while a member it delegates to gets
+`skill_timeout` (default 600s). The INNER budget was twice the OUTER one, so a
+delegating phone request was allowed to outlive the request that started it.
+
+Observed twice on a real device (2026-07-26): identical CML questions failed at
+exactly 300s while their `cml-node-operations` delegation completed
+*afterwards* — the work succeeded and the answer had nowhere to land. A third,
+warm-cache run finished in 114s and looked fine, which is the worst failure
+profile: passes on retry, fails cold.
+"""
+import os
+import sys
+import types
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..",
+                                "mcp-servers", "protocol-mcp"))
+
+
+def _service_with(skill_timeout=600, env=None):
+    """A bare FederationService-like object exposing only what the budget
+    helpers touch — this is a units-of-arithmetic test, not an integration one.
+    """
+    from bgp.federation.service import FederationService
+    svc = object.__new__(FederationService)
+    svc.invoker = types.SimpleNamespace(skill_timeout=skill_timeout)
+    return svc
+
+
+def test_phone_budget_exceeds_the_member_budget_it_may_wait_on(monkeypatch):
+    monkeypatch.delenv("N2N_EDGE_ASK_TIMEOUT_S", raising=False)
+    monkeypatch.delenv("N2N_EDGE_ASK_STALL_EXTENSION_S", raising=False)
+    svc = _service_with(skill_timeout=600)
+
+    budget = svc._edge_ask_timeout()
+
+    assert budget > 600, (
+        "the phone's turn must outlast the member turn it delegates into; "
+        f"got {budget}s for a 600s member budget")
+    # And it must be a real improvement on the old inherited default.
+    assert budget > 300
+
+
+def test_budget_tracks_a_raised_member_timeout(monkeypatch):
+    """Raising the member budget must raise the phone budget with it —
+    otherwise the same inversion silently returns."""
+    monkeypatch.delenv("N2N_EDGE_ASK_TIMEOUT_S", raising=False)
+    monkeypatch.delenv("N2N_EDGE_ASK_STALL_EXTENSION_S", raising=False)
+
+    for member_budget in (300, 600, 1200, 3600):
+        svc = _service_with(skill_timeout=member_budget)
+        assert svc._edge_ask_timeout() > member_budget, (
+            f"inversion returned at skill_timeout={member_budget}")
+
+
+def test_explicit_override_wins(monkeypatch):
+    monkeypatch.setenv("N2N_EDGE_ASK_TIMEOUT_S", "900")
+    svc = _service_with(skill_timeout=600)
+    assert svc._edge_ask_timeout() == 900
+
+
+def test_override_is_floored_not_trusted_blindly(monkeypatch):
+    """A nonsensically small override would reintroduce the original bug in a
+    worse form; floor it instead of honouring it."""
+    monkeypatch.setenv("N2N_EDGE_ASK_TIMEOUT_S", "1")
+    svc = _service_with(skill_timeout=600)
+    assert svc._edge_ask_timeout() >= 60
+
+
+def test_garbage_override_falls_back_instead_of_crashing(monkeypatch):
+    monkeypatch.setenv("N2N_EDGE_ASK_TIMEOUT_S", "not-a-number")
+    monkeypatch.delenv("N2N_EDGE_ASK_STALL_EXTENSION_S", raising=False)
+    svc = _service_with(skill_timeout=600)
+    # Falls through to the derived value rather than raising ValueError inside
+    # a live phone request.
+    assert svc._edge_ask_timeout() > 600
+
+
+def test_stall_extension_has_a_sane_floor(monkeypatch):
+    monkeypatch.setenv("N2N_EDGE_ASK_STALL_EXTENSION_S", "0")
+    svc = _service_with()
+    assert svc._edge_ask_timeout.__self__ is svc  # bound, sanity
+    assert svc._edge_ask_stall_extension() >= 30
+
+
+def test_task_progress_is_a_declared_edge_method():
+    """The stall notification rides a declared method — an undeclared one would
+    be dropped by EdgeChannel's own EDGE_METHODS filter."""
+    from bgp.federation.edge import EDGE_METHODS
+    assert "n2n/edge/task_progress" in EDGE_METHODS
+
+
+@pytest.mark.parametrize("method", [
+    "n2n/edge/ask", "n2n/edge/ask_result", "n2n/tasks/status",
+    "n2n/tasks/result", "n2n/tasks/cancel",
+])
+def test_existing_edge_surface_is_unchanged(method):
+    """Adding task_progress must not disturb the existing command channel."""
+    from bgp.federation.edge import EDGE_METHODS
+    assert method in EDGE_METHODS


### PR DESCRIPTION
## The bug

`_edge_on_ask` called `run_agent_turn()` with **no `timeout_s`**, inheriting the 300s default — while a member it delegates into gets `skill_timeout` (**600s**).

**The inner budget was twice the outer one.** A delegating phone request was allowed to outlive the request that started it. Every other `run_agent_turn` call site passes an explicit timeout (`tool_timeout`, `skill_timeout`); only the edge path didn't. An omission, not a decision — and the phone is the client *most* likely to delegate.

## Observed on real hardware

| Attempt | Duration | Outcome |
|---|---|---|
| 15:09 | hit 300s | **failed** — `cml-node-operations` completed *afterwards*, answer lost |
| 15:16 | hit 300s | **failed** — zero-byte body |
| 15:25 | 114s | completed (warm cache) |

The first is the proof: the work succeeded and had nowhere to land. The third is why it looked fine — **passes on retry, fails cold**, which is the worst profile for something about to ship.

## Fix

- Phone budget derived from the member budget it may wait on: `skill_timeout + headroom` = **780s**, overridable via `N2N_EDGE_ASK_TIMEOUT_S`, floored at 60s. Raising the member timeout raises the phone's with it, so **the inversion cannot silently return**.
- **`on_stall` wired** — built for exactly this, left unconnected. A turn alive at the 120s checkpoint pushes `n2n/edge/task_progress` and extends, instead of dying blind. Fire-and-forget; an app with no handler drops it silently, so version skew is safe both directions.

## Two client-side gaps found alongside

- `TaskUpdate.fromAskResult` read only `output_text`. A failure's reason lives under `error` (`TaskManager.run` stores `{"error": ...}`), so **every failure explanation was dropped** — a timeout showed as bare "Failed" with no text.
- Chat now shows live progress instead of a static "Working…", so a multi-minute turn doesn't look hung.

Verified: **284 Python** (12 new — the inversion is asserted at four different member budgets), **80 Dart**, analyze clean, daemon restarted and 780s confirmed live.

**Not addressed:** the channel still drops every 20–50s on both platforms. Real but separate — it wasn't what broke these requests, and conflating the two is what sent my first two diagnoses wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)