### PR TITLE
Add kepner-tregoe-network-troubleshooting skill

### DIFF
--- a/workspace/skills/kepner-tregoe-network-troubleshooting/SKILL.md
+++ b/workspace/skills/kepner-tregoe-network-troubleshooting/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: kepner-tregoe-network-troubleshooting
+description: >-
+  Structured Kepner-Tregoe (K-T) rational-process methodology for network operations. Use this
+  whenever diagnosing a network fault, outage, or performance deviation; triaging multiple
+  concurrent alarms or an alert storm; choosing between remediation options, designs, or vendors;
+  or planning and protecting a network change, migration, or upgrade. Apply it to ANY network
+  troubleshooting task — routing/BGP, wireless/RF, firewall/security, SD-WAN/overlay, DNS/DHCP,
+  cloud/hybrid connectivity, or performance — even when the request is only "why is X down",
+  "figure out what's wrong", or "the network is slow". It exists to stop guess-and-swap
+  troubleshooting: it forces you to specify the fault's boundary before hypothesizing, test causes
+  against evidence, verify the root cause before changing anything, and separate the fast reversible
+  incident fix from the permanent fix. Consult it before making state-changing actions on a network.
+license: Apache-2.0
+user-invocable: true
+---
+
+# Kepner-Tregoe for Network Troubleshooting
+
+## What this skill is for
+
+This skill gives a network-troubleshooting agent a disciplined method so it reaches a **verified root
+cause before acting**, instead of pattern-matching to a familiar cause and swapping components. The
+entire value is *sequencing and separation*: appraise before diagnosing, specify before theorizing,
+verify before fixing, decide before acting, protect before executing.
+
+You will usually have tools that can read network state (telemetry, device configs, routing/ARP/session
+tables, logs, packet/flow data, inventory/CMDB). Use those tools to **gather the evidence that fills the
+specification** — do not reason from memory when you can observe. The method tells you *which* evidence
+matters and *what to conclude from it*.
+
+## Non-negotiable principles
+
+1. **Specify before you hypothesize.** Never name a cause until you have drawn the fault's boundary
+   (what IS affected vs. what IS-NOT). The boundary is where the cause hides; skipping it is why
+   troubleshooting drifts from symptom to symptom.
+2. **The IS-NOT carries the answer.** Recording what is broken eliminates almost nothing. Recording the
+   *nearest comparable thing that could be broken but isn't* eliminates whole classes of cause in one line.
+3. **Test every candidate cause against the whole specification.** A cause that explains what IS but
+   contradicts an IS-NOT is wrong, however plausible. Prefer the cause that fits with the **fewest
+   assumptions**.
+4. **Verify in the real world before you fix.** A cause proven on paper is a hypothesis until a log line,
+   a counter, a table entry, or a controlled test confirms it. Fixing an unverified cause "fixes" a
+   symptom and leaves the root.
+5. **Separate the incident fix from the permanent fix.** Stop the bleeding with the fastest *reversible*
+   known-good action; the proper fix is a separate, planned decision. Conflating them extends outages.
+6. **Protect every change before executing it.** Prevention + contingency with explicit triggers.
+7. **Do not take state-changing actions without authorization.** Diagnose and recommend freely. Before
+   any config change, failover, reboot, or traffic-affecting action, confirm with the human/operator
+   unless you have standing authorization for that specific action. Read-only investigation needs no
+   confirmation.
+
+## Step 0 — Route to the right process
+
+Ask these in order and stop at the first "yes". Running the wrong process is the most common misuse
+(e.g. debating fixes before the cause is known).
+
+| Situation | Process | Reference |
+|---|---|---|
+| Several things happening at once; unclear priority or whether they're related | **Situation Appraisal** | `references/situation-appraisal.md` |
+| A single deviation from expected behavior, cause unknown | **Problem Analysis** | `references/problem-analysis.md` |
+| Cause known (or no fault) and you must choose among options | **Decision Analysis** | `references/decision-analysis.md` |
+| An action is decided and about to be executed | **Potential Problem Analysis** | `references/potential-problem-analysis.md` |
+| An incident already closed; you want the true root + systemic fixes | **Retrospective Problem Analysis** (postmortem) | `references/potential-problem-analysis.md` |
+
+A single incident often flows **SA → PA → DA → PPA**: triage the mess, find the cause, choose the fix,
+protect the fix. See `references/integrated-workflow.md` for a full worked end-to-end incident.
+
+## Problem Analysis — the core loop (run this most often)
+
+This is the process you will use most. Full detail and worked examples: `references/problem-analysis.md`.
+Execute these steps and **emit the specification as a structured record** (template below).
+
+1. **State the problem.** One object, one defect: "*what* is wrong with *what*." Two defects = two
+   problems; split them.
+2. **Build the specification (IS / IS-NOT)** across four dimensions. Use your tools to gather each cell.
+   For every IS, find the **nearest** comparable case that could show the fault but doesn't.
+   - **WHAT** — which object/service; which exact defect (and which defect it is *not*, e.g. resolution
+     vs. reachability, drop vs. error, SYN-drop vs. mid-session hang).
+   - **WHERE** — site / VLAN / interface / peer / zone / region / path; and which comparable locations
+     are clean.
+   - **WHEN** — first seen; last known-good; time-of-day/load pattern; and comparable times that are clean.
+   - **EXTENT** — how many / how much / what proportion / trend; and how much is unaffected / not spreading.
+3. **Distinctions & changes.** For each row: what is different/unique about the IS side vs. the IS-NOT
+   side? Within each distinction, **what changed and when?** Changes anchored to the WHEN boundary are
+   the strongest leads — but the most recent change is a *candidate*, not a conviction.
+4. **Generate possible causes** from distinctions and changes only (not folklore, not the last incident,
+   not the component you distrust).
+5. **Test each cause** against the full spec: "If this were true, would it produce *everything that IS*
+   and *nothing that IS-NOT*, with the fewest assumptions?" Eliminate any cause that contradicts an
+   IS-NOT. Rank survivors by assumption count.
+6. **Verify the most probable cause** with a targeted, ideally read-only observation before proposing a
+   fix. Name the exact command / query / test that confirms it.
+
+If a cause that *should* be right contradicts an IS-NOT, the specification is wrong or incomplete
+(a mis-recorded IS-NOT, a blank dimension) — **re-specify, don't re-guess**. If the best cause leaves
+exactly one boundary unexplained, suspect a **second, interacting cause** and re-specify that boundary.
+
+### Fast elimination: domain signature library
+
+Before generating causes, check the fault's signature against `references/domain-signatures.md`. It maps
+common observable signatures to the cause classes they eliminate or point to, per domain (routing/BGP,
+wireless/RF, firewall/security, SD-WAN/overlay, DNS/DHCP, cloud/hybrid, performance). Example: *interface
+errors are zero* eliminates physical-layer causes; *auth succeeds but clients drop, band-specific* points
+to RF/DFS, not RADIUS. This is Problem Analysis compressed into a lookup — use it to prune fast.
+
+## Output format — the troubleshooting record
+
+Always produce the reasoning as a structured record so a human (or the next agent) inherits the logic,
+not just the conclusion. Use this template:
+
+```
+PROBLEM: <object> — <defect>
+
+SPECIFICATION
+  WHAT   IS: <...>        IS-NOT: <...>
+  WHERE  IS: <...>        IS-NOT: <...>
+  WHEN   IS: <...>        IS-NOT: <...>
+  EXTENT IS: <...>        IS-NOT: <...>
+
+DISTINCTIONS / CHANGES: <what differs about the IS side; what changed and when>
+
+CANDIDATE CAUSES → TEST
+  - <cause>: explains IS? explains IS-NOT? assumptions? → <verdict>
+  ...
+
+MOST PROBABLE CAUSE: <cause>
+VERIFICATION: <exact read-only command/query/test to confirm, and expected result>
+
+INCIDENT FIX (fast, reversible): <action + how to roll back>   [requires authorization]
+PERMANENT FIX (planned decision): <route to Decision Analysis if options exist>
+```
+
+For Situation Appraisal, Decision Analysis, and Potential Problem Analysis, use the record templates in
+`references/worksheets.md`.
+
+## The other three processes (summaries; see references for full method + examples)
+
+- **Situation Appraisal** — triage. List concerns (single & specific), rate each on **Serious / Urgent /
+  Growth**, rank, and route each to PA/DA/PPA with an owner. In an alert storm, **collapse alarms sharing
+  a time+location signature into their root**, then hunt the one alarm that does *not* fit the pattern —
+  it is noise or a second incident. Full method: `references/situation-appraisal.md`.
+- **Decision Analysis** — choosing. Define **MUSTs** (mandatory, measurable, pass/fail) and weighted
+  **WANTs** (1–10). Screen alternatives against MUSTs (eliminate failures before scoring), score
+  survivors on weighted WANTs, then **assess adverse consequences of the leader before committing** — the
+  winner is the best score that survives its own risk review. Full method: `references/decision-analysis.md`.
+- **Potential Problem Analysis** — protecting a plan. For each vulnerable step: the potential problem, a
+  **preventive action** (reduces probability, acts on the cause) and a **contingent action** (reduces
+  impact, acts on the effect) with an **observable trigger and a named owner**. Golden rule: **never
+  remove the fallback until the replacement is verified.** Full method:
+  `references/potential-problem-analysis.md`.
+
+## When NOT to run the full method
+
+A known, trivial fault with an obvious fix (port admin-down, full disk, obviously-expired cert) should be
+fixed, not specified. Run the full apparatus when the cause is genuinely unknown, the blast radius is
+large, the situation is cluttered, or a wrong move is expensive/hard to reverse. Even then, the *habit* —
+"what's the IS-NOT?" and "have I verified this?" — costs nothing and should be reflexive.
+
+## Reference files
+
+- `references/problem-analysis.md` — Full PA method, IS/IS-NOT deep dive, six worked network faults, hard cases.
+- `references/situation-appraisal.md` — Full SA method, Serious/Urgent/Growth, on-call and alert-storm examples.
+- `references/decision-analysis.md` — Full DA method, MUST/WANT, three worked decisions incl. vendor selection.
+- `references/potential-problem-analysis.md` — Full PPA/POA method, change/migration protection, postmortems.
+- `references/domain-signatures.md` — Signature→cause lookup tables for seven network domains.
+- `references/worksheets.md` — Fill-in record templates for all four processes and a facilitation script.
+- `references/integrated-workflow.md` — One incident worked end-to-end through all four processes.

