### PR TITLE
fix(mcp,gait): repair GAIT audit logging and MCP launch failures

### DIFF
--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -999,6 +999,23 @@
         "HALO_PAGE_SIZE": "${HALO_PAGE_SIZE:-50}",
         "HALO_MAX_PAGES": "${HALO_MAX_PAGES:-20}"
       }
+    },
+    "memory-mcp": {
+      "command": "python3",
+      "args": [
+        "-u",
+        "mcp-servers/memory-mcp/memory_mcp_server.py"
+      ],
+      "env": {
+        "MEMORY_DATA_DIR": "${MEMORY_DATA_DIR:-~/.openclaw/memory}"
+      }
+    },
+    "gait-mcp": {
+      "command": "python3",
+      "args": [
+        "-u",
+        "scripts/gait-stdio.py"
+      ]
     }
   }
 }

--- a/scripts/defenseclaw-disable.sh
+++ b/scripts/defenseclaw-disable.sh
@@ -21,7 +21,7 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 log_step()  { echo -e "${CYAN}[STEP]${NC} $1"; }
 
 NETCLAW_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-OPENCLAW_CONFIG="$HOME/.openclaw/config/openclaw.json"
+OPENCLAW_CONFIG="$HOME/.openclaw/openclaw.json"
 
 echo "========================================="
 echo "  NetClaw - Disable DefenseClaw"

--- a/scripts/defenseclaw-enable.sh
+++ b/scripts/defenseclaw-enable.sh
@@ -24,7 +24,7 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 log_step()  { echo -e "${CYAN}[STEP]${NC} $1"; }
 
 NETCLAW_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-OPENCLAW_CONFIG="$HOME/.openclaw/config/openclaw.json"
+OPENCLAW_CONFIG="$HOME/.openclaw/openclaw.json"
 
 echo "========================================="
 echo "  NetClaw - Enable DefenseClaw + OpenShell"

--- a/scripts/gait-stdio.py
+++ b/scripts/gait-stdio.py
@@ -1,8 +1,49 @@
 #!/usr/bin/env python3
-"""Wrapper to run GAIT MCP server in stdio mode (default is SSE)."""
-import sys
+"""Wrapper to run GAIT MCP server in stdio mode (default is SSE).
+
+The 25 skills that record to GAIT all invoke this as `python3 -u $GAIT_MCP_SCRIPT`,
+so whichever interpreter `python3` resolves to must be able to import `gait`
+(the `gait-ai` package). A distro Python upgrade moves `python3` to a new minor
+version and strands the old site-packages, which breaks every one of those
+skills with `ModuleNotFoundError: No module named 'gait'`.
+
+To stay upgrade-proof, re-exec into the dedicated GAIT venv when `gait` is not
+importable under the current interpreter. Create that venv with
+`scripts/gait-venv-setup.sh`. Set GAIT_VENV to override its location.
+"""
 import os
-import asyncio
+import sys
+
+DEFAULT_VENV = os.path.expanduser(
+    os.environ.get("GAIT_VENV", "~/.openclaw/gait-venv"))
+
+
+def _reexec_into_venv() -> None:
+    """Re-exec under the GAIT venv interpreter. Returns only if that is
+    impossible, leaving the caller to fail with the original ImportError."""
+    if os.environ.get("_GAIT_STDIO_REEXEC"):
+        return  # already re-execed once; do not loop
+    # Compare paths literally, not with samefile(): a venv's bin/python is a
+    # symlink to the same real interpreter binary, so samefile() would report a
+    # match and skip the re-exec. It is the *path* we invoke that sets
+    # sys.prefix and therefore which site-packages get imported.
+    venv_python = os.path.join(DEFAULT_VENV, "bin", "python")
+    if not os.path.exists(venv_python) or venv_python == sys.executable:
+        return
+    os.environ["_GAIT_STDIO_REEXEC"] = "1"
+    os.execv(venv_python, [venv_python, os.path.abspath(__file__), *sys.argv[1:]])
+
+
+try:
+    import gait  # noqa: F401
+except ImportError:
+    _reexec_into_venv()
+    raise SystemExit(
+        f"GAIT unavailable: cannot import 'gait' under {sys.executable} and no "
+        f"usable venv at {DEFAULT_VENV}. Run scripts/gait-venv-setup.sh."
+    )
+
+import asyncio  # noqa: E402
 
 # Add the gait_mcp directory to path
 gait_dir = os.path.join(os.path.dirname(__file__), "..", "mcp-servers", "gait_mcp")

