### PR TITLE
fix(edge): device labels at enrollment; one shared member-liveness definition

### DIFF
--- a/mcp-servers/protocol-mcp/bgp-daemon-v2.py
+++ b/mcp-servers/protocol-mcp/bgp-daemon-v2.py
@@ -645,16 +645,12 @@ async def handle_n2n(method, path, body):
                  "node_type": m["node_type"],
                  "specialty_count": fed.risk.specialty_count(m["scope"]),
                  "skills": _spec_names(m["scope"]),
-                 # An edge (phone) member's live connection lives in
-                 # edge_channels, never member_channels (agent members
-                 # only) -- checking only the latter meant every edge node
-                 # showed live=false forever regardless of actual
-                 # connection health, and the HUD's own edge-node panel
-                 # (node_type filter) silently rendered nothing since 066
-                 # first shipped, since node_type wasn't even in this
-                 # response at all until this fix.
-                 "live": m["member_id"] in fed.member_channels
-                         or m["member_id"] in fed.edge_channels}
+                 # Liveness comes from ONE shared definition
+                 # (FederationService.member_liveness) so this endpoint and
+                 # /n2n/members/health can never drift apart again, and both
+                 # carry heartbeat_age_s -- `state` alone flips constantly on a
+                 # phone and reads as endpoints contradicting each other.
+                 **fed.member_liveness(m)}
                 for m in fed.risk.list_members()]}
 
         if path == "/n2n/members/health" and method == "GET":
@@ -667,8 +663,7 @@ async def handle_n2n(method, path, body):
                     health = {}
                 out.append({"member_id": m["member_id"], "state": m["state"],
                             "auth_failures": m["auth_failures"],
-                            "live": m["member_id"] in fed.member_channels
-                                    or m["member_id"] in fed.edge_channels,
+                            **fed.member_liveness(m),
                             "health": health})
             return 200, {"members": out}
 

--- a/mcp-servers/protocol-mcp/bgp/federation/service.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/service.py
@@ -800,14 +800,10 @@ class FederationService:
         member_fault = backend_fault = False
         for m in self.risk.list_members():
             mid = m["member_id"]
-            # An edge (phone) member's live connection lives in edge_channels,
-            # never member_channels (agent members only) -- checking only the
-            # latter reported every connected phone as down, and since its DB
-            # row is `active` that also tripped member_fault, mislabelling the
-            # WHOLE risk fault_class="member" when nothing was wrong. Same bug
-            # class fixed in ec7acdd for GET /n2n/members and
-            # /n2n/members/health; this third call site was missed.
-            live = mid in self.member_channels or mid in self.edge_channels
+            # Shared definition -- see member_liveness(). Computing this
+            # inline is what let three call sites drift into reporting every
+            # connected phone as down.
+            live = self.member_liveness(m)["live"]
             will_cold = (not live) and bool(m.get("launch_cmd")) and (
                 bool(m.get("on_demand")) or self.risk.managed_by(mid) == "service")
             members[mid] = {"state": "up" if live else "down", "will_cold_start": will_cold}
@@ -996,6 +992,37 @@ class FederationService:
     # names (in2n/enroll, in2n/hello) as agent-member iN2N enrollment (contract
     # §2) — only consume_token()'s new node_type="edge" argument (T006) and a
     # separate registry (self.edge_channels, T008) distinguish it.