--- a/workspace/skills/kepner-tregoe-network-troubleshooting/references/decision-analysis.md
+++ b/workspace/skills/kepner-tregoe-network-troubleshooting/references/decision-analysis.md
@@ -1,0 +1,71 @@
+# Decision Analysis (DA) — full method
+
+Use DA to choose among alternatives — a fix (once the cause is verified), a design, a remediation path, a
+vendor. Do **not** run DA before PA when the cause is unknown: choosing a fix for an unverified cause is
+deciding what to do about an undiagnosed problem.
+
+## Six steps
+
+1. **State the decision** — one sentence: the choice + scope.
+2. **Objectives → MUSTs and WANTs**.
+   - **MUST**: mandatory, pass/fail, **measurable**. Any option failing a MUST is out, regardless of merit.
+     Test: if you'd still consider an option that fails it, it's not a MUST — it's a WANT.
+   - **WANT**: desirable, **weighted 1–10** by importance.
+3. **Generate alternatives** — include "do nothing" and sensible hybrids.
+4. **Screen against MUSTs** — eliminate failures now, before any scoring, on objective bars.
+5. **Score survivors on weighted WANTs** — score each 1–10 per WANT, ×weight, sum → ranked shortlist
+   (not yet the answer).
+6. **Assess adverse consequences, then choose** — for top contenders list what could go wrong, rate
+   probability × severity, and let the risk review (not the raw score alone) drive the call. The winner
+   is the **best score that survives its own risk assessment**.
+
+Weight WANTs **before** scoring, never after (setting weights once you see scores back-fits the answer).
+
+## Worked example 1 — Remediating a weak IPsec tunnel (cause known)
+
+Decision: replace IKEv1/AES-128/SHA-1 site-to-site tunnel with a policy-compliant one, acceptable risk.
+
+- **MUSTs**: result is IKEv2 + AES-256/SHA-256; interops with partner device; ≤30-min change; no new HW.
+- **WANTs**: minimize downtime (9); low coordination-failure risk (8); minimal ongoing complexity (6);
+  fast to schedule (5).
+
+MUST screen: "SASE overlay" fails (partner not onboarded, weeks) and "do nothing" fails (compliance) —
+both eliminated before scoring. Survivors: **A** in-place proposal upgrade vs **B** parallel new tunnel
+then migrate. Weighted WANTs: **B wins 203 vs 188** — it scores higher on the heavily-weighted downtime
+and coordination-risk WANTs because a parallel build validates the new tunnel *before* cutover and keeps
+the old tunnel as a fallback. Adverse-consequence review of B (selector overlap, partner delay, forgotten
+teardown) — all mitigable and non-service-affecting. **Choose B.** Score and risk review agree.
+
+## Worked example 2 — Access-layer refresh (design choice)
+
+MUSTs: central cloud management across all sites; multigig access; within FY budget. Top WANTs: low
+per-site deploy effort (9); zero-touch provisioning quality (8); 5-yr cost incl. licensing (8); roadmap
+fit for automation (6). A naive "cheapest per port" comparison picks the wrong box; the MUSTs remove any
+option lacking cloud mgmt/multigig, then the weighted WANTs push toward lowest deploy effort + 5-yr
+licensed cost. The winner is usually the cheapest to **operate at fleet scale**, not the cheapest to buy.
+
+## Worked example 3 — SD-WAN / SASE platform selection (high-stakes, hard to reverse)
+
+Decision: standardize one SASE platform across 60 sites over 5 years, within budget, deployable by the
+existing team.
+
+- **MUSTs**: integrated SASE (SD-WAN+SWG+ZTNA+FWaaS) from one policy plane; central cloud orchestration
+  for all 60 sites; meets data-residency/compliance in all regions; interops during migration; in budget.
+- **WANTs**: operational simplicity / single pane (9); 5-yr TCO incl. licensing & bandwidth (9); support
+  & local presence (7); API/automation & NetOps integration (7); deployment speed (6); roadmap/viability (5).
+
+MUST screen eliminates best-of-breed two-vendor (fails single-plane) and incumbent add-on (no cloud
+ZTNA/SWG) — **if** you won't eliminate the two-vendor option, then "single plane" was never a real MUST
+and belongs in WANTs; the method forces that honesty. Survivors V1/V4 score close (322 vs 310). **A close
+score means the adverse-consequence step decides, not the total.** V1's top risk (lock-in pricing) is
+mitigable contractually (price protection + data-portability terms) → **choose V1 contingent on those
+terms.** A feature-count spreadsheet would pick the most checkboxes; the method picks the option cheapest
+and safest to operate for 5 years.
+
+## Discipline reminders
+
+- No DA before a verified cause when the cause was the question.
+- Keep MUSTs few, mandatory, measurable — soft MUSTs wrongly eliminate good options.
+- Weight before scoring.
+- Never skip the adverse-consequence step — a top score with an unassessed catastrophic downside is how
+  good scores produce bad outcomes.

