### PR TITLE
fix(gait): cover in-process importers, not just the stdio wrapper

### DIFF
--- a/scripts/gait-venv-setup.sh
+++ b/scripts/gait-venv-setup.sh
@@ -52,5 +52,23 @@ echo ""
 echo "Verifying..."
 "${GAIT_VENV}/bin/python" -c "import gait, mcp, fastmcp; print('  gait   :', gait.__file__)"
 
+# The venv only covers callers that go through scripts/gait-stdio.py. Some
+# long-running servers import gait *directly* in-process and cannot re-exec:
+#   mcp-servers/memory-mcp/memory_mcp_server.py  (gait_log)
+#   mcp-servers/rag-mcp/rag_mcp_server.py        (gait_log)
+# Both wrap the import in `except Exception: pass`, so a missing gait makes
+# their audit logging a silent no-op rather than an error. Ensure the default
+# interpreter can import it too.
+echo ""
+if "${PYTHON_BIN}" -c "import gait" 2>/dev/null; then
+    echo "Direct importers: ${PYTHON_BIN} can already import gait."
+else
+    echo "Installing gait-ai for ${PYTHON_BIN} (direct in-process importers)..."
+    "${PYTHON_BIN}" -m pip install --user --break-system-packages -q gait-ai \
+        || echo "  WARNING: could not install gait-ai for ${PYTHON_BIN};" \
+                "memory-mcp and rag-mcp audit logging will silently no-op."
+    "${PYTHON_BIN}" -c "import gait; print('  ok:', gait.__file__)" 2>/dev/null || true
+fi
+
 echo ""
 echo "GAIT venv ready. scripts/gait-stdio.py will re-exec into it as needed."


### PR DESCRIPTION
The venv + re-exec shim from #182 only fixed callers going through `scripts/gait-stdio.py`. Two long-running servers import `gait` **directly** and cannot re-exec mid-process:

- `mcp-servers/memory-mcp/memory_mcp_server.py:107` — `gait_log()`
- `mcp-servers/rag-mcp/rag_mcp_server.py:72` — `gait_log()`

Both wrap the import in `except Exception`, so under python3.14 (where `gait-ai` was stranded) their audit logging degraded to a **silent no-op** rather than an error. Nothing surfaced — the calls just stopped being recorded.

`gait-venv-setup.sh` now also ensures the default interpreter can import `gait`, with a comment explaining why, so a rebuild after the next interpreter upgrade covers both code paths.

Verified: `python3 -c "from gait.repo import GaitRepo"` now succeeds on the system interpreter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)