--- a/scripts/gait-venv-setup.sh
+++ b/scripts/gait-venv-setup.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# gait-venv-setup.sh - Create the dedicated GAIT virtualenv
+#
+# Usage: ./scripts/gait-venv-setup.sh
+#
+# The 25 skills that record to the GAIT audit trail invoke the server as
+# `python3 -u $GAIT_MCP_SCRIPT`. When a distro upgrade moves `python3` to a new
+# minor version, the previously installed `gait-ai` is stranded in the old
+# site-packages and every one of those skills fails with
+# `ModuleNotFoundError: No module named 'gait'`.
+#
+# This script pins GAIT's dependencies into a venv that survives interpreter
+# upgrades. scripts/gait-stdio.py re-execs into it automatically when `gait` is
+# not importable, so no skill needs to change.
+#
+# Re-run this after a Python upgrade.
+
+set -euo pipefail
+
+GAIT_VENV="${GAIT_VENV:-${HOME}/.openclaw/gait-venv}"
+
+echo "=== GAIT venv setup ==="
+echo ""
+
+if ! command -v uv &> /dev/null; then
+    echo "ERROR: uv not found. Please install uv first:"
+    echo "  curl -LsSf https://astral.sh/uv/install.sh | sh"
+    echo ""
+    echo "(uv is required because Debian/Ubuntu ship python3 without ensurepip,"
+    echo " so 'python3 -m venv' cannot bootstrap pip on this host.)"
+    exit 1
+fi
+
+# Prefer the system interpreter so the venv tracks the OS Python, not a
+# uv-managed prerelease.
+PYTHON_BIN="$(command -v python3)"
+echo "Base interpreter: ${PYTHON_BIN} ($("${PYTHON_BIN}" -V 2>&1))"
+echo "Target venv     : ${GAIT_VENV}"
+echo ""
+
+if [ -d "${GAIT_VENV}" ]; then
+    echo "Removing existing venv..."
+    rm -rf "${GAIT_VENV}"
+fi
+
+uv venv "${GAIT_VENV}" --python "${PYTHON_BIN}"
+
+# Dependencies mirror mcp-servers/gait_mcp/pyproject.toml
+VIRTUAL_ENV="${GAIT_VENV}" uv pip install gait-ai mcp fastmcp
+
+echo ""
+echo "Verifying..."
+"${GAIT_VENV}/bin/python" -c "import gait, mcp, fastmcp; print('  gait   :', gait.__file__)"
+
+echo ""
+echo "GAIT venv ready. scripts/gait-stdio.py will re-exec into it as needed."

--- a/scripts/lib/install-steps.sh
+++ b/scripts/lib/install-steps.sh
@@ -2729,6 +2729,13 @@ else
         if [ -f "$NETCLAW_DIR/config/openclaw.json" ]; then
             cp "$NETCLAW_DIR/config/openclaw.json" "$OPENCLAW_DIR/openclaw.json"
             log_info "Deployed fallback openclaw.json (gateway.mode=local)"
+            # The template registers servers with repo-relative paths, but the
+            # gateway does not run from the repo — without an explicit cwd every
+            # one of them dies at launch with "can't open file".
+            python3 "$NETCLAW_DIR/scripts/normalize-mcp-cwd.py" \
+                --config "$OPENCLAW_DIR/openclaw.json" \
+                --repo   "$NETCLAW_DIR" \
+                || log_warn "Could not normalize MCP cwd entries — relative-path servers may fail to launch"
         else
             log_warn "config/openclaw.json not found in repo"
         fi
@@ -3104,7 +3111,7 @@ if [[ "$ENABLE_DEFENSECLAW" =~ ^[Yy] ]]; then
             fi
 
             # Update openclaw.json with security.mode = defenseclaw
-            OPENCLAW_CONFIG="$HOME/.openclaw/config/openclaw.json"
+            OPENCLAW_CONFIG="$HOME/.openclaw/openclaw.json"
             if [ -f "$OPENCLAW_CONFIG" ]; then
                 python3 -c "
 import json
@@ -3181,7 +3188,7 @@ else
     log_info "NetClaw will run in hobby mode (no security layer)."
 
     # Update openclaw.json with security.mode = hobby