--- a/workspace/skills/kepner-tregoe-network-troubleshooting/references/domain-signatures.md
+++ b/workspace/skills/kepner-tregoe-network-troubleshooting/references/domain-signatures.md
@@ -1,0 +1,102 @@
+# Domain signature library
+
+Problem Analysis compressed into lookups. For a fault in a given domain, match the observed **signature**
+to what it **eliminates or points to**, and use the **specification prompts** to fill the IS/IS-NOT grid
+faster. Signatures are just IS/IS-NOT boundaries that recur so often they can be pre-listed. Confirm with
+tools; don't conclude from the table alone.
+
+## Routing / BGP
+
+Prompts — WHERE: which prefixes vs. which fine? which peer/VRF/AS-path? one direction or both? WHEN:
+correlate to flap timers, route-refresh, peer maintenance, policy commits, dampening. WHAT: route
+missing, present-not-best, present-not-installed, or installed-but-blackholed (four different problems).
+EXTENT: one prefix/peer or whole table? spreading?
+
+| Signature | Eliminates / points to |
+|---|---|
+| Route present but not selected best | Best-path attribute issue (local-pref, MED, AS-path len, weight, origin) — not a peering problem |
+| Session flaps on a regular interval | Keepalive/hold-timer mismatch, MTU/PMTUD on peering link, or underlay flap — not policy |
+| Best route chosen but traffic blackholes | RIB/FIB inconsistency or recursive next-hop resolution failure — not control-plane selection |
+| Only one direction affected | Return-path policy or asymmetric next-hop; specify both directions separately |
+
+## Wireless / RF
+
+Prompts — WHERE: which APs, band (2.4/5/6 GHz), area, SSID? (a floor plan is part of the spec). WHEN:
+time-of-day/week (client density, interference, DFS radar) matters enormously. WHAT: association vs
+authentication vs roaming failure vs good-signal-poor-throughput — separate the RF problem from the AAA
+problem (they present identically to the user). EXTENT: all clients or certain device types/drivers?
+
+| Signature | Eliminates / points to |
+|---|---|
+| Fails on 5/6 GHz, fine on 2.4 | DFS channel changes, min-RSSI/band-steering, coverage holes — not authentication |
+| Association fine, drops at auth | AAA/RADIUS/certificate — not RF. Specify the RADIUS server/realm, not the AP |
+| Only one client model affected | Client driver/powersave/band support — not the WLAN; exclude from infra PA |
+| Degrades at predictable busy hours | Contention/co-channel/capacity — a design issue, not a "reboot" fault |
+
+## Firewall / Security policy
+
+Prompts — WHERE: which policy/rule, zone pair, NAT, UTM profile? which direction? WHEN: policy commits,
+signature/feed auto-updates, cert rotations, HA failovers. WHAT: dropped at policy, by UTM/inspection, NAT
+failure, session-state failure, or decryption failure (a flow debug names the drop reason — use it).
+
+| Signature | Eliminates / points to |
+|---|---|
+| Forward works, return dropped | Stateful session not established, or asymmetric routing across an HA pair — not a simple deny |
+| Breaks after a feed/signature update | Threat/geo/IPS feed false-positive or new category block — not the base policy |
+| Only HTTPS to certain sites breaks | Deep-inspection/decryption or SNI filtering — not L3/L4 reachability |
+| Long sessions drop at a fixed interval | Idle/session timeout or HA session-sync gap — not congestion |
+
+## SD-WAN / overlay
+
+Prompts — WHERE: which site, underlay transport, overlay tunnel, app/SLA class? (separate overlay from
+underlay). WHEN: path-quality SLA thresholds triggering failover, controller/orchestrator pushes,
+transport events. WHAT: tunnel down vs up-but-steering-wrong (SLA steering can look like a fault while
+working as designed). EXTENT: one app class/site or fleet-wide (implicates controller/policy)?
+
+| Signature | Eliminates / points to |
+|---|---|
+| Traffic on "wrong" path but app works | Working-as-designed SLA steering or app-path policy — check policy intent before calling it a fault |
+| Repeated failover flaps between transports | A transport near an SLA threshold or over-tight thresholds causing hysteresis — tune, don't replace |
+| Fleet-wide simultaneous change | Controller/orchestrator push or template change — one root, many sites; specify last template version |
+| Overlay down but underlay up | IPsec/overlay parameter or controller reachability — not the transport circuit |
+
+## DNS / DHCP / core services
+
+Prompts — WHAT: **resolution vs connectivity** (the most misattributed distinction); within DNS —
+NXDOMAIN vs SERVFAIL vs timeout vs wrong-answer (different cause families). WHERE: which resolver, zone
+(internal vs forwarded), client scope; for DHCP — scope, relay, server in a pair. WHEN: lease renewals,
+zone-transfer schedules, cache TTL expiry, patch windows.
+
+| Signature | Eliminates / points to |
+|---|---|
+| External names resolve, internal don't | Authoritative/zone-transfer or conditional-forwarder issue on a specific resolver — not the network |
+| Fails on one resolver, retry succeeds | Per-server problem (stale zone, overloaded recursion) masked as "slowness" — specify per resolver |
+| Clients get no/duplicate IP intermittently | DHCP scope exhaustion, rogue server, or relay/helper misconfig — not DNS, not connectivity |
+| "Site down" but ping-by-IP works | It's resolution, not reachability — re-specify the defect before touching the path |
+
+## Cloud / hybrid connectivity
+
+Prompts — WHERE: connection type (IPsec-over-internet vs private circuit), VPC/VNet, region,
+peering/transit, direction. WHAT: underlay circuit vs BGP session vs route propagation into the cloud
+route table vs cloud-side security group/NACL (four layers, all present as "can't reach the workload").
+WHEN: cloud-console change events, MTU-related onset (overlay+IPsec shrinks MTU), BGP reconvergence.
+
+| Signature | Eliminates / points to |
+|---|---|
+| Circuit/tunnel up, BGP up, one prefix unreachable | Route-table propagation or a security-group/NACL rule — not transport or tunnel |
+| Small packets pass, larger flows to cloud stall | MTU/MSS (overlay+IPsec overhead); needs MSS clamping — not routing/security |
+| Breaks right after a cloud-console change | Cloud-side route-table or security-group edit — specify the change event first |
+| Reachable from one region/VPC not a peered one | Transit/peering route-propagation or a missing route — not on-prem |
+
+## Performance / throughput
+
+Prompts — WHAT: loss vs latency vs jitter vs throughput ceiling (four different problems; "slow" is not a
+spec). WHERE: which segment, direction, flow size? WHEN+EXTENT: utilization-correlated (congestion) vs
+constant (config/MTU) vs distance-correlated (BDP/window)?
+
+| Signature | Eliminates / points to |
+|---|---|
+| Small transfers fine, large ones stall | MTU/PMTUD blackhole or TCP window/BDP limit — not a link fault (no interface errors) |
+| Throughput tracks utilization crossing CIR | Congestion/policing — shaping/QoS issue, not hardware |
+| Poor throughput only over long distances | Bandwidth-delay-product / TCP window scaling — a tuning issue, not loss |
+| Interface errors present (CRC/input) | Physical layer — optic, fiber, duplex. The one signature that DOES point at hardware |

