### PR TITLE
fix(security): restore DefenseClaw tool inspection and report Ring 3 honestly

### DIFF
--- a/mcp-servers/protocol-mcp/bgp/federation/invocation.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/invocation.py
@@ -53,11 +53,21 @@ def _openclaw_config() -> dict:
 
 
 def _security_mode() -> str:
-    try:
-        cfg = json.loads(Path(os.path.expanduser("~/.openclaw/openclaw.json")).read_text())
-        return (cfg.get("security") or {}).get("mode", "hobby")
-    except Exception:
-        return "hobby"
+    """Delegate to controls.security_mode() — the single source of truth.
+
+    This previously read ~/.openclaw/openclaw.json, which is the *gateway*
+    config. That file's schema has no `security.mode` key (OpenClaw rejects it
+    outright: "security: Unrecognized key"), so the lookup could never succeed
+    and this always fell through to "hobby". The visible effect was that
+    _defenseclaw_inspect() below returned True unconditionally, silently
+    disabling the per-tool block-list check on every federated tool call even
+    with DefenseClaw fully enabled.
+
+    controls._security_config_path() reads ~/.openclaw/config/openclaw.json,
+    which is where the mode actually lives (see CLAUDE.md and that docstring).
+    """
+    from .controls import security_mode
+    return security_mode()
 
 
 async def _defenseclaw_inspect(tool: str, arguments: dict) -> bool:

--- a/scripts/defenseclaw-disable.sh
+++ b/scripts/defenseclaw-disable.sh
@@ -21,7 +21,12 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 log_step()  { echo -e "${CYAN}[STEP]${NC} $1"; }
 
 NETCLAW_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-OPENCLAW_CONFIG="$HOME/.openclaw/openclaw.json"
+# security.mode lives in ~/.openclaw/config/openclaw.json, NOT the gateway's
+# ~/.openclaw/openclaw.json. The gateway config schema has no security.mode key
+# and OpenClaw rejects the whole file if you add one ("security: Unrecognized
+# key"), taking every MCP server down with it. bgp/federation/controls.py reads
+# this same path. Do not "fix" this to the gateway config.
+OPENCLAW_CONFIG="$HOME/.openclaw/config/openclaw.json"
 
 echo "========================================="
 echo "  NetClaw - Disable DefenseClaw"

--- a/scripts/defenseclaw-enable.sh
+++ b/scripts/defenseclaw-enable.sh
@@ -24,7 +24,14 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 log_step()  { echo -e "${CYAN}[STEP]${NC} $1"; }
 
 NETCLAW_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-OPENCLAW_CONFIG="$HOME/.openclaw/openclaw.json"
+# security.mode lives in ~/.openclaw/config/openclaw.json, NOT the gateway's
+# ~/.openclaw/openclaw.json. The gateway config schema has no security.mode key
+# and OpenClaw rejects the whole file if you add one ("security: Unrecognized
+# key"), taking every MCP server down with it. bgp/federation/controls.py reads
+# this same path. Do not "fix" this to the gateway config.
+OPENCLAW_CONFIG="$HOME/.openclaw/config/openclaw.json"
+# The gateway config is a separate file and is where mcp.servers lives.
+GATEWAY_CONFIG="$HOME/.openclaw/openclaw.json"
 
 echo "========================================="
 echo "  NetClaw - Enable DefenseClaw + OpenShell"
@@ -253,7 +260,7 @@ import os
 import subprocess
 import sys
 
-config_path = os.path.expanduser('$OPENCLAW_CONFIG')
+config_path = os.path.expanduser('$GATEWAY_CONFIG')
 netclaw_dir = '$NETCLAW_DIR'
 defenseclaw = '$DEFENSECLAW_CMD'
 

--- a/scripts/lib/install-steps.sh
+++ b/scripts/lib/install-steps.sh
@@ -3111,7 +3111,10 @@ if [[ "$ENABLE_DEFENSECLAW" =~ ^[Yy] ]]; then
             fi
 
             # Update openclaw.json with security.mode = defenseclaw
-            OPENCLAW_CONFIG="$HOME/.openclaw/openclaw.json"
+            # security.mode belongs in the DefenseClaw config, not the gateway config:
+            # the gateway schema rejects a security.mode key and refuses the whole
+            # file. bgp/federation/controls.py reads this same path.
+            OPENCLAW_CONFIG="$HOME/.openclaw/config/openclaw.json"
             if [ -f "$OPENCLAW_CONFIG" ]; then
                 python3 -c "
 import json
@@ -3188,7 +3191,10 @@ else
     log_info "NetClaw will run in hobby mode (no security layer)."
 
     # Update openclaw.json with security.mode = hobby
-    OPENCLAW_CONFIG="$HOME/.openclaw/openclaw.json"
+    # security.mode belongs in the DefenseClaw config, not the gateway config:
+    # the gateway schema rejects a security.mode key and refuses the whole
+    # file. bgp/federation/controls.py reads this same path.
+    OPENCLAW_CONFIG="$HOME/.openclaw/config/openclaw.json"
     if [ -f "$OPENCLAW_CONFIG" ]; then
         python3 -c "
 import json