+
+    # ---- member liveness (one definition, used everywhere) --------------
+
+    def member_liveness(self, m) -> dict:
+        """The single source of truth for "is this member reachable right now".
+
+        Every caller that reported liveness used to compute it inline, and they
+        drifted: three separate call sites checked only `member_channels` and so
+        reported every connected PHONE as down (an edge member's channel lives
+        in `edge_channels`). Two were fixed in ec7acdd and a third in the
+        health_report() fix; this exists so there is no fourth.
+
+        `heartbeat_age_s` is included because `state` alone is genuinely
+        misleading on a phone. `state` is written on connect/disconnect, and a
+        phone reconnects constantly (82 deregistrations and 94 dial-ins in one
+        day on this Border), so two reads seconds apart can honestly disagree —
+        which reads to an operator as endpoints contradicting each other. The
+        heartbeat age is what actually distinguishes "briefly between sockets"
+        from "gone", and without it `state: active` next to a stale heartbeat,
+        or `state: unreachable` next to a 20s-old one, both look like lies.
+        """
+        mid = m["member_id"]
+        live = mid in self.member_channels or mid in self.edge_channels
+        age = None
+        try:
+            hb = (json.loads(m["health"]) if m["health"] else {}).get("last_heartbeat")
+            if hb:
+                age = round(max(0.0, time.time() - float(hb)), 1)
+        except (ValueError, TypeError, KeyError):
+            age = None
+        return {"live": live, "heartbeat_age_s": age}
 
     # ---- edge (phone) agent-turn budget --------------------------------
 

--- a/mobile/netclaw-mobile/lib/ncfed/enrollment_flow.dart
+++ b/mobile/netclaw-mobile/lib/ncfed/enrollment_flow.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'edge_client.dart';
 import 'edge_identity.dart';
 import 'enrollment_qr_payload.dart';