--- a/workspace/skills/kepner-tregoe-network-troubleshooting/references/integrated-workflow.md
+++ b/workspace/skills/kepner-tregoe-network-troubleshooting/references/integrated-workflow.md
@@ -1,0 +1,71 @@
+# Integrated workflow — one incident, all four processes
+
+Real incidents flow **SA → PA → DA → PPA**. The hand-offs are where undisciplined teams blur cause into
+fix into risk and get all three wrong. Watch for them.
+
+## The incident
+
+Monday 09:20. E-commerce checkout failing intermittently for customers; payments API timing out; internal
+warehouse app slow; a DC core switch logging errors; the edge firewall HA flapped this morning. Five loud
+symptoms across revenue-critical systems. Everyone has a theory.
+
+## Phase 1 — Situation Appraisal (impose order)
+
+Clarify and rank before diagnosing. The pattern — checkout + payments + warehouse app, plus a flapping
+core switch and edge firewall — reads as **one infrastructure fault expressing in many apps**, not five
+independent problems. Route the two infra concerns (core switch errors; firewall HA flap) to PA as the
+likely common cause; **hold** the three app symptoms rather than opening three parallel investigations.
+Not chasing the revenue symptom directly is the move a panicked bridge never makes.
+
+## Phase 2 — Problem Analysis (find the cause)
+
+Specify the infra deviation (core-switch errors + HA flap, onset ~06:30).
+
+| Dim | IS | IS-NOT |
+|---|---|---|
+| WHAT | Intermittent loss + HA heartbeat loss; output drops | No hard link-down; no CRC/input errors; DC-CORE-2 clean |
+| WHERE | The DC-CORE-1 ↔ firewall segment | DC-CORE-2 path clean; access layer clean |
+| WHEN | Since ~06:30; bursts track morning traffic ramp | Fine over the weekend; fine overnight |
+| EXTENT | Worsens as utilization rises; everything on that segment degrades | Redundant path unaffected; not 100% loss |
+
+Change: a weekend maintenance added LAG members between DC-CORE-1 and the firewall pair; onset is the
+first business-day ramp after it. Output-drops + heartbeat-loss under load with **zero physical errors** →
+logical/forwarding, not a bad optic. **Most probable**: the LAG change left a mismatched member / L2 loop
+that intermittently floods the segment under load, starving the HA heartbeat → firewall flaps → apps fail
+intermittently. **Verify**: STP/interface counters show flooding + TCN churn correlating with load bursts.
+Now the three held app symptoms are explained as one root — without ever being investigated separately.
+
+## Phase 3 — Decision Analysis (choose the fix)
+
+Cause known; choose under active revenue impact (time-boxed, but still MUST/WANT — pressure is exactly
+when skipping the method causes a second outage).
+
+- MUSTs: stops the flooding/flap now; no new outage to the redundant path; executable in minutes.
+- WANTs: preserves bandwidth gain (5); lowest collateral risk (9); reversible (7).
+
+Alternatives: **A** shut the new LAG members (revert to known-good pre-change topology); **B** reconfigure
+LAG hashing live (fails "minutes/low-collateral" MUST — defer to a window); **C** fail all to DC-CORE-2
+(bigger blast radius). On the heavily-weighted collateral-risk and reversible WANTs, **A wins** — it ends
+the incident instantly and reversibly. The proper LAG reconfiguration (B) is a **separate planned
+decision**. Conflating incident fix and permanent fix ("do it properly now" by tuning live) is how teams
+extend outages.
+
+## Phase 4 — Potential Problem Analysis (protect the permanent fix)
+
+The permanent fix (re-add bandwidth via a correctly configured LAG) is a planned change → PPA before the
+window. Preventive: lab/stage the exact LAG config; verify member consistency; enable one member at a
+time. Contingent: trigger on any flooding/TCN churn on enable → shut the member, revert (owner: change
+lead). Plus HA-flap and insufficient-bandwidth contingencies with triggers.
+
+## The hand-offs, made explicit
+
+| Transition | Question that changed | What breaks if blurred |
+|---|---|---|
+| SA → PA | "what do we work on?" → "what caused the infra fault?" | Chasing five app symptoms as five problems; never seeing the one root |
+| PA → DA | "what caused it?" → "which fix?" | Applying the first fix before the cause is verified — fixing a symptom |
+| DA → PPA | "which fix?" → "how do we protect the permanent fix?" | Re-doing the LAG change with the same lack of staging that caused the incident |
+
+One badly-staged change produced five loud symptoms. The K-T team reaches the root in one investigation,
+stops the incident with a reversible known-good action, and protects the permanent fix from repeating the
+mistake. The other team opens five tickets, argues firewall-vs-ISP, reboots something, and re-triggers the
+outage next weekend.

