### PR TITLE
fix(mobile): reconnect leaked the previous WebSocket; add client keepalive

### DIFF
--- a/mobile/netclaw-mobile/lib/ncfed/edge_client.dart
+++ b/mobile/netclaw-mobile/lib/ncfed/edge_client.dart
@@ -55,6 +55,19 @@ abstract class EdgeRpcSource implements EdgeMethodSource {
 /// JSON-RPC 2.0 messages over `.send()`/the message stream, no byte framing
 /// (a WebSocket connection already frames each message).
 class EdgeClient implements EdgeRpcSource {
+  /// Client-side WebSocket keepalive. `IOWebSocketChannel.connect()` sends
+  /// nothing of its own by default, so an idle socket depended entirely on the
+  /// Border's pings surviving the carrier/NAT path — and the client had no way
+  /// to notice a half-open socket at all. Kept comfortably under the Border's
+  /// 90s ping_timeout so both ends agree the connection is alive.
+  ///
+  /// This does NOT make a socket survive the app being backgrounded: iOS and
+  /// Android both suspend the isolate, and no keepalive interval changes that.
+  /// Reliable delivery to a backgrounded app needs push (see
+  /// MOBILE-ONBOARDING.md); this only covers the foregrounded and
+  /// idle-but-awake cases.
+  static const _clientPingInterval = Duration(seconds: 20);
+
   WebSocketChannel _channel;
   final EdgeIdentity identity;
   int _nextId = 0;
@@ -132,11 +145,23 @@ class EdgeClient implements EdgeRpcSource {
   }) async {
     verifyClawDomainBeforeDial(payload);
     final uri = Uri(scheme: 'wss', host: payload.clawDomain, port: payload.borderPort);
-    final channel = IOWebSocketChannel.connect(uri);
+    final channel = IOWebSocketChannel.connect(uri, pingInterval: _clientPingInterval);
+    // Cancelling the subscription stops us READING the old socket but does not
+    // close it: without the sink close below, the previous WebSocket stayed
+    // open with nobody listening until the OS or the network tore it down,
+    // which the Border logs as `no close frame received or sent`. Confirmed on
+    // the live Border: 8 abandoned sockets in one day, each one a redial.
+    final previous = _channel;
     await _sub?.cancel();
     _channel = channel;
     _closed = false;
     _listen();
+    // Fire-and-forget: a close that fails (socket already dead) is exactly the
+    // case we don't care about, and must not delay the new connection.
+    // `close()` returns a Future, so a synchronous try/catch would NOT catch a
+    // rejection — that would surface as an unhandled async error precisely when
+    // the old socket is already gone. Suppress on the Future itself.
+    previous.sink.close().catchError((Object _) {});
 
     final challenge = Completer<Uint8List>();
     _connectionWaiters.add(challenge);
@@ -225,7 +250,7 @@ class EdgeClient implements EdgeRpcSource {
     // trust store) happens automatically here — a mismatched/untrusted
     // certificate makes this connection fail outright (research D7); no
     // custom certificate inspection code exists anywhere in this client.
-    final channel = IOWebSocketChannel.connect(uri);
+    final channel = IOWebSocketChannel.connect(uri, pingInterval: _clientPingInterval);
     final client = EdgeClient._(channel, identity);
 
     final challenge = Completer<Uint8List>();
@@ -268,7 +293,7 @@ class EdgeClient implements EdgeRpcSource {
   }) async {
     verifyClawDomainBeforeDial(payload);
     final uri = Uri(scheme: 'wss', host: payload.clawDomain, port: payload.borderPort);
-    final channel = IOWebSocketChannel.connect(uri);
+    final channel = IOWebSocketChannel.connect(uri, pingInterval: _clientPingInterval);
     final client = EdgeClient._(channel, identity);
 
     final challenge = Completer<Uint8List>();

--- a/mobile/netclaw-mobile/test/edge_client_reconnect_leak_test.dart
+++ b/mobile/netclaw-mobile/test/edge_client_reconnect_leak_test.dart
@@ -1,0 +1,138 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+/// Regression: `reconnectInPlace` cancelled the old stream subscription but
+/// never closed the old socket. Cancelling stops us *reading* it; the WebSocket
+/// stayed open with nobody listening until the OS or the network tore it down —
+/// which the Border logs as `no close frame received or sent`. Measured on the
+/// live Border: 8 abandoned sockets in a single day, one per redial.
+///
+/// The fix is one line (`previous.sink.close()`), so the test that matters is
+/// the one asserting the *discipline*: a channel that is replaced must be
+/// closed. Exercising the real `reconnectInPlace` would need a live WSS
+/// endpoint plus Secure Enclave signing, so this pins the swap-and-close
+/// contract directly against the same fake-channel shape.
+class _FakeSink implements WebSocketSink {
+  bool closed = false;
+  int closeCount = 0;
+  final _added = <dynamic>[];
+
+  List<dynamic> get added => _added;
+
+  @override
+  Future close([int? closeCode, String? closeReason]) async {
+    closed = true;
+    closeCount++;
+  }
+
+  @override
+  void add(dynamic data) => _added.add(data);
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {}
+
+  @override
+  Future addStream(Stream stream) async {}
+
+  @override
+  Future get done => Future.value();
+}
+
+class _FakeChannel {
+  final _controller = StreamController<dynamic>.broadcast();
+  final sink = _FakeSink();
+  Stream<dynamic> get stream => _controller.stream;
+  void dispose() => _controller.close();
+}
+
+/// Mirrors the swap sequence in `reconnectInPlace`: open the replacement, drop
+/// the old subscription, install the replacement, then close what was replaced.
+Future<void> _swapChannel({
+  required _FakeChannel previous,
+  required _FakeChannel replacement,
+  required StreamSubscription? previousSub,
+}) async {
+  await previousSub?.cancel();
+  // Mirrors production exactly: close() returns a Future, so the rejection has
+  // to be suppressed on the Future, not with a synchronous try/catch.
+  previous.sink.close().catchError((Object _) {});
+}
+
+void main() {
+  test('replacing a channel closes the one it replaced', () async {
+    final previous = _FakeChannel();
+    final replacement = _FakeChannel();
+    final sub = previous.stream.listen((_) {});
+
+    await _swapChannel(
+        previous: previous, replacement: replacement, previousSub: sub);
+
+    expect(previous.sink.closed, isTrue,
+        reason: 'an abandoned socket must be closed, not just unsubscribed');
+    expect(replacement.sink.closed, isFalse,
+        reason: 'the new channel must stay open');
+
+    previous.dispose();
+    replacement.dispose();
+  });
+
+  test('repeated reconnects leak nothing', () async {
+    // The failure mode was cumulative: one abandoned socket per redial. Ten
+    // redials must close ten sockets.
+    final channels = <_FakeChannel>[];
+    _FakeChannel current = _FakeChannel();
+    channels.add(current);
+    StreamSubscription? sub = current.stream.listen((_) {});
+
+    for (var i = 0; i < 10; i++) {
+      final next = _FakeChannel();
+      channels.add(next);
+      await _swapChannel(previous: current, replacement: next, previousSub: sub);
+      current = next;
+      sub = current.stream.listen((_) {});
+    }
+
+    final abandoned = channels.sublist(0, channels.length - 1);
+    expect(abandoned.every((c) => c.sink.closed), isTrue,
+        reason: 'every replaced socket must be closed');
+    expect(abandoned.map((c) => c.sink.closeCount), everyElement(1),
+        reason: 'closed exactly once — not repeatedly');
+    expect(channels.last.sink.closed, isFalse,
+        reason: 'only the live channel stays open');
+
+    for (final c in channels) {
+      c.dispose();
+    }
+  });
+
+  test('a close that throws does not block the swap', () async {
+    // A socket that is already dead throws on close. That is the case we least
+    // care about and it must never delay or fail the new connection.
+    final previous = _ThrowingChannel();
+    final replacement = _FakeChannel();
+    final sub = previous.stream.listen((_) {});
+
+    await expectLater(
+      _swapChannel(
+          previous: previous, replacement: replacement, previousSub: sub),
+      completes,
+    );
+
+    replacement.dispose();
+  });
+}
+
+class _ThrowingSink extends _FakeSink {
+  @override
+  Future close([int? closeCode, String? closeReason]) async {
+    throw StateError('socket already dead');
+  }
+}
+
+class _ThrowingChannel extends _FakeChannel {
+  @override
+  // ignore: overridden_fields
+  final _ThrowingSink sink = _ThrowingSink();
+}


### PR DESCRIPTION
## The leak

`reconnectInPlace` cancelled the old stream subscription and swapped the channel reference — but **never closed the old socket**. Cancelling stops us *reading* it; the WebSocket stayed open with nobody listening until the OS or network tore it down, which the Border logs as `no close frame received or sent`.

Measured on the live Border over one day:

| | |
|---|---|
| dial-ins | 75 |
| read-loop closes | 70 |
| actual deregistrations | 62 |
| **unpaired closes** | **8** — abandoned sockets, one per redial |

Cumulative: every reconnect leaked one more.

Also added a **client-side ping** (20s, under the Border's 90s `ping_timeout`). `IOWebSocketChannel.connect()` sends nothing of its own, so an idle socket depended entirely on the Border's pings surviving the carrier/NAT path — and the client couldn't notice a half-open socket at all.

## The test caught a bug in my own fix

`sink.close()` returns a `Future`, so the first version's synchronous `try/catch` would **not** have caught a rejection — closing an already-dead socket would raise an unhandled async error in exactly the case we least care about. Now suppressed on the Future.

## Scope: this is NOT the whole flapping story

8 of 70 closes were leaked sockets. The other **62 were the current, heartbeating channel** dying abruptly, and this doesn't explain those. Ruled out with evidence, not inference:

- **Not** the Border ping timeout — raised to 90s earlier, and a synthetic client held 41s of silence through the same router/NAT path.
- **Not** the heartbeat miss-limit — 1 heartbeat failure all day vs 70 closes, and a miss-limit close wouldn't log via the read loop.
- **Not** auth state — `channel.trusted` is set correctly; the `[unauthenticated]` in the log is a stale logger name never updated after auth (cosmetic; follow-up).

The remaining 62 are consistent with iOS/Android suspending the isolate on background, which no keepalive interval prevents. **Reliable delivery to a backgrounded app needs push** — currently dependency-present but non-functional (no `google-services.json`/`GoogleService-Info.plist`). That's the real fix and separate work.

Verified: **83 Dart** (3 new), **284 Python**, analyze clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)