@@ -25,14 +27,43 @@ class EnrollmentFailure extends EnrollmentOutcome {
 /// and mapped to a friendly message before any state changes — a
 /// domain-mismatched payload never reaches `EdgeClient.enroll`'s network
 /// call at all (`verifyClawDomainBeforeDial` throws first).
+/// A never-null, human-distinguishable label for this device.
+///
+/// Every edge member used to enroll with `display_name: null`, because this is
+/// the only caller of `EdgeClient.enroll` and it never passed one. Owner
+/// attribution then had to be guessed from enrollment timestamps, which caused
+/// a real misroute: a message intended for one operator's phone was delivered
+/// to another's because the mesh carried no way to tell them apart.
+///
+/// Derived rather than prompted so it can never be skipped or left empty. The
+/// memberId tail disambiguates two devices on the same platform (memberId is
+/// `risk/<millis>`, so the tail is stable and unique per enrollment). An
+/// operator-supplied name overrides it — see [attemptEnrollmentFromQr].
+String defaultDeviceLabel(String memberId) {
+  final platform = switch (Platform.operatingSystem) {
+    'ios' => 'iPhone',
+    'android' => 'Android',
+    final other => other,
+  };
+  final tail = memberId.length >= 4 ? memberId.substring(memberId.length - 4) : memberId;
+  return '$platform · $tail';
+}
+
 Future<EnrollmentOutcome> attemptEnrollmentFromQr(
   String raw, {
   required String memberId,
   required EdgeIdentity identity,
+  /// Optional operator-supplied device name. When null or blank, a derived
+  /// label is sent instead — the Border must never receive a null again.
+  String? displayName,
 }) async {
   try {
     final payload = EnrollmentQrPayload.parse(raw);
-    final client = await EdgeClient.enroll(payload, memberId: memberId, identity: identity);
+    final label = (displayName == null || displayName.trim().isEmpty)
+        ? defaultDeviceLabel(memberId)
+        : displayName.trim();
+    final client = await EdgeClient.enroll(payload,
+        memberId: memberId, identity: identity, displayName: label);
     return EnrollmentSuccess(client, payload);
   } on ClawDomainMismatchException catch (e) {
     return EnrollmentFailure('This QR points at the wrong Border.\n${e.toString()}');

--- a/mobile/netclaw-mobile/lib/screens/manual_enrollment_screen.dart
+++ b/mobile/netclaw-mobile/lib/screens/manual_enrollment_screen.dart
@@ -53,6 +53,9 @@ class _ManualEnrollmentScreenState extends State<ManualEnrollmentScreen> {
   final _domainController = TextEditingController();
   final _portController = TextEditingController(text: '8443');
   final _tokenController = TextEditingController();
+  /// Optional. Blank falls back to a derived label — the Border is never
+  /// sent a null display_name again (see defaultDeviceLabel).
+  final _nameController = TextEditingController();
   bool _busy = false;
   String? _errorText;
 
@@ -61,6 +64,7 @@ class _ManualEnrollmentScreenState extends State<ManualEnrollmentScreen> {
     _domainController.dispose();
     _portController.dispose();
     _tokenController.dispose();
+    _nameController.dispose();
     super.dispose();
   }
 
@@ -85,6 +89,7 @@ class _ManualEnrollmentScreenState extends State<ManualEnrollmentScreen> {
       raw,
       memberId: widget.memberId,
       identity: widget.identity,
+      displayName: _nameController.text,
     );
     switch (outcome) {
       case EnrollmentSuccess(client: final client, payload: final payload):
@@ -140,6 +145,16 @@ class _ManualEnrollmentScreenState extends State<ManualEnrollmentScreen> {
                 autocorrect: false,
                 minLines: 1,
                 maxLines: 3,
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _nameController,
+                enabled: !_busy,
+                decoration: const InputDecoration(
+                  labelText: 'Device name (optional)',
+                  hintText: "e.g. John's iPhone",
+                  helperText: 'Helps the Border tell your devices apart',
+                ),
               ),
               const SizedBox(height: 20),
               if (_errorText != null)

--- a/mobile/netclaw-mobile/test/enrollment_display_name_test.dart
+++ b/mobile/netclaw-mobile/test/enrollment_display_name_test.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:netclaw_mobile/ncfed/enrollment_flow.dart';
+
+/// Every edge member enrolled with `display_name: null`, because
+/// `attemptEnrollmentFromQr` is the only caller of `EdgeClient.enroll` and never
+/// passed one — even though both already supported it. Owner attribution then
+/// had to be guessed from enrollment timestamps, which caused a real misroute:
+/// a message intended for one operator's phone was delivered to another's
+/// because the mesh carried no way to tell the two apart.
+///
+/// The label is derived rather than prompted so it can never be skipped or left
+/// blank; the manual-enrollment screen can override it.
+void main() {
+  group('defaultDeviceLabel', () {
+    test('is never empty', () {
+      expect(defaultDeviceLabel('risk/1785078347014').trim(), isNotEmpty);
+    });
+
+    test('distinguishes two devices on the same platform', () {
+      // The whole point: two Androids must not collapse to one indistinguishable
+      // label, which is what made the misroute possible.
+      final a = defaultDeviceLabel('risk/1785077389894');
+      final b = defaultDeviceLabel('risk/1785078347014');
+      expect(a, isNot(equals(b)));
+    });
+
+    test('carries the memberId tail so it maps back to the mesh identity', () {
+      final label = defaultDeviceLabel('risk/1785078347014');
+      expect(label, contains('7014'),
+          reason: 'an operator must be able to tie the label to the member row');
+    });
+
+    test('names the platform in human terms', () {
+      final label = defaultDeviceLabel('risk/1785078347014');
+      final expected = switch (Platform.operatingSystem) {
+        'ios' => 'iPhone',
+        'android' => 'Android',
+        final other => other,
+      };
+      expect(label, contains(expected));
+    });
+
+    test('handles a short memberId without throwing', () {
+      // Defensive: memberId is normally `risk/<millis>`, but the label must not
+      // be the thing that breaks enrollment if that ever changes.
+      for (final id in ['', 'a', 'ab', 'abc', 'abcd']) {
+        expect(() => defaultDeviceLabel(id), returnsNormally);
+        expect(defaultDeviceLabel(id).trim(), isNotEmpty);
+      }
+    });
+
+    test('is stable for the same memberId', () {
+      // Reconnect/re-enroll of the same device must not produce a new name.
+      final id = 'risk/1785078347014';
+      expect(defaultDeviceLabel(id), defaultDeviceLabel(id));
+    });
+  });
+}

--- a/tests/n2n/test_member_liveness_shared.py
+++ b/tests/n2n/test_member_liveness_shared.py
@@ -1,0 +1,119 @@
+"""One definition of member liveness, used by every reporting call site.
+
+Three call sites each computed liveness inline and drifted into checking only
+`member_channels` — the AGENT-member registry — so every connected PHONE was
+reported down (an edge member's channel lives in `edge_channels`). Two were
+fixed in ec7acdd, a third in the health_report() fix. This pins the shared
+helper so there is never a fourth.
+
+`heartbeat_age_s` is part of the contract because `state` alone misleads on a
+phone: it is written on connect/disconnect, and a phone reconnects constantly
+(82 deregistrations and 94 dial-ins in one day on the live Border), so two reads
+seconds apart can honestly disagree. Reported as "endpoints contradicting each
+other" in a defect report; the heartbeat age is what actually distinguishes
+"briefly between sockets" from "gone".
+"""
+import json
+import os
+import sys
+import time
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..",
+                                "mcp-servers", "protocol-mcp"))
+
+
+def _svc(member_channels=(), edge_channels=()):
+    from bgp.federation.service import FederationService
+    s = object.__new__(FederationService)
+    s.member_channels = {k: object() for k in member_channels}
+    s.edge_channels = {k: object() for k in edge_channels}
+    return s
+
+
+def _member(member_id, health=None):
+    return {"member_id": member_id,
+            "health": json.dumps(health) if health is not None else None}
+
+
+def test_a_connected_phone_is_live():
+    """The original bug: an edge channel lives in edge_channels, so a phone
+    checked against member_channels alone read as down while connected."""
+    s = _svc(edge_channels=["risk/phone"])
+    assert s.member_liveness(_member("risk/phone"))["live"] is True
+
+
+def test_a_connected_agent_member_is_live():
+    s = _svc(member_channels=["johns-risk/pyats"])
+    assert s.member_liveness(_member("johns-risk/pyats"))["live"] is True
+
+
+def test_a_member_in_neither_registry_is_not_live():
+    s = _svc()
+    assert s.member_liveness(_member("risk/phone"))["live"] is False
+
+
+def test_edge_and_agent_registries_are_both_consulted():
+    """A regression that dropped either registry would pass a test that only
+    covered the other."""
+    s = _svc(member_channels=["a"], edge_channels=["b"])
+    assert s.member_liveness(_member("a"))["live"] is True
+    assert s.member_liveness(_member("b"))["live"] is True
+
+
+def test_heartbeat_age_is_reported():
+    s = _svc(edge_channels=["risk/phone"])
+    out = s.member_liveness(_member("risk/phone",
+                                    {"last_heartbeat": time.time() - 42}))
+    assert out["heartbeat_age_s"] == pytest.approx(42, abs=2)
+
+
+def test_a_stale_heartbeat_on_a_live_channel_is_visible():
+    """This combination is exactly what looked like a lie to an operator:
+    state/live say one thing, the heartbeat is minutes old."""
+    s = _svc(edge_channels=["risk/phone"])
+    out = s.member_liveness(_member("risk/phone",
+                                    {"last_heartbeat": time.time() - 600}))
+    assert out["live"] is True
+    assert out["heartbeat_age_s"] > 500, "staleness must be visible, not hidden"
+
+
+def test_missing_or_malformed_health_does_not_raise():
+    s = _svc(edge_channels=["risk/phone"])
+    for health in (None, {}, {"last_heartbeat": None}, {"last_heartbeat": "nonsense"}):
+        out = s.member_liveness(_member("risk/phone", health))
+        assert out["heartbeat_age_s"] is None
+        assert out["live"] is True, "a bad health blob must not affect liveness"
+
+
+def test_health_that_is_not_json_does_not_raise():
+    s = _svc(edge_channels=["risk/phone"])
+    out = s.member_liveness({"member_id": "risk/phone", "health": "{not json"})
+    assert out["heartbeat_age_s"] is None
+
+
+def test_heartbeat_age_is_never_negative():
+    """Clock skew must not produce a negative age an operator has to interpret."""
+    s = _svc(edge_channels=["risk/phone"])
+    out = s.member_liveness(_member("risk/phone",
+                                    {"last_heartbeat": time.time() + 120}))
+    assert out["heartbeat_age_s"] >= 0
+
+
+def test_no_reporting_call_site_computes_liveness_inline():
+    """Guard against a fourth divergent copy appearing."""
+    root = os.path.join(os.path.dirname(__file__), "..", "..",
+                        "mcp-servers", "protocol-mcp")
+    inline = "in fed.member_channels"
+    with open(os.path.join(root, "bgp-daemon-v2.py")) as f:
+        daemon = f.read()
+    assert inline not in daemon, (
+        "a daemon endpoint is computing liveness inline again — use "
+        "FederationService.member_liveness() so the endpoints cannot drift")
+
+    with open(os.path.join(root, "bgp", "federation", "service.py")) as f:
+        svc = f.read()
+    # Exactly one occurrence: the definition inside member_liveness itself.
+    assert svc.count("in self.member_channels or mid in self.edge_channels") == 1


### PR DESCRIPTION
From Justin's test-build defect report. Two of four fixed here. **The report's headline defect is corrected — it was mischaracterised.**

## Defect 3 — every device enrolled as `display_name: null` ✅ fixed

`attemptEnrollmentFromQr` is the **only** caller of `EdgeClient.enroll` and never passed a display name — though both sides already supported the field. Owner attribution had to be guessed from enrollment timestamps, which caused a **real misroute**: a message for one operator's phone went to another's.

Now always sends a label, derived so it can't be skipped: platform + memberId tail (`iPhone · 7014`) — stable per enrollment, distinguishes two devices on the same platform. Manual enrollment gained an optional **Device name** override. No new packages (`Platform` is dart:io), so `pubspec.yaml` is untouched.

## Defect 2 — endpoints "disagreeing" ✅ fixed, but not as diagnosed

**Not an endpoint inconsistency.** Both already computed `live` identically; `state` differed — it's written on connect/disconnect, and a phone reconnects constantly (**82 deregistrations, 94 dial-ins in one day**). Two reads seconds apart honestly disagree, which reads as contradiction.

- Liveness now has **one** definition, `FederationService.member_liveness()`, used by `/n2n/members`, `/n2n/members/health` and `health_report()`. Three sites had computed it inline and drifted into checking only `member_channels` (the *agent* registry), reporting every connected phone as down. A test greps for a fourth copy.
- Both endpoints now return **`heartbeat_age_s`** — what actually separates "briefly between sockets" from "gone".

## Defect 1 — CORRECTED ⚠️

The report says Justin's Android had a push token and the iPhone didn't, concluding the fault was one-sided and enrollment needed fixing. **Neither device has ever had a push token:**

```
Android  push_platform=None  push_token=NONE
iPhone   push_platform=None  push_token=NONE
```

`push_to_edge()` delivers over the live WebSocket and raises if not connected; the route then falls back to push. Justin's phone was *connected*; the iPhone wasn't, fell through to push, found no token, failed. **The states have since inverted** — proof it isn't device-specific.

The enrollment path is fine. Push is non-functional on **both** platforms: no Firebase project anywhere. That's a config gap (Firebase project, plus APNs key + Xcode capabilities for iOS), not a code fix — already documented in `MOBILE-ONBOARDING.md`.

## Defect 4 — not ours

"speak speak" for "speech" is the on-device STT engine mistranscribing. No NetClaw code involved.

Verified: **302 Python** (10 new), **97 Dart** (6 new), analyze clean, daemon restarted, both endpoints confirmed agreeing live with `heartbeat_age_s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)