--- a/workspace/skills/kepner-tregoe-network-troubleshooting/references/potential-problem-analysis.md
+++ b/workspace/skills/kepner-tregoe-network-troubleshooting/references/potential-problem-analysis.md
@@ -1,0 +1,76 @@
+# Potential Problem Analysis (PPA) — full method
+
+Use PPA on a plan that is **decided and about to be executed** — a maintenance window, cutover,
+migration, upgrade. It is the only forward-looking process: what could go wrong, and how do we protect
+against it before it does? It turns a runbook from a list of steps into steps + failure modes +
+contingencies.
+
+## Prevention vs contingency — the core distinction
+
+- **Preventive action**: reduces the **probability** a cause occurs. Acts **before** the problem, **on the
+  cause**. (Take + test-restore a backup before an upgrade.)
+- **Contingent action**: reduces the **impact** if the problem occurs anyway. Acts **after** the problem,
+  **on the effect**. (Have the tested rollback one command away.)
+
+You need both. Prevention is never perfect; contingency without prevention is planning to fail.
+
+**Every contingency needs an observable trigger and a named owner.** "If BGP hasn't reconverged within 5
+min of cutover, execute rollback" is a trigger. "Roll back if it looks bad" is not.
+
+## Six steps
+
+1. Identify vulnerable areas (steps that are new, complex, tightly timed, dependent, or failure-prone).
+2. List specific potential problems in those areas.
+3. Rate probability × seriousness; focus on high-P or high-S.
+4. Identify likely causes of each.
+5. Set **preventive** actions (on the causes).
+6. Set **contingent** actions (on the effects) with **trigger + owner**.
+
+## Worked example — HA firewall firmware upgrade (abridged)
+
+| Potential problem | P/S | Preventive (on cause) | Contingent + trigger |
+|---|---|---|---|
+| Config doesn't migrate cleanly | M/H | Read deprecation notes; validate vs upgrade matrix; test migration on a VM clone | Trigger: post-upgrade policy audit shows breakage → restore staged backup, abort. Owner: change lead |
+| No clean rollback point | L/H | Full config+system backup, **test-restore** it before the window | Trigger: any need to roll back → restore verified backup / prior partition |
+| HA split-brain / both-active | M/H | Follow vendor HA sequence (upgrade passive first, fail over, then primary); verify heartbeat health first | Trigger: duplicate-IP/both-active alarm → force one unit standby; isolate if needed. Owner: on-console |
+| Tunnels don't re-establish | M/H | Pre-stage expected phase-1/2 params; partner NOC on standby | Trigger: tunnel down >5 min → apply known-good config; escalate to partner bridge |
+| Window overruns | M/M | Time-box phases with go/no-go; rehearse to estimate duration | Trigger: reach **point-of-no-return clock** without green primary → full rollback, reschedule |
+
+The window isn't longer to execute; it's **survivable** because each response is pre-decided, not
+improvised at 2 a.m.
+
+## Worked example — cloud/management-plane migration (abridged)
+
+Recurring strongest preventive pattern: **keep the old thing alive and reachable until the new thing is
+proven** — batch migration with the old plane retained; a canary site before wider rollout; policy
+export+diff before/after adoption; a retained out-of-band management path. Contingencies trigger on: a
+device unmanaged > X min (revert that device); migration idle past a set date (escalate); canary traffic
+failures (hold rollout, reconcile diff).
+
+## Potential Opportunity Analysis (POA) — the mirror
+
+Apply the same structure to upside: where could the plan go *better* than expected, what would cause that,
+and what **promoting** (make it more likely) and **capitalizing** (seize it) actions to take. E.g. canary
+automation beats the deploy-time estimate → instrument the canary to *prove* the saving (promoting) +
+pre-approve an accelerated rollout and early old-stack retirement (capitalizing). Most teams plan
+exhaustively for downside and not at all for upside, so good surprises go unexploited.
+
+## Postmortems as retrospective Problem Analysis
+
+A postmortem is PA after the fact with pressure removed. Specify in IS/IS-NOT terms, then **separate the
+trigger from the latent conditions**:
+
+- **Trigger**: the single change/event that set it off (e.g. a fat-fingered command).
+- **Latent conditions**: the missing guardrails that let the trigger become an outage.
+
+Corrective actions must target the **latent conditions** (systemic) — those make the next, different
+trigger harmless. A postmortem whose only action is "be more careful" found a trigger and no cause.
+Prompt set: specification → trigger → latent conditions → detection (why did we learn of it that way?) →
+corrective actions (systemic vs local).
+
+## Discipline reminders
+
+- Separate preventive from contingent for every item.
+- Every contingency: observable trigger + named owner.
+- Prioritize by probability × seriousness.
+- Never remove the fallback until the replacement is verified.