-    OPENCLAW_CONFIG="$HOME/.openclaw/config/openclaw.json"
+    OPENCLAW_CONFIG="$HOME/.openclaw/openclaw.json"
     if [ -f "$OPENCLAW_CONFIG" ]; then
         python3 -c "
 import json

--- a/scripts/memory-enable.sh
+++ b/scripts/memory-enable.sh
@@ -14,7 +14,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 OPENCLAW_DIR="${HOME}/.openclaw"
 MEMORY_DIR="${OPENCLAW_DIR}/memory"
-CONFIG_FILE="${OPENCLAW_DIR}/config/openclaw.json"
+CONFIG_FILE="${OPENCLAW_DIR}/openclaw.json"
 
 echo "=== Memory MCP Server Enable Script ==="
 echo ""

--- a/scripts/normalize-mcp-cwd.py
+++ b/scripts/normalize-mcp-cwd.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Give every relative-path MCP server entry an explicit cwd.
+
+config/openclaw.json registers most NetClaw servers with repo-relative paths,
+e.g. `python3 -u mcp-servers/memory-mcp/memory_mcp_server.py`. The installer
+copies that file verbatim to ~/.openclaw/openclaw.json, but the OpenClaw
+gateway does not run from the repo — it typically runs from $HOME. Any entry
+without a `cwd` then resolves its script path against the wrong directory and
+dies at launch with:
+
+    python3: can't open file '/home/<user>/mcp-servers/...': [Errno 2]
+
+Entries that already declare a `cwd` are left alone, as are entries whose
+command and args are all absolute paths or plain package names (uvx/npx).
+
+An arg is treated as a repo-relative path only when it actually resolves to an
+existing file under the repo root, so package specs that merely contain a slash
+(`npx -y @zereight/mcp-gitlab`) are not misread as paths.
+
+Usage:
+    normalize-mcp-cwd.py --config <path> --repo <netclaw repo root> [--dry-run]
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def needs_cwd(entry: dict, repo: Path) -> bool:
+    if entry.get("cwd"):
+        return False
+    command = entry.get("command")
+    if not command:
+        return False
+
+    candidates = [command, *entry.get("args", [])]
+    for c in candidates:
+        if not isinstance(c, str) or c.startswith(("-", "/", "~", "$")):
+            continue
+        if (repo / c).exists():
+            return True
+    return False
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", required=True)
+    ap.add_argument("--repo", required=True)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    cfg_path = Path(args.config)
+    repo = Path(args.repo).resolve()
+
+    if not cfg_path.is_file():
+        print(f"normalize-mcp-cwd: {cfg_path} not found — nothing to do")
+        return 0
+
+    cfg = json.loads(cfg_path.read_text())
+
+    # Support both the flat `mcpServers` shape and the nested `mcp.servers`.
+    if isinstance(cfg.get("mcpServers"), dict):
+        servers = cfg["mcpServers"]
+    elif isinstance(cfg.get("mcp"), dict) and isinstance(cfg["mcp"].get("servers"), dict):
+        servers = cfg["mcp"]["servers"]
+    else:
+        print("normalize-mcp-cwd: no MCP server block found — nothing to do")
+        return 0
+
+    fixed = []
+    for name, entry in servers.items():
+        if isinstance(entry, dict) and needs_cwd(entry, repo):
+            entry["cwd"] = str(repo)
+            fixed.append(name)
+
+    if not fixed:
+        print("normalize-mcp-cwd: all MCP entries already resolve correctly")
+        return 0
+
+    print(f"normalize-mcp-cwd: set cwd={repo} on {len(fixed)} entries:")
+    for name in fixed:
+        print(f"  - {name}")
+
+    if args.dry_run:
+        print("normalize-mcp-cwd: dry run, not writing")
+        return 0
+
+    cfg_path.write_text(json.dumps(cfg, indent=2) + "\n")
+    print(f"normalize-mcp-cwd: wrote {cfg_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/scan-all-mcps.sh
+++ b/scripts/scan-all-mcps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Scan all MCP servers configured in openclaw.json
 
-CONFIG="$HOME/.openclaw/config/openclaw.json"
+CONFIG="$HOME/.openclaw/openclaw.json"
 OUTPUT="${1:-DefenseClawMCPScan.md}"
 
 echo "# DefenseClaw MCP Server Scan Report" > "$OUTPUT"


### PR DESCRIPTION
Five faults, all traceable to two root causes: the python3.13 → 3.14 upgrade stranding user site-packages, and MCP config being written to a path the gateway does not read.

## GAIT was down since 2026-07-26 — three independent reasons

**1. `gait-ai` stranded on the old interpreter.** Installed only under python3.10/3.13, but `python3` is now 3.14, so the 25 skills that shell out to `python3 -u $GAIT_MCP_SCRIPT` all failed with `ModuleNotFoundError: No module named 'gait'`.

Adds `scripts/gait-venv-setup.sh` to pin GAIT's deps into a dedicated venv, and makes `scripts/gait-stdio.py` re-exec into it when `gait` is not importable. No skill had to change, and the next interpreter upgrade cannot re-break it.

> The re-exec deliberately compares interpreter paths **literally** rather than with `os.path.samefile()` — a venv's `bin/python` is a symlink to the same real binary, so `samefile()` reports a match and silently skips the re-exec. It is the invoked path that sets `sys.prefix`.

**2. `gait-mcp` was never registered** as an MCP server, in the template or live. Now registered (23 tools).

**3. The federation trail repo was corrupt.** Repaired out-of-tree at `~/.openclaw/n2n/gait`; that repo carries its own recovery commit with full detail. Summary: the host died mid-`emit()` at 2026-07-26T12:15:58Z. The ref update reached disk but the three git objects and the appended JSONL bytes did not, leaving `refs/heads/master` pointing at a zero-length commit — so every `emit()` since failed with `bad object HEAD` while the plain-file append kept succeeding. Row 388 was reconstructed from the authoritative `remote_invocation_record` row; the reconstruction is exactly 193 bytes, the same length as the NUL run it replaced, and closes the `sqlite_row_id` sequence with no gaps.

## MCP launch failures

**4. `memory-mcp` had a relative script path and no `cwd`.** The gateway runs from `$HOME`, so it died at launch with `can't open file` whenever the gateway was not started from the repo.

This was latent across the whole template: **42 of its entries would fail the same way on a fresh install**, because `install-steps.sh` copies `config/openclaw.json` verbatim without rewriting paths. Adds `scripts/normalize-mcp-cwd.py`, invoked by the installer, which injects an absolute `cwd` into entries whose command/args resolve to real files under the repo. Package specs that merely contain a slash (`npx -y @zereight/mcp-gitlab`) are left alone; the pass is idempotent.

**5. Two more servers were failing.** `twilio-voice-mcp` on `import pytz` — same stranded-site-packages cause as (1); deps reinstalled for 3.14, no code change needed. `pagerduty-mcp` lost its `env` block when its entry was migrated to the live config, so it started without `PAGERDUTY_USER_API_KEY`. Restored.

## Config path corrections

`defenseclaw-enable.sh`, `defenseclaw-disable.sh`, `memory-enable.sh`, `scan-all-mcps.sh` and `install-steps.sh` all read/wrote `~/.openclaw/config/openclaw.json`, which OpenClaw does not read — it reads `~/.openclaw/openclaw.json`. That stale file had accumulated **47 server entries and a `security.mode`** that were silently inert; `scan-all-mcps.sh` had been scanning it instead of the live set. `netclaw-secure-start.sh` legitimately handles both paths and is unchanged.

Also adds `memory-mcp` to `config/openclaw.json`, which never had it.

## Verification

All 7 live servers probe green:

| server | tools |
|---|---|
| gait-mcp | 23 |
| memory-mcp | 10 |
| n2n-mcp | 38 |
| pagerduty-mcp | 101 |
| rag-mcp | 10 |
| twilio-voice-mcp | 6 |
| twitter-mcp | 17 |

Federation trail: `fsck` clean, 394 lines, zero NULs, daemon committing again. GAIT session tracking verified end-to-end through the same path the skills use.

Test suite is **identical on `main` and this branch** (264 failed / 541 passed / 56 errors) — no regressions. Those pre-existing failures are unrelated (51 are a `storage.sqlite_store` import-path issue; the rest are ChromaStore and FastMCP 3.x API drift) and are left for separate work.

## Not included

- The 41 orphaned servers in the dead config are still unmigrated — which of those should go live is a judgement call.
- The live config has no `security` block, so DefenseClaw's mode is not recorded where the corrected scripts now look. Run `defenseclaw-enable.sh` to set it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)