### PR TITLE
fix(security): stop claiming "All 3 Rings Active" after provisioning only

### DIFF
--- a/scripts/netclaw-secure-start.sh
+++ b/scripts/netclaw-secure-start.sh
@@ -980,14 +980,27 @@ start_all() {
 
     echo ""
     echo "═══════════════════════════════════════════════════════════════"
-    echo "  All 3 Rings Active!"
+    echo "  Sandbox provisioned — Ring 3 NOT yet running"
     echo "═══════════════════════════════════════════════════════════════"
     echo ""
     echo "  ┌─────────────────────────────────────────────────────────┐"
     echo "  │  Ring 1: OpenShell     - Container isolation    [✓]    │"
     echo "  │  Ring 2: DefenseClaw   - LLM guardrails ($GUARDRAIL_MODE)  [✓]    │"
-    echo "  │  Ring 3: NetClaw       - AI agent sandbox       [✓]    │"
+    echo "  │  Ring 3: NetClaw       - sandbox READY, not started     │"
     echo "  └─────────────────────────────────────────────────────────┘"
+    echo ""
+    # This script only provisions the sandbox; it never starts a gateway inside
+    # it and never stops the host one. Claiming "All 3 Rings Active" here was a
+    # false green: at this point nothing is running in the sandbox, and if a
+    # gateway is running on the host it is running OUTSIDE Ring 1.
+    echo "  Run './scripts/netclaw-secure-start.sh status' to see where the"
+    echo "  agent is actually running. Before cutting over, check that:"
+    echo "    - skills are present in /sandbox/.openclaw/workspace (they are"
+    echo "      NOT uploaded by this script)"
+    echo "    - the MCP paths in the migrated config resolve INSIDE the sandbox"
+    echo "      (a host cwd like /home/<user>/netclaw does not exist in it)"
+    echo "    - whatever calls the gateway on 127.0.0.1 can still reach it once"
+    echo "      it moves into the sandbox's own network namespace"
     echo ""
     echo "  ─────────────────────────────────────────────────────────────"
     echo "  CONNECT TO NETCLAW:"


### PR DESCRIPTION
`start_all()` provisions the sandbox then prints a banner asserting all three rings are active, Ring 3 ticked. At that point **nothing is running in the sandbox** — the script never starts a gateway inside it and never stops the host one. If a gateway is running at all, it's on the host, outside Ring 1: the exact opposite of what the banner claims.

Same class of false green as the `status` fix in #183, on the other code path.

The banner now states the sandbox is provisioned and Ring 3 is not started, and lists the three preconditions for a real cutover. All three were found false on this host after a **successful** provisioning run:

- skills are not uploaded by this script at all — `/sandbox/.openclaw/workspace` was empty
- the migrated config's MCP entries carry a host `cwd` (`/home/<user>/netclaw`) that does not exist inside the sandbox, so all 7 servers would fail to launch
- the gateway binds `127.0.0.1`, and the mesh daemon + 4 member services reach it there; moving it into the sandbox netns breaks them

🤖 Generated with [Claude Code](https://claude.com/claude-code)