--- a/workspace/skills/kepner-tregoe-network-troubleshooting/references/problem-analysis.md
+++ b/workspace/skills/kepner-tregoe-network-troubleshooting/references/problem-analysis.md
@@ -1,0 +1,187 @@
+# Problem Analysis (PA) — full method
+
+Use PA when there is a **deviation** (observed ≠ expected performance) and the **cause is unknown**.
+Both conditions matter: no deviation → nothing to analyze; known cause → go to Decision Analysis.
+
+Core insight: every deviation was produced by a **change**. Locate the change by first drawing a precise
+**boundary** around the deviation, because the cause must lie exactly on that boundary. Find the boundary
+and the candidate space collapses from "anything" to "only things consistent with this edge".
+
+## The seven steps
+
+1. **State the problem** — one object, one defect. "What is wrong with what." Two defects = two problems.
+2. **Specify (IS / IS-NOT)** across WHAT / WHERE / WHEN / EXTENT. ~70% of the work.
+3. **Identify distinctions** — what is different/odd/unique about the IS vs. the IS-NOT?
+4. **Identify changes** — within each distinction, what changed and when?
+5. **Generate possible causes** — from distinctions and changes only.
+6. **Test each cause** against the full spec — does it explain the IS *and* the IS-NOT, with fewest assumptions?
+7. **Verify** the most probable cause in the real world before fixing.
+
+## Building the specification
+
+Two columns. **IS** = where/when/how the problem appears. **IS-NOT** = the *nearest* comparable place,
+time, or object where it could reasonably appear but does not. Choose IS-NOTs that are close (only one or
+two variables differ) — distant comparisons teach nothing.
+
+| Dimension | IS — ask | IS-NOT — the sharp comparison |
+|---|---|---|
+| **WHAT** | Which object has the defect? Which exact defect? | Which similar object could but doesn't? Which other defect could it have but doesn't? |
+| **WHERE** | Where geographically / on the topology / in the object? Site, VLAN, interface, peer, zone, layer? | Where else could it appear but doesn't? Which comparable segments are clean? |
+| **WHEN** | First seen? Time-of-day/week pattern? Point in a session/lifecycle? Last known-good? | When could it appear but doesn't? Which comparable time is clean? Before what date was it fine? |
+| **EXTENT** | How many? How big? What proportion? Trend — stable/growing/shrinking? | How many unaffected? How big could it be but isn't? Not spreading? |
+
+**Gather each cell with tools where possible** (interface counters, session/routing tables, logs, flow
+data, config diffs, inventory). The IS-NOT is the part most engineers skip and the part that carries the
+answer.
+
+## Distinctions → changes → causes
+
+- **Distinction**: what is peculiar about the IS side. (Site A fails, Site B clean, only difference is
+  firmware 7.4.11 vs 7.2.8 → firmware is a distinction.)
+- **Change**: within a distinction, what changed and when. (Site A upgraded on the 9th, fault started the
+  10th → prime candidate.) Changes anchored to the WHEN boundary are the strongest leads.
+- A candidate cause is **admissible only if it traces to a real distinction or change** on the affected side.
+
+## Testing causes (the elimination engine)
+
+For each candidate: *"If this is the cause, does it produce everything that IS and nothing that IS-NOT,
+with the fewest assumptions?"*
+
+- Explains IS but contradicts an IS-NOT → **eliminated**.
+- Survives only by adding assumptions → ranked below one that survives cleanly.
+- Most probable = fits the whole spec, no contradictions, no borrowed assumptions.
+
+## Verify before fixing
+
+Confirm with a log line, counter, table entry, or controlled (ideally read-only) test. Name the exact
+check and expected result. Only then propose the fix. Then split: fast **reversible incident fix** now,
+**permanent fix** as a separate decision (route to Decision Analysis if there are options).
+
+## Hard cases
+
+- **Multiple / interacting causes**: your best cause explains most of the spec but leaves one boundary
+  unexplained and needs an assumption to fit. Don't accept the awkward fit — suspect a second cause
+  (often a latent condition + a trigger, e.g. missing shaping + a traffic ramp). Re-specify the
+  unexplained boundary as its own sub-problem.
+- **Never-worked / greenfield**: no "was fine before" moment. Shift emphasis from WHEN (find the change)
+  to WHERE/WHAT (find the difference from a working peer). The IS-NOT becomes an existing working
+  instance; the distinction between it and the never-working one is the cause.
+
+Rule of thumb: *deviation from known-good* → hunt the change (WHEN-anchored). *Greenfield* → hunt the
+difference from a working peer (WHERE/WHAT-anchored). *One boundary unexplained* → suspect a second cause.
+
+---
+
+# Worked examples
+
+Each shows the specification driving elimination. Compress your own records to the same shape.
+
+## Example 1 — One SaaS app unreachable from one site
+
+**Problem**: Pune branch (VLAN 30) — ERP app `erp.vendor-cloud.com` times out at TCP connect.
+
+| Dim | IS | IS-NOT |
+|---|---|---|
+| WHAT | TCP connect to that one host times out; name resolves fine | Every other SaaS app works; not a DNS failure |
+| WHERE | Only from Pune (local internet breakout via its own firewall) | Not from HQ/Mumbai/VPN (egress via central cluster) |
+| WHEN | Since ~09:15 on the 10th, constant | Fine end of day on the 9th |
+| EXTENT | 100% of attempts to that one IP from that one site; SYN sent, no SYN-ACK | 0% of other sites; 0% of other destinations from Pune |
+
+Changes in window: (a) vendor rotated the ERP IP overnight; (b) Pune firewall threat/geo feed
+auto-updated at 09:00. **Tested**: "app is down" contradicts other-sites-work (eliminated); MTU
+blackhole contradicts failure-at-SYN (eliminated); vendor deny-list needs an unproven assumption (weak).
+**Most probable**: Pune firewall's updated feed now blocks the new ERP IP — explains Pune-only
+(independent egress), single-IP, SYN-dropped-with-DNS-fine, and the 09:00 timing, with zero assumptions.
+**Verify**: firewall security log / flow trace shows a deny to the new IP; confirm the IP is in the
+updated feed object. Fix (exempt destination / correct categorization) only after the log confirms.
+
+## Example 2 — Intermittent packet loss on a WAN link
+
+**Problem**: DC↔Bengaluru MPLS (WAN1) — bursts of 3–8% loss, minutes long, several times a day.
+
+| Dim | IS | IS-NOT |
+|---|---|---|
+| WHAT | Packet drops | Zero CRC/input errors; link never goes fully down |
+| WHERE | On WAN1 DC↔Bengaluru | LTE backup clean; sibling campuses clean; LAN clean |
+| WHEN | Weekday business peaks (10–11, 14:30–15:30) | Never overnight/weekends (despite weekend replication) |
+| EXTENT | 3–8% loss when utilization nears ~90% CIR | 0% loss below ~80% CIR; not growing week/week |
+
+Zero-error IS-NOT eliminates physical (optic/fiber/duplex). Weekend-clean IS-NOT eliminates provider
+fault. **Most probable**: congestion against CIR with no egress shaping — peaks hit the provider policer
+and drop; weekend replication stays under CIR. **Verify**: correlate drops to utilization crossing CIR;
+inspect egress queueing/shaping. Fix: shape to CIR with LLQ for voice — not a circuit swap, not a reboot.
+
+## Example 3 — Subset of VLAN devices lose gateway after a change
+
+**Problem**: ~half of VLAN 50 hosts lose off-subnet reachability after a distribution-switch change;
+intra-VLAN L2 still works.
+
+| Dim | IS | IS-NOT |
+|---|---|---|
+| WHAT | Gateway unreachable; L3 first-hop lost | Intra-VLAN L2 works; other VLANs fine |
+| WHERE | Hosts using DSW-B as active gateway | DSW-A-active hosts fine; wired VLANs on same pair fine |
+| WHEN | Since 22:40, at DSW-B reload in the window | Fine before; DSW-A (unchanged) fine |
+| EXTENT | ~50% (the DSW-B share); stable | Other ~50% never lost connectivity |
+
+The clean 50/50-by-gateway-role split is the fingerprint of a first-hop-redundancy (HSRP/VRRP) problem,
+not L2 or STP (which would break intra-VLAN too). Change time-locks to the DSW-B reload. **Most
+probable**: the change left the VLAN 50 SVI down / reset the FHRP virtual IP, so DSW-B wins active but
+can't route ("active but black-holing"). **Verify**: `show` the SVI state and FHRP group on DSW-B vs
+DSW-A. Fix the SVI/FHRP config — don't just fail everything to DSW-A (that masks a latent failover bug).
+
+## Example 4 — Intermittent internal DNS resolution failures
+
+**Problem**: Internal clients intermittently fail/slow to resolve internal zone names; external names fine.
+
+| Dim | IS | IS-NOT |
+|---|---|---|
+| WHAT | SERVFAIL/timeout on internal zone, retry succeeds | External resolution fine; not NXDOMAIN; resolver pings fine |
+| WHERE | Clients whose first resolver is DNS-SRV-2 | Clients hitting SRV-1 first are clean (tracks the server) |
+| WHEN | Bursts, worse under business load; ~4 days | Rare overnight; fine before ~4 days ago |
+| EXTENT | Minority of queries fail first attempt | Never total outage; external 0% failure |
+
+Tracks SRV-2 specifically → server problem, not path/clients. Internal-fails-but-forwarding-works → zone
+issue, not server-down. **Most probable**: SRV-2 has a stale/partial internal zone (failed transfer) or
+overloaded recursion, SERVFAILing under load until the client retries SRV-1. **Verify**: query SRV-2
+directly for internal names; compare zone serial to SRV-1; check transfer/recursion logs. Fix the
+transfer — don't "restart DNS" or bump client timeouts (masks it as tolerable slowness).
+
+## Example 5 — One-way traffic after a firewall policy change
+
+**Problem**: A client↔DMZ flow: client→server arrives, server→client return dropped; sessions stall/RST.
+
+| Dim | IS | IS-NOT |
+|---|---|---|
+| WHAT | One-way: forward ok, return dropped | Not a full block; not DNS/ARP; forward path clean |
+| WHERE | Return dropped at the firewall DMZ↔user | Flows not crossing this firewall unaffected |
+| WHEN | Since the 15:00 policy change, constant | Fine before; unchanged policies still pass return traffic |
+| EXTENT | 100% of this app's return flows; matches changed policy scope | Flows outside the policy's match criteria fine |
+
+Directionality (recorded explicitly) points at stateful-session handling, not routing. Server replies do
+leave the server → eliminates server-side gateway problem. **Most probable**: the 15:00 edit broke
+stateful session creation (changed service, removed NAT, narrowed match), so return traffic is
+un-associated and dropped. Secondary: asymmetric routing to the passive firewall. **Verify**: session
+table for the flow + flow debug drop reason on the changed policy.
+
+## Example 6 — Wi-Fi clients dropping in one area
+
+**Problem**: East-wing 3rd-floor clients associate, work briefly, drop; poor throughput while connected.
+
+| Dim | IS | IS-NOT |
+|---|---|---|
+| WHAT | Assoc succeeds then drops; poor throughput | Auth succeeds (RADIUS accepts); not a "can't see SSID" issue |
+| WHERE | East wing near two APs; 5 GHz worse than 2.4 | West wing/other floors clean |
+| WHEN | ~1 week; worse afternoons; clustered drops | Fine two weeks ago; overnight clean |
+| EXTENT | All client types in that zone; tied to a specific AP's channel changes | Only the east-wing pair; not site-wide |
+
+Auth-succeeds IS-NOT eliminates RADIUS/cert. Location + band + channel-change signature → RF/DFS, not
+controller-wide. **Most probable**: new 5 GHz interference / DFS radar hits forcing repeated channel
+changes on the east-wing APs, causing drops/retries under load. **Verify**: AP/controller DFS
+channel-change events + spectrum/interference report for that zone/time. Fix is RF (channel plan, AP
+placement, remediate interference) — not RADIUS, not a reboot.
+
+---
+
+**Discipline reminders**: don't skip the IS-NOT; anchor causes to changes but test the recent change like
+any other; count assumptions; verify before fixing; if nothing fits cleanly, the spec is incomplete —
+re-specify.