--- a/scripts/netclaw-secure-start.sh
+++ b/scripts/netclaw-secure-start.sh
@@ -58,11 +58,39 @@ show_status() {
     echo ""
 
     # Ring 3: NetClaw
+    #
+    # A bare `pgrep -f "openclaw.*gateway"` is NOT sufficient here: container
+    # processes are visible in the host PID namespace, and — more importantly —
+    # a gateway running directly on the host also matches. That made this report
+    # "Running" (implying protected) while NetClaw was in fact executing outside
+    # Ring 1 entirely, with no container isolation. Classify by cgroup instead,
+    # and say plainly which side of the boundary the process is on.
     echo -e "${CYAN}Ring 3 - NetClaw (AI Agent):${NC}"
-    if pgrep -f "openclaw.*gateway" &> /dev/null; then
-        echo "  Gateway:  Running"
+    local host_pids=() sandboxed_pids=() pid
+    for pid in $(pgrep -f "openclaw.*gateway" 2>/dev/null); do
+        if grep -qE '(docker|kubepods|containerd|libpod)' "/proc/$pid/cgroup" 2>/dev/null; then
+            sandboxed_pids+=("$pid")
+        else
+            host_pids+=("$pid")
+        fi
+    done
+
+    if [ ${#sandboxed_pids[@]} -gt 0 ]; then
+        echo -e "  Gateway:  ${GREEN}Running inside a container (pid ${sandboxed_pids[0]})${NC}"
+        echo "  Isolation: Ring 1 applies to this process"
+    elif [ ${#host_pids[@]} -gt 0 ]; then
+        echo -e "  Gateway:  ${YELLOW}Running on the HOST (pid ${host_pids[0]})${NC}"
+        echo -e "  Isolation: ${YELLOW}NONE — this process is OUTSIDE Ring 1${NC}"
+        echo "             OpenShell cannot constrain a host process. Ring 2"
+        echo "             (DefenseClaw) still applies; Ring 1 does not."
+        echo "             To get full 3-ring coverage, run the gateway in the"
+        echo "             sandbox: ./scripts/netclaw-secure-start.sh"
     else
         echo "  Gateway:  Not running"
+    fi
+
+    if [ ${#host_pids[@]} -gt 0 ] && [ ${#sandboxed_pids[@]} -gt 0 ]; then
+        echo -e "  ${YELLOW}Warning: both a host and a sandboxed gateway are running.${NC}"
     fi
     echo ""
 }


### PR DESCRIPTION
Found while bringing the 3-ring stack to production mode. Three defects, one of them a real security gap.

## 1. DefenseClaw per-tool inspection was dead on every federated tool call

`invocation.py::_security_mode()` read `security.mode` from `~/.openclaw/openclaw.json` — the **gateway** config. That file's schema has no such key; OpenClaw rejects it outright (`security: Unrecognized key`) and refuses the entire config, so the value can never legitimately live there.

The lookup therefore always fell through to its `"hobby"` default, and `_defenseclaw_inspect()` returned `True` unconditionally — silently skipping the block-list check on **every** `n2n/tools/call`, even with DefenseClaw fully enabled and `mode=action`.

`controls.py` already reads the correct path and its docstring documents exactly this trap. `_security_mode()` now delegates to `controls.security_mode()`, so there is one source of truth instead of two that disagreed.

## 2. `netclaw-secure-start.sh status` reported a false green for Ring 3

The check was `pgrep -f "openclaw.*gateway"`, which matches a gateway running directly on the host. It printed `Running` — implying protected — while NetClaw was executing **outside Ring 1 with no container isolation at all**. That is precisely the condition an operator runs this command to detect.

Ring 3 now classifies by cgroup and states plainly which side of the boundary the process is on, and warns if both a host and a sandboxed gateway are running. Worth noting: container processes *are* visible in the host PID namespace, so `pgrep` alone cannot make this distinction.

Before / after on this host:

```
Ring 3 - NetClaw (AI Agent):        Ring 3 - NetClaw (AI Agent):
  Gateway:  Running                   Gateway:  Running on the HOST (pid 164956)
                                      Isolation: NONE — this process is OUTSIDE Ring 1
```

## 3. Reverts the `security.mode` path change from #182

#182 repointed `defenseclaw-{enable,disable}.sh` and two `install-steps.sh` blocks at the gateway config. For MCP-server *scanning* that was correct — but these same scripts also write `security.mode`, and writing it to the gateway config invalidates the file and takes all 7 MCP servers down. Confirmed empirically: `openclaw mcp list` reported `OpenClaw config is invalid`.

`security.mode` stays in `~/.openclaw/config/openclaw.json`. That file is **not** dead — `controls.py` reads it deliberately. `defenseclaw-enable.sh` now carries a separate `GATEWAY_CONFIG` for the MCP-scanning pass that genuinely needs the live config, and both paths carry comments explaining why, so this doesn't get "fixed" back.

## Verification

Live host, full production posture now green:

| control | value |
|---|---|
| `security_mode` | `defenseclaw` |
| `is_production` | `True` |
| `require_defenseclaw_mode` | `True` |
| `gait_recording` | `True` |
| `openshell_available` | `True` |
| `sandbox_available` | `True` |
| `defenseclaw_available` | `True` |

`tests/n2n`: **307 passed**. Mesh daemon restarted to load the fix; all 4 members active and federated peers re-established unchanged.

## Still outstanding (not in this PR)

NetClaw itself still runs on the host, outside Ring 1. Rings 1 and 2 are up and Ring 2 applies, but container isolation does not wrap the agent. Moving it into the sandbox is a live cutover and needs scheduling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)