--- a/workspace/skills/kepner-tregoe-network-troubleshooting/references/situation-appraisal.md
+++ b/workspace/skills/kepner-tregoe-network-troubleshooting/references/situation-appraisal.md
@@ -1,0 +1,67 @@
+# Situation Appraisal (SA) — full method
+
+Use SA when the situation is cluttered — many concerns at once, unclear priorities, unclear whether
+things are related. It is triage: run it *before* you know whether you face a cause problem, a decision,
+or a risk. Do not deep-dive one alarm while others grow.
+
+## Four steps
+
+1. **List concerns** — enumerate everything needing attention: deviations, decisions, plans to protect,
+   unexplained observations, half-finished changes. Don't filter yet.
+2. **Separate & clarify** — break compound concerns into single, specific ones. A concern is clarified
+   when you can name the exact deviation or exact choice. "Site is down" is not a concern; the specific
+   deviations that make you say so are.
+3. **Set priority** — rate each on three independent dimensions and rank.
+4. **Plan next steps & route** — for each concern decide the process (PA/DA/PPA), the owner, and the
+   immediate action. Some need only an interim fix; some full analysis; some can wait. Every concern
+   exits SA with a named route and owner.
+
+## Priority dimensions — Serious / Urgent / Growth
+
+Rate each separately (High/Med/Low); "importance" is three questions that pull differently.
+
+| Dimension | Question | Network read |
+|---|---|---|
+| **Seriousness** | Current impact if we do nothing now? | Users, revenue, SLA, security exposure, blast radius |
+| **Urgency** | How much time before we must act? | Hard deadline — expiring cert, closing window, market open, compliance cutoff |
+| **Growth** | Is it getting worse, how fast? | Memory leak, filling partition, spreading MAC-flap, widening BGP flap |
+
+Concerns High on two or three rise to the top. A **High-Growth** item earns an early containment action
+even at low current seriousness — it's tomorrow's High-Seriousness incident.
+
+## Alert-storm correlation
+
+When dozens of alarms fire at once, the key SA skill is separating **correlated symptoms** from
+**independent concerns**:
+
+- **Collapse** alarms sharing a common time signature *and* a common location into their single root.
+  (All device/BGP/server-down alarms in the same rack rows, same 14:07 onset, same power phase → ONE
+  concern: the power event. The rest are its symptoms — don't dispatch them separately.)
+- Then **hunt the outlier**: the one alarm that does *not* fit the pattern (different location/time). It
+  is either noise or a **second, independent incident hiding in the storm** — verify it on its own. A
+  second incident masked by a storm is how a bad afternoon becomes a bad week.
+
+## Worked example — 2 a.m. on-call shift
+
+Five signals arrive. Clarify, then rank, then route.
+
+| Concern (clarified) | S | U | G | Rank / route |
+|---|---|---|---|---|
+| C1 FortiGate HQ CPU 95%+ for 20 min | H | H | H | 1 → PA (likely common cause of C2/C3) |
+| C2 Finance VLAN can't reach ERP (other apps fine) | H | M | L | 2 → PA, but hold — may be symptom of C1 |
+| C5 Syslog partition 88%, +3%/h | M | M | H | 3 → obvious cause → extend/rotate NOW (kills a high-growth item) |
+| C3 Branch-7 WAN flapping (SD-WAN failed to LTE) | M | L | M | 4 → service protected; defer PA |
+| C4 Portal cert expires in 34 h | H | L | None | 5 → PPA at day shift; add T-7d alarm |
+
+C1 wins (High×3, plausible common root). C5 outranks C3 on Growth (self-inflicts a monitoring blackout in
+4 h). C4 has the highest consequence but 34 h runway and zero growth → correctly last tonight. Result:
+three of five concerns resolved or safely parked without any deep investigation — the point of triage.
+
+## Common traps
+
+- Treating the loudest/reddest alarm as highest priority (alert severity is a static threshold, not live
+  blast radius) — re-rank by S/U/G.
+- Failing to separate — "site down" hides three faults with three owners.
+- Analyzing before triaging — appraise the whole board first, deep-dive second.
+- Ignoring Growth — the trivial-but-doubling item ambushes the next shift.
+- No explicit routing — a concern with no route and owner gets forgotten.

--- a/workspace/skills/kepner-tregoe-network-troubleshooting/references/worksheets.md
+++ b/workspace/skills/kepner-tregoe-network-troubleshooting/references/worksheets.md
@@ -1,0 +1,80 @@
+# Record templates and facilitation
+
+Emit reasoning as structured records so the next agent/human inherits the logic, not just the conclusion.
+Fill every field; write "none" where a cell is genuinely empty (an empty IS-NOT is often the point).
+
+## Situation Appraisal record
+
+```
+CONCERNS (single & specific):
+  C1: <deviation/decision/plan>   S:<H/M/L> U:<H/M/L> G:<H/M/L>  rank:<n>  route:<PA/DA/PPA> owner:<who> action:<now>
+  C2: ...
+CORRELATION NOTES: <which concerns share a time+location signature = one root; which outlier needs its own check>
+```
+
+## Problem Analysis record
+
+```
+PROBLEM: <object> — <defect>
+
+SPECIFICATION
+  WHAT   IS: <...>   IS-NOT: <...>
+  WHERE  IS: <...>   IS-NOT: <...>
+  WHEN   IS: <...>   IS-NOT: <...>
+  EXTENT IS: <...>   IS-NOT: <...>
+
+DISTINCTIONS/CHANGES: <what differs about the IS side; what changed and when>
+
+CANDIDATE CAUSES → TEST
+  - <cause>: IS? <y/n> | IS-NOT? <y/n> | assumptions:<...> → <keep/weak/eliminated>
+
+MOST PROBABLE CAUSE: <cause>
+VERIFICATION: <exact read-only command/query/test + expected result>
+
+INCIDENT FIX (fast, reversible): <action + rollback>          [needs authorization before executing]
+PERMANENT FIX: <route to Decision Analysis if options exist>
+```
+
+## Decision Analysis record
+
+```
+DECISION: <choice + scope>
+
+MUSTs (mandatory, measurable): <...>
+WANTs (weighted 1-10): <want (wt)> ...
+
+ALTERNATIVES:
+  <alt>: MUST screen <PASS/FAIL — which MUST> | weighted-WANT total <n>
+  ...
+ADVERSE CONSEQUENCES OF LEADER: <problem — P×S — mitigation>
+DECISION: <choice> — <why score AND risk review agree>
+```
+
+## Potential Problem Analysis record
+
+```
+PLAN/CHANGE BEING PROTECTED: <...>
+
+  POTENTIAL PROBLEM: <...>  P/S:<.../...>
+    LIKELY CAUSE: <...>
+    PREVENTIVE (on cause): <...>
+    CONTINGENT (on effect): <...>  TRIGGER: <observable> OWNER: <who>
+  ...
+POINT OF NO RETURN: <clock/condition by which success must show or rollback executes>
+```
+
+## Facilitation script (live incident bridge)
+
+1. **Appraise before diagnosing** (60–90s): list distinct concerns, one line each; rate S/U/G; what's
+   rank 1, and is it a cause, a choice, or a symptom of another concern?
+2. **Specify before theorizing**: before anyone names a cause — where IS it, where could it but IS-NOT?
+   when did it start, when last fine? what's affected, what comparable thing isn't? Put the grid where all
+   can see it.
+3. **Collect causes, then test**: for each — does it explain the IS *and* the IS-NOT? what are we
+   assuming? Eliminate out loud.
+4. **Verify before touching anything**: what one read-only test/log confirms this cause? Get it before
+   changing state.
+5. **Separate incident fix from permanent fix**: fastest reversible action that stops the bleeding; the
+   proper fix is a separate planned decision.
+6. **Protect the permanent fix**: before scheduling — what could go wrong, what prevents each cause,
+   what's the trigger and owner for each contingency?


### PR DESCRIPTION
Kepner-Tregoe is a problem-solving methodology through critical thinking. It was developed during the 1960s, intended to help floor managers in factories solve complex problems. When something broke in complex machinery or a production line, troubleshooting was always a complex task, and it cost the factory huge revenue loss.

Fast forward to the 2000s, Cisco thought it would be a great idea to apply this methodology to TAC, where we were solving complex network problems. I was one of the lucky few engineers — probably the last batch — who got this $10,000 workshop on Kepner-Tregoe for network troubleshooting. Post-training, we felt like we had a superpower. We could go into any call without needing full knowledge of the platform. It was all about asking the right questions and eliminating ambiguity.

I thought it would be a good idea to convert this into a skill for the AI agent in charge of network operations. I continue to test this every day in the lab and on my office network. It would be great if colleagues here can test it in complex problem situations and let me know how it goes.

## What's included
- Structured K-T rational-process methodology: Situation Appraisal, Problem Analysis, Decision Analysis, and Potential Problem Analysis
- Domain-signature lookup tables (routing/BGP, wireless/RF, firewall/security, SD-WAN/overlay, DNS/DHCP, cloud/hybrid, performance) and worked end-to-end examples
- Pure reasoning skill, no MCP/tool dependency — complements the OSI-layer approach in `pyats-troubleshoot` as a vendor-agnostic diagnostic discipline usable alongside any device-specific skill

## Test plan
- [ ] Skill auto-discovered via `workspace/skills/kepner-tregoe-network-troubleshooting/SKILL.md`
- [ ] Passes DefenseClaw skill scan (no HIGH/CRITICAL findings expected — pure markdown, no code)
- [ ] Try it on a real (or lab) fault and compare against the OSI-layer flow in `pyats-troubleshoot`
