### PR TITLE
HUD 2.0 — top-down trust org chart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # netclaw Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-07-25
+Auto-generated from all feature plans. Last updated: 2026-07-27
 
 ## Active Technologies
 - N/A (stateless server; subscription state held in-memory during runtime) (003-gnmi-mcp-server)
@@ -95,6 +95,8 @@ Auto-generated from all feature plans. Last updated: 2026-07-25
 - No Border-side schema change — `session_key=f"n2n-edge-{member_id}"` passed to `run_agent_turn` already gives each enrolled device its own agent session (research D6); the per-device conversation history itself (FR-007) is entirely on-device, a second JSON-Lines store mirroring 066's `MessageFeedStore` pattern (`ConversationStore`). (067-ncfed-mobile-command-channel)
 - Swift 5.0 (existing `ios/Runner/*.swift`, `SWIFT_VERSION = 5.0` in + None new. Reuses what's already in `pubspec.yaml`: `local_auth ^3.0.2` (071-ios-mobile-port)
 - N/A — Secure Enclave key storage is managed entirely by the Keychain/Secure Enclave (071-ios-mobile-port)
+- JavaScript ES2022 (ESM), Node 22+ for tooling + three.js `^0.170.0` (existing), `OrbitControls`, (072-hud-2-org-chart)
+- N/A — stateless client; all state from `/api/n2n` and `/api/graph` (072-hud-2-org-chart)
 
 - Python 3.10+ + FastMCP (MCP framework), grpcio + grpcio-tools (gRPC transport), pygnmi (gNMI client library), protobuf, cryptography (TLS handling) (003-gnmi-mcp-server)
 
@@ -114,9 +116,9 @@ cd src [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLO
 Python 3.10+: Follow standard conventions
 
 ## Recent Changes
+- 072-hud-2-org-chart: Added JavaScript ES2022 (ESM), Node 22+ for tooling + three.js `^0.170.0` (existing), `OrbitControls`,
 - 071-ios-mobile-port: Added Swift 5.0 (existing `ios/Runner/*.swift`, `SWIFT_VERSION = 5.0` in + None new. Reuses what's already in `pubspec.yaml`: `local_auth ^3.0.2`
 - 067-ncfed-mobile-command-channel: Added Python 3.10+ (daemon + `bgp/federation/*`, matching 052–066); Dart 3.x / Flutter 3.x (extends `mobile/netclaw-mobile/`, the same codebase 066 established) + Python: none new — reuses `gateway.run_agent_turn()`, `tasks.py`'s `TaskManager`, `edge.py`'s `EdgeChannel`/`EDGE_METHODS`, `invocation.py`'s `handle_task_status`/`result`/`cancel` exactly as-is. Dart: an on-device speech-to-text package for US4 (voice → text before sending, research D7) and (for US5) reuses `mobile_scanner` (already added in 066) for the QR half of the device deep link; the `netclaw://device/<id>` URI-scheme half needs a deep-link/app-links package (e.g. `app_links` or platform intent filters) — exact package choice is a Phase 2 task detail, not fixed here.
-- 068-ncfed-mobile-biometrics-capture: Added Python 3.10+ (daemon + `bgp/federation/*`, matching 052–067); Dart 3.x / Flutter 3.x (extends `mobile/netclaw-mobile/`) + Python: none new — reuses `push_to_edge()`, `resolve_approval()`, `RiskRouter`/`member.scope`, `TaskManager`. Dart: `local_auth` (biometric gating, US1), `camera` (photo/video capture, US2/US3) — exact audio-recording package (distinct from 067's speech-to-text, which discards audio after transcribing) is a Phase 2 task detail.
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/072-hud-2-org-chart/contracts/layout-contract.md
+++ b/specs/072-hud-2-org-chart/contracts/layout-contract.md
@@ -1,0 +1,135 @@
+# Contract: `orgchart/` pure-layout modules
+
+Feature: `072-hud-2-org-chart` · Phase 1
+
+The HUD exposes no public API to other systems, so the meaningful contract here
+is the **internal boundary between pure layout logic and three.js rendering**.
+That boundary is what makes the feature testable (research R1), so it is
+specified rather than left to emerge.
+
+## Invariants (binding on every module in `orgchart/`)
+
+1. **No three.js.** No module in `orgchart/` may import `three`, any
+   `three/addons/*`, or touch `window`, `document`, or a WebGL context. Each
+   must be importable in bare Node.
+2. **Pure.** Same input → same output. No I/O, no clocks, no randomness, no
+   module-level mutable state. Anything time-dependent (heartbeat age) is passed
+   in, never read from `Date.now()` inside.
+3. **Non-mutating.** Input payloads are treated as frozen; modules return new
+   objects.
+4. **Total.** Never throw on malformed input. Missing/null fields resolve to a
+   documented default (`Uncategorised`, `COLD`, `member_id` fallback label).
+
+Invariant 1 is enforced by construction: the tests run under `node --test` with
+no DOM, so a stray three.js import fails the suite rather than passing quietly.
+
+---
+
+## `categorize.js`
+
+```js
+categorizeMembers(members, integrationCatalog) -> Map<categoryName, Member[]>
+categorizeMember(member, integrationCatalog)   -> string   // category name
+```
+
+- Catalog is an **argument, never an import** — this is what makes Constitution
+  Principle VI (multi-vendor neutrality) testable: the same code must produce
+  different correct charts for different catalogs.
+- Matching: `skill.startsWith(prefix)` for each `integration.prefixes[]`.
+- A member's category is the **most frequent** among its skills; ties broken by
+  first catalog order for determinism.
+- No match, no skills, or empty catalog → `"Uncategorised"`. Never dropped, never
+  thrown (FR-006a).
+
+**Required tests:** the live 29 (expect 25 categorised); empty catalog (all
+`Uncategorised`); a member with zero skills; a synthetic alternate catalog
+producing a different-but-correct chart (Principle VI).
+
+---
+
+## `health.js`
+
+```js
+WARM_THRESHOLD_S = 900                        // single named constant (FR-008a)
+classifyHealth(member, nowEpochS) -> 'HOT' | 'WARM' | 'COLD' | 'FAULT'
+```
+
+- Evaluated strictly in precedence order: HOT → FAULT → WARM → COLD.
+- `nowEpochS` is **injected**, never read internally — otherwise the WARM/FAULT
+  boundary is untestable.
+- `live === true` ⇒ HOT, regardless of every other field.
+- `state ∈ {unreachable, quarantined}` ⇒ FAULT, regardless of heartbeat age.
+- `heartbeat_age_s` null/absent and not otherwise FAULT ⇒ COLD (never seen).
+
+**Required tests:** all four states; boundary at exactly 900 s; `active` but
+`!live` (the real 5-vs-4 disagreement); `unreachable` with a *fresh* heartbeat
+still FAULT; null heartbeat ⇒ COLD not FAULT. **The COLD/FAULT distinction is
+the highest-value assertion in the suite** — conflating them is the specific
+failure this design exists to prevent.
+
+---
+
+## `normalize.js`
+
+```js
+dedupePeers(peers)     -> Peer[]     // by identity; most restrictive state wins
+resolveLabel(entity)   -> string     // never empty
+```
+
+- State restrictiveness: `severed` > `unreachable` > `reconnecting` > `federated`.
+- Label precedence: `display_name` → tail of `member_id` after `/` →
+  `identity` → `"unknown"`.
+
+**Required tests:** the real duplicated-`Hermes` payload collapses to one peer
+in `severed`; both real edge nodes (`display_name: null`) resolve to non-empty
+labels (FR-015).
+
+---
+
+## `ordering.js`
+
+```js
+orderCategories(categories) -> Category[]   // heat desc, then size desc, then name
+```
+
+- `Uncategorised` always sorts last regardless of heat.
+- Deterministic: name is the final tiebreak, so two runs over equal input give
+  identical order.
+- **Called once per session.** The contract does not forbid re-invocation, but
+  `main.js` must not call it from the poll path (FR-034).
+
+**Required tests:** hot-before-cold; equal-heat falls back to size; equal both
+falls back to name; `Uncategorised` last even when it contains a HOT member (it
+does, on the live data — `ipfabric`).
+
+---
+
+## `layout.js`
+
+```js
+computeLayout(chartModel, viewport) -> { nodes: ChartNode[], bands: Band[] }
+appendMember(layout, member)        -> ChartNode   // no existing node moves
+```
+
+- Assigns `{x, y, z}` once. Three bands plus the edge lane always present, even
+  when empty (FR-033).
+- Internal band: category columns left→right, wrapping on viewport width;
+  members stack vertically within a column.
+- Edge nodes are routed to the edge lane and never appear in a category column
+  (FR-007). More edges than lane slots wrap — they must never overlap, which is
+  the bug in the current three-slot implementation.
+- `appendMember` is the FR-034b path: a member enrolling mid-session gets a
+  position **without any existing node changing** its own.
+
+**Required tests:** all five fixtures (0, 1, 29, 100, uncategorised); no two
+nodes share a position; `appendMember` leaves every prior coordinate byte-identical;
+edge nodes never receive a member-column position; bands exist at zero members.
+
+---
+
+## Consumer contract (`orgchart-render/`)
+
+Render modules **consume** this output and may not re-derive it. Specifically
+they must not classify health, choose categories, or compute positions — those
+answers come from `orgchart/` only. This keeps the render layer swappable and
+keeps every falsifiable rule inside the tested half.

--- a/specs/072-hud-2-org-chart/data-model.md
+++ b/specs/072-hud-2-org-chart/data-model.md
@@ -1,0 +1,137 @@
+# Phase 1 Data Model: HUD 2.0
+
+Feature: `072-hud-2-org-chart` · Date: 2026-07-27
+
+The HUD owns no persistent state. Every entity below is derived, in-memory, from
+`GET /api/n2n` (and, for retained panel renderers only, `GET /api/graph`). No
+schema change and no server change (FR-019).
+
+---
+
+## Source payload (existing, unchanged)
+
+### `n2n.risk`
+| Field | Type | Use |
+|---|---|---|
+| `role` | `"border"` \| other | `!= "border"` must still render structure (FR-033b) |
+| `risk_name` | string | Border node label |
+| `member_count`, `members_active` | int | Header counts |
+
+### `n2n.peers[]` — eN2N, external band
+| Field | Type | Use |
+|---|---|---|
+| `identity` | string | **Dedup key** (FR-014) |
+| `display_name` | string \| null | Label; falls back to `identity` (FR-015) |
+| `state` | `federated` \| `severed` | Link style (FR-010) |
+| `channel_state` | `unknown` \| `reconnecting` \| `unreachable` | Link style |
+| `in_flight_tasks[]` | array | Activity badge |
+
+> Live feed returns **`Hermes` twice** with conflicting `state`
+> (`severed` + `federated`). Dedup by `identity`; **most restrictive state wins**
+> (FR-014).
+
+### `n2n.members[]` — iN2N, internal band and edge lane
+| Field | Type | Use |
+|---|---|---|
+| `member_id` | `<risk>/<name>` | Identity; label fallback source (FR-015) |
+| `display_name` | string \| null | **Null for both live edge nodes** — must not render blank |
+| `node_type` | `agent` \| `edge` | `edge` → edge lane, never the member chart (FR-007) |
+| `state` | `active` \| `provisioned` \| `unreachable` \| `quarantined` | Health input |
+| `live` | bool | **Primary** health input — disagrees with `state` (5 active vs 4 live) |
+| `heartbeat_age_s` | number \| null | WARM/FAULT discriminator (FR-008) |
+| `skills[]` | string[] | Category derivation + tool expansion |
+| `specialty_count` | int | Collapsed tool count (FR-024) |
+
+### Integration catalog (existing, in `server.js`)
+72 entries × `{ id, name, category, prefixes[] }`, 22 distinct categories.
+**Passed as an argument**, never imported, so vendor neutrality is testable.
+
+---
+
+## Derived entities
+
+### `HealthState` — enum (FR-008)
+
+| Value | Derivation | Precedence |
+|---|---|---|
+| `HOT` | `live === true` | 1 (checked first) |
+| `FAULT` | `state ∈ {unreachable, quarantined}` **or** (`heartbeat_age_s != null` and `> WARM_THRESHOLD_S`) | 2 |
+| `WARM` | `heartbeat_age_s != null` and `<= WARM_THRESHOLD_S` | 3 |
+| `COLD` | otherwise (never seen — `heartbeat_age_s` null/absent) | 4 (default) |
+
+`WARM_THRESHOLD_S = 900` — a single named constant (FR-008a).
+
+Precedence matters: it is evaluated top-down, so an explicitly `unreachable`
+member is FAULT regardless of heartbeat age, and a member with no heartbeat
+history is COLD rather than FAULT. **COLD (never started, normal) and FAULT
+(died, needs attention) must never collapse into one another** — that
+distinction is the reason four states exist.
+
+### `Category`
+| Field | Type | Notes |
+|---|---|---|
+| `name` | string | From the catalog, or `"Uncategorised"` (FR-006a) |
+| `members[]` | Member[] | Ordered within the category |
+| `heat` | int | Count of HOT members — ordering input |
+| `column`, `row` | int | Assigned once (FR-034) |
+
+Derivation: `member.skills[]` → first matching `integration.prefixes[]` →
+`integration.category`; the **most frequent** category among a member's skills
+wins; no match → `Uncategorised`. Measured: 25/29 members, 93% of agent members.
+
+### `ChartNode`
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string | `identity` (peer) or `member_id` (member/edge) |
+| `kind` | `peer` \| `border` \| `member` \| `edge` | Band assignment |
+| `label` | string | Never blank — falls back to `member_id` tail (FR-015) |
+| `health` | HealthState | Members and edges only |
+| `position` | `{x, y, z}` | **Immutable for the session** (FR-034) |
+| `expanded` | bool | Runtime only; not positional |
+| `toolCount` | int | Shown when collapsed (FR-024) |
+
+### `Band` — three, fixed
+`external` (north, y > boundary) · `border` (centre, y = 0) · `internal`
+(south, y < boundary). Plus `edgeLane`, flanking the Border **inside** the
+boundary but outside the member chart (FR-007). Bands render even when empty
+(FR-033).
+
+### `LinkStyle` — six distinct (FR-010/011)
+`en2n-healthy` · `en2n-unreachable` · `en2n-severed` · `in2n-healthy` ·
+`in2n-cold` · `edge-push` (asymmetric Border→device, FR-011).
+
+---
+
+## State transitions
+
+Only **appearance** changes at runtime. Position is assigned once (FR-034).
+
+```
+                 heartbeat within 900s
+        HOT ──────────────────────────► WARM
+         ▲                                │  age > 900s
+         │ live=true                      ▼
+        COLD ◄──(never seen)         FAULT ◄── state=unreachable|quarantined
+         └──────────── live=true ──────────┘
+```
+
+A transition repaints the node. It **must not** move it, reorder its category,
+or re-pack the chart (FR-034a) — a claw that fails changes how it looks, never
+where it is.
+
+---
+
+## Validation rules
+
+| Rule | Source | Enforced in |
+|---|---|---|
+| Peers deduped by `identity`; most restrictive state wins | FR-014 | `normalize.js` |
+| No node renders a blank label | FR-015 | `normalize.js` |
+| `node_type=edge` never enters the member chart | FR-007 | `layout.js` |
+| Every member lands in exactly one category | FR-006a | `categorize.js` |
+| Unmatched members → `Uncategorised`, never dropped | FR-006a | `categorize.js` |
+| Health precedence HOT → FAULT → WARM → COLD | FR-008 | `health.js` |
+| Category order computed once per session | FR-006b, FR-034 | `ordering.js` |
+| Positions stable across polls | FR-034 | `layout.js` |
+| New member appends without displacing siblings | FR-034b | `layout.js` |
+| Correct at 0, 1, 29, 100 members | FR-029, FR-033 | fixtures × all modules |

--- a/specs/072-hud-2-org-chart/fixtures/README.md
+++ b/specs/072-hud-2-org-chart/fixtures/README.md
@@ -1,0 +1,34 @@
+# Fixtures — synthetic and captured `/api/n2n` payloads
+
+Research R4. These make SC-006 (product generality) and FR-029 (100-member
+ceiling) falsifiable — neither can be evidenced against a single 29-member
+Border.
+
+| File | Members | Peers | Exercises |
+|---|---:|---:|---|
+| `empty.json` | 0 | 0 | FR-033 first-run: bands, boundary and CTAs with no data |
+| `single.json` | 1 | 0 | Degenerate single-member chart |
+| `live-29.json` | 29 | 5 | Captured real Border — regression baseline |
+| `scale-100.json` | 102 | 5 | FR-029 ceiling + FR-029b frame rate; all four health states |
+| `uncategorised.json` | 29 | 5 | FR-006a: every member matches no integration prefix |
+
+## Notes
+
+**`live-29.json` is a point-in-time capture (2026-07-27) and will drift from the
+live Border.** It is committed deliberately as a fixed regression baseline; do
+not refresh it casually, or the tests asserting against it lose their meaning.
+
+Its 5 `live` members are **not** a contradiction of the spec's "4 live
+(`cml`, `ipfabric`, `pyats`, `viz`)". Those 4 are agent members. The 5th is an
+**edge node that reconnected between the spec measurement and the capture** —
+and it is a useful accident: its `display_name` is `null`, so it renders as the
+`member_id` tail (`1785078347014`). That is exactly the case FR-015 exists for,
+now present in the baseline fixture rather than only in prose.
+
+**`scale-100.json` has 102 members**: 100 generated plus the 2 real edge nodes,
+so the edge lane is exercised at the ceiling too. Health states are seeded
+(`random.seed(72)`) for reproducibility — roughly 10% HOT, 10% WARM, 10% FAULT,
+70% COLD, which approximates a real fleet where most claws are cold by design.
+
+**No credentials are present.** The `/api/n2n` payload carries topology and state
+only. Peer `endpoint` fields were nulled during capture regardless.

--- a/specs/072-hud-2-org-chart/fixtures/empty.json
+++ b/specs/072-hud-2-org-chart/fixtures/empty.json
@@ -1,0 +1,58 @@
+{
+  "available": true,
+  "identity": "as65000-0.0.0.0",
+  "peers": [],
+  "approvals": [],
+  "risk": null,
+  "members": [],
+  "posture": {
+    "mode": "production",
+    "state": "enforced",
+    "controls": [
+      {
+        "name": "sandbox",
+        "kind": "containment",
+        "available": true,
+        "detail": "",
+        "probed_at": 1785179850.0359924
+      },
+      {
+        "name": "model-guard",
+        "kind": "containment",
+        "available": true,
+        "detail": "",
+        "probed_at": 1785179850.0359924
+      },
+      {
+        "name": "audit",
+        "kind": "audit",
+        "available": true,
+        "detail": "",
+        "probed_at": 1785179850.0359924
+      }
+    ],
+    "missing": [],
+    "strict_all": false,
+    "model": {
+      "primary": "anthropic/claude-opus-5",
+      "guarded": false
+    },
+    "channel_security": {
+      "mode": "on",
+      "by_trust_model": {
+        "legacy": 2,
+        "pinned": 3
+      },
+      "degraded": 2,
+      "amber": 0,
+      "red": 0,
+      "renewals_failing": 0,
+      "pq_mode": "opportunistic",
+      "pq_available": false,
+      "ech_available": false,
+      "channels_kex": []
+    },
+    "computed_at": 1785179850.0363233,
+    "summary": "production \u2014 enforced"
+  }
+}

--- a/specs/072-hud-2-org-chart/fixtures/integration-catalog.json
+++ b/specs/072-hud-2-org-chart/fixtures/integration-catalog.json
@@ -1,0 +1,498 @@
+[
+  {
+    "id": "batfish",
+    "category": "Analysis",
+    "prefixes": [
+      "batfish-"
+    ]
+  },
+  {
+    "id": "aap",
+    "category": "Automation",
+    "prefixes": [
+      "aap-"
+    ]
+  },
+  {
+    "id": "chrome-devtools",
+    "category": "Browser Automation",
+    "prefixes": [
+      "chrome-devtools-",
+      "browser-viz-verify",
+      "browser-gui-inspect"
+    ]
+  },
+  {
+    "id": "aws",
+    "category": "Cloud",
+    "prefixes": [
+      "aws-"
+    ]
+  },
+  {
+    "id": "azure-network",
+    "category": "Cloud",
+    "prefixes": [
+      "azure-"
+    ]
+  },
+  {
+    "id": "gcp",
+    "category": "Cloud",
+    "prefixes": [
+      "gcp-"
+    ]
+  },
+  {
+    "id": "webex",
+    "category": "Collaboration",
+    "prefixes": [
+      "webex-"
+    ]
+  },
+  {
+    "id": "msgraph",
+    "category": "Collaboration",
+    "prefixes": [
+      "msgraph-"
+    ]
+  },
+  {
+    "id": "slack",
+    "category": "Collaboration",
+    "prefixes": [
+      "slack-"
+    ]
+  },
+  {
+    "id": "arista",
+    "category": "Controller Platforms",
+    "prefixes": [
+      "arista-"
+    ]
+  },
+  {
+    "id": "catc",
+    "category": "Controller Platforms",
+    "prefixes": [
+      "catc-"
+    ]
+  },
+  {
+    "id": "computer-use",
+    "category": "Desktop Automation",
+    "prefixes": [
+      "desktop-gui-inspect"
+    ]
+  },
+  {
+    "id": "gnmi",
+    "category": "Device Automation",
+    "prefixes": [
+      "gnmi-",
+      "gnmi_"
+    ]
+  },
+  {
+    "id": "junos",
+    "category": "Device Automation",
+    "prefixes": [
+      "junos-",
+      "pyats-junos-"
+    ]
+  },
+  {
+    "id": "pyats",
+    "category": "Device Automation",
+    "prefixes": [
+      "pyats-"
+    ]
+  },
+  {
+    "id": "cloudflare",
+    "category": "Edge Platform",
+    "prefixes": [
+      "cloudflare-"
+    ]
+  },
+  {
+    "id": "aci",
+    "category": "Fabric Control",
+    "prefixes": [
+      "aci-"
+    ]
+  },
+  {
+    "id": "atlassian",
+    "category": "Governance",
+    "prefixes": [
+      "atlassian-"
+    ]
+  },
+  {
+    "id": "gait",
+    "category": "Governance",
+    "prefixes": [
+      "gait-"
+    ]
+  },
+  {
+    "id": "github",
+    "category": "Governance",
+    "prefixes": [
+      "github-"
+    ]
+  },
+  {
+    "id": "gitlab",
+    "category": "Governance",
+    "prefixes": [
+      "gitlab-"
+    ]
+  },
+  {
+    "id": "halo",
+    "category": "Governance",
+    "prefixes": [
+      "halo-"
+    ]
+  },
+  {
+    "id": "jenkins",
+    "category": "Governance",
+    "prefixes": [
+      "jenkins-"
+    ]
+  },
+  {
+    "id": "servicenow",
+    "category": "Governance",
+    "prefixes": [
+      "servicenow-"
+    ]
+  },
+  {
+    "id": "pagerduty",
+    "category": "Incident Management",
+    "prefixes": [
+      "pagerduty-"
+    ]
+  },
+  {
+    "id": "terraform",
+    "category": "Infrastructure",
+    "prefixes": [
+      "terraform-"
+    ]
+  },
+  {
+    "id": "cml",
+    "category": "Labs",
+    "prefixes": [
+      "cml-"
+    ]
+  },
+  {
+    "id": "clab",
+    "category": "Labs",
+    "prefixes": [
+      "clab-"
+    ]
+  },
+  {
+    "id": "gns3",
+    "category": "Labs",
+    "prefixes": [
+      "gns3-"
+    ]
+  },
+  {
+    "id": "f5",
+    "category": "Load Balancing",
+    "prefixes": [
+      "f5-",
+      "pyats-f5-"
+    ]
+  },
+  {
+    "id": "nso",
+    "category": "Network Platforms",
+    "prefixes": [
+      "nso-"
+    ]
+  },
+  {
+    "id": "evpn",
+    "category": "Network Platforms",
+    "prefixes": [
+      "evpn-"
+    ]
+  },
+  {
+    "id": "itential",
+    "category": "Network Platforms",
+    "prefixes": [
+      "itential-"
+    ]
+  },
+  {
+    "id": "meraki",
+    "category": "Network Platforms",
+    "prefixes": [
+      "meraki-"
+    ]
+  },
+  {
+    "id": "prisma-sdwan",
+    "category": "Network Platforms",
+    "prefixes": [
+      "prisma-sdwan-"
+    ]
+  },
+  {
+    "id": "protocol",
+    "category": "Network Platforms",
+    "prefixes": [
+      "protocol-"
+    ]
+  },
+  {
+    "id": "sdwan",
+    "category": "Network Platforms",
+    "prefixes": [
+      "sdwan-"
+    ]
+  },
+  {
+    "id": "auvik",
+    "category": "Observability",
+    "prefixes": [
+      "auvik-"
+    ]
+  },
+  {
+    "id": "datadog",
+    "category": "Observability",
+    "prefixes": [
+      "datadog-"
+    ]
+  },
+  {
+    "id": "grafana",
+    "category": "Observability",
+    "prefixes": [
+      "grafana-",
+      "flow-"
+    ]
+  },
+  {
+    "id": "gtrace",
+    "category": "Observability",
+    "prefixes": [
+      "gtrace-"
+    ]
+  },
+  {
+    "id": "kubeshark",
+    "category": "Observability",
+    "prefixes": [
+      "kubeshark-"
+    ]
+  },
+  {
+    "id": "prometheus",
+    "category": "Observability",
+    "prefixes": [
+      "prometheus-"
+    ]
+  },
+  {
+    "id": "splunk",
+    "category": "Observability",
+    "prefixes": [
+      "splunk-"
+    ]
+  },
+  {
+    "id": "suzieq",
+    "category": "Observability",
+    "prefixes": [
+      "suzieq-"
+    ]
+  },
+  {
+    "id": "telemetry-receivers",
+    "category": "Observability",
+    "prefixes": [
+      "syslog-",
+      "snmptrap-",
+      "ipfix-",
+      "telemetry-"
+    ]
+  },
+  {
+    "id": "thousandeyes",
+    "category": "Observability",
+    "prefixes": [
+      "te-"
+    ]
+  },
+  {
+    "id": "token-tracker",
+    "category": "Observability",
+    "prefixes": [
+      "token-"
+    ]
+  },
+  {
+    "id": "wiki",
+    "category": "Reference",
+    "prefixes": [
+      "wikipedia-",
+      "rfc-",
+      "subnet-",
+      "packet-analysis"
+    ]
+  },
+  {
+    "id": "radkit",
+    "category": "Remote Access",
+    "prefixes": [
+      "radkit-"
+    ]
+  },
+  {
+    "id": "fmc",
+    "category": "Security",
+    "prefixes": [
+      "fmc-"
+    ]
+  },
+  {
+    "id": "ise",
+    "category": "Security",
+    "prefixes": [
+      "ise-"
+    ]
+  },
+  {
+    "id": "claroty",
+    "category": "Security",
+    "prefixes": [
+      "claroty-"
+    ]
+  },
+  {
+    "id": "fortimanager",
+    "category": "Security",
+    "prefixes": [
+      "fortimanager-"
+    ]
+  },
+  {
+    "id": "fwrule",
+    "category": "Security",
+    "prefixes": [
+      "fwrule-"
+    ]
+  },
+  {
+    "id": "vault",
+    "category": "Security",
+    "prefixes": [
+      "vault-"
+    ]
+  },
+  {
+    "id": "nmap",
+    "category": "Security",
+    "prefixes": [
+      "nmap-"
+    ]
+  },
+  {
+    "id": "nvd",
+    "category": "Security",
+    "prefixes": [
+      "nvd-"
+    ]
+  },
+  {
+    "id": "paloalto",
+    "category": "Security",
+    "prefixes": [
+      "paloalto-"
+    ]
+  },
+  {
+    "id": "zscaler",
+    "category": "Security",
+    "prefixes": [
+      "zscaler-"
+    ]
+  },
+  {
+    "id": "infoblox",
+    "category": "Source of Truth",
+    "prefixes": [
+      "infoblox-"
+    ]
+  },
+  {
+    "id": "infrahub",
+    "category": "Source of Truth",
+    "prefixes": [
+      "infrahub-"
+    ]
+  },
+  {
+    "id": "nautobot",
+    "category": "Source of Truth",
+    "prefixes": [
+      "nautobot-"
+    ]
+  },
+  {
+    "id": "netbox",
+    "category": "Source of Truth",
+    "prefixes": [
+      "netbox-"
+    ]
+  },
+  {
+    "id": "canvas-viz",
+    "category": "Visualization",
+    "prefixes": [
+      "canvas-network-viz",
+      "canvas-"
+    ]
+  },
+  {
+    "id": "drawio",
+    "category": "Visualization",
+    "prefixes": [
+      "drawio-"
+    ]
+  },
+  {
+    "id": "markmap",
+    "category": "Visualization",
+    "prefixes": [
+      "markmap-"
+    ]
+  },
+  {
+    "id": "threejs-viz",
+    "category": "Visualization",
+    "prefixes": [
+      "threejs-network-viz"
+    ]
+  },
+  {
+    "id": "uml",
+    "category": "Visualization",
+    "prefixes": [
+      "uml-"
+    ]
+  }
+]

--- a/specs/072-hud-2-org-chart/fixtures/live-29.json
+++ b/specs/072-hud-2-org-chart/fixtures/live-29.json
@@ -1,0 +1,5474 @@
+{
+  "available": true,
+  "identity": "as65001-4.4.4.4",
+  "peers": [
+    {
+      "identity": "as65003-3.3.3.3",
+      "display_name": "AB",
+      "state": "federated",
+      "chat_enabled": false,
+      "inventory_version": null,
+      "inventory_received_at": null,
+      "stale": null,
+      "inventory": null,
+      "channel_state": "unknown",
+      "last_seen": 0,
+      "endpoint_updated_at": null,
+      "in_flight_tasks": [],
+      "endpoint": null
+    },
+    {
+      "identity": "as65007-7.7.7.7",
+      "display_name": "Nicholas",
+      "state": "federated",
+      "chat_enabled": true,
+      "inventory_version": 1,
+      "inventory_received_at": "2026-07-18T17:04:37Z",
+      "stale": true,
+      "inventory": {
+        "inventory": {
+          "identity": "as65007-7.7.7.7",
+          "issued_at": "2026-07-18T17:04:36Z",
+          "version": 1,
+          "skills": [
+            {
+              "name": "aap-automation",
+              "description": "description: \"Red Hat Ansible Automation Platform \u2014 inventory management, job template execution, project SCM sync, ad-hoc commands, host management, Galaxy content discovery. Use when automating infr",
+              "invocable": true
+            },
+            {
+              "name": "aap-eda",
+              "description": "description: \"Event-Driven Ansible (EDA) \u2014 activation lifecycle, rulebook management, decision environments, event stream monitoring. Use when managing event-driven automation triggers, enabling/disab",
+              "invocable": true
+            },
+            {
+              "name": "aap-lint",
+              "description": "description: \"ansible-lint playbook and role validation \u2014 syntax checking, best practice enforcement, project-wide analysis, rule filtering. Use when validating Ansible playbooks, checking code qualit",
+              "invocable": true
+            },
+            {
+              "name": "aci-change-deploy",
+              "description": "description: \"Safe ACI policy change deployment - ServiceNow CR lifecycle, pre/post-change fault baselines, APIC policy application, automatic rollback on fault delta, and GAIT audit trail. Use when d",
+              "invocable": true
+            },
+            {
+              "name": "aci-fabric-audit",
+              "description": "description: \"Comprehensive Cisco ACI fabric health audit - node status, tenant/VRF/BD/EPG policy review, contract analysis, fault triage, and endpoint learning verification. Use when auditing ACI fab",
+              "invocable": true
+            },
+            {
+              "name": "arista-cvp",
+              "description": "description: \"Arista CloudVision Portal (CVP) automation via REST API \u2014 device inventory, events, connectivity monitoring, tag management (4 tools). Use when managing Arista devices, checking CloudVis",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-config",
+              "description": "description: \"View and manage Aruba CX switch configurations, perform ISSU upgrades, and firmware operations\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-interfaces",
+              "description": "description: \"Monitor Aruba CX switch interface status, LLDP neighbors, and optical transceiver health\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-switching",
+              "description": "description: \"View and manage Aruba CX switch VLANs and MAC address tables for Layer 2 operations\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-system",
+              "description": "description: \"Discover Aruba CX switch system information, firmware versions, and VSF topology\"",
+              "invocable": true
+            },
+            {
+              "name": "atlassian-itsm",
+              "description": "description: IT Service Management workflows using Jira for issue tracking and Confluence for documentation",
+              "invocable": true
+            },
+            {
+              "name": "aws-architecture-diagram",
+              "description": "description: \"AWS architecture diagrams \u2014 generate visual network topology diagrams from live AWS infrastructure. Use when drawing AWS network diagrams, visualizing VPCs, mapping Transit Gateway topol",
+              "invocable": true
+            },
+            {
+              "name": "aws-cloud-monitoring",
+              "description": "description: \"AWS CloudWatch monitoring \u2014 metrics, alarms, log queries, VPC flow log analysis, network performance. Use when checking AWS alarms, analyzing VPC flow logs, investigating network latency",
+              "invocable": true
+            },
+            {
+              "name": "aws-cost-ops",
+              "description": "description: \"AWS Cost Explorer \u2014 spending analysis, service breakdowns, forecasts, cost anomalies. Use when analyzing AWS spending, investigating cost spikes, reviewing network cost drivers like NAT ",
+              "invocable": true
+            },
+            {
+              "name": "aws-network-ops",
+              "description": "description: \"AWS cloud networking \u2014 VPC, Transit Gateway, Cloud WAN, VPN, Network Firewall, ENI, flow logs. Use when auditing AWS VPCs, troubleshooting connectivity between EC2 instances, checking Tr",
+              "invocable": true
+            },
+            {
+              "name": "aws-security-audit",
+              "description": "description: \"AWS security auditing \u2014 IAM users/roles/policies, CloudTrail API events, security posture analysis. Use when auditing IAM permissions, investigating security incidents, checking MFA comp",
+              "invocable": true
+            },
+            {
+              "name": "azure-network-ops",
+              "description": "description: \"Azure cloud networking -- VNets, NSGs, ExpressRoute, VPN Gateways, Azure Firewalls, Load Balancers, Application Gateways, Route Tables, Network Watcher, Private Endpoints, DNS zones. Use",
+              "invocable": true
+            },
+            {
+              "name": "azure-security-audit",
+              "description": "description: \"Azure NSG compliance auditing and security posture assessment. CIS Azure Foundations Benchmark rules, effective security rule analysis, orphaned NSG detection. Use when auditing Azure NS",
+              "invocable": true
+            },
+            {
+              "name": "batfish-config-analysis",
+              "description": "description: \"Batfish network configuration analysis -- pre-deployment validation, reachability testing, ACL/firewall tracing, differential analysis, compliance checking. Use when validating configs b",
+              "invocable": true
+            },
+            {
+              "name": "blender-3d-viz",
+              "description": "description: \"Create 3D network topology visualizations in Blender from CDP/LLDP neighbor data\"",
+              "invocable": true
+            },
+            {
+              "name": "browser-gui-inspect",
+              "description": "description: \"Controller-agnostic browser automation and inspection \u2014 navigate, read, click, fill, and capture network traffic on any web GUI using a persistent, manually-authenticated Chrome profile.",
+              "invocable": true
+            },
+            {
+              "name": "browser-viz-verify",
+              "description": "description: \"Verifies that a NetClaw-generated visualization HTML file (three.js, canvas, drawio, UML, markmap) actually renders correctly \u2014 screenshot, console-error check, and an optional Lighthous",
+              "invocable": true
+            },
+            {
+              "name": "canvas-network-viz",
+              "description": "description: \"Canvas/A2UI inline network visualizations \u2014 topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards rendered directly in the Ope",
+              "invocable": true
+            },
+            {
+              "name": "catc-client-ops",
+              "description": "description: \"Catalyst Center client operations and monitoring - list/filter wired and wireless clients, detailed client lookup by MAC, client count analytics, time-based analysis, SSID and band filte",
+              "invocable": true
+            },
+            {
+              "name": "catc-inventory",
+              "description": "description: \"Catalyst Center device inventory and site management - list/filter devices by hostname, IP, platform, family, role, reachability; view site hierarchy; get interface details per device; d",
+              "invocable": true
+            },
+            {
+              "name": "catc-troubleshoot",
+              "description": "description: \"Catalyst Center troubleshooting workflows - device unreachable investigation, client connectivity issues, interface down analysis, site-wide outage triage, wireless roaming problems, int",
+              "invocable": true
+            },
+            {
+              "name": "checkpoint",
+              "description": "A comprehensive skill for interacting with Check Point enterprise security infrastructure through 15 MCP servers.",
+              "invocable": true
+            },
+            {
+              "name": "clab-lab-management",
+              "description": "description: \"ContainerLab network lab lifecycle management \u2014 authenticate, list, deploy, inspect, execute commands on, and destroy containerized network labs via the ContainerLab API. Use when deploy",
+              "invocable": true
+            },
+            {
+              "name": "claroty-asset-inventory",
+              "description": "description: \"Discover and classify OT / IoT / IoMT assets via Claroty xDome. List devices by site, Purdue level, and device purpose; assign Purdue layers and custom attributes; cross-reference with N",
+              "invocable": true
+            },
+            {
+              "name": "claroty-ot-topology",
+              "description": "description: \"Render Claroty xDome OT / IoT communication maps and zone segmentation as inline Canvas/A2UI topology, draw.io diagrams, and timeline summaries.\"",
+              "invocable": true
+            },
+            {
+              "name": "claroty-risk-triage",
+              "description": "description: \"Triage Claroty xDome alerts and vulnerabilities, compute blast radius, correlate with NVD CVE data, and drive ITSM-gated workflow actions (acknowledge, label, assign, set relevance).\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-analytics",
+              "description": "description: \"Access Cloudflare traffic analytics, logs, and Radar global Internet insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-dns",
+              "description": "description: \"Manage Cloudflare DNS zones and records with analytics insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-security",
+              "description": "description: \"Monitor Cloudflare WAF, firewall events, audit logs, and threat intelligence.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-workers",
+              "description": "description: \"Monitor Cloudflare Workers deployments, bindings, and build insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-zerotrust",
+              "description": "description: \"Inspect Cloudflare Zero Trust access applications, policies, tunnels, and CASB findings.\"",
+              "invocable": true
+            },
+            {
+              "name": "cml-admin",
+              "description": "description: \"CML administration \u2014 user/group management, system info, licensing, resource monitoring. Use when creating CML users, checking license status, monitoring CML server resources, or auditin",
+              "invocable": true
+            },
+            {
+              "name": "cml-lab-lifecycle",
+              "description": "description: \"Cisco CML lab lifecycle management \u2014 create, start, stop, wipe, delete, clone, import/export labs. Use when building a network lab, starting or stopping a CML lab, cloning a topology, or",
+              "invocable": true
+            },
+            {
+              "name": "cml-node-operations",
+              "description": "description: \"CML node operations \u2014 start, stop, console access, CLI execution, config management, node details. Use when starting or stopping a CML node, running show commands on a lab router, settin",
+              "invocable": true
+            },
+            {
+              "name": "cml-packet-capture",
+              "description": "description: \"CML packet capture \u2014 start, stop, download pcaps from CML lab links, integrate with Packet Buddy for analysis. Use when capturing packets in a CML lab, troubleshooting BGP or OSPF with p",
+              "invocable": true
+            },
+            {
+              "name": "cml-topology-builder",
+              "description": "description: \"Build CML topologies \u2014 add nodes, create interfaces, wire links, set link conditioning, add annotations. Use when building a network topology in CML, adding routers or switches to a lab,",
+              "invocable": true
+            },
+            {
+              "name": "datadog-apm",
+              "description": "description: \"Analyze distributed traces and service performance in Datadog APM.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-incidents",
+              "description": "description: \"Manage incidents in Datadog Incident Management.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-logs",
+              "description": "description: \"Search and analyze logs in Datadog Log Management.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-metrics",
+              "description": "description: \"Query metrics and explore dashboards in Datadog.\"",
+              "invocable": true
+            },
+            {
+              "name": "defenseclaw-ops",
+              "description": "description: Manage DefenseClaw enterprise security - scan components, manage tool permissions, view alerts, configure guardrails",
+              "invocable": true
+            },
+            {
+              "name": "desktop-gui-inspect",
+              "description": "description: \"Full-desktop automation for targets that have no browser and no API at all \u2014 a legacy Java-based NMS client, a vendor's Windows-only configuration utility, a terminal emulator with no sc",
+              "invocable": true
+            },
+            {
+              "name": "devnet-catalyst-search",
+              "description": "description: Search Cisco Catalyst Center API documentation for device management and policy automation",
+              "invocable": true
+            },
+            {
+              "name": "devnet-meraki-search",
+              "description": "description: Search Cisco Meraki API documentation and lookup specific operations",
+              "invocable": true
+            },
+            {
+              "name": "drawio-diagram",
+              "description": "description: \"Generate draw.io network diagrams \u2014 native .drawio files with CLI export (PNG/SVG/PDF), plus browser-based Mermaid/XML/CSV via MCP server. Use when creating network topology diagrams, ge",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-build",
+              "description": "description: Build or rewire EVE-NG lab topology. Use when creating or deleting virtual networks, connecting node interfaces to networks, inspecting topology links, checking interface mappings, or lis",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-design",
+              "description": "description: Design EVE-NG lab topology and coordinate the design workflow. Use when the user asks for lab design, architecture advice, topology planning, design review, or a build plan, especially wh",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-discovery",
+              "description": "description: Gather missing requirements for EVE-NG topology design. Use when the request is vague or incomplete, when you need discovery questions, defaults, trade-off framing, image recommendations,",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-validation",
+              "description": "description: Validate EVE-NG topology designs and enforce final delivery structure. Use when reviewing a design, checking build readiness, producing the final design output, building an implementation",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-config-ops",
+              "description": "description: Manage EVE-NG startup configurations stored in lab files. Use when exporting configs natively into the lab, reading embedded startup configs, pushing startup config before boot, clearing ",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-console-ops",
+              "description": "description: Execute live CLI commands on running EVE-NG nodes over telnet console. Use when running show commands, making live config changes, verifying protocol state, testing connectivity, checking",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-lab-management",
+              "description": "description: Manage EVE-NG labs and platform inventory. Use when listing labs, checking lab metadata, creating or deleting labs, importing or exporting lab archives, checking EVE-NG health or auth, or",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-node-operations",
+              "description": "description: Manage EVE-NG node lifecycle. Use when listing nodes, checking runtime state, creating or deleting nodes, starting or stopping nodes or whole labs, verifying node details, or wiping node ",
+              "invocable": true
+            },
+            {
+              "name": "evpn-vxlan-fabric",
+              "description": "description: \"EVPN/VXLAN fabric audit and troubleshooting \u2014 VTEPs, VNIs, route types, multihoming, underlay/overlay validation. Use when troubleshooting VXLAN overlay reachability, auditing leaf-spine",
+              "invocable": true
+            },
+            {
+              "name": "f5-config-mgmt",
+              "description": "description: \"F5 BIG-IP configuration management - safe change workflow with baseline capture, planning, creation/update/deletion of virtual servers, pools, iRules, and profiles with full verification",
+              "invocable": true
+            },
+            {
+              "name": "f5-health-check",
+              "description": "description: \"F5 BIG-IP health monitoring - virtual server status, pool member health, log analysis, performance statistics, and systematic health assessment. Use when checking F5 load balancer health",
+              "invocable": true
+            },
+            {
+              "name": "f5-troubleshoot",
+              "description": "description: \"F5 BIG-IP troubleshooting - virtual server failures, pool member health, connection issues, SSL/TLS problems, iRule errors, persistence issues, and performance degradation. Use when a VI",
+              "invocable": true
+            },
+            {
+              "name": "fmc-firewall-ops",
+              "description": "description: \"Cisco Secure Firewall FMC \u2014 access policy search, rule inspection, FTD device targeting, multi-FMC profile management. Use when searching firewall rules by IP or FQDN, checking if host A",
+              "invocable": true
+            },
+            {
+              "name": "fortimanager-ops",
+              "description": "description: \"FortiManager operations \u2014 ADOM inventory, policy package review, object search, install preview, and compliance workflows. Use when auditing FortiGate firewall policies, reviewing ADOM p",
+              "invocable": true
+            },
+            {
+              "name": "forward",
+              "description": "description: Forward snapshot assurance, path search, app-aware path search, NQE, checks, vulnerabilities, diffs, configuration, lifecycle, collection, and topology workflows through the upstream forw",
+              "invocable": true
+            },
+            {
+              "name": "fwrule-analyzer",
+              "description": "description: \"Multi-vendor firewall rule analysis \u2014 overlap detection, shadowing, conflict identification, duplication checking across PAN-OS, ASA, FTD, IOS/IOS-XE, IOS-XR, Check Point, SRX, Junos, No",
+              "invocable": true
+            },
+            {
+              "name": "gait-session-tracking",
+              "description": "description: \"GAIT session lifecycle management - branch creation, turn recording, audit logging for every NetClaw operation. Use when starting a new NetClaw session, recording a health check or confi",
+              "invocable": true
+            },
+            {
+              "name": "gcp-cloud-logging",
+              "description": "description: \"Google Cloud Logging \u2014 log search, VPC flow logs, firewall logs, audit logs, log buckets and views. Use when searching GCP logs, investigating denied VPC flow traffic, checking who delet",
+              "invocable": true
+            },
+            {
+              "name": "gcp-cloud-monitoring",
+              "description": "description: \"Google Cloud Monitoring \u2014 time series metrics, alert policies, active alerts, metric discovery. Use when checking GCP network performance, investigating firing alerts, querying VM CPU or",
+              "invocable": true
+            },
+            {
+              "name": "gcp-compute-ops",
+              "description": "description: \"Google Cloud Compute Engine \u2014 VM instances, disks, templates, instance groups, reservations, project discovery. Use when listing GCP VMs, troubleshooting a Compute Engine instance, check",
+              "invocable": true
+            },
+            {
+              "name": "github-ops",
+              "description": "description: \"GitHub repository operations \u2014 issues, PRs, code search, and config-as-code workflows. Use when creating a GitHub issue for a network finding, opening a pull request for a config change,",
+              "invocable": true
+            },
+            {
+              "name": "gitlab-devops",
+              "description": "description: \"GitLab DevOps operations \u2014 issues, merge requests, CI/CD pipelines, repository browsing, labels, milestones, releases, and wiki management. Use when querying GitLab project status, monit",
+              "invocable": true
+            },
+            {
+              "name": "gnmi-telemetry",
+              "description": "description: \"gNMI streaming telemetry operations for multi-vendor network devices. Query device state via structured YANG model paths, subscribe to real-time telemetry streams, apply ITSM-gated confi",
+              "invocable": true
+            },
+            {
+              "name": "gns3-link-management",
+              "description": "description: \"Manage GNS3 links - connect/disconnect node interfaces, isolate nodes\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-node-operations",
+              "description": "description: \"Manage GNS3 nodes - add from templates, start/stop/suspend/reload, console access\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-packet-capture",
+              "description": "description: \"Capture network traffic on GNS3 links - start/stop captures, retrieve PCAP data\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-project-lifecycle",
+              "description": "description: \"Manage GNS3 network lab projects - create, open, close, delete, clone, export/import\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-snapshot-ops",
+              "description": "description: \"Manage GNS3 project snapshots - create, restore, delete for safe experimentation\"",
+              "invocable": true
+            },
+            {
+              "name": "grafana-observability",
+              "description": "description: \"Grafana observability platform \u2014 dashboards, Prometheus PromQL, Loki LogQL, alerting, incidents, OnCall schedules, annotations, datasource queries, panel rendering (75+ tools). Use when ",
+              "invocable": true
+            },
+            {
+              "name": "gtrace-ip-enrichment",
+              "description": "description: \"IP address enrichment \u2014 ASN ownership lookup, geolocation (city/region/country/coordinates), and reverse DNS resolution. Use when identifying who owns an IP address, locating an IP geogr",
+              "invocable": true
+            },
+            {
+              "name": "gtrace-path-analysis",
+              "description": "description: \"Network path tracing and monitoring \u2014 traceroute with MPLS/ECMP/NAT detection, continuous MTR monitoring, and distributed GlobalPing probes from 500+ worldwide locations. Use when tracin",
+              "invocable": true
+            },
+            {
+              "name": "humanrail-escalation",
+              "description": "description: \"Human-in-the-loop escalation via HumanRail \u2014 route low-confidence agent decisions, pre-destructive operation approvals, and ambiguous incident tickets to real human engineers. Human answ",
+              "invocable": true
+            },
+            {
+              "name": "infoblox-ddi",
+              "description": "description: \"Infoblox DDI operations \u2014 DNS zones/records, DHCP scopes and leases, IPAM networks and address utilization. Use when checking DNS records, validating IPAM address allocation, investigati",
+              "invocable": true
+            },
+            {
+              "name": "infrahub-sot",
+              "description": "description: \"OpsMill Infrahub \u2014 infrastructure source of truth with schema-driven nodes, GraphQL queries, and branch-isolated changes. Use when querying Infrahub for device/IPAM inventory, browsing i",
+              "invocable": true
+            },
+            {
+              "name": "ipfabric",
+              "description": "**Skill**: `/ipfabric`",
+              "invocable": true
+            },
+            {
+              "name": "ipfix-receiver",
+              "description": "description: \"Receive and query IPFIX and NetFlow flow records from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "ise-incident-response",
+              "description": "description: \"Rapid ISE endpoint investigation and quarantine workflow - endpoint lookup, auth history, posture review, human-authorized quarantine, ServiceNow Security Incident. Use when a SOC alert ",
+              "invocable": true
+            },
+            {
+              "name": "ise-posture-audit",
+              "description": "description: \"Cisco ISE posture and policy audit - authorization rules, posture compliance, profiling gaps, TrustSec SGT matrix, active session health. Use when running a periodic ISE compliance audit",
+              "invocable": true
+            },
+            {
+              "name": "itential-automation",
+              "description": "description: \"Itential Automation Platform (IAP) \u2014 network automation orchestration, device configuration management, compliance enforcement, workflow execution, golden config, lifecycle management, a",
+              "invocable": true
+            },
+            {
+              "name": "jenkins-cicd",
+              "description": "description: Jenkins CI/CD pipeline management \u2014 monitor builds, trigger pipelines, analyze logs, and track SCM changes for network automation workflows.",
+              "invocable": true
+            },
+            {
+              "name": "junos-network",
+              "description": "description: \"Juniper JunOS device automation via PyEZ/NETCONF \u2014 CLI execution, configuration management, Jinja2 template rendering, device facts, batch operations, config diff and rollback comparison",
+              "invocable": true
+            },
+            {
+              "name": "kubeshark-traffic",
+              "description": "description: \"Kubeshark Kubernetes traffic analysis \u2014 L4/L7 deep packet inspection, TLS decryption, pcap export, flow analysis, service mapping (6 tools). Use when capturing Kubernetes pod traffic, de",
+              "invocable": true
+            },
+            {
+              "name": "markmap-viz",
+              "description": "description: \"Create interactive mind map visualizations from markdown - network inventory, OSPF areas, BGP topology, security audit results. Use when visualizing network topology as a mind map, creat",
+              "invocable": true
+            },
+            {
+              "name": "memory",
+              "description": "**Purpose**: Provide persistent context across NetClaw sessions through structured facts, semantic search, and entity relationships.",
+              "invocable": true
+            },
+            {
+              "name": "mempalace",
+              "description": "description: \"MemPalace AI memory \u2014 persistent memory across sessions. Search past decisions, store architecture choices, track temporal network facts via knowledge graph, navigate cross-domain connec",
+              "invocable": true
+            },
+            {
+              "name": "meraki-monitoring",
+              "description": "description: \"Cisco Meraki Monitoring & Diagnostics \u2014 live ping, cable test, LED blink, wake-on-LAN, camera analytics, config change tracking. Use when running ping tests from Meraki devices, troubles",
+              "invocable": true
+            },
+            {
+              "name": "meraki-network-ops",
+              "description": "description: \"Cisco Meraki Dashboard \u2014 organization inventory, network management, device lifecycle, client discovery, action batches. Use when listing Meraki devices, managing networks, checking devi",
+              "invocable": true
+            },
+            {
+              "name": "meraki-security-appliance",
+              "description": "description: \"Cisco Meraki Security Appliance (MX) \u2014 firewall rules, site-to-site VPN, content filtering, traffic shaping, security events. Use when auditing Meraki MX firewall rules, troubleshooting ",
+              "invocable": true
+            },
+            {
+              "name": "meraki-switch-ops",
+              "description": "description: \"Cisco Meraki Switching \u2014 port configuration, VLANs, port status, ACLs, QoS rules, port cycling. Use when configuring Meraki switch ports, creating VLANs, checking port status and PoE, tr",
+              "invocable": true
+            },
+            {
+              "name": "meraki-wireless-ops",
+              "description": "description: \"Cisco Meraki Wireless \u2014 SSID management, RF profiles, channel utilization, signal quality, client connectivity events. Use when managing Meraki SSIDs, troubleshooting WiFi connectivity, ",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-files",
+              "description": "description: \"Manage files on OneDrive and SharePoint via Microsoft Graph API - upload, download, list, search, and organize network documentation and artifacts. Use when uploading reports to SharePoi",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-teams",
+              "description": "description: \"Send notifications and reports to Microsoft Teams channels via Graph API - alert delivery, report posting, incident updates, and diagram sharing. Use when posting health alerts to Teams,",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-visio",
+              "description": "description: \"Generate and manage Visio network diagrams on SharePoint via Microsoft Graph API - create topology diagrams from CDP/LLDP discovery, update existing diagrams, export to PDF. Use when cre",
+              "invocable": true
+            },
+            {
+              "name": "n2n-federation",
+              "description": "description: Federate your NetClaw with other NetClaw operators over the BGP mesh \u2014 exchange capability inventories and ask your claw what a peer can do. (US1; remote invocation and chat land in later",
+              "invocable": true
+            },
+            {
+              "name": "nautobot-sot",
+              "description": "description: \"Nautobot IPAM & source of truth \u2014 IP address queries, prefix lookups, VRF/tenant/site filtering, IPAM search, connection testing. Use when looking up IP addresses in Nautobot, checking s",
+              "invocable": true
+            },
+            {
+              "name": "netbox-reconcile",
+              "description": "description: \"Reconcile NetBox source of truth against live network state - detect IP drift, missing interfaces, undocumented links, cable mismatches, VLAN mismatches, and ticket discrepancies in Serv",
+              "invocable": true
+            },
+            {
+              "name": "nmap-network-scan",
+              "description": "description: \"Host discovery and port scanning using nmap \u2014 ICMP/ARP host discovery, SYN/TCP/UDP port scanning with scope enforcement and audit logging. Use when discovering live hosts on a subnet, sc",
+              "invocable": true
+            },
+            {
+              "name": "nmap-scan-management",
+              "description": "description: \"Custom nmap scans with arbitrary flags, plus scan history retrieval and management. Use when running nmap with custom flags, reviewing past scan results, comparing before/after scans, or",
+              "invocable": true
+            },
+            {
+              "name": "nmap-service-detection",
+              "description": "description: \"Service fingerprinting, OS detection, NSE script execution, and vulnerability scanning using nmap MCP. Use when identifying services on open ports, fingerprinting OS versions, running NS",
+              "invocable": true
+            },
+            {
+              "name": "nso-device-ops",
+              "description": "description: \"Cisco NSO device operations \u2014 config retrieval, state inspection, sync, platform info, NED IDs, device groups. Use when retrieving device configs from NSO, checking sync status, pulling ",
+              "invocable": true
+            },
+            {
+              "name": "nso-service-mgmt",
+              "description": "description: \"Cisco NSO service management \u2014 discover service types, list service instances, orchestrate network services. Use when listing NSO services, checking service health, auditing deployed ser",
+              "invocable": true
+            },
+            {
+              "name": "nvd-cve",
+              "description": "description: \"Search the National Vulnerability Database for CVEs - find vulnerabilities by keyword or ID, get CVSS scores, weaknesses, affected configurations, and remediation references. Use when lo",
+              "invocable": true
+            },
+            {
+              "name": "packet-analysis",
+              "description": "description: \"Analyze network packet captures (.pcap/.pcapng) using Packet Buddy MCP. Use when opening a pcap file, inspecting packet captures, troubleshooting network traffic, analyzing retransmissio",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-incidents",
+              "description": "description: \"Manage and investigate incidents in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-oncall",
+              "description": "description: \"Manage on-call schedules and escalation policies in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-orchestration",
+              "description": "description: \"Manage event orchestration and routing rules in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-services",
+              "description": "description: \"Manage service catalog and service health in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "paloalto-panorama",
+              "description": "description: \"Palo Alto Panorama operations \u2014 device groups, templates, security policy search, NAT review, commit status, and audit workflows. Use when searching Palo Alto firewall rules, checking if",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-apps",
+              "description": "description: \"View Prisma SD-WAN application definitions for policy visibility\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-config",
+              "description": "description: \"Inspect Prisma SD-WAN interfaces, routing (BGP, static), policies, and security zones\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-status",
+              "description": "description: \"Monitor Prisma SD-WAN element health, software versions, events, and alarms\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-topology",
+              "description": "description: \"Discover Prisma SD-WAN sites, ION elements, machines, and network topology\"",
+              "invocable": true
+            },
+            {
+              "name": "prometheus-monitoring",
+              "description": "description: \"Prometheus monitoring \u2014 PromQL instant/range queries, metric discovery, metadata, scrape target health, system health checks (6 tools). Use when querying Prometheus metrics, checking scr",
+              "invocable": true
+            },
+            {
+              "name": "protocol-participation",
+              "description": "description: \"Live BGP and OSPF control-plane participation \u2014 peer with real routers, inject/withdraw routes, query RIB/LSDB, adjust metrics, GRE tunnel status. Use when injecting or withdrawing BGP r",
+              "invocable": true
+            },
+            {
+              "name": "pyats-asa-firewall",
+              "description": "description: \"Cisco ASA firewall operations via pyATS \u2014 VPN sessions, failover state, interfaces, routing, service policies, resource usage, AnyConnect monitoring. Use when checking ASA failover statu",
+              "invocable": true
+            },
+            {
+              "name": "pyats-config-mgmt",
+              "description": "description: \"Network change management - pre-change baselines, configuration deployment, post-change verification, rollback procedures, and compliance validation. Use when pushing config to a device,",
+              "invocable": true
+            },
+            {
+              "name": "pyats-dynamic-test",
+              "description": "description: \"Generate and execute deterministic pyATS aetest validation scripts - interface state, OSPF neighbors, BGP paths, ping matrices, and custom compliance tests. Use when writing a network te",
+              "invocable": true
+            },
+            {
+              "name": "pyats-f5-ltm",
+              "description": "description: \"F5 BIG-IP LTM/GTM operations via pyATS iControl REST \u2014 virtual servers, pools, nodes, monitors, profiles, iRules, persistence, GTM wide IPs, DNS, data groups. Use when checking F5 virtua",
+              "invocable": true
+            },
+            {
+              "name": "pyats-f5-platform",
+              "description": "description: \"F5 BIG-IP platform operations via pyATS iControl REST \u2014 system, networking, HA/CM, auth, analytics, security, APM, live-update, ADC certs, file management. Use when checking BIG-IP syste",
+              "invocable": true
+            },
+            {
+              "name": "pyats-health-check",
+              "description": "description: \"Comprehensive network device health monitoring - CPU, memory, interfaces, hardware, NTP, logging, environment, and uptime analysis. Use when running a device health check, monitoring CPU",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-interfaces",
+              "description": "description: \"JunOS interface operations via pyATS \u2014 physical/logical interfaces, LACP, CoS, LLDP, ARP, BFD, IPv6 neighbors, traffic monitoring, optics diagnostics. Use when checking Juniper interface",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-routing",
+              "description": "description: \"JunOS routing operations via pyATS \u2014 OSPF/OSPFv3, BGP, route table, MPLS/LDP/RSVP, TED, PFE, ping, traceroute across Juniper devices. Use when checking Juniper OSPF neighbors, viewing BG",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-system",
+              "description": "description: \"JunOS system operations via pyATS \u2014 chassis health, hardware inventory, system info, NTP, SNMP, files/logs, firewall counters, DDoS protection, services accounting. Use when checking Jun",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-network",
+              "description": "description: \"Linux host network operations via pyATS \u2014 interface configuration, routing tables, network connections, and multi-table route inspection across fleet hosts. Use when checking Linux inter",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-system",
+              "description": "description: \"Linux host system operations via pyATS \u2014 process monitoring, filesystem inspection, Docker container stats, package/tool verification across fleet hosts. Use when checking running proces",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-vmware",
+              "description": "description: \"VMware ESXi host operations via pyATS \u2014 VM inventory, snapshot management, hypervisor inspection across ESXi hosts in the testbed. Use when listing VMs on ESXi, checking snapshot age, au",
+              "invocable": true
+            },
+            {
+              "name": "pyats-network",
+              "description": "description: \"Network device automation via pyATS - run show commands, ping, apply config, learn config/logging, list devices, run Linux commands, execute dynamic tests on Cisco IOS-XE/NX-OS devices. ",
+              "invocable": true
+            },
+            {
+              "name": "pyats-parallel-ops",
+              "description": "description: \"Fleet-wide parallel device operations - concurrent health checks, config audits, routing snapshots, severity-sorted reporting, and failure-isolated multi-device automation. Use when chec",
+              "invocable": true
+            },
+            {
+              "name": "pyats-routing",
+              "description": "description: \"CCIE-level routing protocol analysis - OSPF, BGP, EIGRP, IS-IS, static routes, RIB/FIB verification, redistribution audit, and convergence validation. Use when analyzing routing tables, ",
+              "invocable": true
+            },
+            {
+              "name": "pyats-security",
+              "description": "description: \"Network security audit - ACLs, AAA, control plane policing, management plane hardening, encryption, port security, and CIS benchmark checks. Use when auditing device security posture, ch",
+              "invocable": true
+            },
+            {
+              "name": "pyats-topology",
+              "description": "description: \"Network topology discovery via CDP/LLDP neighbors, ARP tables, routing peers, and interface mapping to build complete network maps. Use when mapping the network, building a diagram, disc",
+              "invocable": true
+            },
+            {
+              "name": "pyats-troubleshoot",
+              "description": "description: \"Systematic network troubleshooting - connectivity, routing, interface, protocol, and performance issues using structured OSI-layer and divide-and-conquer methodology. Use when something ",
+              "invocable": true
+            },
+            {
+              "name": "radkit-remote-access",
+              "description": "description: \"Cisco RADKit \u2014 cloud-relayed remote device access, CLI execution, SNMP polling, device inventory discovery, attribute inspection. Use when accessing remote network devices through a clou",
+              "invocable": true
+            },
+            {
+              "name": "rag",
+              "description": "**Purpose**: Give NetClaw a fully offline, user-curated document knowledge base \u2014 vendor guides, standards (RFC/IEEE/vendor), customer design documents, install guides \u2014 with agentic retrieval, mandat",
+              "invocable": true
+            },
+            {
+              "name": "rfc-lookup",
+              "description": "description: \"Search and retrieve IETF RFC documents - lookup by number, search by keyword, extract sections. Use when looking up an RFC, checking protocol specifications, verifying standards complian",
+              "invocable": true
+            },
+            {
+              "name": "sdwan-ops",
+              "description": "description: \"Cisco SD-WAN vManage read-only operations \u2014 fabric devices, WAN Edge inventory, templates, policies, alarms, events, interface stats, BFD sessions, OMP routes, control connections, runni",
+              "invocable": true
+            },
+            {
+              "name": "servicenow-change-workflow",
+              "description": "description: \"Full ITSM-gated change lifecycle - CR creation, pre-change incident validation, approval gate, execution via pyats-config-mgmt, post-change verification, and closure with GAIT audit trai",
+              "invocable": true
+            },
+            {
+              "name": "slack-incident-workflow",
+              "description": "description: \"Manage network incident response workflows in Slack - incident channels, status updates, escalation, resolution tracking, and post-incident review coordination. Use when declaring a netw",
+              "invocable": true
+            },
+            {
+              "name": "slack-network-alerts",
+              "description": "description: \"Format and deliver network alerts, health warnings, and critical notifications via Slack with rich formatting, reactions, and file attachments. Use when sending alerts to Slack, posting ",
+              "invocable": true
+            },
+            {
+              "name": "slack-report-delivery",
+              "description": "description: \"Deliver formatted network reports, audit results, topology diagrams, and compliance documentation to Slack channels with rich Block Kit formatting. Use when posting a health check report",
+              "invocable": true
+            },
+            {
+              "name": "slack-user-context",
+              "description": "description: \"Leverage Slack user profiles, presence, DND status, and workspace context to personalize responses, route escalations, and coordinate team operations. Use when checking who is on-call, r",
+              "invocable": true
+            },
+            {
+              "name": "slack-voice-interface",
+              "description": "description: \"Respond to Slack voice clips with both text and an MP3 voice reply using edge-tts. Voice IN is already handled by OpenClaw transcription. Use when a user sends a voice message in Slack, ",
+              "invocable": true
+            },
+            {
+              "name": "snmptrap-receiver",
+              "description": "description: \"Receive and query SNMP traps from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-indexes",
+              "description": "description: \"Discover and inspect Splunk indexes and configuration.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-saved",
+              "description": "description: \"Manage and run saved searches in Splunk.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-search",
+              "description": "description: \"Execute and validate SPL (Search Processing Language) queries.\"",
+              "invocable": true
+            },
+            {
+              "name": "subnet-calculator",
+              "description": "description: \"IPv4 and IPv6 subnet calculator - CIDR breakdown, usable hosts, previous/next subnets, address classification, VLSM planning, and dual-stack analysis. Use when calculating subnets, figur",
+              "invocable": true
+            },
+            {
+              "name": "suzieq-observability",
+              "description": "description: \"SuzieQ network observability \u2014 query current and historical network state, run validation assertions, get summary statistics, trace forwarding paths, and discover unique values across 20",
+              "invocable": true
+            },
+            {
+              "name": "syslog-receiver",
+              "description": "description: \"Receive and query syslog messages from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "te-network-monitoring",
+              "description": "description: \"Cisco ThousandEyes \u2014 test management, agent inventory, test results, dashboards, path visualization, user/account management. Use when checking ThousandEyes test results, viewing network",
+              "invocable": true
+            },
+            {
+              "name": "te-path-analysis",
+              "description": "description: \"Cisco ThousandEyes \u2014 path visualization, BGP route analysis, outage investigation, instant tests, endpoint agent diagnostics. Use when tracing network paths hop-by-hop, investigating why",
+              "invocable": true
+            },
+            {
+              "name": "telemetry-ops",
+              "description": "description: \"Comprehensive network telemetry and event collection across multiple protocols.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-operations",
+              "description": "description: \"Execute local Terraform operations with ServiceNow change control.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-registry",
+              "description": "description: \"Discover providers and modules from the Terraform Registry.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-workspaces",
+              "description": "description: \"Manage HCP Terraform (Terraform Cloud/Enterprise) workspaces.\"",
+              "invocable": true
+            },
+            {
+              "name": "threejs-network-viz",
+              "description": "**Version**: 1.0.0",
+              "invocable": true
+            },
+            {
+              "name": "token-tracker",
+              "description": "description: \"Track and display token consumption and cost for every NetClaw interaction.\"",
+              "invocable": true
+            },
+            {
+              "name": "twilio-daily-briefing",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-emergency-call",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-inbound-voice",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-outbound-call",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twitter-check",
+              "description": "**Purpose**: Quick invocation to check mentions and respond to #netclaw threads.",
+              "invocable": true
+            },
+            {
+              "name": "twitter-heartbeat",
+              "description": "**Purpose**: Autonomous periodic tweeting AND mention monitoring to maintain NetClaw's Twitter presence with CCIE-level network engineering content.",
+              "invocable": true
+            },
+            {
+              "name": "twitter-respond",
+              "description": "**Skill ID**: twitter-respond",
+              "invocable": true
+            },
+            {
+              "name": "twitter-share",
+              "description": "**Purpose**: Manual tweet posting with content guardrails and human approval flow.",
+              "invocable": true
+            },
+            {
+              "name": "ue5-network-viz",
+              "description": "description: \"3D network topology visualization and interactive digital twin in Unreal Engine 5.8 via the built-in UE5 MCP server.\"",
+              "invocable": true
+            },
+            {
+              "name": "uml-diagram",
+              "description": "description: \"UML and diagram generation via Kroki \u2014 class, sequence, activity, state, component, deployment, network, ER, C4, Mermaid, D2, Graphviz, BPMN, 27+ types. Use when generating a network dia",
+              "invocable": true
+            },
+            {
+              "name": "vault-mounts",
+              "description": "description: \"Discover and manage HashiCorp Vault secret engine mounts.\"",
+              "invocable": true
+            },
+            {
+              "name": "vault-pki",
+              "description": "description: \"Manage HashiCorp Vault PKI certificate infrastructure.\"",
+              "invocable": true
+            },
+            {
+              "name": "vault-secrets",
+              "description": "description: \"Manage HashiCorp Vault KV secrets with strict value protection.\"",
+              "invocable": true
+            },
+            {
+              "name": "webex-incident-workflow",
+              "description": "description: \"Manage network incident response workflows in Cisco WebEx - incident spaces, status updates, escalation, resolution tracking, and post-incident review coordination. Use when declaring a ",
+              "invocable": true
+            },
+            {
+              "name": "webex-network-alerts",
+              "description": "description: \"Format and deliver network alerts, health warnings, and critical notifications via Cisco WebEx with Adaptive Cards, markdown formatting, and file attachments. Use when sending alerts to ",
+              "invocable": true
+            },
+            {
+              "name": "webex-report-delivery",
+              "description": "description: \"Deliver formatted network reports, audit results, topology diagrams, and compliance documentation to WebEx spaces with Adaptive Cards and markdown formatting. Use when posting a health c",
+              "invocable": true
+            },
+            {
+              "name": "webex-user-context",
+              "description": "description: \"Leverage WebEx user profiles, presence status, and workspace context to personalize responses, route escalations, and coordinate team operations. Use when checking who is available, rout",
+              "invocable": true
+            },
+            {
+              "name": "webex-voice-interface",
+              "description": "description: \"Respond to WebEx voice clips with both text and an MP3 voice reply using edge-tts. Voice IN is already handled by OpenClaw transcription. Use when a user sends a voice message in WebEx, ",
+              "invocable": true
+            },
+            {
+              "name": "wikipedia-research",
+              "description": "description: \"Research networking protocols, standards history, and technology context via Wikipedia - OSPF, BGP, MPLS, 802.1X, VXLAN, and more. Use when looking up protocol background, researching ho",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-identity",
+              "description": "description: \"Manage users, groups, departments, and identity provider configurations.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-insights",
+              "description": "description: \"Access analytics, threat intelligence, and security event data.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zdx",
+              "description": "description: \"Monitor digital experience scores, user performance, and application health.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zia",
+              "description": "description: \"Manage Zscaler Internet Access firewall rules, URL filtering, DLP, and security policies.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zpa",
+              "description": "description: \"Manage Zscaler Private Access applications, segments, policies, and connectors.\"",
+              "invocable": true
+            }
+          ],
+          "mcp_servers": [
+            {
+              "name": "forward-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "suzieq-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "batfish-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gnmi-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "azure-network-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gitlab-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chrome-devtools-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chrome-devtools-mcp-visible",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "jenkins-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "atlassian-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gns3-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "prisma-sdwan-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "datadog-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "pagerduty-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "splunk-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "infrahub-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "terraform-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "vault-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "zscaler-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-dns-analytics",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-security",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-zerotrust",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-analytics",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-workers",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "blender-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aruba-cx-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "devnet-content-search",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-golden-config-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-routing-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-management",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-management-logs",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-threat-prevention",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-https-inspection",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-harmony-sase",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-reputation-service",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-quantum-gw-cli",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-gw-connection-analysis",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-threat-emulation",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-quantum-gaia",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-documentation",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-spark-management",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-cpinfo-analysis",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-argos-erm",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-policy-insights",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "claroty-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twitter-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twilio-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twilio-voice-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "unreal-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "sketchfab-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "n2n-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "rag-mcp",
+              "tools": [],
+              "invocable_tools": []
+            }
+          ],
+          "badges": [
+            "Azure",
+            "Batfish",
+            "Check Point",
+            "Forward",
+            "GNS3",
+            "Nautobot",
+            "SuzieQ",
+            "gNMI"
+          ],
+          "posture": {
+            "mode": "testing",
+            "state": "unknown",
+            "summary": "testing",
+            "controls": {}
+          },
+          "llm": {
+            "primary_model": "anthropic/claude-sonnet-4-6",
+            "guarded": false
+          }
+        },
+        "received_at": "2026-07-18T17:04:37Z",
+        "stale": true
+      },
+      "channel_state": "unreachable",
+      "last_seen": 0,
+      "endpoint_updated_at": null,
+      "in_flight_tasks": [],
+      "endpoint": null
+    },
+    {
+      "identity": "as65007-8.8.8.8",
+      "display_name": "Hermes",
+      "state": "severed",
+      "chat_enabled": false,
+      "inventory_version": null,
+      "inventory_received_at": null,
+      "stale": null,
+      "inventory": null,
+      "channel_state": "unknown",
+      "last_seen": 0,
+      "endpoint_updated_at": null,
+      "in_flight_tasks": [],
+      "endpoint": null
+    },
+    {
+      "identity": "as65008-8.8.8.8",
+      "display_name": "Hermes",
+      "state": "federated",
+      "chat_enabled": false,
+      "inventory_version": 3,
+      "inventory_received_at": "2026-07-23T00:34:20Z",
+      "stale": true,
+      "inventory": {
+        "inventory": {
+          "identity": "as65008-8.8.8.8",
+          "issued_at": "2026-07-23T00:34:13Z",
+          "version": 3,
+          "skills": [
+            {
+              "name": "aap-automation",
+              "description": "description: \"Red Hat Ansible Automation Platform \u2014 inventory management, job template execution, project SCM sync, ad-hoc commands, host management, Galaxy content discovery. Use when automating infr",
+              "invocable": true
+            },
+            {
+              "name": "aap-eda",
+              "description": "description: \"Event-Driven Ansible (EDA) \u2014 activation lifecycle, rulebook management, decision environments, event stream monitoring. Use when managing event-driven automation triggers, enabling/disab",
+              "invocable": true
+            },
+            {
+              "name": "aap-lint",
+              "description": "description: \"ansible-lint playbook and role validation \u2014 syntax checking, best practice enforcement, project-wide analysis, rule filtering. Use when validating Ansible playbooks, checking code qualit",
+              "invocable": true
+            },
+            {
+              "name": "aci-change-deploy",
+              "description": "description: \"Safe ACI policy change deployment - ServiceNow CR lifecycle, pre/post-change fault baselines, APIC policy application, automatic rollback on fault delta, and GAIT audit trail. Use when d",
+              "invocable": true
+            },
+            {
+              "name": "aci-fabric-audit",
+              "description": "description: \"Comprehensive Cisco ACI fabric health audit - node status, tenant/VRF/BD/EPG policy review, contract analysis, fault triage, and endpoint learning verification. Use when auditing ACI fab",
+              "invocable": true
+            },
+            {
+              "name": "arista-cvp",
+              "description": "description: \"Arista CloudVision Portal (CVP) automation via REST API \u2014 device inventory, events, connectivity monitoring, tag management (4 tools). Use when managing Arista devices, checking CloudVis",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-config",
+              "description": "description: \"View and manage Aruba CX switch configurations, perform ISSU upgrades, and firmware operations\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-interfaces",
+              "description": "description: \"Monitor Aruba CX switch interface status, LLDP neighbors, and optical transceiver health\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-switching",
+              "description": "description: \"View and manage Aruba CX switch VLANs and MAC address tables for Layer 2 operations\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-system",
+              "description": "description: \"Discover Aruba CX switch system information, firmware versions, and VSF topology\"",
+              "invocable": true
+            },
+            {
+              "name": "atlassian-itsm",
+              "description": "description: IT Service Management workflows using Jira for issue tracking and Confluence for documentation",
+              "invocable": true
+            },
+            {
+              "name": "aws-architecture-diagram",
+              "description": "description: \"AWS architecture diagrams \u2014 generate visual network topology diagrams from live AWS infrastructure. Use when drawing AWS network diagrams, visualizing VPCs, mapping Transit Gateway topol",
+              "invocable": true
+            },
+            {
+              "name": "aws-cloud-monitoring",
+              "description": "description: \"AWS CloudWatch monitoring \u2014 metrics, alarms, log queries, VPC flow log analysis, network performance. Use when checking AWS alarms, analyzing VPC flow logs, investigating network latency",
+              "invocable": true
+            },
+            {
+              "name": "aws-cost-ops",
+              "description": "description: \"AWS Cost Explorer \u2014 spending analysis, service breakdowns, forecasts, cost anomalies. Use when analyzing AWS spending, investigating cost spikes, reviewing network cost drivers like NAT ",
+              "invocable": true
+            },
+            {
+              "name": "aws-network-ops",
+              "description": "description: \"AWS cloud networking \u2014 VPC, Transit Gateway, Cloud WAN, VPN, Network Firewall, ENI, flow logs. Use when auditing AWS VPCs, troubleshooting connectivity between EC2 instances, checking Tr",
+              "invocable": true
+            },
+            {
+              "name": "aws-security-audit",
+              "description": "description: \"AWS security auditing \u2014 IAM users/roles/policies, CloudTrail API events, security posture analysis. Use when auditing IAM permissions, investigating security incidents, checking MFA comp",
+              "invocable": true
+            },
+            {
+              "name": "azure-network-ops",
+              "description": "description: \"Azure cloud networking -- VNets, NSGs, ExpressRoute, VPN Gateways, Azure Firewalls, Load Balancers, Application Gateways, Route Tables, Network Watcher, Private Endpoints, DNS zones. Use",
+              "invocable": true
+            },
+            {
+              "name": "azure-security-audit",
+              "description": "description: \"Azure NSG compliance auditing and security posture assessment. CIS Azure Foundations Benchmark rules, effective security rule analysis, orphaned NSG detection. Use when auditing Azure NS",
+              "invocable": true
+            },
+            {
+              "name": "batfish-config-analysis",
+              "description": "description: \"Batfish network configuration analysis -- pre-deployment validation, reachability testing, ACL/firewall tracing, differential analysis, compliance checking. Use when validating configs b",
+              "invocable": true
+            },
+            {
+              "name": "blender-3d-viz",
+              "description": "description: \"Create 3D network topology visualizations in Blender from CDP/LLDP neighbor data\"",
+              "invocable": true
+            },
+            {
+              "name": "browser-gui-inspect",
+              "description": "description: \"Controller-agnostic browser automation and inspection \u2014 navigate, read, click, fill, and capture network traffic on any web GUI using a persistent, manually-authenticated Chrome profile.",
+              "invocable": true
+            },
+            {
+              "name": "browser-viz-verify",
+              "description": "description: \"Verifies that a NetClaw-generated visualization HTML file (three.js, canvas, drawio, UML, markmap) actually renders correctly \u2014 screenshot, console-error check, and an optional Lighthous",
+              "invocable": true
+            },
+            {
+              "name": "canvas-network-viz",
+              "description": "description: \"Canvas/A2UI inline network visualizations \u2014 topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards rendered directly in the Ope",
+              "invocable": true
+            },
+            {
+              "name": "catc-client-ops",
+              "description": "description: \"Catalyst Center client operations and monitoring - list/filter wired and wireless clients, detailed client lookup by MAC, client count analytics, time-based analysis, SSID and band filte",
+              "invocable": true
+            },
+            {
+              "name": "catc-inventory",
+              "description": "description: \"Catalyst Center device inventory and site management - list/filter devices by hostname, IP, platform, family, role, reachability; view site hierarchy; get interface details per device; d",
+              "invocable": true
+            },
+            {
+              "name": "catc-troubleshoot",
+              "description": "description: \"Catalyst Center troubleshooting workflows - device unreachable investigation, client connectivity issues, interface down analysis, site-wide outage triage, wireless roaming problems, int",
+              "invocable": true
+            },
+            {
+              "name": "checkpoint",
+              "description": "A comprehensive skill for interacting with Check Point enterprise security infrastructure through 15 MCP servers.",
+              "invocable": true
+            },
+            {
+              "name": "clab-lab-management",
+              "description": "description: \"ContainerLab network lab lifecycle management \u2014 authenticate, list, deploy, inspect, execute commands on, and destroy containerized network labs via the ContainerLab API. Use when deploy",
+              "invocable": true
+            },
+            {
+              "name": "claroty-asset-inventory",
+              "description": "description: \"Discover and classify OT / IoT / IoMT assets via Claroty xDome. List devices by site, Purdue level, and device purpose; assign Purdue layers and custom attributes; cross-reference with N",
+              "invocable": true
+            },
+            {
+              "name": "claroty-ot-topology",
+              "description": "description: \"Render Claroty xDome OT / IoT communication maps and zone segmentation as inline Canvas/A2UI topology, draw.io diagrams, and timeline summaries.\"",
+              "invocable": true
+            },
+            {
+              "name": "claroty-risk-triage",
+              "description": "description: \"Triage Claroty xDome alerts and vulnerabilities, compute blast radius, correlate with NVD CVE data, and drive ITSM-gated workflow actions (acknowledge, label, assign, set relevance).\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-analytics",
+              "description": "description: \"Access Cloudflare traffic analytics, logs, and Radar global Internet insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-dns",
+              "description": "description: \"Manage Cloudflare DNS zones and records with analytics insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-security",
+              "description": "description: \"Monitor Cloudflare WAF, firewall events, audit logs, and threat intelligence.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-workers",
+              "description": "description: \"Monitor Cloudflare Workers deployments, bindings, and build insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-zerotrust",
+              "description": "description: \"Inspect Cloudflare Zero Trust access applications, policies, tunnels, and CASB findings.\"",
+              "invocable": true
+            },
+            {
+              "name": "cml-admin",
+              "description": "description: \"CML administration \u2014 user/group management, system info, licensing, resource monitoring. Use when creating CML users, checking license status, monitoring CML server resources, or auditin",
+              "invocable": true
+            },
+            {
+              "name": "cml-lab-lifecycle",
+              "description": "description: \"Cisco CML lab lifecycle management \u2014 create, start, stop, wipe, delete, clone, import/export labs. Use when building a network lab, starting or stopping a CML lab, cloning a topology, or",
+              "invocable": true
+            },
+            {
+              "name": "cml-node-operations",
+              "description": "description: \"CML node operations \u2014 start, stop, console access, CLI execution, config management, node details. Use when starting or stopping a CML node, running show commands on a lab router, settin",
+              "invocable": true
+            },
+            {
+              "name": "cml-packet-capture",
+              "description": "description: \"CML packet capture \u2014 start, stop, download pcaps from CML lab links, integrate with Packet Buddy for analysis. Use when capturing packets in a CML lab, troubleshooting BGP or OSPF with p",
+              "invocable": true
+            },
+            {
+              "name": "cml-topology-builder",
+              "description": "description: \"Build CML topologies \u2014 add nodes, create interfaces, wire links, set link conditioning, add annotations. Use when building a network topology in CML, adding routers or switches to a lab,",
+              "invocable": true
+            },
+            {
+              "name": "datadog-apm",
+              "description": "description: \"Analyze distributed traces and service performance in Datadog APM.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-incidents",
+              "description": "description: \"Manage incidents in Datadog Incident Management.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-logs",
+              "description": "description: \"Search and analyze logs in Datadog Log Management.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-metrics",
+              "description": "description: \"Query metrics and explore dashboards in Datadog.\"",
+              "invocable": true
+            },
+            {
+              "name": "defenseclaw-ops",
+              "description": "description: Manage DefenseClaw enterprise security - scan components, manage tool permissions, view alerts, configure guardrails",
+              "invocable": true
+            },
+            {
+              "name": "desktop-gui-inspect",
+              "description": "description: \"Full-desktop automation for targets that have no browser and no API at all \u2014 a legacy Java-based NMS client, a vendor's Windows-only configuration utility, a terminal emulator with no sc",
+              "invocable": true
+            },
+            {
+              "name": "devnet-catalyst-search",
+              "description": "description: Search Cisco Catalyst Center API documentation for device management and policy automation",
+              "invocable": true
+            },
+            {
+              "name": "devnet-meraki-search",
+              "description": "description: Search Cisco Meraki API documentation and lookup specific operations",
+              "invocable": true
+            },
+            {
+              "name": "drawio-diagram",
+              "description": "description: \"Generate draw.io network diagrams \u2014 native .drawio files with CLI export (PNG/SVG/PDF), plus browser-based Mermaid/XML/CSV via MCP server. Use when creating network topology diagrams, ge",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-build",
+              "description": "description: Build or rewire EVE-NG lab topology. Use when creating or deleting virtual networks, connecting node interfaces to networks, inspecting topology links, checking interface mappings, or lis",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-design",
+              "description": "description: Design EVE-NG lab topology and coordinate the design workflow. Use when the user asks for lab design, architecture advice, topology planning, design review, or a build plan, especially wh",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-discovery",
+              "description": "description: Gather missing requirements for EVE-NG topology design. Use when the request is vague or incomplete, when you need discovery questions, defaults, trade-off framing, image recommendations,",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-validation",
+              "description": "description: Validate EVE-NG topology designs and enforce final delivery structure. Use when reviewing a design, checking build readiness, producing the final design output, building an implementation",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-config-ops",
+              "description": "description: Manage EVE-NG startup configurations stored in lab files. Use when exporting configs natively into the lab, reading embedded startup configs, pushing startup config before boot, clearing ",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-console-ops",
+              "description": "description: Execute live CLI commands on running EVE-NG nodes over telnet console. Use when running show commands, making live config changes, verifying protocol state, testing connectivity, checking",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-lab-management",
+              "description": "description: Manage EVE-NG labs and platform inventory. Use when listing labs, checking lab metadata, creating or deleting labs, importing or exporting lab archives, checking EVE-NG health or auth, or",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-node-operations",
+              "description": "description: Manage EVE-NG node lifecycle. Use when listing nodes, checking runtime state, creating or deleting nodes, starting or stopping nodes or whole labs, verifying node details, or wiping node ",
+              "invocable": true
+            },
+            {
+              "name": "evpn-vxlan-fabric",
+              "description": "description: \"EVPN/VXLAN fabric audit and troubleshooting \u2014 VTEPs, VNIs, route types, multihoming, underlay/overlay validation. Use when troubleshooting VXLAN overlay reachability, auditing leaf-spine",
+              "invocable": true
+            },
+            {
+              "name": "f5-config-mgmt",
+              "description": "description: \"F5 BIG-IP configuration management - safe change workflow with baseline capture, planning, creation/update/deletion of virtual servers, pools, iRules, and profiles with full verification",
+              "invocable": true
+            },
+            {
+              "name": "f5-health-check",
+              "description": "description: \"F5 BIG-IP health monitoring - virtual server status, pool member health, log analysis, performance statistics, and systematic health assessment. Use when checking F5 load balancer health",
+              "invocable": true
+            },
+            {
+              "name": "f5-troubleshoot",
+              "description": "description: \"F5 BIG-IP troubleshooting - virtual server failures, pool member health, connection issues, SSL/TLS problems, iRule errors, persistence issues, and performance degradation. Use when a VI",
+              "invocable": true
+            },
+            {
+              "name": "fmc-firewall-ops",
+              "description": "description: \"Cisco Secure Firewall FMC \u2014 access policy search, rule inspection, FTD device targeting, multi-FMC profile management. Use when searching firewall rules by IP or FQDN, checking if host A",
+              "invocable": true
+            },
+            {
+              "name": "fortimanager-ops",
+              "description": "description: \"FortiManager operations \u2014 ADOM inventory, policy package review, object search, install preview, and compliance workflows. Use when auditing FortiGate firewall policies, reviewing ADOM p",
+              "invocable": true
+            },
+            {
+              "name": "forward",
+              "description": "description: Forward snapshot assurance, path search, app-aware path search, NQE, checks, vulnerabilities, diffs, configuration, lifecycle, collection, and topology workflows through the upstream forw",
+              "invocable": true
+            },
+            {
+              "name": "fwrule-analyzer",
+              "description": "description: \"Multi-vendor firewall rule analysis \u2014 overlap detection, shadowing, conflict identification, duplication checking across PAN-OS, ASA, FTD, IOS/IOS-XE, IOS-XR, Check Point, SRX, Junos, No",
+              "invocable": true
+            },
+            {
+              "name": "gait-session-tracking",
+              "description": "description: \"GAIT session lifecycle management - branch creation, turn recording, audit logging for every NetClaw operation. Use when starting a new NetClaw session, recording a health check or confi",
+              "invocable": true
+            },
+            {
+              "name": "gcp-cloud-logging",
+              "description": "description: \"Google Cloud Logging \u2014 log search, VPC flow logs, firewall logs, audit logs, log buckets and views. Use when searching GCP logs, investigating denied VPC flow traffic, checking who delet",
+              "invocable": true
+            },
+            {
+              "name": "gcp-cloud-monitoring",
+              "description": "description: \"Google Cloud Monitoring \u2014 time series metrics, alert policies, active alerts, metric discovery. Use when checking GCP network performance, investigating firing alerts, querying VM CPU or",
+              "invocable": true
+            },
+            {
+              "name": "gcp-compute-ops",
+              "description": "description: \"Google Cloud Compute Engine \u2014 VM instances, disks, templates, instance groups, reservations, project discovery. Use when listing GCP VMs, troubleshooting a Compute Engine instance, check",
+              "invocable": true
+            },
+            {
+              "name": "github-ops",
+              "description": "description: \"GitHub repository operations \u2014 issues, PRs, code search, and config-as-code workflows. Use when creating a GitHub issue for a network finding, opening a pull request for a config change,",
+              "invocable": true
+            },
+            {
+              "name": "gitlab-devops",
+              "description": "description: \"GitLab DevOps operations \u2014 issues, merge requests, CI/CD pipelines, repository browsing, labels, milestones, releases, and wiki management. Use when querying GitLab project status, monit",
+              "invocable": true
+            },
+            {
+              "name": "gnmi-telemetry",
+              "description": "description: \"gNMI streaming telemetry operations for multi-vendor network devices. Query device state via structured YANG model paths, subscribe to real-time telemetry streams, apply ITSM-gated confi",
+              "invocable": true
+            },
+            {
+              "name": "gns3-link-management",
+              "description": "description: \"Manage GNS3 links - connect/disconnect node interfaces, isolate nodes\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-node-operations",
+              "description": "description: \"Manage GNS3 nodes - add from templates, start/stop/suspend/reload, console access\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-packet-capture",
+              "description": "description: \"Capture network traffic on GNS3 links - start/stop captures, retrieve PCAP data\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-project-lifecycle",
+              "description": "description: \"Manage GNS3 network lab projects - create, open, close, delete, clone, export/import\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-snapshot-ops",
+              "description": "description: \"Manage GNS3 project snapshots - create, restore, delete for safe experimentation\"",
+              "invocable": true
+            },
+            {
+              "name": "grafana-observability",
+              "description": "description: \"Grafana observability platform \u2014 dashboards, Prometheus PromQL, Loki LogQL, alerting, incidents, OnCall schedules, annotations, datasource queries, panel rendering (75+ tools). Use when ",
+              "invocable": true
+            },
+            {
+              "name": "gtrace-ip-enrichment",
+              "description": "description: \"IP address enrichment \u2014 ASN ownership lookup, geolocation (city/region/country/coordinates), and reverse DNS resolution. Use when identifying who owns an IP address, locating an IP geogr",
+              "invocable": true
+            },
+            {
+              "name": "gtrace-path-analysis",
+              "description": "description: \"Network path tracing and monitoring \u2014 traceroute with MPLS/ECMP/NAT detection, continuous MTR monitoring, and distributed GlobalPing probes from 500+ worldwide locations. Use when tracin",
+              "invocable": true
+            },
+            {
+              "name": "humanrail-escalation",
+              "description": "description: \"Human-in-the-loop escalation via HumanRail \u2014 route low-confidence agent decisions, pre-destructive operation approvals, and ambiguous incident tickets to real human engineers. Human answ",
+              "invocable": true
+            },
+            {
+              "name": "infoblox-ddi",
+              "description": "description: \"Infoblox DDI operations \u2014 DNS zones/records, DHCP scopes and leases, IPAM networks and address utilization. Use when checking DNS records, validating IPAM address allocation, investigati",
+              "invocable": true
+            },
+            {
+              "name": "infrahub-sot",
+              "description": "description: \"OpsMill Infrahub \u2014 infrastructure source of truth with schema-driven nodes, GraphQL queries, and branch-isolated changes. Use when querying Infrahub for device/IPAM inventory, browsing i",
+              "invocable": true
+            },
+            {
+              "name": "ipfabric",
+              "description": "**Skill**: `/ipfabric`",
+              "invocable": true
+            },
+            {
+              "name": "ipfix-receiver",
+              "description": "description: \"Receive and query IPFIX and NetFlow flow records from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "ise-incident-response",
+              "description": "description: \"Rapid ISE endpoint investigation and quarantine workflow - endpoint lookup, auth history, posture review, human-authorized quarantine, ServiceNow Security Incident. Use when a SOC alert ",
+              "invocable": true
+            },
+            {
+              "name": "ise-posture-audit",
+              "description": "description: \"Cisco ISE posture and policy audit - authorization rules, posture compliance, profiling gaps, TrustSec SGT matrix, active session health. Use when running a periodic ISE compliance audit",
+              "invocable": true
+            },
+            {
+              "name": "itential-automation",
+              "description": "description: \"Itential Automation Platform (IAP) \u2014 network automation orchestration, device configuration management, compliance enforcement, workflow execution, golden config, lifecycle management, a",
+              "invocable": true
+            },
+            {
+              "name": "jenkins-cicd",
+              "description": "description: Jenkins CI/CD pipeline management \u2014 monitor builds, trigger pipelines, analyze logs, and track SCM changes for network automation workflows.",
+              "invocable": true
+            },
+            {
+              "name": "junos-network",
+              "description": "description: \"Juniper JunOS device automation via PyEZ/NETCONF \u2014 CLI execution, configuration management, Jinja2 template rendering, device facts, batch operations, config diff and rollback comparison",
+              "invocable": true
+            },
+            {
+              "name": "kubeshark-traffic",
+              "description": "description: \"Kubeshark Kubernetes traffic analysis \u2014 L4/L7 deep packet inspection, TLS decryption, pcap export, flow analysis, service mapping (6 tools). Use when capturing Kubernetes pod traffic, de",
+              "invocable": true
+            },
+            {
+              "name": "markmap-viz",
+              "description": "description: \"Create interactive mind map visualizations from markdown - network inventory, OSPF areas, BGP topology, security audit results. Use when visualizing network topology as a mind map, creat",
+              "invocable": true
+            },
+            {
+              "name": "memory",
+              "description": "**Purpose**: Provide persistent context across NetClaw sessions through structured facts, semantic search, and entity relationships.",
+              "invocable": true
+            },
+            {
+              "name": "mempalace",
+              "description": "description: \"MemPalace AI memory \u2014 persistent memory across sessions. Search past decisions, store architecture choices, track temporal network facts via knowledge graph, navigate cross-domain connec",
+              "invocable": true
+            },
+            {
+              "name": "meraki-monitoring",
+              "description": "description: \"Cisco Meraki Monitoring & Diagnostics \u2014 live ping, cable test, LED blink, wake-on-LAN, camera analytics, config change tracking. Use when running ping tests from Meraki devices, troubles",
+              "invocable": true
+            },
+            {
+              "name": "meraki-network-ops",
+              "description": "description: \"Cisco Meraki Dashboard \u2014 organization inventory, network management, device lifecycle, client discovery, action batches. Use when listing Meraki devices, managing networks, checking devi",
+              "invocable": true
+            },
+            {
+              "name": "meraki-security-appliance",
+              "description": "description: \"Cisco Meraki Security Appliance (MX) \u2014 firewall rules, site-to-site VPN, content filtering, traffic shaping, security events. Use when auditing Meraki MX firewall rules, troubleshooting ",
+              "invocable": true
+            },
+            {
+              "name": "meraki-switch-ops",
+              "description": "description: \"Cisco Meraki Switching \u2014 port configuration, VLANs, port status, ACLs, QoS rules, port cycling. Use when configuring Meraki switch ports, creating VLANs, checking port status and PoE, tr",
+              "invocable": true
+            },
+            {
+              "name": "meraki-wireless-ops",
+              "description": "description: \"Cisco Meraki Wireless \u2014 SSID management, RF profiles, channel utilization, signal quality, client connectivity events. Use when managing Meraki SSIDs, troubleshooting WiFi connectivity, ",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-files",
+              "description": "description: \"Manage files on OneDrive and SharePoint via Microsoft Graph API - upload, download, list, search, and organize network documentation and artifacts. Use when uploading reports to SharePoi",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-teams",
+              "description": "description: \"Send notifications and reports to Microsoft Teams channels via Graph API - alert delivery, report posting, incident updates, and diagram sharing. Use when posting health alerts to Teams,",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-visio",
+              "description": "description: \"Generate and manage Visio network diagrams on SharePoint via Microsoft Graph API - create topology diagrams from CDP/LLDP discovery, update existing diagrams, export to PDF. Use when cre",
+              "invocable": true
+            },
+            {
+              "name": "n2n-federation",
+              "description": "description: Federate your NetClaw with other NetClaw operators over the BGP mesh \u2014 exchange capability inventories and ask your claw what a peer can do. (US1; remote invocation and chat land in later",
+              "invocable": true
+            },
+            {
+              "name": "nautobot-sot",
+              "description": "description: \"Nautobot IPAM & source of truth \u2014 IP address queries, prefix lookups, VRF/tenant/site filtering, IPAM search, connection testing. Use when looking up IP addresses in Nautobot, checking s",
+              "invocable": true
+            },
+            {
+              "name": "netbox-reconcile",
+              "description": "description: \"Reconcile NetBox source of truth against live network state - detect IP drift, missing interfaces, undocumented links, cable mismatches, VLAN mismatches, and ticket discrepancies in Serv",
+              "invocable": true
+            },
+            {
+              "name": "nmap-network-scan",
+              "description": "description: \"Host discovery and port scanning using nmap \u2014 ICMP/ARP host discovery, SYN/TCP/UDP port scanning with scope enforcement and audit logging. Use when discovering live hosts on a subnet, sc",
+              "invocable": true
+            },
+            {
+              "name": "nmap-scan-management",
+              "description": "description: \"Custom nmap scans with arbitrary flags, plus scan history retrieval and management. Use when running nmap with custom flags, reviewing past scan results, comparing before/after scans, or",
+              "invocable": true
+            },
+            {
+              "name": "nmap-service-detection",
+              "description": "description: \"Service fingerprinting, OS detection, NSE script execution, and vulnerability scanning using nmap MCP. Use when identifying services on open ports, fingerprinting OS versions, running NS",
+              "invocable": true
+            },
+            {
+              "name": "nso-device-ops",
+              "description": "description: \"Cisco NSO device operations \u2014 config retrieval, state inspection, sync, platform info, NED IDs, device groups. Use when retrieving device configs from NSO, checking sync status, pulling ",
+              "invocable": true
+            },
+            {
+              "name": "nso-service-mgmt",
+              "description": "description: \"Cisco NSO service management \u2014 discover service types, list service instances, orchestrate network services. Use when listing NSO services, checking service health, auditing deployed ser",
+              "invocable": true
+            },
+            {
+              "name": "nvd-cve",
+              "description": "description: \"Search the National Vulnerability Database for CVEs - find vulnerabilities by keyword or ID, get CVSS scores, weaknesses, affected configurations, and remediation references. Use when lo",
+              "invocable": true
+            },
+            {
+              "name": "packet-analysis",
+              "description": "description: \"Analyze network packet captures (.pcap/.pcapng) using Packet Buddy MCP. Use when opening a pcap file, inspecting packet captures, troubleshooting network traffic, analyzing retransmissio",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-incidents",
+              "description": "description: \"Manage and investigate incidents in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-oncall",
+              "description": "description: \"Manage on-call schedules and escalation policies in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-orchestration",
+              "description": "description: \"Manage event orchestration and routing rules in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-services",
+              "description": "description: \"Manage service catalog and service health in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "paloalto-panorama",
+              "description": "description: \"Palo Alto Panorama operations \u2014 device groups, templates, security policy search, NAT review, commit status, and audit workflows. Use when searching Palo Alto firewall rules, checking if",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-apps",
+              "description": "description: \"View Prisma SD-WAN application definitions for policy visibility\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-config",
+              "description": "description: \"Inspect Prisma SD-WAN interfaces, routing (BGP, static), policies, and security zones\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-status",
+              "description": "description: \"Monitor Prisma SD-WAN element health, software versions, events, and alarms\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-topology",
+              "description": "description: \"Discover Prisma SD-WAN sites, ION elements, machines, and network topology\"",
+              "invocable": true
+            },
+            {
+              "name": "prometheus-monitoring",
+              "description": "description: \"Prometheus monitoring \u2014 PromQL instant/range queries, metric discovery, metadata, scrape target health, system health checks (6 tools). Use when querying Prometheus metrics, checking scr",
+              "invocable": true
+            },
+            {
+              "name": "protocol-participation",
+              "description": "description: \"Live BGP and OSPF control-plane participation \u2014 peer with real routers, inject/withdraw routes, query RIB/LSDB, adjust metrics, GRE tunnel status. Use when injecting or withdrawing BGP r",
+              "invocable": true
+            },
+            {
+              "name": "pyats-asa-firewall",
+              "description": "description: \"Cisco ASA firewall operations via pyATS \u2014 VPN sessions, failover state, interfaces, routing, service policies, resource usage, AnyConnect monitoring. Use when checking ASA failover statu",
+              "invocable": true
+            },
+            {
+              "name": "pyats-config-mgmt",
+              "description": "description: \"Network change management - pre-change baselines, configuration deployment, post-change verification, rollback procedures, and compliance validation. Use when pushing config to a device,",
+              "invocable": true
+            },
+            {
+              "name": "pyats-dynamic-test",
+              "description": "description: \"Generate and execute deterministic pyATS aetest validation scripts - interface state, OSPF neighbors, BGP paths, ping matrices, and custom compliance tests. Use when writing a network te",
+              "invocable": true
+            },
+            {
+              "name": "pyats-f5-ltm",
+              "description": "description: \"F5 BIG-IP LTM/GTM operations via pyATS iControl REST \u2014 virtual servers, pools, nodes, monitors, profiles, iRules, persistence, GTM wide IPs, DNS, data groups. Use when checking F5 virtua",
+              "invocable": true
+            },
+            {
+              "name": "pyats-f5-platform",
+              "description": "description: \"F5 BIG-IP platform operations via pyATS iControl REST \u2014 system, networking, HA/CM, auth, analytics, security, APM, live-update, ADC certs, file management. Use when checking BIG-IP syste",
+              "invocable": true
+            },
+            {
+              "name": "pyats-health-check",
+              "description": "description: \"Comprehensive network device health monitoring - CPU, memory, interfaces, hardware, NTP, logging, environment, and uptime analysis. Use when running a device health check, monitoring CPU",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-interfaces",
+              "description": "description: \"JunOS interface operations via pyATS \u2014 physical/logical interfaces, LACP, CoS, LLDP, ARP, BFD, IPv6 neighbors, traffic monitoring, optics diagnostics. Use when checking Juniper interface",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-routing",
+              "description": "description: \"JunOS routing operations via pyATS \u2014 OSPF/OSPFv3, BGP, route table, MPLS/LDP/RSVP, TED, PFE, ping, traceroute across Juniper devices. Use when checking Juniper OSPF neighbors, viewing BG",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-system",
+              "description": "description: \"JunOS system operations via pyATS \u2014 chassis health, hardware inventory, system info, NTP, SNMP, files/logs, firewall counters, DDoS protection, services accounting. Use when checking Jun",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-network",
+              "description": "description: \"Linux host network operations via pyATS \u2014 interface configuration, routing tables, network connections, and multi-table route inspection across fleet hosts. Use when checking Linux inter",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-system",
+              "description": "description: \"Linux host system operations via pyATS \u2014 process monitoring, filesystem inspection, Docker container stats, package/tool verification across fleet hosts. Use when checking running proces",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-vmware",
+              "description": "description: \"VMware ESXi host operations via pyATS \u2014 VM inventory, snapshot management, hypervisor inspection across ESXi hosts in the testbed. Use when listing VMs on ESXi, checking snapshot age, au",
+              "invocable": true
+            },
+            {
+              "name": "pyats-network",
+              "description": "description: \"Network device automation via pyATS - run show commands, ping, apply config, learn config/logging, list devices, run Linux commands, execute dynamic tests on Cisco IOS-XE/NX-OS devices. ",
+              "invocable": true
+            },
+            {
+              "name": "pyats-parallel-ops",
+              "description": "description: \"Fleet-wide parallel device operations - concurrent health checks, config audits, routing snapshots, severity-sorted reporting, and failure-isolated multi-device automation. Use when chec",
+              "invocable": true
+            },
+            {
+              "name": "pyats-routing",
+              "description": "description: \"CCIE-level routing protocol analysis - OSPF, BGP, EIGRP, IS-IS, static routes, RIB/FIB verification, redistribution audit, and convergence validation. Use when analyzing routing tables, ",
+              "invocable": true
+            },
+            {
+              "name": "pyats-security",
+              "description": "description: \"Network security audit - ACLs, AAA, control plane policing, management plane hardening, encryption, port security, and CIS benchmark checks. Use when auditing device security posture, ch",
+              "invocable": true
+            },
+            {
+              "name": "pyats-topology",
+              "description": "description: \"Network topology discovery via CDP/LLDP neighbors, ARP tables, routing peers, and interface mapping to build complete network maps. Use when mapping the network, building a diagram, disc",
+              "invocable": true
+            },
+            {
+              "name": "pyats-troubleshoot",
+              "description": "description: \"Systematic network troubleshooting - connectivity, routing, interface, protocol, and performance issues using structured OSI-layer and divide-and-conquer methodology. Use when something ",
+              "invocable": true
+            },
+            {
+              "name": "radkit-remote-access",
+              "description": "description: \"Cisco RADKit \u2014 cloud-relayed remote device access, CLI execution, SNMP polling, device inventory discovery, attribute inspection. Use when accessing remote network devices through a clou",
+              "invocable": true
+            },
+            {
+              "name": "rag",
+              "description": "**Purpose**: Give NetClaw a fully offline, user-curated document knowledge base \u2014 vendor guides, standards (RFC/IEEE/vendor), customer design documents, install guides \u2014 with agentic retrieval, mandat",
+              "invocable": true
+            },
+            {
+              "name": "rfc-lookup",
+              "description": "description: \"Search and retrieve IETF RFC documents - lookup by number, search by keyword, extract sections. Use when looking up an RFC, checking protocol specifications, verifying standards complian",
+              "invocable": true
+            },
+            {
+              "name": "sdwan-ops",
+              "description": "description: \"Cisco SD-WAN vManage read-only operations \u2014 fabric devices, WAN Edge inventory, templates, policies, alarms, events, interface stats, BFD sessions, OMP routes, control connections, runni",
+              "invocable": true
+            },
+            {
+              "name": "servicenow-change-workflow",
+              "description": "description: \"Full ITSM-gated change lifecycle - CR creation, pre-change incident validation, approval gate, execution via pyats-config-mgmt, post-change verification, and closure with GAIT audit trai",
+              "invocable": true
+            },
+            {
+              "name": "slack-incident-workflow",
+              "description": "description: \"Manage network incident response workflows in Slack - incident channels, status updates, escalation, resolution tracking, and post-incident review coordination. Use when declaring a netw",
+              "invocable": true
+            },
+            {
+              "name": "slack-network-alerts",
+              "description": "description: \"Format and deliver network alerts, health warnings, and critical notifications via Slack with rich formatting, reactions, and file attachments. Use when sending alerts to Slack, posting ",
+              "invocable": true
+            },
+            {
+              "name": "slack-report-delivery",
+              "description": "description: \"Deliver formatted network reports, audit results, topology diagrams, and compliance documentation to Slack channels with rich Block Kit formatting. Use when posting a health check report",
+              "invocable": true
+            },
+            {
+              "name": "slack-user-context",
+              "description": "description: \"Leverage Slack user profiles, presence, DND status, and workspace context to personalize responses, route escalations, and coordinate team operations. Use when checking who is on-call, r",
+              "invocable": true
+            },
+            {
+              "name": "slack-voice-interface",
+              "description": "description: \"Respond to Slack voice clips with both text and an MP3 voice reply using edge-tts. Voice IN is already handled by OpenClaw transcription. Use when a user sends a voice message in Slack, ",
+              "invocable": true
+            },
+            {
+              "name": "snmptrap-receiver",
+              "description": "description: \"Receive and query SNMP traps from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-indexes",
+              "description": "description: \"Discover and inspect Splunk indexes and configuration.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-saved",
+              "description": "description: \"Manage and run saved searches in Splunk.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-search",
+              "description": "description: \"Execute and validate SPL (Search Processing Language) queries.\"",
+              "invocable": true
+            },
+            {
+              "name": "subnet-calculator",
+              "description": "description: \"IPv4 and IPv6 subnet calculator - CIDR breakdown, usable hosts, previous/next subnets, address classification, VLSM planning, and dual-stack analysis. Use when calculating subnets, figur",
+              "invocable": true
+            },
+            {
+              "name": "suzieq-observability",
+              "description": "description: \"SuzieQ network observability \u2014 query current and historical network state, run validation assertions, get summary statistics, trace forwarding paths, and discover unique values across 20",
+              "invocable": true
+            },
+            {
+              "name": "syslog-receiver",
+              "description": "description: \"Receive and query syslog messages from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "te-network-monitoring",
+              "description": "description: \"Cisco ThousandEyes \u2014 test management, agent inventory, test results, dashboards, path visualization, user/account management. Use when checking ThousandEyes test results, viewing network",
+              "invocable": true
+            },
+            {
+              "name": "te-path-analysis",
+              "description": "description: \"Cisco ThousandEyes \u2014 path visualization, BGP route analysis, outage investigation, instant tests, endpoint agent diagnostics. Use when tracing network paths hop-by-hop, investigating why",
+              "invocable": true
+            },
+            {
+              "name": "telemetry-ops",
+              "description": "description: \"Comprehensive network telemetry and event collection across multiple protocols.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-operations",
+              "description": "description: \"Execute local Terraform operations with ServiceNow change control.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-registry",
+              "description": "description: \"Discover providers and modules from the Terraform Registry.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-workspaces",
+              "description": "description: \"Manage HCP Terraform (Terraform Cloud/Enterprise) workspaces.\"",
+              "invocable": true
+            },
+            {
+              "name": "threejs-network-viz",
+              "description": "**Version**: 1.0.0",
+              "invocable": true
+            },
+            {
+              "name": "token-tracker",
+              "description": "description: \"Track and display token consumption and cost for every NetClaw interaction.\"",
+              "invocable": true
+            },
+            {
+              "name": "twilio-daily-briefing",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-emergency-call",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-inbound-voice",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-outbound-call",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twitter-check",
+              "description": "**Purpose**: Quick invocation to check mentions and respond to #netclaw threads.",
+              "invocable": true
+            },
+            {
+              "name": "twitter-heartbeat",
+              "description": "**Purpose**: Autonomous periodic tweeting AND mention monitoring to maintain NetClaw's Twitter presence with CCIE-level network engineering content.",
+              "invocable": true
+            },
+            {
+              "name": "twitter-respond",
+              "description": "**Skill ID**: twitter-respond",
+              "invocable": true
+            },
+            {
+              "name": "twitter-share",
+              "description": "**Purpose**: Manual tweet posting with content guardrails and human approval flow.",
+              "invocable": true
+            },
+            {
+              "name": "ue5-network-viz",
+              "description": "description: \"3D network topology visualization and interactive digital twin in Unreal Engine 5.8 via the built-in UE5 MCP server.\"",
+              "invocable": true
+            },
+            {
+              "name": "uml-diagram",
+              "description": "description: \"UML and diagram generation via Kroki \u2014 class, sequence, activity, state, component, deployment, network, ER, C4, Mermaid, D2, Graphviz, BPMN, 27+ types. Use when generating a network dia",
+              "invocable": true
+            },
+            {
+              "name": "vault-mounts",
+              "description": "description: \"Discover and manage HashiCorp Vault secret engine mounts.\"",
+              "invocable": true
+            },
+            {
+              "name": "vault-pki",
+              "description": "description: \"Manage HashiCorp Vault PKI certificate infrastructure.\"",
+              "invocable": true
+            },
+            {
+              "name": "vault-secrets",
+              "description": "description: \"Manage HashiCorp Vault KV secrets with strict value protection.\"",
+              "invocable": true
+            },
+            {
+              "name": "webex-incident-workflow",
+              "description": "description: \"Manage network incident response workflows in Cisco WebEx - incident spaces, status updates, escalation, resolution tracking, and post-incident review coordination. Use when declaring a ",
+              "invocable": true
+            },
+            {
+              "name": "webex-network-alerts",
+              "description": "description: \"Format and deliver network alerts, health warnings, and critical notifications via Cisco WebEx with Adaptive Cards, markdown formatting, and file attachments. Use when sending alerts to ",
+              "invocable": true
+            },
+            {
+              "name": "webex-report-delivery",
+              "description": "description: \"Deliver formatted network reports, audit results, topology diagrams, and compliance documentation to WebEx spaces with Adaptive Cards and markdown formatting. Use when posting a health c",
+              "invocable": true
+            },
+            {
+              "name": "webex-user-context",
+              "description": "description: \"Leverage WebEx user profiles, presence status, and workspace context to personalize responses, route escalations, and coordinate team operations. Use when checking who is available, rout",
+              "invocable": true
+            },
+            {
+              "name": "webex-voice-interface",
+              "description": "description: \"Respond to WebEx voice clips with both text and an MP3 voice reply using edge-tts. Voice IN is already handled by OpenClaw transcription. Use when a user sends a voice message in WebEx, ",
+              "invocable": true
+            },
+            {
+              "name": "wikipedia-research",
+              "description": "description: \"Research networking protocols, standards history, and technology context via Wikipedia - OSPF, BGP, MPLS, 802.1X, VXLAN, and more. Use when looking up protocol background, researching ho",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-identity",
+              "description": "description: \"Manage users, groups, departments, and identity provider configurations.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-insights",
+              "description": "description: \"Access analytics, threat intelligence, and security event data.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zdx",
+              "description": "description: \"Monitor digital experience scores, user performance, and application health.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zia",
+              "description": "description: \"Manage Zscaler Internet Access firewall rules, URL filtering, DLP, and security policies.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zpa",
+              "description": "description: \"Manage Zscaler Private Access applications, segments, policies, and connectors.\"",
+              "invocable": true
+            }
+          ],
+          "mcp_servers": [
+            {
+              "name": "forward-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "suzieq-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "batfish-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gnmi-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "azure-network-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gitlab-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chrome-devtools-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chrome-devtools-mcp-visible",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "jenkins-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "atlassian-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gns3-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "prisma-sdwan-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "datadog-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "pagerduty-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "splunk-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "infrahub-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "terraform-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "vault-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "zscaler-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-dns-analytics",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-security",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-zerotrust",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-analytics",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-workers",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "blender-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aruba-cx-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "devnet-content-search",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-golden-config-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-routing-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-management",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-management-logs",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-threat-prevention",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-https-inspection",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-harmony-sase",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-reputation-service",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-quantum-gw-cli",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-gw-connection-analysis",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-threat-emulation",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-quantum-gaia",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-documentation",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-spark-management",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-cpinfo-analysis",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-argos-erm",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-policy-insights",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "claroty-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twitter-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twilio-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twilio-voice-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "unreal-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "sketchfab-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "n2n-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "rag-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cml-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nso-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "itential-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "prometheus-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "grafana-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "meraki-magic-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "radkit-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "junos-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "arista-cvp-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cisco-fmc-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "thousandeyes-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "github-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-network-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-cloudwatch-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-iam-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-cloudtrail-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-cost-explorer-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-diagram-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-compute-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-monitoring-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-logging-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-resource-manager-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "thousandeyes-official-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "kubeshark-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "uml-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "protocol-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "ollama-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "fwrule-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-ansible-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-eda-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-lint-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-docs-mcp",
+              "tools": [],
+              "invocable_tools": []
+            }
+          ],
+          "knowledge": [],
+          "badges": [
+            "AWS",
+            "Azure",
+            "Batfish",
+            "CML",
+            "Check Point",
+            "Forward",
+            "GNS3",
+            "Meraki",
+            "Nautobot",
+            "SuzieQ",
+            "gNMI"
+          ],
+          "posture": {
+            "mode": "testing",
+            "state": "unknown",
+            "summary": "testing",
+            "controls": {}
+          },
+          "llm": {
+            "primary_model": null,
+            "guarded": false
+          }
+        },
+        "received_at": "2026-07-23T00:34:20Z",
+        "stale": true
+      },
+      "channel_state": "unreachable",
+      "last_seen": 0,
+      "endpoint_updated_at": null,
+      "in_flight_tasks": [],
+      "endpoint": null
+    },
+    {
+      "identity": "as65099-10.255.255.1",
+      "display_name": "Byrn",
+      "state": "federated",
+      "chat_enabled": true,
+      "inventory_version": 18,
+      "inventory_received_at": "2026-07-25T16:43:51Z",
+      "stale": true,
+      "inventory": {
+        "inventory": {
+          "identity": "as65099-10.255.255.1",
+          "issued_at": "2026-07-25T16:43:48Z",
+          "version": 18,
+          "skills": [
+            {
+              "name": "aap-automation",
+              "description": "description: \"Red Hat Ansible Automation Platform \u2014 inventory management, job template execution, project SCM sync, ad-hoc commands, host management, Galaxy content discovery. Use when automating infr",
+              "invocable": true
+            },
+            {
+              "name": "aap-eda",
+              "description": "description: \"Event-Driven Ansible (EDA) \u2014 activation lifecycle, rulebook management, decision environments, event stream monitoring. Use when managing event-driven automation triggers, enabling/disab",
+              "invocable": true
+            },
+            {
+              "name": "aap-lint",
+              "description": "description: \"ansible-lint playbook and role validation \u2014 syntax checking, best practice enforcement, project-wide analysis, rule filtering. Use when validating Ansible playbooks, checking code qualit",
+              "invocable": true
+            },
+            {
+              "name": "aci-change-deploy",
+              "description": "description: \"Safe ACI policy change deployment - ServiceNow CR lifecycle, pre/post-change fault baselines, APIC policy application, automatic rollback on fault delta, and GAIT audit trail. Use when d",
+              "invocable": true
+            },
+            {
+              "name": "aci-fabric-audit",
+              "description": "description: \"Comprehensive Cisco ACI fabric health audit - node status, tenant/VRF/BD/EPG policy review, contract analysis, fault triage, and endpoint learning verification. Use when auditing ACI fab",
+              "invocable": true
+            },
+            {
+              "name": "alert-triage",
+              "description": "description: \"Investigate alerts from the home/edge observability stack via adapters (firewall, wireless, SoT). Receives enriched alert context (device name, IP, platform, role) from the alert receive",
+              "invocable": true
+            },
+            {
+              "name": "arista-cvp",
+              "description": "description: \"Arista CloudVision Portal (CVP) automation via REST API \u2014 device inventory, events, connectivity monitoring, tag management (4 tools). Use when managing Arista devices, checking CloudVis",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-config",
+              "description": "description: \"View and manage Aruba CX switch configurations, perform ISSU upgrades, and firmware operations\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-interfaces",
+              "description": "description: \"Monitor Aruba CX switch interface status, LLDP neighbors, and optical transceiver health\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-switching",
+              "description": "description: \"View and manage Aruba CX switch VLANs and MAC address tables for Layer 2 operations\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-system",
+              "description": "description: \"Discover Aruba CX switch system information, firmware versions, and VSF topology\"",
+              "invocable": true
+            },
+            {
+              "name": "atlassian-itsm",
+              "description": "description: IT Service Management workflows using Jira for issue tracking and Confluence for documentation",
+              "invocable": true
+            },
+            {
+              "name": "aws-architecture-diagram",
+              "description": "description: \"AWS architecture diagrams \u2014 generate visual network topology diagrams from live AWS infrastructure. Use when drawing AWS network diagrams, visualizing VPCs, mapping Transit Gateway topol",
+              "invocable": true
+            },
+            {
+              "name": "aws-cloud-monitoring",
+              "description": "description: \"AWS CloudWatch monitoring \u2014 metrics, alarms, log queries, VPC flow log analysis, network performance. Use when checking AWS alarms, analyzing VPC flow logs, investigating network latency",
+              "invocable": true
+            },
+            {
+              "name": "aws-cost-ops",
+              "description": "description: \"AWS Cost Explorer \u2014 spending analysis, service breakdowns, forecasts, cost anomalies. Use when analyzing AWS spending, investigating cost spikes, reviewing network cost drivers like NAT ",
+              "invocable": true
+            },
+            {
+              "name": "aws-network-ops",
+              "description": "description: \"AWS cloud networking \u2014 VPC, Transit Gateway, Cloud WAN, VPN, Network Firewall, ENI, flow logs. Use when auditing AWS VPCs, troubleshooting connectivity between EC2 instances, checking Tr",
+              "invocable": true
+            },
+            {
+              "name": "aws-security-audit",
+              "description": "description: \"AWS security auditing \u2014 IAM users/roles/policies, CloudTrail API events, security posture analysis. Use when auditing IAM permissions, investigating security incidents, checking MFA comp",
+              "invocable": true
+            },
+            {
+              "name": "azure-network-ops",
+              "description": "description: \"Azure cloud networking -- VNets, NSGs, ExpressRoute, VPN Gateways, Azure Firewalls, Load Balancers, Application Gateways, Route Tables, Network Watcher, Private Endpoints, DNS zones. Use",
+              "invocable": true
+            },
+            {
+              "name": "azure-security-audit",
+              "description": "description: \"Azure NSG compliance auditing and security posture assessment. CIS Azure Foundations Benchmark rules, effective security rule analysis, orphaned NSG detection. Use when auditing Azure NS",
+              "invocable": true
+            },
+            {
+              "name": "batfish-config-analysis",
+              "description": "description: \"Batfish network configuration analysis -- pre-deployment validation, reachability testing, ACL/firewall tracing, differential analysis, compliance checking. Use when validating configs b",
+              "invocable": true
+            },
+            {
+              "name": "blender-3d-viz",
+              "description": "description: \"Create 3D network topology visualizations in Blender from CDP/LLDP neighbor data\"",
+              "invocable": true
+            },
+            {
+              "name": "browser-gui-inspect",
+              "description": "description: \"Controller-agnostic browser automation and inspection \u2014 navigate, read, click, fill, and capture network traffic on any web GUI using a persistent, manually-authenticated Chrome profile.",
+              "invocable": true
+            },
+            {
+              "name": "browser-viz-verify",
+              "description": "description: \"Verifies that a NetClaw-generated visualization HTML file (three.js, canvas, drawio, UML, markmap) actually renders correctly \u2014 screenshot, console-error check, and an optional Lighthous",
+              "invocable": true
+            },
+            {
+              "name": "canvas-network-viz",
+              "description": "description: \"Canvas/A2UI inline network visualizations \u2014 topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards rendered directly in the Ope",
+              "invocable": true
+            },
+            {
+              "name": "catc-client-ops",
+              "description": "description: \"Catalyst Center client operations and monitoring - list/filter wired and wireless clients, detailed client lookup by MAC, client count analytics, time-based analysis, SSID and band filte",
+              "invocable": true
+            },
+            {
+              "name": "catc-inventory",
+              "description": "description: \"Catalyst Center device inventory and site management - list/filter devices by hostname, IP, platform, family, role, reachability; view site hierarchy; get interface details per device; d",
+              "invocable": true
+            },
+            {
+              "name": "catc-troubleshoot",
+              "description": "description: \"Catalyst Center troubleshooting workflows - device unreachable investigation, client connectivity issues, interface down analysis, site-wide outage triage, wireless roaming problems, int",
+              "invocable": true
+            },
+            {
+              "name": "checkpoint",
+              "description": "A comprehensive skill for interacting with Check Point enterprise security infrastructure through 15 MCP servers.",
+              "invocable": true
+            },
+            {
+              "name": "clab-lab-management",
+              "description": "description: \"ContainerLab network lab lifecycle management \u2014 authenticate, list, deploy, inspect, execute commands on, and destroy containerized network labs via the ContainerLab API. Use when deploy",
+              "invocable": true
+            },
+            {
+              "name": "claroty-asset-inventory",
+              "description": "description: \"Discover and classify OT / IoT / IoMT assets via Claroty xDome. List devices by site, Purdue level, and device purpose; assign Purdue layers and custom attributes; cross-reference with N",
+              "invocable": true
+            },
+            {
+              "name": "claroty-ot-topology",
+              "description": "description: \"Render Claroty xDome OT / IoT communication maps and zone segmentation as inline Canvas/A2UI topology, draw.io diagrams, and timeline summaries.\"",
+              "invocable": true
+            },
+            {
+              "name": "claroty-risk-triage",
+              "description": "description: \"Triage Claroty xDome alerts and vulnerabilities, compute blast radius, correlate with NVD CVE data, and drive ITSM-gated workflow actions (acknowledge, label, assign, set relevance).\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-analytics",
+              "description": "description: \"Access Cloudflare traffic analytics, logs, and Radar global Internet insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-dns",
+              "description": "description: \"Manage Cloudflare DNS zones and records with analytics insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-security",
+              "description": "description: \"Monitor Cloudflare WAF, firewall events, audit logs, and threat intelligence.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-workers",
+              "description": "description: \"Monitor Cloudflare Workers deployments, bindings, and build insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-zerotrust",
+              "description": "description: \"Inspect Cloudflare Zero Trust access applications, policies, tunnels, and CASB findings.\"",
+              "invocable": true
+            },
+            {
+              "name": "cml-admin",
+              "description": "description: \"CML administration \u2014 user/group management, system info, licensing, resource monitoring. Use when creating CML users, checking license status, monitoring CML server resources, or auditin",
+              "invocable": true
+            },
+            {
+              "name": "cml-lab-lifecycle",
+              "description": "description: \"Cisco CML lab lifecycle management \u2014 create, start, stop, wipe, delete, clone, import/export labs. Use when building a network lab, starting or stopping a CML lab, cloning a topology, or",
+              "invocable": true
+            },
+            {
+              "name": "cml-node-operations",
+              "description": "description: \"CML node operations \u2014 start, stop, console access, CLI execution, config management, node details. Use when starting or stopping a CML node, running show commands on a lab router, settin",
+              "invocable": true
+            },
+            {
+              "name": "cml-packet-capture",
+              "description": "description: \"CML packet capture \u2014 start, stop, download pcaps from CML lab links, integrate with Packet Buddy for analysis. Use when capturing packets in a CML lab, troubleshooting BGP or OSPF with p",
+              "invocable": true
+            },
+            {
+              "name": "cml-topology-builder",
+              "description": "description: \"Build CML topologies \u2014 add nodes, create interfaces, wire links, set link conditioning, add annotations. Use when building a network topology in CML, adding routers or switches to a lab,",
+              "invocable": true
+            },
+            {
+              "name": "datadog-apm",
+              "description": "description: \"Analyze distributed traces and service performance in Datadog APM.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-incidents",
+              "description": "description: \"Manage incidents in Datadog Incident Management.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-logs",
+              "description": "description: \"Search and analyze logs in Datadog Log Management.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-metrics",
+              "description": "description: \"Query metrics and explore dashboards in Datadog.\"",
+              "invocable": true
+            },
+            {
+              "name": "defenseclaw-ops",
+              "description": "description: Manage DefenseClaw enterprise security - scan components, manage tool permissions, view alerts, configure guardrails",
+              "invocable": true
+            },
+            {
+              "name": "demo-lab-setup",
+              "description": "Deploy the byrn-baker/Nautobot-Workshop environment end-to-end. Fully autonomous \u2014 validate each step before proceeding, no user input required except at session checkpoints.",
+              "invocable": true
+            },
+            {
+              "name": "desktop-gui-inspect",
+              "description": "description: \"Full-desktop automation for targets that have no browser and no API at all \u2014 a legacy Java-based NMS client, a vendor's Windows-only configuration utility, a terminal emulator with no sc",
+              "invocable": true
+            },
+            {
+              "name": "devnet-catalyst-search",
+              "description": "description: Search Cisco Catalyst Center API documentation for device management and policy automation",
+              "invocable": true
+            },
+            {
+              "name": "devnet-meraki-search",
+              "description": "description: Search Cisco Meraki API documentation and lookup specific operations",
+              "invocable": true
+            },
+            {
+              "name": "domain-expert-delegation",
+              "description": "description: \"Offload structured workloads (config generation, design validation, GraphQL building, state summarization, context compression) to local or cloud LLM providers via the ollama-mcp server.",
+              "invocable": true
+            },
+            {
+              "name": "drawio-diagram",
+              "description": "description: \"Generate draw.io network diagrams \u2014 native .drawio files with CLI export (PNG/SVG/PDF), plus browser-based Mermaid/XML/CSV via MCP server. Use when creating network topology diagrams, ge",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-build",
+              "description": "description: Build or rewire EVE-NG lab topology. Use when creating or deleting virtual networks, connecting node interfaces to networks, inspecting topology links, checking interface mappings, or lis",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-design",
+              "description": "description: Design EVE-NG lab topology and coordinate the design workflow. Use when the user asks for lab design, architecture advice, topology planning, design review, or a build plan, especially wh",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-discovery",
+              "description": "description: Gather missing requirements for EVE-NG topology design. Use when the request is vague or incomplete, when you need discovery questions, defaults, trade-off framing, image recommendations,",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-validation",
+              "description": "description: Validate EVE-NG topology designs and enforce final delivery structure. Use when reviewing a design, checking build readiness, producing the final design output, building an implementation",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-config-ops",
+              "description": "description: Manage EVE-NG startup configurations stored in lab files. Use when exporting configs natively into the lab, reading embedded startup configs, pushing startup config before boot, clearing ",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-console-ops",
+              "description": "description: Execute live CLI commands on running EVE-NG nodes over telnet console. Use when running show commands, making live config changes, verifying protocol state, testing connectivity, checking",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-lab-management",
+              "description": "description: Manage EVE-NG labs and platform inventory. Use when listing labs, checking lab metadata, creating or deleting labs, importing or exporting lab archives, checking EVE-NG health or auth, or",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-node-operations",
+              "description": "description: Manage EVE-NG node lifecycle. Use when listing nodes, checking runtime state, creating or deleting nodes, starting or stopping nodes or whole labs, verifying node details, or wiping node ",
+              "invocable": true
+            },
+            {
+              "name": "evpn-vxlan-fabric",
+              "description": "description: \"EVPN/VXLAN fabric audit and troubleshooting \u2014 VTEPs, VNIs, route types, multihoming, underlay/overlay validation. Use when troubleshooting VXLAN overlay reachability, auditing leaf-spine",
+              "invocable": true
+            },
+            {
+              "name": "f5-config-mgmt",
+              "description": "description: \"F5 BIG-IP configuration management - safe change workflow with baseline capture, planning, creation/update/deletion of virtual servers, pools, iRules, and profiles with full verification",
+              "invocable": true
+            },
+            {
+              "name": "f5-health-check",
+              "description": "description: \"F5 BIG-IP health monitoring - virtual server status, pool member health, log analysis, performance statistics, and systematic health assessment. Use when checking F5 load balancer health",
+              "invocable": true
+            },
+            {
+              "name": "f5-troubleshoot",
+              "description": "description: \"F5 BIG-IP troubleshooting - virtual server failures, pool member health, connection issues, SSL/TLS problems, iRule errors, persistence issues, and performance degradation. Use when a VI",
+              "invocable": true
+            },
+            {
+              "name": "fmc-firewall-ops",
+              "description": "description: \"Cisco Secure Firewall FMC \u2014 access policy search, rule inspection, FTD device targeting, multi-FMC profile management. Use when searching firewall rules by IP or FQDN, checking if host A",
+              "invocable": true
+            },
+            {
+              "name": "fortimanager-ops",
+              "description": "description: \"FortiManager operations \u2014 ADOM inventory, policy package review, object search, install preview, and compliance workflows. Use when auditing FortiGate firewall policies, reviewing ADOM p",
+              "invocable": true
+            },
+            {
+              "name": "forward",
+              "description": "description: Forward snapshot assurance, path search, app-aware path search, NQE, checks, vulnerabilities, diffs, configuration, lifecycle, collection, and topology workflows through the upstream forw",
+              "invocable": true
+            },
+            {
+              "name": "fwrule-analyzer",
+              "description": "description: \"Multi-vendor firewall rule analysis \u2014 overlap detection, shadowing, conflict identification, duplication checking across PAN-OS, ASA, FTD, IOS/IOS-XE, IOS-XR, Check Point, SRX, Junos, No",
+              "invocable": true
+            },
+            {
+              "name": "gait-session-tracking",
+              "description": "description: \"GAIT session lifecycle management - branch creation, turn recording, audit logging for every NetClaw operation. Use when starting a new NetClaw session, recording a health check or confi",
+              "invocable": true
+            },
+            {
+              "name": "gcp-cloud-logging",
+              "description": "description: \"Google Cloud Logging \u2014 log search, VPC flow logs, firewall logs, audit logs, log buckets and views. Use when searching GCP logs, investigating denied VPC flow traffic, checking who delet",
+              "invocable": true
+            },
+            {
+              "name": "gcp-cloud-monitoring",
+              "description": "description: \"Google Cloud Monitoring \u2014 time series metrics, alert policies, active alerts, metric discovery. Use when checking GCP network performance, investigating firing alerts, querying VM CPU or",
+              "invocable": true
+            },
+            {
+              "name": "gcp-compute-ops",
+              "description": "description: \"Google Cloud Compute Engine \u2014 VM instances, disks, templates, instance groups, reservations, project discovery. Use when listing GCP VMs, troubleshooting a Compute Engine instance, check",
+              "invocable": true
+            },
+            {
+              "name": "github-ops",
+              "description": "description: \"GitHub repository operations \u2014 issues, PRs, code search, and config-as-code workflows. Use when creating a GitHub issue for a network finding, opening a pull request for a config change,",
+              "invocable": true
+            },
+            {
+              "name": "gitlab-devops",
+              "description": "description: \"GitLab DevOps operations \u2014 issues, merge requests, CI/CD pipelines, repository browsing, labels, milestones, releases, and wiki management. Use when querying GitLab project status, monit",
+              "invocable": true
+            },
+            {
+              "name": "gnmi-telemetry",
+              "description": "description: \"gNMI streaming telemetry operations for multi-vendor network devices. Query device state via structured YANG model paths, subscribe to real-time telemetry streams, apply ITSM-gated confi",
+              "invocable": true
+            },
+            {
+              "name": "gns3-link-management",
+              "description": "description: \"Manage GNS3 links - connect/disconnect node interfaces, isolate nodes\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-node-operations",
+              "description": "description: \"Manage GNS3 nodes - add from templates, start/stop/suspend/reload, console access\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-packet-capture",
+              "description": "description: \"Capture network traffic on GNS3 links - start/stop captures, retrieve PCAP data\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-project-lifecycle",
+              "description": "description: \"Manage GNS3 network lab projects - create, open, close, delete, clone, export/import\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-snapshot-ops",
+              "description": "description: \"Manage GNS3 project snapshots - create, restore, delete for safe experimentation\"",
+              "invocable": true
+            },
+            {
+              "name": "golden-config-bootstrap",
+              "description": "Interactively set up the Nautobot Golden Config plugin from scratch. This is a conversational workflow \u2014 the agent guides the user through analyzing their running configs, designing compliance feature",
+              "invocable": true
+            },
+            {
+              "name": "grafana-observability",
+              "description": "description: \"Grafana observability platform \u2014 dashboards, Prometheus PromQL, Loki LogQL, alerting, incidents, OnCall schedules, annotations, datasource queries, panel rendering (75+ tools). Use when ",
+              "invocable": true
+            },
+            {
+              "name": "gtrace-ip-enrichment",
+              "description": "description: \"IP address enrichment \u2014 ASN ownership lookup, geolocation (city/region/country/coordinates), and reverse DNS resolution. Use when identifying who owns an IP address, locating an IP geogr",
+              "invocable": true
+            },
+            {
+              "name": "gtrace-path-analysis",
+              "description": "description: \"Network path tracing and monitoring \u2014 traceroute with MPLS/ECMP/NAT detection, continuous MTR monitoring, and distributed GlobalPing probes from 500+ worldwide locations. Use when tracin",
+              "invocable": true
+            },
+            {
+              "name": "humanrail-escalation",
+              "description": "description: \"Human-in-the-loop escalation via HumanRail \u2014 route low-confidence agent decisions, pre-destructive operation approvals, and ambiguous incident tickets to real human engineers. Human answ",
+              "invocable": true
+            },
+            {
+              "name": "infoblox-ddi",
+              "description": "description: \"Infoblox DDI operations \u2014 DNS zones/records, DHCP scopes and leases, IPAM networks and address utilization. Use when checking DNS records, validating IPAM address allocation, investigati",
+              "invocable": true
+            },
+            {
+              "name": "infrahub-sot",
+              "description": "description: \"OpsMill Infrahub \u2014 infrastructure source of truth with schema-driven nodes, GraphQL queries, and branch-isolated changes. Use when querying Infrahub for device/IPAM inventory, browsing i",
+              "invocable": true
+            },
+            {
+              "name": "intent-reconcile",
+              "description": "description: \"Reconcile live network devices to Nautobot intent, with a human approval gate over Discord. Triggered by a Nautobot webhook (device interface change) or by an approval/denial reply. Prop",
+              "invocable": true
+            },
+            {
+              "name": "ipfabric",
+              "description": "**Skill**: `/ipfabric`",
+              "invocable": true
+            },
+            {
+              "name": "ipfix-receiver",
+              "description": "description: \"Receive and query IPFIX and NetFlow flow records from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "ise-incident-response",
+              "description": "description: \"Rapid ISE endpoint investigation and quarantine workflow - endpoint lookup, auth history, posture review, human-authorized quarantine, ServiceNow Security Incident. Use when a SOC alert ",
+              "invocable": true
+            },
+            {
+              "name": "ise-posture-audit",
+              "description": "description: \"Cisco ISE posture and policy audit - authorization rules, posture compliance, profiling gaps, TrustSec SGT matrix, active session health. Use when running a periodic ISE compliance audit",
+              "invocable": true
+            },
+            {
+              "name": "isp-sla-claim",
+              "description": "description: \"Draft ISP service credit claims after WAN outages. Gathers evidence from Prometheus, pfSense, and dpinger logs to prove the outage was ISP-side (not CPE). Produces a ready-to-send email ",
+              "invocable": true
+            },
+            {
+              "name": "itential-automation",
+              "description": "description: \"Itential Automation Platform (IAP) \u2014 network automation orchestration, device configuration management, compliance enforcement, workflow execution, golden config, lifecycle management, a",
+              "invocable": true
+            },
+            {
+              "name": "jenkins-cicd",
+              "description": "description: Jenkins CI/CD pipeline management \u2014 monitor builds, trigger pipelines, analyze logs, and track SCM changes for network automation workflows.",
+              "invocable": true
+            },
+            {
+              "name": "junos-network",
+              "description": "description: \"Juniper JunOS device automation via PyEZ/NETCONF \u2014 CLI execution, configuration management, Jinja2 template rendering, device facts, batch operations, config diff and rollback comparison",
+              "invocable": true
+            },
+            {
+              "name": "kubeshark-traffic",
+              "description": "description: \"Kubeshark Kubernetes traffic analysis \u2014 L4/L7 deep packet inspection, TLS decryption, pcap export, flow analysis, service mapping (6 tools). Use when capturing Kubernetes pod traffic, de",
+              "invocable": true
+            },
+            {
+              "name": "lab-troubleshoot",
+              "description": "description: \"Detect and diagnose network failures by correlating observability metrics (Grafana/Prometheus), syslog (Loki), and live device state (pyATS). Use when investigating connectivity issues, ",
+              "invocable": true
+            },
+            {
+              "name": "markmap-viz",
+              "description": "description: \"Create interactive mind map visualizations from markdown - network inventory, OSPF areas, BGP topology, security audit results. Use when visualizing network topology as a mind map, creat",
+              "invocable": true
+            },
+            {
+              "name": "memory",
+              "description": "**Purpose**: Provide persistent context across NetClaw sessions through structured facts, semantic search, and entity relationships.",
+              "invocable": true
+            },
+            {
+              "name": "memory-management",
+              "description": "description: \"Record and recall network facts, decisions, and session context using hybrid structured + semantic memory\"",
+              "invocable": true
+            },
+            {
+              "name": "mempalace",
+              "description": "description: \"MemPalace AI memory \u2014 persistent memory across sessions. Search past decisions, store architecture choices, track temporal network facts via knowledge graph, navigate cross-domain connec",
+              "invocable": true
+            },
+            {
+              "name": "meraki-monitoring",
+              "description": "description: \"Cisco Meraki Monitoring & Diagnostics \u2014 live ping, cable test, LED blink, wake-on-LAN, camera analytics, config change tracking. Use when running ping tests from Meraki devices, troubles",
+              "invocable": true
+            },
+            {
+              "name": "meraki-network-ops",
+              "description": "description: \"Cisco Meraki Dashboard \u2014 organization inventory, network management, device lifecycle, client discovery, action batches. Use when listing Meraki devices, managing networks, checking devi",
+              "invocable": true
+            },
+            {
+              "name": "meraki-security-appliance",
+              "description": "description: \"Cisco Meraki Security Appliance (MX) \u2014 firewall rules, site-to-site VPN, content filtering, traffic shaping, security events. Use when auditing Meraki MX firewall rules, troubleshooting ",
+              "invocable": true
+            },
+            {
+              "name": "meraki-switch-ops",
+              "description": "description: \"Cisco Meraki Switching \u2014 port configuration, VLANs, port status, ACLs, QoS rules, port cycling. Use when configuring Meraki switch ports, creating VLANs, checking port status and PoE, tr",
+              "invocable": true
+            },
+            {
+              "name": "meraki-wireless-ops",
+              "description": "description: \"Cisco Meraki Wireless \u2014 SSID management, RF profiles, channel utilization, signal quality, client connectivity events. Use when managing Meraki SSIDs, troubleshooting WiFi connectivity, ",
+              "invocable": true
+            },
+            {
+              "name": "monitoring-onboard",
+              "description": "description: \"Configure network devices to send telemetry to the existing observability stack. Supports pfSense, Cisco IOS/IOS-XE switches, Proxmox hosts, and Linux servers. Generates Prometheus scrap",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-files",
+              "description": "description: \"Manage files on OneDrive and SharePoint via Microsoft Graph API - upload, download, list, search, and organize network documentation and artifacts. Use when uploading reports to SharePoi",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-teams",
+              "description": "description: \"Send notifications and reports to Microsoft Teams channels via Graph API - alert delivery, report posting, incident updates, and diagram sharing. Use when posting health alerts to Teams,",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-visio",
+              "description": "description: \"Generate and manage Visio network diagrams on SharePoint via Microsoft Graph API - create topology diagrams from CDP/LLDP discovery, update existing diagrams, export to PDF. Use when cre",
+              "invocable": true
+            },
+            {
+              "name": "n2n-federation",
+              "description": "description: Federate your NetClaw with other NetClaw operators over the BGP mesh \u2014 exchange capability inventories and ask your claw what a peer can do. (US1; remote invocation and chat land in later",
+              "invocable": true
+            },
+            {
+              "name": "nautobot-dev-setup",
+              "description": "Deploy a Nautobot development instance using the official `nautobot/nautobot-docker-compose` repository.",
+              "invocable": true
+            },
+            {
+              "name": "nautobot-sot",
+              "description": "description: \"Nautobot IPAM & source of truth \u2014 IP address queries, prefix lookups, VRF/tenant/site filtering, IPAM search, connection testing. Use when looking up IP addresses in Nautobot, checking s",
+              "invocable": true
+            },
+            {
+              "name": "netbox-reconcile",
+              "description": "description: \"Reconcile NetBox source of truth against live network state - detect IP drift, missing interfaces, undocumented links, cable mismatches, VLAN mismatches, and ticket discrepancies in Serv",
+              "invocable": true
+            },
+            {
+              "name": "nmap-network-scan",
+              "description": "description: \"Host discovery and port scanning using nmap \u2014 ICMP/ARP host discovery, SYN/TCP/UDP port scanning with scope enforcement and audit logging. Use when discovering live hosts on a subnet, sc",
+              "invocable": true
+            },
+            {
+              "name": "nmap-scan-management",
+              "description": "description: \"Custom nmap scans with arbitrary flags, plus scan history retrieval and management. Use when running nmap with custom flags, reviewing past scan results, comparing before/after scans, or",
+              "invocable": true
+            },
+            {
+              "name": "nmap-service-detection",
+              "description": "description: \"Service fingerprinting, OS detection, NSE script execution, and vulnerability scanning using nmap MCP. Use when identifying services on open ports, fingerprinting OS versions, running NS",
+              "invocable": true
+            },
+            {
+              "name": "nso-device-ops",
+              "description": "description: \"Cisco NSO device operations \u2014 config retrieval, state inspection, sync, platform info, NED IDs, device groups. Use when retrieving device configs from NSO, checking sync status, pulling ",
+              "invocable": true
+            },
+            {
+              "name": "nso-service-mgmt",
+              "description": "description: \"Cisco NSO service management \u2014 discover service types, list service instances, orchestrate network services. Use when listing NSO services, checking service health, auditing deployed ser",
+              "invocable": true
+            },
+            {
+              "name": "nvd-cve",
+              "description": "description: \"Search the National Vulnerability Database for CVEs - find vulnerabilities by keyword or ID, get CVSS scores, weaknesses, affected configurations, and remediation references. Use when lo",
+              "invocable": true
+            },
+            {
+              "name": "packet-analysis",
+              "description": "description: \"Analyze network packet captures (.pcap/.pcapng) using Packet Buddy MCP. Use when opening a pcap file, inspecting packet captures, troubleshooting network traffic, analyzing retransmissio",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-incidents",
+              "description": "description: \"Manage and investigate incidents in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-oncall",
+              "description": "description: \"Manage on-call schedules and escalation policies in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-orchestration",
+              "description": "description: \"Manage event orchestration and routing rules in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-services",
+              "description": "description: \"Manage service catalog and service health in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "paloalto-panorama",
+              "description": "description: \"Palo Alto Panorama operations \u2014 device groups, templates, security policy search, NAT review, commit status, and audit workflows. Use when searching Palo Alto firewall rules, checking if",
+              "invocable": true
+            },
+            {
+              "name": "pfsense-threat-intel",
+              "description": "version: 2.0.0",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-apps",
+              "description": "description: \"View Prisma SD-WAN application definitions for policy visibility\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-config",
+              "description": "description: \"Inspect Prisma SD-WAN interfaces, routing (BGP, static), policies, and security zones\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-status",
+              "description": "description: \"Monitor Prisma SD-WAN element health, software versions, events, and alarms\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-topology",
+              "description": "description: \"Discover Prisma SD-WAN sites, ION elements, machines, and network topology\"",
+              "invocable": true
+            },
+            {
+              "name": "prometheus-monitoring",
+              "description": "description: \"Prometheus monitoring \u2014 PromQL instant/range queries, metric discovery, metadata, scrape target health, system health checks (6 tools). Use when querying Prometheus metrics, checking scr",
+              "invocable": true
+            },
+            {
+              "name": "protocol-participation",
+              "description": "description: \"Live BGP and OSPF control-plane participation \u2014 peer with real routers, inject/withdraw routes, query RIB/LSDB, adjust metrics, GRE tunnel status. Use when injecting or withdrawing BGP r",
+              "invocable": true
+            },
+            {
+              "name": "pyats-asa-firewall",
+              "description": "description: \"Cisco ASA firewall operations via pyATS \u2014 VPN sessions, failover state, interfaces, routing, service policies, resource usage, AnyConnect monitoring. Use when checking ASA failover statu",
+              "invocable": true
+            },
+            {
+              "name": "pyats-config-mgmt",
+              "description": "description: \"Network change management - pre-change baselines, configuration deployment, post-change verification, rollback procedures, and compliance validation. Use when pushing config to a device,",
+              "invocable": true
+            },
+            {
+              "name": "pyats-dynamic-test",
+              "description": "description: \"Generate and execute deterministic pyATS aetest validation scripts - interface state, OSPF neighbors, BGP paths, ping matrices, and custom compliance tests. Use when writing a network te",
+              "invocable": true
+            },
+            {
+              "name": "pyats-f5-ltm",
+              "description": "description: \"F5 BIG-IP LTM/GTM operations via pyATS iControl REST \u2014 virtual servers, pools, nodes, monitors, profiles, iRules, persistence, GTM wide IPs, DNS, data groups. Use when checking F5 virtua",
+              "invocable": true
+            },
+            {
+              "name": "pyats-f5-platform",
+              "description": "description: \"F5 BIG-IP platform operations via pyATS iControl REST \u2014 system, networking, HA/CM, auth, analytics, security, APM, live-update, ADC certs, file management. Use when checking BIG-IP syste",
+              "invocable": true
+            },
+            {
+              "name": "pyats-health-check",
+              "description": "description: \"Comprehensive network device health monitoring - CPU, memory, interfaces, hardware, NTP, logging, environment, and uptime analysis. Use when running a device health check, monitoring CPU",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-interfaces",
+              "description": "description: \"JunOS interface operations via pyATS \u2014 physical/logical interfaces, LACP, CoS, LLDP, ARP, BFD, IPv6 neighbors, traffic monitoring, optics diagnostics. Use when checking Juniper interface",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-routing",
+              "description": "description: \"JunOS routing operations via pyATS \u2014 OSPF/OSPFv3, BGP, route table, MPLS/LDP/RSVP, TED, PFE, ping, traceroute across Juniper devices. Use when checking Juniper OSPF neighbors, viewing BG",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-system",
+              "description": "description: \"JunOS system operations via pyATS \u2014 chassis health, hardware inventory, system info, NTP, SNMP, files/logs, firewall counters, DDoS protection, services accounting. Use when checking Jun",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-network",
+              "description": "description: \"Linux host network operations via pyATS \u2014 interface configuration, routing tables, network connections, and multi-table route inspection across fleet hosts. Use when checking Linux inter",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-system",
+              "description": "description: \"Linux host system operations via pyATS \u2014 process monitoring, filesystem inspection, Docker container stats, package/tool verification across fleet hosts. Use when checking running proces",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-vmware",
+              "description": "description: \"VMware ESXi host operations via pyATS \u2014 VM inventory, snapshot management, hypervisor inspection across ESXi hosts in the testbed. Use when listing VMs on ESXi, checking snapshot age, au",
+              "invocable": true
+            },
+            {
+              "name": "pyats-network",
+              "description": "description: \"Network device automation via pyATS - run show commands, ping, apply config, learn config/logging, list devices, run Linux commands, execute dynamic tests on Cisco IOS-XE/NX-OS devices. ",
+              "invocable": true
+            },
+            {
+              "name": "pyats-parallel-ops",
+              "description": "description: \"Fleet-wide parallel device operations - concurrent health checks, config audits, routing snapshots, severity-sorted reporting, and failure-isolated multi-device automation. Use when chec",
+              "invocable": true
+            },
+            {
+              "name": "pyats-routing",
+              "description": "description: \"CCIE-level routing protocol analysis - OSPF, BGP, EIGRP, IS-IS, static routes, RIB/FIB verification, redistribution audit, and convergence validation. Use when analyzing routing tables, ",
+              "invocable": true
+            },
+            {
+              "name": "pyats-security",
+              "description": "description: \"Network security audit - ACLs, AAA, control plane policing, management plane hardening, encryption, port security, and CIS benchmark checks. Use when auditing device security posture, ch",
+              "invocable": true
+            },
+            {
+              "name": "pyats-topology",
+              "description": "description: \"Network topology discovery via CDP/LLDP neighbors, ARP tables, routing peers, and interface mapping to build complete network maps. Use when mapping the network, building a diagram, disc",
+              "invocable": true
+            },
+            {
+              "name": "pyats-troubleshoot",
+              "description": "description: \"Systematic network troubleshooting - connectivity, routing, interface, protocol, and performance issues using structured OSI-layer and divide-and-conquer methodology. Use when something ",
+              "invocable": true
+            },
+            {
+              "name": "radkit-remote-access",
+              "description": "description: \"Cisco RADKit \u2014 cloud-relayed remote device access, CLI execution, SNMP polling, device inventory discovery, attribute inspection. Use when accessing remote network devices through a clou",
+              "invocable": true
+            },
+            {
+              "name": "rag",
+              "description": "**Purpose**: Give NetClaw a fully offline, user-curated document knowledge base \u2014 vendor guides, standards (RFC/IEEE/vendor), customer design documents, install guides \u2014 with agentic retrieval, mandat",
+              "invocable": true
+            },
+            {
+              "name": "rfc-lookup",
+              "description": "description: \"Search and retrieve IETF RFC documents - lookup by number, search by keyword, extract sections. Use when looking up an RFC, checking protocol specifications, verifying standards complian",
+              "invocable": true
+            },
+            {
+              "name": "sdwan-ops",
+              "description": "description: \"Cisco SD-WAN vManage read-only operations \u2014 fabric devices, WAN Edge inventory, templates, policies, alarms, events, interface stats, BFD sessions, OMP routes, control connections, runni",
+              "invocable": true
+            },
+            {
+              "name": "servicenow-change-workflow",
+              "description": "description: \"Full ITSM-gated change lifecycle - CR creation, pre-change incident validation, approval gate, execution via pyats-config-mgmt, post-change verification, and closure with GAIT audit trai",
+              "invocable": true
+            },
+            {
+              "name": "slack-incident-workflow",
+              "description": "description: \"Manage network incident response workflows in Slack - incident channels, status updates, escalation, resolution tracking, and post-incident review coordination. Use when declaring a netw",
+              "invocable": true
+            },
+            {
+              "name": "slack-network-alerts",
+              "description": "description: \"Format and deliver network alerts, health warnings, and critical notifications via Slack with rich formatting, reactions, and file attachments. Use when sending alerts to Slack, posting ",
+              "invocable": true
+            },
+            {
+              "name": "slack-report-delivery",
+              "description": "description: \"Deliver formatted network reports, audit results, topology diagrams, and compliance documentation to Slack channels with rich Block Kit formatting. Use when posting a health check report",
+              "invocable": true
+            },
+            {
+              "name": "slack-user-context",
+              "description": "description: \"Leverage Slack user profiles, presence, DND status, and workspace context to personalize responses, route escalations, and coordinate team operations. Use when checking who is on-call, r",
+              "invocable": true
+            },
+            {
+              "name": "slack-voice-interface",
+              "description": "description: \"Respond to Slack voice clips with both text and an MP3 voice reply using edge-tts. Voice IN is already handled by OpenClaw transcription. Use when a user sends a voice message in Slack, ",
+              "invocable": true
+            },
+            {
+              "name": "snmptrap-receiver",
+              "description": "description: \"Receive and query SNMP traps from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-indexes",
+              "description": "description: \"Discover and inspect Splunk indexes and configuration.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-saved",
+              "description": "description: \"Manage and run saved searches in Splunk.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-search",
+              "description": "description: \"Execute and validate SPL (Search Processing Language) queries.\"",
+              "invocable": true
+            },
+            {
+              "name": "subnet-calculator",
+              "description": "description: \"IPv4 and IPv6 subnet calculator - CIDR breakdown, usable hosts, previous/next subnets, address classification, VLSM planning, and dual-stack analysis. Use when calculating subnets, figur",
+              "invocable": true
+            },
+            {
+              "name": "suzieq-observability",
+              "description": "description: \"SuzieQ network observability \u2014 query current and historical network state, run validation assertions, get summary statistics, trace forwarding paths, and discover unique values across 20",
+              "invocable": true
+            },
+            {
+              "name": "syslog-receiver",
+              "description": "description: \"Receive and query syslog messages from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "te-network-monitoring",
+              "description": "description: \"Cisco ThousandEyes \u2014 test management, agent inventory, test results, dashboards, path visualization, user/account management. Use when checking ThousandEyes test results, viewing network",
+              "invocable": true
+            },
+            {
+              "name": "te-path-analysis",
+              "description": "description: \"Cisco ThousandEyes \u2014 path visualization, BGP route analysis, outage investigation, instant tests, endpoint agent diagnostics. Use when tracing network paths hop-by-hop, investigating why",
+              "invocable": true
+            },
+            {
+              "name": "telemetry-ops",
+              "description": "description: \"Comprehensive network telemetry and event collection across multiple protocols.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-operations",
+              "description": "description: \"Execute local Terraform operations with ServiceNow change control.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-registry",
+              "description": "description: \"Discover providers and modules from the Terraform Registry.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-workspaces",
+              "description": "description: \"Manage HCP Terraform (Terraform Cloud/Enterprise) workspaces.\"",
+              "invocable": true
+            },
+            {
+              "name": "threejs-network-viz",
+              "description": "**Version**: 1.0.0",
+              "invocable": true
+            },
+            {
+              "name": "token-tracker",
+              "description": "description: \"Track and display token consumption and cost for every NetClaw interaction.\"",
+              "invocable": true
+            },
+            {
+              "name": "twilio-daily-briefing",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-emergency-call",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-inbound-voice",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-outbound-call",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twitter-check",
+              "description": "**Purpose**: Quick invocation to check mentions and respond to #netclaw threads.",
+              "invocable": true
+            },
+            {
+              "name": "twitter-heartbeat",
+              "description": "**Purpose**: Autonomous periodic tweeting AND mention monitoring to maintain NetClaw's Twitter presence with CCIE-level network engineering content.",
+              "invocable": true
+            },
+            {
+              "name": "twitter-respond",
+              "description": "**Skill ID**: twitter-respond",
+              "invocable": true
+            },
+            {
+              "name": "twitter-share",
+              "description": "**Purpose**: Manual tweet posting with content guardrails and human approval flow.",
+              "invocable": true
+            },
+            {
+              "name": "ue5-network-viz",
+              "description": "description: \"3D network topology visualization and interactive digital twin in Unreal Engine 5.8 via the built-in UE5 MCP server.\"",
+              "invocable": true
+            },
+            {
+              "name": "uml-diagram",
+              "description": "description: \"UML and diagram generation via Kroki \u2014 class, sequence, activity, state, component, deployment, network, ER, C4, Mermaid, D2, Graphviz, BPMN, 27+ types. Use when generating a network dia",
+              "invocable": true
+            },
+            {
+              "name": "vault-mounts",
+              "description": "description: \"Discover and manage HashiCorp Vault secret engine mounts.\"",
+              "invocable": true
+            },
+            {
+              "name": "vault-pki",
+              "description": "description: \"Manage HashiCorp Vault PKI certificate infrastructure.\"",
+              "invocable": true
+            },
+            {
+              "name": "vault-secrets",
+              "description": "description: \"Manage HashiCorp Vault KV secrets with strict value protection.\"",
+              "invocable": true
+            },
+            {
+              "name": "webex-incident-workflow",
+              "description": "description: \"Manage network incident response workflows in Cisco WebEx - incident spaces, status updates, escalation, resolution tracking, and post-incident review coordination. Use when declaring a ",
+              "invocable": true
+            },
+            {
+              "name": "webex-network-alerts",
+              "description": "description: \"Format and deliver network alerts, health warnings, and critical notifications via Cisco WebEx with Adaptive Cards, markdown formatting, and file attachments. Use when sending alerts to ",
+              "invocable": true
+            },
+            {
+              "name": "webex-report-delivery",
+              "description": "description: \"Deliver formatted network reports, audit results, topology diagrams, and compliance documentation to WebEx spaces with Adaptive Cards and markdown formatting. Use when posting a health c",
+              "invocable": true
+            },
+            {
+              "name": "webex-user-context",
+              "description": "description: \"Leverage WebEx user profiles, presence status, and workspace context to personalize responses, route escalations, and coordinate team operations. Use when checking who is available, rout",
+              "invocable": true
+            },
+            {
+              "name": "webex-voice-interface",
+              "description": "description: \"Respond to WebEx voice clips with both text and an MP3 voice reply using edge-tts. Voice IN is already handled by OpenClaw transcription. Use when a user sends a voice message in WebEx, ",
+              "invocable": true
+            },
+            {
+              "name": "wifi-diagnosis",
+              "description": "description: \"Diagnose Wi-Fi and internet connectivity using Home / Network Guardian observability. Prefer adapter metrics (UniFi Integration exporter first; other wireless vendors via stubs later). A",
+              "invocable": true
+            },
+            {
+              "name": "wikipedia-research",
+              "description": "description: \"Research networking protocols, standards history, and technology context via Wikipedia - OSPF, BGP, MPLS, 802.1X, VXLAN, and more. Use when looking up protocol background, researching ho",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-identity",
+              "description": "description: \"Manage users, groups, departments, and identity provider configurations.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-insights",
+              "description": "description: \"Access analytics, threat intelligence, and security event data.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zdx",
+              "description": "description: \"Monitor digital experience scores, user performance, and application health.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zia",
+              "description": "description: \"Manage Zscaler Internet Access firewall rules, URL filtering, DLP, and security policies.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zpa",
+              "description": "description: \"Manage Zscaler Private Access applications, segments, policies, and connectors.\"",
+              "invocable": true
+            }
+          ],
+          "mcp_servers": [
+            {
+              "name": "forward-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "suzieq-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "batfish-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gnmi-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "azure-network-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gitlab-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chrome-devtools-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chrome-devtools-mcp-visible",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "jenkins-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "atlassian-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gns3-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "prisma-sdwan-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "datadog-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "pagerduty-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "splunk-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "infrahub-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "terraform-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "vault-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "zscaler-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-dns-analytics",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-security",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-zerotrust",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-analytics",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-workers",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "blender-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aruba-cx-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "devnet-content-search",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-golden-config-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-routing-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-management",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-management-logs",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-threat-prevention",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-https-inspection",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-harmony-sase",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-reputation-service",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-quantum-gw-cli",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-gw-connection-analysis",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-threat-emulation",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-quantum-gaia",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-documentation",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-spark-management",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-cpinfo-analysis",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-argos-erm",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-policy-insights",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "claroty-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twitter-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twilio-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twilio-voice-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "unreal-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "sketchfab-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "pfsense-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "unifi-network",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "n2n-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "rag-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cml-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nso-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "itential-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "prometheus-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "grafana-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "meraki-magic-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "radkit-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "junos-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "arista-cvp-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cisco-fmc-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "thousandeyes-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "github-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-network-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-cloudwatch-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-iam-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-cloudtrail-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-cost-explorer-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-diagram-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-compute-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-monitoring-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-logging-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-resource-manager-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "thousandeyes-official-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "kubeshark-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "uml-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "protocol-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "ollama-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "fwrule-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-ansible-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-eda-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-lint-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-docs-mcp",
+              "tools": [],
+              "invocable_tools": []
+            }
+          ],
+          "knowledge": [
+            {
+              "collection_id": "knowledge:documents",
+              "name": "Knowledge: documents",
+              "description": "Knowledge collection 'documents': VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches); VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches) - Preface [Cisco Catalyst 9200 Series Switches] - Cisco; VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches) - Configuring VTP [Cisco Catalyst 9200 Series Switches] - Cisco; VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches) - Configuring VLANs [Cisco Catalyst 9200 Series Switches] - Cisco; VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches) - Configuring Voice VLANs [Cisco Catalyst 9200 Series Switches] - Cisco; VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches) - Configuring VLAN Trunks [Cisco Catalyst 9200 Series Switches] - Cisco; VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches) - Configuring Private VLANs [Cisco Catalyst 9200 Series Switches] - Cisco; VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches) - Configuring Wired Dynamic PVLAN [Cisco Catalyst 9200 Series Switches] - Cisco; Quantum Fiber Internet Subscriber Agreement; Documentation crawl; UniFi Network API 10.4.57 OpenAPI (customer, vendor).",
+              "tags": [
+                "customer",
+                "vendor"
+              ],
+              "doc_count": 11,
+              "page_count": 127,
+              "chunk_count": 744,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_WifiDegraded24GHz-Basement-AP---deeper-investigation-with-radio-details_2026-07-24T134400Z",
+              "name": "Knowledge: snapshot_WifiDegraded24GHz-Basement-AP---deeper-investigation-with-radio-details_2026-07-24T134400Z",
+              "description": "Knowledge collection 'snapshot_WifiDegraded24GHz-Basement-AP---deeper-investigation-with-radio-details_2026-07-24T134400Z': WifiDegraded24GHz-Basement-AP---deeper-investigation-with-radio-details (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 3,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_WifiDegraded24GHz_2026-07-24T185304Z",
+              "name": "Knowledge: snapshot_WifiDegraded24GHz_2026-07-24T185304Z",
+              "description": "Knowledge collection 'snapshot_WifiDegraded24GHz_2026-07-24T185304Z': WifiDegraded24GHz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 2,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_convergence-pipe-test-seed_2026-07-24T121341Z",
+              "name": "Knowledge: snapshot_convergence-pipe-test-seed_2026-07-24T121341Z",
+              "description": "Knowledge collection 'snapshot_convergence-pipe-test-seed_2026-07-24T121341Z': convergence-pipe-test-seed (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_convergencepipetest_2026-07-24T121655Z",
+              "name": "Knowledge: snapshot_convergencepipetest_2026-07-24T121655Z",
+              "description": "Knowledge collection 'snapshot_convergencepipetest_2026-07-24T121655Z': convergencepipetest (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_convergencepipetest_2026-07-24T121702Z",
+              "name": "Knowledge: snapshot_convergencepipetest_2026-07-24T121702Z",
+              "description": "Knowledge collection 'snapshot_convergencepipetest_2026-07-24T121702Z': convergencepipetest (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 3,
+              "page_count": 0,
+              "chunk_count": 3,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_convergencepipetest_2026-07-24T121917Z",
+              "name": "Knowledge: snapshot_convergencepipetest_2026-07-24T121917Z",
+              "description": "Knowledge collection 'snapshot_convergencepipetest_2026-07-24T121917Z': convergencepipetest (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_homeapidown_2026-07-24T170417Z",
+              "name": "Knowledge: snapshot_homeapidown_2026-07-24T170417Z",
+              "description": "Knowledge collection 'snapshot_homeapidown_2026-07-24T170417Z': homeapidown (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_homeapidown_2026-07-24T171230Z",
+              "name": "Knowledge: snapshot_homeapidown_2026-07-24T171230Z",
+              "description": "Knowledge collection 'snapshot_homeapidown_2026-07-24T171230Z': homeapidown (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_pfsensewanportscan_2026-07-25T005621Z",
+              "name": "Knowledge: snapshot_pfsensewanportscan_2026-07-25T005621Z",
+              "description": "Knowledge collection 'snapshot_pfsensewanportscan_2026-07-25T005621Z': pfsensewanportscan (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_pfsensewanportscan_2026-07-25T005845Z",
+              "name": "Knowledge: snapshot_pfsensewanportscan_2026-07-25T005845Z",
+              "description": "Knowledge collection 'snapshot_pfsensewanportscan_2026-07-25T005845Z': pfsensewanportscan (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_pfsensewanportscan_2026-07-25T043143Z",
+              "name": "Knowledge: snapshot_pfsensewanportscan_2026-07-25T043143Z",
+              "description": "Knowledge collection 'snapshot_pfsensewanportscan_2026-07-25T043143Z': pfsensewanportscan (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_pfsensewanportscan_2026-07-25T043546Z",
+              "name": "Knowledge: snapshot_pfsensewanportscan_2026-07-25T043546Z",
+              "description": "Knowledge collection 'snapshot_pfsensewanportscan_2026-07-25T043546Z': pfsensewanportscan (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_pfsensewanportscan_2026-07-25T074523Z",
+              "name": "Knowledge: snapshot_pfsensewanportscan_2026-07-25T074523Z",
+              "description": "Knowledge collection 'snapshot_pfsensewanportscan_2026-07-25T074523Z': pfsensewanportscan (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_unifiexporterdown_2026-07-24T170725Z",
+              "name": "Knowledge: snapshot_unifiexporterdown_2026-07-24T170725Z",
+              "description": "Knowledge collection 'snapshot_unifiexporterdown_2026-07-24T170725Z': unifiexporterdown (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_unifiexporterdown_2026-07-24T171619Z",
+              "name": "Knowledge: snapshot_unifiexporterdown_2026-07-24T171619Z",
+              "description": "Knowledge collection 'snapshot_unifiexporterdown_2026-07-24T171619Z': unifiexporterdown (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T121702Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T121702Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T121702Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 2,
+              "page_count": 0,
+              "chunk_count": 2,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T122809Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T122809Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T122809Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T122817Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T122817Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T122817Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T133706Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T133706Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T133706Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T133758Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T133758Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T133758Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T135212Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T135212Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T135212Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T141656Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T141656Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T141656Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T144758Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T144758Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T144758Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T145315Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T145315Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T145315Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T145349Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T145349Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T145349Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T182206Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T182206Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T182206Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T182249Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T182249Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T182249Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-25T065417Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-25T065417Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-25T065417Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-25T065439Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-25T065439Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-25T065439Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded5ghz_2026-07-24T234412Z",
+              "name": "Knowledge: snapshot_wifidegraded5ghz_2026-07-24T234412Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded5ghz_2026-07-24T234412Z': wifidegraded5ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded5ghz_2026-07-24T235329Z",
+              "name": "Knowledge: snapshot_wifidegraded5ghz_2026-07-24T235329Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded5ghz_2026-07-24T235329Z': wifidegraded5ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            }
+          ],
+          "badges": [
+            "AWS",
+            "Azure",
+            "Batfish",
+            "CML",
+            "Check Point",
+            "Forward",
+            "GNS3",
+            "Meraki",
+            "Nautobot",
+            "SuzieQ",
+            "gNMI"
+          ],
+          "posture": {
+            "mode": "testing",
+            "state": "testing",
+            "summary": "testing",
+            "controls": {
+              "sandbox": true,
+              "model-guard": false,
+              "audit": true
+            }
+          },
+          "llm": {
+            "primary_model": "ollama/deepseek-v4-flash:cloud",
+            "guarded": false,
+            "note": "Border reasoning model; member claws run their own per-specialty tiered models"
+          }
+        },
+        "received_at": "2026-07-25T16:43:51Z",
+        "stale": true
+      },
+      "channel_state": "unreachable",
+      "last_seen": 0,
+      "endpoint_updated_at": null,
+      "in_flight_tasks": [],
+      "endpoint": null
+    }
+  ],
+  "approvals": [],
+  "risk": {
+    "role": "border",
+    "risk_name": "johns-risk",
+    "description": null,
+    "enabled_stacks": "both",
+    "self_member_id": null,
+    "member_count": 29,
+    "members_active": 6
+  },
+  "members": [
+    {
+      "member_id": "johns-risk/aap",
+      "display_name": "aap",
+      "profile": "aap",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "aap-automation",
+        "aap-eda",
+        "aap-lint"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/aci",
+      "display_name": "aci",
+      "profile": "aci",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "aci-change-deploy",
+        "aci-fabric-audit"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/azure",
+      "display_name": "azure",
+      "profile": "azure",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "azure-network-ops",
+        "azure-security-audit"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/batfish",
+      "display_name": "batfish",
+      "profile": "batfish",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "batfish-config-analysis"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/catalyst-center",
+      "display_name": "catalyst-center",
+      "profile": "catalyst-center",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "catc-client-ops",
+        "catc-inventory",
+        "catc-troubleshoot"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/cml",
+      "display_name": "cml",
+      "profile": "cml",
+      "state": "active",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 5,
+      "skills": [
+        "cml-topology-builder",
+        "cml-node-operations",
+        "cml-packet-capture",
+        "cml-lab-lifecycle",
+        "cml-admin"
+      ],
+      "live": true,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/containerlab",
+      "display_name": "containerlab",
+      "profile": "containerlab",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "clab-lab-management"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/f5",
+      "display_name": "f5",
+      "profile": "f5",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "f5-config-mgmt",
+        "f5-health-check",
+        "f5-troubleshoot"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/fortimanager",
+      "display_name": "fortimanager",
+      "profile": "fortimanager",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "fortimanager-ops"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/forward",
+      "display_name": "forward",
+      "profile": "forward",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "forward"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/fwrule",
+      "display_name": "fwrule",
+      "profile": "fwrule",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "fwrule-analyzer"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/github",
+      "display_name": "github",
+      "profile": "github",
+      "state": "active",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "github-ops"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/gtrace",
+      "display_name": "gtrace",
+      "profile": "gtrace",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "gtrace-ip-enrichment",
+        "gtrace-path-analysis"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/infoblox",
+      "display_name": "infoblox",
+      "profile": "infoblox",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "infoblox-ddi"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/ipfabric",
+      "display_name": "ipfabric",
+      "profile": "ipfabric",
+      "state": "active",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "ipfabric"
+      ],
+      "live": true,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/ise",
+      "display_name": "ise",
+      "profile": "ise",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "ise-incident-response",
+        "ise-posture-audit"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/itential",
+      "display_name": "itential",
+      "profile": "itential",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "itential-automation"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/netbox",
+      "display_name": "netbox",
+      "profile": "netbox",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "netbox-reconcile"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/nmap",
+      "display_name": "nmap",
+      "profile": "nmap",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "nmap-network-scan",
+        "nmap-scan-management",
+        "nmap-service-detection"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/nso",
+      "display_name": "nso",
+      "profile": "nso",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "nso-device-ops",
+        "nso-service-mgmt"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/nvd",
+      "display_name": "nvd",
+      "profile": "nvd",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "nvd-cve"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/packet",
+      "display_name": "packet",
+      "profile": "packet",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "kubeshark-traffic",
+        "packet-analysis"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/paloalto",
+      "display_name": "paloalto",
+      "profile": "paloalto",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "fmc-firewall-ops",
+        "paloalto-panorama"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/pyats",
+      "display_name": "pyats",
+      "profile": "pyats",
+      "state": "active",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 18,
+      "skills": [
+        "pyats-parallel-ops",
+        "pyats-health-check",
+        "pyats-troubleshoot",
+        "pyats-linux-system",
+        "pyats-f5-ltm",
+        "pyats-security",
+        "pyats-junos-interfaces",
+        "pyats-linux-network",
+        "pyats-junos-system",
+        "pyats-junos-routing",
+        "pyats-f5-platform",
+        "pyats-dynamic-test",
+        "pyats-network",
+        "pyats-asa-firewall",
+        "pyats-config-mgmt",
+        "pyats-routing",
+        "pyats-linux-vmware",
+        "pyats-topology"
+      ],
+      "live": true,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/sdwan",
+      "display_name": "sdwan",
+      "profile": "sdwan",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 5,
+      "skills": [
+        "prisma-sdwan-apps",
+        "prisma-sdwan-config",
+        "prisma-sdwan-status",
+        "prisma-sdwan-topology",
+        "sdwan-ops"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/suzieq",
+      "display_name": "suzieq",
+      "profile": "suzieq",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "suzieq-observability"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/viz",
+      "display_name": "viz",
+      "profile": "viz",
+      "state": "active",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 8,
+      "skills": [
+        "ue5-network-viz",
+        "blender-3d-viz",
+        "threejs-network-viz",
+        "drawio-diagram",
+        "markmap-viz",
+        "canvas-network-viz",
+        "uml-diagram",
+        "aws-architecture-diagram"
+      ],
+      "live": true,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "risk/1785077389894",
+      "display_name": null,
+      "profile": null,
+      "state": "unreachable",
+      "transport_binding": "edge-ws",
+      "node_type": "edge",
+      "specialty_count": 3,
+      "skills": [
+        "camera.capture",
+        "camera.record_video",
+        "audio.record"
+      ],
+      "live": false,
+      "heartbeat_age_s": 1742.2
+    },
+    {
+      "member_id": "risk/1785078347014",
+      "display_name": null,
+      "profile": null,
+      "state": "active",
+      "transport_binding": "edge-ws",
+      "node_type": "edge",
+      "specialty_count": 3,
+      "skills": [
+        "camera.capture",
+        "camera.record_video",
+        "audio.record"
+      ],
+      "live": true,
+      "heartbeat_age_s": 13.3
+    }
+  ],
+  "posture": {
+    "mode": "production",
+    "state": "enforced",
+    "controls": [
+      {
+        "name": "sandbox",
+        "kind": "containment",
+        "available": true,
+        "detail": "",
+        "probed_at": 1785179850.0359924
+      },
+      {
+        "name": "model-guard",
+        "kind": "containment",
+        "available": true,
+        "detail": "",
+        "probed_at": 1785179850.0359924
+      },
+      {
+        "name": "audit",
+        "kind": "audit",
+        "available": true,
+        "detail": "",
+        "probed_at": 1785179850.0359924
+      }
+    ],
+    "missing": [],
+    "strict_all": false,
+    "model": {
+      "primary": "anthropic/claude-opus-5",
+      "guarded": false
+    },
+    "channel_security": {
+      "mode": "on",
+      "by_trust_model": {
+        "legacy": 2,
+        "pinned": 3
+      },
+      "degraded": 2,
+      "amber": 0,
+      "red": 0,
+      "renewals_failing": 0,
+      "pq_mode": "opportunistic",
+      "pq_available": false,
+      "ech_available": false,
+      "channels_kex": []
+    },
+    "computed_at": 1785179850.0363233,
+    "summary": "production \u2014 enforced"
+  },
+  "gait": [
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 471,
+      "ts": "2026-07-27T18:57:50Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/cml",
+      "target": "cml-admin",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 470,
+      "ts": "2026-07-27T18:48:10Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 469,
+      "ts": "2026-07-27T18:35:43Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/cml",
+      "target": "cml-lab-lifecycle",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 468,
+      "ts": "2026-07-27T18:31:49Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/cml",
+      "target": "cml-lab-lifecycle",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 467,
+      "ts": "2026-07-27T18:30:32Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 466,
+      "ts": "2026-07-27T18:27:59Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 465,
+      "ts": "2026-07-27T18:03:35Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 464,
+      "ts": "2026-07-27T17:57:48Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 463,
+      "ts": "2026-07-27T17:33:32Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 462,
+      "ts": "2026-07-27T17:27:57Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 461,
+      "ts": "2026-07-27T17:21:48Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 460,
+      "ts": "2026-07-27T17:17:27Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 459,
+      "ts": "2026-07-27T17:03:31Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 458,
+      "ts": "2026-07-27T16:57:43Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 457,
+      "ts": "2026-07-27T16:33:30Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 456,
+      "ts": "2026-07-27T16:27:43Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 455,
+      "ts": "2026-07-27T16:03:36Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 454,
+      "ts": "2026-07-27T15:57:52Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 453,
+      "ts": "2026-07-27T15:33:32Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 452,
+      "ts": "2026-07-27T15:27:49Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 451,
+      "ts": "2026-07-27T15:03:35Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 450,
+      "ts": "2026-07-27T14:58:19Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 449,
+      "ts": "2026-07-27T14:33:08Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 448,
+      "ts": "2026-07-27T14:27:20Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 447,
+      "ts": "2026-07-27T14:03:24Z"
+    }
+  ],
+  "replicationJobs": [],
+  "edgeNodes": [
+    {
+      "member_id": "risk/1785077389894",
+      "display_name": null,
+      "profile": null,
+      "state": "unreachable",
+      "transport_binding": "edge-ws",
+      "node_type": "edge",
+      "specialty_count": 3,
+      "skills": [
+        "camera.capture",
+        "camera.record_video",
+        "audio.record"
+      ],
+      "live": false,
+      "heartbeat_age_s": 1742.2
+    },
+    {
+      "member_id": "risk/1785078347014",
+      "display_name": null,
+      "profile": null,
+      "state": "active",
+      "transport_binding": "edge-ws",
+      "node_type": "edge",
+      "specialty_count": 3,
+      "skills": [
+        "camera.capture",
+        "camera.record_video",
+        "audio.record"
+      ],
+      "live": true,
+      "heartbeat_age_s": 13.3
+    }
+  ],
+  "recentPushes": [
+    {
+      "id": 440,
+      "direction": "outbound",
+      "peer_identity": "risk/1785077389894",
+      "target_type": "edge_push",
+      "target_name": "text",
+      "request_id": null,
+      "decision": "pushed",
+      "outcome": "success",
+      "requested_at": "2026-07-26T21:01:23Z",
+      "completed_at": "2026-07-26T21:01:23Z",
+      "result_ref": null,
+      "gait_ref": null,
+      "channel_kind": "in2n",
+      "linked_record_id": null
+    },
+    {
+      "id": 423,
+      "direction": "outbound",
+      "peer_identity": "risk/1785077389894",
+      "target_type": "edge_push",
+      "target_name": "text",
+      "request_id": null,
+      "decision": "pushed",
+      "outcome": "success",
+      "requested_at": "2026-07-26T16:20:00Z",
+      "completed_at": "2026-07-26T16:20:00Z",
+      "result_ref": null,
+      "gait_ref": null,
+      "channel_kind": "in2n",
+      "linked_record_id": null
+    }
+  ],
+  "generatedAt": "2026-07-27T19:17:32.063Z"
+}

--- a/specs/072-hud-2-org-chart/fixtures/scale-100.json
+++ b/specs/072-hud-2-org-chart/fixtures/scale-100.json
@@ -1,0 +1,6606 @@
+{
+  "available": true,
+  "identity": "as65001-4.4.4.4",
+  "peers": [
+    {
+      "identity": "as65003-3.3.3.3",
+      "display_name": "AB",
+      "state": "federated",
+      "chat_enabled": false,
+      "inventory_version": null,
+      "inventory_received_at": null,
+      "stale": null,
+      "inventory": null,
+      "channel_state": "unknown",
+      "last_seen": 0,
+      "endpoint_updated_at": null,
+      "in_flight_tasks": [],
+      "endpoint": null
+    },
+    {
+      "identity": "as65007-7.7.7.7",
+      "display_name": "Nicholas",
+      "state": "federated",
+      "chat_enabled": true,
+      "inventory_version": 1,
+      "inventory_received_at": "2026-07-18T17:04:37Z",
+      "stale": true,
+      "inventory": {
+        "inventory": {
+          "identity": "as65007-7.7.7.7",
+          "issued_at": "2026-07-18T17:04:36Z",
+          "version": 1,
+          "skills": [
+            {
+              "name": "aap-automation",
+              "description": "description: \"Red Hat Ansible Automation Platform \u2014 inventory management, job template execution, project SCM sync, ad-hoc commands, host management, Galaxy content discovery. Use when automating infr",
+              "invocable": true
+            },
+            {
+              "name": "aap-eda",
+              "description": "description: \"Event-Driven Ansible (EDA) \u2014 activation lifecycle, rulebook management, decision environments, event stream monitoring. Use when managing event-driven automation triggers, enabling/disab",
+              "invocable": true
+            },
+            {
+              "name": "aap-lint",
+              "description": "description: \"ansible-lint playbook and role validation \u2014 syntax checking, best practice enforcement, project-wide analysis, rule filtering. Use when validating Ansible playbooks, checking code qualit",
+              "invocable": true
+            },
+            {
+              "name": "aci-change-deploy",
+              "description": "description: \"Safe ACI policy change deployment - ServiceNow CR lifecycle, pre/post-change fault baselines, APIC policy application, automatic rollback on fault delta, and GAIT audit trail. Use when d",
+              "invocable": true
+            },
+            {
+              "name": "aci-fabric-audit",
+              "description": "description: \"Comprehensive Cisco ACI fabric health audit - node status, tenant/VRF/BD/EPG policy review, contract analysis, fault triage, and endpoint learning verification. Use when auditing ACI fab",
+              "invocable": true
+            },
+            {
+              "name": "arista-cvp",
+              "description": "description: \"Arista CloudVision Portal (CVP) automation via REST API \u2014 device inventory, events, connectivity monitoring, tag management (4 tools). Use when managing Arista devices, checking CloudVis",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-config",
+              "description": "description: \"View and manage Aruba CX switch configurations, perform ISSU upgrades, and firmware operations\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-interfaces",
+              "description": "description: \"Monitor Aruba CX switch interface status, LLDP neighbors, and optical transceiver health\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-switching",
+              "description": "description: \"View and manage Aruba CX switch VLANs and MAC address tables for Layer 2 operations\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-system",
+              "description": "description: \"Discover Aruba CX switch system information, firmware versions, and VSF topology\"",
+              "invocable": true
+            },
+            {
+              "name": "atlassian-itsm",
+              "description": "description: IT Service Management workflows using Jira for issue tracking and Confluence for documentation",
+              "invocable": true
+            },
+            {
+              "name": "aws-architecture-diagram",
+              "description": "description: \"AWS architecture diagrams \u2014 generate visual network topology diagrams from live AWS infrastructure. Use when drawing AWS network diagrams, visualizing VPCs, mapping Transit Gateway topol",
+              "invocable": true
+            },
+            {
+              "name": "aws-cloud-monitoring",
+              "description": "description: \"AWS CloudWatch monitoring \u2014 metrics, alarms, log queries, VPC flow log analysis, network performance. Use when checking AWS alarms, analyzing VPC flow logs, investigating network latency",
+              "invocable": true
+            },
+            {
+              "name": "aws-cost-ops",
+              "description": "description: \"AWS Cost Explorer \u2014 spending analysis, service breakdowns, forecasts, cost anomalies. Use when analyzing AWS spending, investigating cost spikes, reviewing network cost drivers like NAT ",
+              "invocable": true
+            },
+            {
+              "name": "aws-network-ops",
+              "description": "description: \"AWS cloud networking \u2014 VPC, Transit Gateway, Cloud WAN, VPN, Network Firewall, ENI, flow logs. Use when auditing AWS VPCs, troubleshooting connectivity between EC2 instances, checking Tr",
+              "invocable": true
+            },
+            {
+              "name": "aws-security-audit",
+              "description": "description: \"AWS security auditing \u2014 IAM users/roles/policies, CloudTrail API events, security posture analysis. Use when auditing IAM permissions, investigating security incidents, checking MFA comp",
+              "invocable": true
+            },
+            {
+              "name": "azure-network-ops",
+              "description": "description: \"Azure cloud networking -- VNets, NSGs, ExpressRoute, VPN Gateways, Azure Firewalls, Load Balancers, Application Gateways, Route Tables, Network Watcher, Private Endpoints, DNS zones. Use",
+              "invocable": true
+            },
+            {
+              "name": "azure-security-audit",
+              "description": "description: \"Azure NSG compliance auditing and security posture assessment. CIS Azure Foundations Benchmark rules, effective security rule analysis, orphaned NSG detection. Use when auditing Azure NS",
+              "invocable": true
+            },
+            {
+              "name": "batfish-config-analysis",
+              "description": "description: \"Batfish network configuration analysis -- pre-deployment validation, reachability testing, ACL/firewall tracing, differential analysis, compliance checking. Use when validating configs b",
+              "invocable": true
+            },
+            {
+              "name": "blender-3d-viz",
+              "description": "description: \"Create 3D network topology visualizations in Blender from CDP/LLDP neighbor data\"",
+              "invocable": true
+            },
+            {
+              "name": "browser-gui-inspect",
+              "description": "description: \"Controller-agnostic browser automation and inspection \u2014 navigate, read, click, fill, and capture network traffic on any web GUI using a persistent, manually-authenticated Chrome profile.",
+              "invocable": true
+            },
+            {
+              "name": "browser-viz-verify",
+              "description": "description: \"Verifies that a NetClaw-generated visualization HTML file (three.js, canvas, drawio, UML, markmap) actually renders correctly \u2014 screenshot, console-error check, and an optional Lighthous",
+              "invocable": true
+            },
+            {
+              "name": "canvas-network-viz",
+              "description": "description: \"Canvas/A2UI inline network visualizations \u2014 topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards rendered directly in the Ope",
+              "invocable": true
+            },
+            {
+              "name": "catc-client-ops",
+              "description": "description: \"Catalyst Center client operations and monitoring - list/filter wired and wireless clients, detailed client lookup by MAC, client count analytics, time-based analysis, SSID and band filte",
+              "invocable": true
+            },
+            {
+              "name": "catc-inventory",
+              "description": "description: \"Catalyst Center device inventory and site management - list/filter devices by hostname, IP, platform, family, role, reachability; view site hierarchy; get interface details per device; d",
+              "invocable": true
+            },
+            {
+              "name": "catc-troubleshoot",
+              "description": "description: \"Catalyst Center troubleshooting workflows - device unreachable investigation, client connectivity issues, interface down analysis, site-wide outage triage, wireless roaming problems, int",
+              "invocable": true
+            },
+            {
+              "name": "checkpoint",
+              "description": "A comprehensive skill for interacting with Check Point enterprise security infrastructure through 15 MCP servers.",
+              "invocable": true
+            },
+            {
+              "name": "clab-lab-management",
+              "description": "description: \"ContainerLab network lab lifecycle management \u2014 authenticate, list, deploy, inspect, execute commands on, and destroy containerized network labs via the ContainerLab API. Use when deploy",
+              "invocable": true
+            },
+            {
+              "name": "claroty-asset-inventory",
+              "description": "description: \"Discover and classify OT / IoT / IoMT assets via Claroty xDome. List devices by site, Purdue level, and device purpose; assign Purdue layers and custom attributes; cross-reference with N",
+              "invocable": true
+            },
+            {
+              "name": "claroty-ot-topology",
+              "description": "description: \"Render Claroty xDome OT / IoT communication maps and zone segmentation as inline Canvas/A2UI topology, draw.io diagrams, and timeline summaries.\"",
+              "invocable": true
+            },
+            {
+              "name": "claroty-risk-triage",
+              "description": "description: \"Triage Claroty xDome alerts and vulnerabilities, compute blast radius, correlate with NVD CVE data, and drive ITSM-gated workflow actions (acknowledge, label, assign, set relevance).\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-analytics",
+              "description": "description: \"Access Cloudflare traffic analytics, logs, and Radar global Internet insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-dns",
+              "description": "description: \"Manage Cloudflare DNS zones and records with analytics insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-security",
+              "description": "description: \"Monitor Cloudflare WAF, firewall events, audit logs, and threat intelligence.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-workers",
+              "description": "description: \"Monitor Cloudflare Workers deployments, bindings, and build insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-zerotrust",
+              "description": "description: \"Inspect Cloudflare Zero Trust access applications, policies, tunnels, and CASB findings.\"",
+              "invocable": true
+            },
+            {
+              "name": "cml-admin",
+              "description": "description: \"CML administration \u2014 user/group management, system info, licensing, resource monitoring. Use when creating CML users, checking license status, monitoring CML server resources, or auditin",
+              "invocable": true
+            },
+            {
+              "name": "cml-lab-lifecycle",
+              "description": "description: \"Cisco CML lab lifecycle management \u2014 create, start, stop, wipe, delete, clone, import/export labs. Use when building a network lab, starting or stopping a CML lab, cloning a topology, or",
+              "invocable": true
+            },
+            {
+              "name": "cml-node-operations",
+              "description": "description: \"CML node operations \u2014 start, stop, console access, CLI execution, config management, node details. Use when starting or stopping a CML node, running show commands on a lab router, settin",
+              "invocable": true
+            },
+            {
+              "name": "cml-packet-capture",
+              "description": "description: \"CML packet capture \u2014 start, stop, download pcaps from CML lab links, integrate with Packet Buddy for analysis. Use when capturing packets in a CML lab, troubleshooting BGP or OSPF with p",
+              "invocable": true
+            },
+            {
+              "name": "cml-topology-builder",
+              "description": "description: \"Build CML topologies \u2014 add nodes, create interfaces, wire links, set link conditioning, add annotations. Use when building a network topology in CML, adding routers or switches to a lab,",
+              "invocable": true
+            },
+            {
+              "name": "datadog-apm",
+              "description": "description: \"Analyze distributed traces and service performance in Datadog APM.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-incidents",
+              "description": "description: \"Manage incidents in Datadog Incident Management.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-logs",
+              "description": "description: \"Search and analyze logs in Datadog Log Management.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-metrics",
+              "description": "description: \"Query metrics and explore dashboards in Datadog.\"",
+              "invocable": true
+            },
+            {
+              "name": "defenseclaw-ops",
+              "description": "description: Manage DefenseClaw enterprise security - scan components, manage tool permissions, view alerts, configure guardrails",
+              "invocable": true
+            },
+            {
+              "name": "desktop-gui-inspect",
+              "description": "description: \"Full-desktop automation for targets that have no browser and no API at all \u2014 a legacy Java-based NMS client, a vendor's Windows-only configuration utility, a terminal emulator with no sc",
+              "invocable": true
+            },
+            {
+              "name": "devnet-catalyst-search",
+              "description": "description: Search Cisco Catalyst Center API documentation for device management and policy automation",
+              "invocable": true
+            },
+            {
+              "name": "devnet-meraki-search",
+              "description": "description: Search Cisco Meraki API documentation and lookup specific operations",
+              "invocable": true
+            },
+            {
+              "name": "drawio-diagram",
+              "description": "description: \"Generate draw.io network diagrams \u2014 native .drawio files with CLI export (PNG/SVG/PDF), plus browser-based Mermaid/XML/CSV via MCP server. Use when creating network topology diagrams, ge",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-build",
+              "description": "description: Build or rewire EVE-NG lab topology. Use when creating or deleting virtual networks, connecting node interfaces to networks, inspecting topology links, checking interface mappings, or lis",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-design",
+              "description": "description: Design EVE-NG lab topology and coordinate the design workflow. Use when the user asks for lab design, architecture advice, topology planning, design review, or a build plan, especially wh",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-discovery",
+              "description": "description: Gather missing requirements for EVE-NG topology design. Use when the request is vague or incomplete, when you need discovery questions, defaults, trade-off framing, image recommendations,",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-validation",
+              "description": "description: Validate EVE-NG topology designs and enforce final delivery structure. Use when reviewing a design, checking build readiness, producing the final design output, building an implementation",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-config-ops",
+              "description": "description: Manage EVE-NG startup configurations stored in lab files. Use when exporting configs natively into the lab, reading embedded startup configs, pushing startup config before boot, clearing ",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-console-ops",
+              "description": "description: Execute live CLI commands on running EVE-NG nodes over telnet console. Use when running show commands, making live config changes, verifying protocol state, testing connectivity, checking",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-lab-management",
+              "description": "description: Manage EVE-NG labs and platform inventory. Use when listing labs, checking lab metadata, creating or deleting labs, importing or exporting lab archives, checking EVE-NG health or auth, or",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-node-operations",
+              "description": "description: Manage EVE-NG node lifecycle. Use when listing nodes, checking runtime state, creating or deleting nodes, starting or stopping nodes or whole labs, verifying node details, or wiping node ",
+              "invocable": true
+            },
+            {
+              "name": "evpn-vxlan-fabric",
+              "description": "description: \"EVPN/VXLAN fabric audit and troubleshooting \u2014 VTEPs, VNIs, route types, multihoming, underlay/overlay validation. Use when troubleshooting VXLAN overlay reachability, auditing leaf-spine",
+              "invocable": true
+            },
+            {
+              "name": "f5-config-mgmt",
+              "description": "description: \"F5 BIG-IP configuration management - safe change workflow with baseline capture, planning, creation/update/deletion of virtual servers, pools, iRules, and profiles with full verification",
+              "invocable": true
+            },
+            {
+              "name": "f5-health-check",
+              "description": "description: \"F5 BIG-IP health monitoring - virtual server status, pool member health, log analysis, performance statistics, and systematic health assessment. Use when checking F5 load balancer health",
+              "invocable": true
+            },
+            {
+              "name": "f5-troubleshoot",
+              "description": "description: \"F5 BIG-IP troubleshooting - virtual server failures, pool member health, connection issues, SSL/TLS problems, iRule errors, persistence issues, and performance degradation. Use when a VI",
+              "invocable": true
+            },
+            {
+              "name": "fmc-firewall-ops",
+              "description": "description: \"Cisco Secure Firewall FMC \u2014 access policy search, rule inspection, FTD device targeting, multi-FMC profile management. Use when searching firewall rules by IP or FQDN, checking if host A",
+              "invocable": true
+            },
+            {
+              "name": "fortimanager-ops",
+              "description": "description: \"FortiManager operations \u2014 ADOM inventory, policy package review, object search, install preview, and compliance workflows. Use when auditing FortiGate firewall policies, reviewing ADOM p",
+              "invocable": true
+            },
+            {
+              "name": "forward",
+              "description": "description: Forward snapshot assurance, path search, app-aware path search, NQE, checks, vulnerabilities, diffs, configuration, lifecycle, collection, and topology workflows through the upstream forw",
+              "invocable": true
+            },
+            {
+              "name": "fwrule-analyzer",
+              "description": "description: \"Multi-vendor firewall rule analysis \u2014 overlap detection, shadowing, conflict identification, duplication checking across PAN-OS, ASA, FTD, IOS/IOS-XE, IOS-XR, Check Point, SRX, Junos, No",
+              "invocable": true
+            },
+            {
+              "name": "gait-session-tracking",
+              "description": "description: \"GAIT session lifecycle management - branch creation, turn recording, audit logging for every NetClaw operation. Use when starting a new NetClaw session, recording a health check or confi",
+              "invocable": true
+            },
+            {
+              "name": "gcp-cloud-logging",
+              "description": "description: \"Google Cloud Logging \u2014 log search, VPC flow logs, firewall logs, audit logs, log buckets and views. Use when searching GCP logs, investigating denied VPC flow traffic, checking who delet",
+              "invocable": true
+            },
+            {
+              "name": "gcp-cloud-monitoring",
+              "description": "description: \"Google Cloud Monitoring \u2014 time series metrics, alert policies, active alerts, metric discovery. Use when checking GCP network performance, investigating firing alerts, querying VM CPU or",
+              "invocable": true
+            },
+            {
+              "name": "gcp-compute-ops",
+              "description": "description: \"Google Cloud Compute Engine \u2014 VM instances, disks, templates, instance groups, reservations, project discovery. Use when listing GCP VMs, troubleshooting a Compute Engine instance, check",
+              "invocable": true
+            },
+            {
+              "name": "github-ops",
+              "description": "description: \"GitHub repository operations \u2014 issues, PRs, code search, and config-as-code workflows. Use when creating a GitHub issue for a network finding, opening a pull request for a config change,",
+              "invocable": true
+            },
+            {
+              "name": "gitlab-devops",
+              "description": "description: \"GitLab DevOps operations \u2014 issues, merge requests, CI/CD pipelines, repository browsing, labels, milestones, releases, and wiki management. Use when querying GitLab project status, monit",
+              "invocable": true
+            },
+            {
+              "name": "gnmi-telemetry",
+              "description": "description: \"gNMI streaming telemetry operations for multi-vendor network devices. Query device state via structured YANG model paths, subscribe to real-time telemetry streams, apply ITSM-gated confi",
+              "invocable": true
+            },
+            {
+              "name": "gns3-link-management",
+              "description": "description: \"Manage GNS3 links - connect/disconnect node interfaces, isolate nodes\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-node-operations",
+              "description": "description: \"Manage GNS3 nodes - add from templates, start/stop/suspend/reload, console access\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-packet-capture",
+              "description": "description: \"Capture network traffic on GNS3 links - start/stop captures, retrieve PCAP data\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-project-lifecycle",
+              "description": "description: \"Manage GNS3 network lab projects - create, open, close, delete, clone, export/import\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-snapshot-ops",
+              "description": "description: \"Manage GNS3 project snapshots - create, restore, delete for safe experimentation\"",
+              "invocable": true
+            },
+            {
+              "name": "grafana-observability",
+              "description": "description: \"Grafana observability platform \u2014 dashboards, Prometheus PromQL, Loki LogQL, alerting, incidents, OnCall schedules, annotations, datasource queries, panel rendering (75+ tools). Use when ",
+              "invocable": true
+            },
+            {
+              "name": "gtrace-ip-enrichment",
+              "description": "description: \"IP address enrichment \u2014 ASN ownership lookup, geolocation (city/region/country/coordinates), and reverse DNS resolution. Use when identifying who owns an IP address, locating an IP geogr",
+              "invocable": true
+            },
+            {
+              "name": "gtrace-path-analysis",
+              "description": "description: \"Network path tracing and monitoring \u2014 traceroute with MPLS/ECMP/NAT detection, continuous MTR monitoring, and distributed GlobalPing probes from 500+ worldwide locations. Use when tracin",
+              "invocable": true
+            },
+            {
+              "name": "humanrail-escalation",
+              "description": "description: \"Human-in-the-loop escalation via HumanRail \u2014 route low-confidence agent decisions, pre-destructive operation approvals, and ambiguous incident tickets to real human engineers. Human answ",
+              "invocable": true
+            },
+            {
+              "name": "infoblox-ddi",
+              "description": "description: \"Infoblox DDI operations \u2014 DNS zones/records, DHCP scopes and leases, IPAM networks and address utilization. Use when checking DNS records, validating IPAM address allocation, investigati",
+              "invocable": true
+            },
+            {
+              "name": "infrahub-sot",
+              "description": "description: \"OpsMill Infrahub \u2014 infrastructure source of truth with schema-driven nodes, GraphQL queries, and branch-isolated changes. Use when querying Infrahub for device/IPAM inventory, browsing i",
+              "invocable": true
+            },
+            {
+              "name": "ipfabric",
+              "description": "**Skill**: `/ipfabric`",
+              "invocable": true
+            },
+            {
+              "name": "ipfix-receiver",
+              "description": "description: \"Receive and query IPFIX and NetFlow flow records from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "ise-incident-response",
+              "description": "description: \"Rapid ISE endpoint investigation and quarantine workflow - endpoint lookup, auth history, posture review, human-authorized quarantine, ServiceNow Security Incident. Use when a SOC alert ",
+              "invocable": true
+            },
+            {
+              "name": "ise-posture-audit",
+              "description": "description: \"Cisco ISE posture and policy audit - authorization rules, posture compliance, profiling gaps, TrustSec SGT matrix, active session health. Use when running a periodic ISE compliance audit",
+              "invocable": true
+            },
+            {
+              "name": "itential-automation",
+              "description": "description: \"Itential Automation Platform (IAP) \u2014 network automation orchestration, device configuration management, compliance enforcement, workflow execution, golden config, lifecycle management, a",
+              "invocable": true
+            },
+            {
+              "name": "jenkins-cicd",
+              "description": "description: Jenkins CI/CD pipeline management \u2014 monitor builds, trigger pipelines, analyze logs, and track SCM changes for network automation workflows.",
+              "invocable": true
+            },
+            {
+              "name": "junos-network",
+              "description": "description: \"Juniper JunOS device automation via PyEZ/NETCONF \u2014 CLI execution, configuration management, Jinja2 template rendering, device facts, batch operations, config diff and rollback comparison",
+              "invocable": true
+            },
+            {
+              "name": "kubeshark-traffic",
+              "description": "description: \"Kubeshark Kubernetes traffic analysis \u2014 L4/L7 deep packet inspection, TLS decryption, pcap export, flow analysis, service mapping (6 tools). Use when capturing Kubernetes pod traffic, de",
+              "invocable": true
+            },
+            {
+              "name": "markmap-viz",
+              "description": "description: \"Create interactive mind map visualizations from markdown - network inventory, OSPF areas, BGP topology, security audit results. Use when visualizing network topology as a mind map, creat",
+              "invocable": true
+            },
+            {
+              "name": "memory",
+              "description": "**Purpose**: Provide persistent context across NetClaw sessions through structured facts, semantic search, and entity relationships.",
+              "invocable": true
+            },
+            {
+              "name": "mempalace",
+              "description": "description: \"MemPalace AI memory \u2014 persistent memory across sessions. Search past decisions, store architecture choices, track temporal network facts via knowledge graph, navigate cross-domain connec",
+              "invocable": true
+            },
+            {
+              "name": "meraki-monitoring",
+              "description": "description: \"Cisco Meraki Monitoring & Diagnostics \u2014 live ping, cable test, LED blink, wake-on-LAN, camera analytics, config change tracking. Use when running ping tests from Meraki devices, troubles",
+              "invocable": true
+            },
+            {
+              "name": "meraki-network-ops",
+              "description": "description: \"Cisco Meraki Dashboard \u2014 organization inventory, network management, device lifecycle, client discovery, action batches. Use when listing Meraki devices, managing networks, checking devi",
+              "invocable": true
+            },
+            {
+              "name": "meraki-security-appliance",
+              "description": "description: \"Cisco Meraki Security Appliance (MX) \u2014 firewall rules, site-to-site VPN, content filtering, traffic shaping, security events. Use when auditing Meraki MX firewall rules, troubleshooting ",
+              "invocable": true
+            },
+            {
+              "name": "meraki-switch-ops",
+              "description": "description: \"Cisco Meraki Switching \u2014 port configuration, VLANs, port status, ACLs, QoS rules, port cycling. Use when configuring Meraki switch ports, creating VLANs, checking port status and PoE, tr",
+              "invocable": true
+            },
+            {
+              "name": "meraki-wireless-ops",
+              "description": "description: \"Cisco Meraki Wireless \u2014 SSID management, RF profiles, channel utilization, signal quality, client connectivity events. Use when managing Meraki SSIDs, troubleshooting WiFi connectivity, ",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-files",
+              "description": "description: \"Manage files on OneDrive and SharePoint via Microsoft Graph API - upload, download, list, search, and organize network documentation and artifacts. Use when uploading reports to SharePoi",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-teams",
+              "description": "description: \"Send notifications and reports to Microsoft Teams channels via Graph API - alert delivery, report posting, incident updates, and diagram sharing. Use when posting health alerts to Teams,",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-visio",
+              "description": "description: \"Generate and manage Visio network diagrams on SharePoint via Microsoft Graph API - create topology diagrams from CDP/LLDP discovery, update existing diagrams, export to PDF. Use when cre",
+              "invocable": true
+            },
+            {
+              "name": "n2n-federation",
+              "description": "description: Federate your NetClaw with other NetClaw operators over the BGP mesh \u2014 exchange capability inventories and ask your claw what a peer can do. (US1; remote invocation and chat land in later",
+              "invocable": true
+            },
+            {
+              "name": "nautobot-sot",
+              "description": "description: \"Nautobot IPAM & source of truth \u2014 IP address queries, prefix lookups, VRF/tenant/site filtering, IPAM search, connection testing. Use when looking up IP addresses in Nautobot, checking s",
+              "invocable": true
+            },
+            {
+              "name": "netbox-reconcile",
+              "description": "description: \"Reconcile NetBox source of truth against live network state - detect IP drift, missing interfaces, undocumented links, cable mismatches, VLAN mismatches, and ticket discrepancies in Serv",
+              "invocable": true
+            },
+            {
+              "name": "nmap-network-scan",
+              "description": "description: \"Host discovery and port scanning using nmap \u2014 ICMP/ARP host discovery, SYN/TCP/UDP port scanning with scope enforcement and audit logging. Use when discovering live hosts on a subnet, sc",
+              "invocable": true
+            },
+            {
+              "name": "nmap-scan-management",
+              "description": "description: \"Custom nmap scans with arbitrary flags, plus scan history retrieval and management. Use when running nmap with custom flags, reviewing past scan results, comparing before/after scans, or",
+              "invocable": true
+            },
+            {
+              "name": "nmap-service-detection",
+              "description": "description: \"Service fingerprinting, OS detection, NSE script execution, and vulnerability scanning using nmap MCP. Use when identifying services on open ports, fingerprinting OS versions, running NS",
+              "invocable": true
+            },
+            {
+              "name": "nso-device-ops",
+              "description": "description: \"Cisco NSO device operations \u2014 config retrieval, state inspection, sync, platform info, NED IDs, device groups. Use when retrieving device configs from NSO, checking sync status, pulling ",
+              "invocable": true
+            },
+            {
+              "name": "nso-service-mgmt",
+              "description": "description: \"Cisco NSO service management \u2014 discover service types, list service instances, orchestrate network services. Use when listing NSO services, checking service health, auditing deployed ser",
+              "invocable": true
+            },
+            {
+              "name": "nvd-cve",
+              "description": "description: \"Search the National Vulnerability Database for CVEs - find vulnerabilities by keyword or ID, get CVSS scores, weaknesses, affected configurations, and remediation references. Use when lo",
+              "invocable": true
+            },
+            {
+              "name": "packet-analysis",
+              "description": "description: \"Analyze network packet captures (.pcap/.pcapng) using Packet Buddy MCP. Use when opening a pcap file, inspecting packet captures, troubleshooting network traffic, analyzing retransmissio",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-incidents",
+              "description": "description: \"Manage and investigate incidents in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-oncall",
+              "description": "description: \"Manage on-call schedules and escalation policies in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-orchestration",
+              "description": "description: \"Manage event orchestration and routing rules in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-services",
+              "description": "description: \"Manage service catalog and service health in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "paloalto-panorama",
+              "description": "description: \"Palo Alto Panorama operations \u2014 device groups, templates, security policy search, NAT review, commit status, and audit workflows. Use when searching Palo Alto firewall rules, checking if",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-apps",
+              "description": "description: \"View Prisma SD-WAN application definitions for policy visibility\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-config",
+              "description": "description: \"Inspect Prisma SD-WAN interfaces, routing (BGP, static), policies, and security zones\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-status",
+              "description": "description: \"Monitor Prisma SD-WAN element health, software versions, events, and alarms\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-topology",
+              "description": "description: \"Discover Prisma SD-WAN sites, ION elements, machines, and network topology\"",
+              "invocable": true
+            },
+            {
+              "name": "prometheus-monitoring",
+              "description": "description: \"Prometheus monitoring \u2014 PromQL instant/range queries, metric discovery, metadata, scrape target health, system health checks (6 tools). Use when querying Prometheus metrics, checking scr",
+              "invocable": true
+            },
+            {
+              "name": "protocol-participation",
+              "description": "description: \"Live BGP and OSPF control-plane participation \u2014 peer with real routers, inject/withdraw routes, query RIB/LSDB, adjust metrics, GRE tunnel status. Use when injecting or withdrawing BGP r",
+              "invocable": true
+            },
+            {
+              "name": "pyats-asa-firewall",
+              "description": "description: \"Cisco ASA firewall operations via pyATS \u2014 VPN sessions, failover state, interfaces, routing, service policies, resource usage, AnyConnect monitoring. Use when checking ASA failover statu",
+              "invocable": true
+            },
+            {
+              "name": "pyats-config-mgmt",
+              "description": "description: \"Network change management - pre-change baselines, configuration deployment, post-change verification, rollback procedures, and compliance validation. Use when pushing config to a device,",
+              "invocable": true
+            },
+            {
+              "name": "pyats-dynamic-test",
+              "description": "description: \"Generate and execute deterministic pyATS aetest validation scripts - interface state, OSPF neighbors, BGP paths, ping matrices, and custom compliance tests. Use when writing a network te",
+              "invocable": true
+            },
+            {
+              "name": "pyats-f5-ltm",
+              "description": "description: \"F5 BIG-IP LTM/GTM operations via pyATS iControl REST \u2014 virtual servers, pools, nodes, monitors, profiles, iRules, persistence, GTM wide IPs, DNS, data groups. Use when checking F5 virtua",
+              "invocable": true
+            },
+            {
+              "name": "pyats-f5-platform",
+              "description": "description: \"F5 BIG-IP platform operations via pyATS iControl REST \u2014 system, networking, HA/CM, auth, analytics, security, APM, live-update, ADC certs, file management. Use when checking BIG-IP syste",
+              "invocable": true
+            },
+            {
+              "name": "pyats-health-check",
+              "description": "description: \"Comprehensive network device health monitoring - CPU, memory, interfaces, hardware, NTP, logging, environment, and uptime analysis. Use when running a device health check, monitoring CPU",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-interfaces",
+              "description": "description: \"JunOS interface operations via pyATS \u2014 physical/logical interfaces, LACP, CoS, LLDP, ARP, BFD, IPv6 neighbors, traffic monitoring, optics diagnostics. Use when checking Juniper interface",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-routing",
+              "description": "description: \"JunOS routing operations via pyATS \u2014 OSPF/OSPFv3, BGP, route table, MPLS/LDP/RSVP, TED, PFE, ping, traceroute across Juniper devices. Use when checking Juniper OSPF neighbors, viewing BG",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-system",
+              "description": "description: \"JunOS system operations via pyATS \u2014 chassis health, hardware inventory, system info, NTP, SNMP, files/logs, firewall counters, DDoS protection, services accounting. Use when checking Jun",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-network",
+              "description": "description: \"Linux host network operations via pyATS \u2014 interface configuration, routing tables, network connections, and multi-table route inspection across fleet hosts. Use when checking Linux inter",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-system",
+              "description": "description: \"Linux host system operations via pyATS \u2014 process monitoring, filesystem inspection, Docker container stats, package/tool verification across fleet hosts. Use when checking running proces",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-vmware",
+              "description": "description: \"VMware ESXi host operations via pyATS \u2014 VM inventory, snapshot management, hypervisor inspection across ESXi hosts in the testbed. Use when listing VMs on ESXi, checking snapshot age, au",
+              "invocable": true
+            },
+            {
+              "name": "pyats-network",
+              "description": "description: \"Network device automation via pyATS - run show commands, ping, apply config, learn config/logging, list devices, run Linux commands, execute dynamic tests on Cisco IOS-XE/NX-OS devices. ",
+              "invocable": true
+            },
+            {
+              "name": "pyats-parallel-ops",
+              "description": "description: \"Fleet-wide parallel device operations - concurrent health checks, config audits, routing snapshots, severity-sorted reporting, and failure-isolated multi-device automation. Use when chec",
+              "invocable": true
+            },
+            {
+              "name": "pyats-routing",
+              "description": "description: \"CCIE-level routing protocol analysis - OSPF, BGP, EIGRP, IS-IS, static routes, RIB/FIB verification, redistribution audit, and convergence validation. Use when analyzing routing tables, ",
+              "invocable": true
+            },
+            {
+              "name": "pyats-security",
+              "description": "description: \"Network security audit - ACLs, AAA, control plane policing, management plane hardening, encryption, port security, and CIS benchmark checks. Use when auditing device security posture, ch",
+              "invocable": true
+            },
+            {
+              "name": "pyats-topology",
+              "description": "description: \"Network topology discovery via CDP/LLDP neighbors, ARP tables, routing peers, and interface mapping to build complete network maps. Use when mapping the network, building a diagram, disc",
+              "invocable": true
+            },
+            {
+              "name": "pyats-troubleshoot",
+              "description": "description: \"Systematic network troubleshooting - connectivity, routing, interface, protocol, and performance issues using structured OSI-layer and divide-and-conquer methodology. Use when something ",
+              "invocable": true
+            },
+            {
+              "name": "radkit-remote-access",
+              "description": "description: \"Cisco RADKit \u2014 cloud-relayed remote device access, CLI execution, SNMP polling, device inventory discovery, attribute inspection. Use when accessing remote network devices through a clou",
+              "invocable": true
+            },
+            {
+              "name": "rag",
+              "description": "**Purpose**: Give NetClaw a fully offline, user-curated document knowledge base \u2014 vendor guides, standards (RFC/IEEE/vendor), customer design documents, install guides \u2014 with agentic retrieval, mandat",
+              "invocable": true
+            },
+            {
+              "name": "rfc-lookup",
+              "description": "description: \"Search and retrieve IETF RFC documents - lookup by number, search by keyword, extract sections. Use when looking up an RFC, checking protocol specifications, verifying standards complian",
+              "invocable": true
+            },
+            {
+              "name": "sdwan-ops",
+              "description": "description: \"Cisco SD-WAN vManage read-only operations \u2014 fabric devices, WAN Edge inventory, templates, policies, alarms, events, interface stats, BFD sessions, OMP routes, control connections, runni",
+              "invocable": true
+            },
+            {
+              "name": "servicenow-change-workflow",
+              "description": "description: \"Full ITSM-gated change lifecycle - CR creation, pre-change incident validation, approval gate, execution via pyats-config-mgmt, post-change verification, and closure with GAIT audit trai",
+              "invocable": true
+            },
+            {
+              "name": "slack-incident-workflow",
+              "description": "description: \"Manage network incident response workflows in Slack - incident channels, status updates, escalation, resolution tracking, and post-incident review coordination. Use when declaring a netw",
+              "invocable": true
+            },
+            {
+              "name": "slack-network-alerts",
+              "description": "description: \"Format and deliver network alerts, health warnings, and critical notifications via Slack with rich formatting, reactions, and file attachments. Use when sending alerts to Slack, posting ",
+              "invocable": true
+            },
+            {
+              "name": "slack-report-delivery",
+              "description": "description: \"Deliver formatted network reports, audit results, topology diagrams, and compliance documentation to Slack channels with rich Block Kit formatting. Use when posting a health check report",
+              "invocable": true
+            },
+            {
+              "name": "slack-user-context",
+              "description": "description: \"Leverage Slack user profiles, presence, DND status, and workspace context to personalize responses, route escalations, and coordinate team operations. Use when checking who is on-call, r",
+              "invocable": true
+            },
+            {
+              "name": "slack-voice-interface",
+              "description": "description: \"Respond to Slack voice clips with both text and an MP3 voice reply using edge-tts. Voice IN is already handled by OpenClaw transcription. Use when a user sends a voice message in Slack, ",
+              "invocable": true
+            },
+            {
+              "name": "snmptrap-receiver",
+              "description": "description: \"Receive and query SNMP traps from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-indexes",
+              "description": "description: \"Discover and inspect Splunk indexes and configuration.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-saved",
+              "description": "description: \"Manage and run saved searches in Splunk.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-search",
+              "description": "description: \"Execute and validate SPL (Search Processing Language) queries.\"",
+              "invocable": true
+            },
+            {
+              "name": "subnet-calculator",
+              "description": "description: \"IPv4 and IPv6 subnet calculator - CIDR breakdown, usable hosts, previous/next subnets, address classification, VLSM planning, and dual-stack analysis. Use when calculating subnets, figur",
+              "invocable": true
+            },
+            {
+              "name": "suzieq-observability",
+              "description": "description: \"SuzieQ network observability \u2014 query current and historical network state, run validation assertions, get summary statistics, trace forwarding paths, and discover unique values across 20",
+              "invocable": true
+            },
+            {
+              "name": "syslog-receiver",
+              "description": "description: \"Receive and query syslog messages from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "te-network-monitoring",
+              "description": "description: \"Cisco ThousandEyes \u2014 test management, agent inventory, test results, dashboards, path visualization, user/account management. Use when checking ThousandEyes test results, viewing network",
+              "invocable": true
+            },
+            {
+              "name": "te-path-analysis",
+              "description": "description: \"Cisco ThousandEyes \u2014 path visualization, BGP route analysis, outage investigation, instant tests, endpoint agent diagnostics. Use when tracing network paths hop-by-hop, investigating why",
+              "invocable": true
+            },
+            {
+              "name": "telemetry-ops",
+              "description": "description: \"Comprehensive network telemetry and event collection across multiple protocols.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-operations",
+              "description": "description: \"Execute local Terraform operations with ServiceNow change control.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-registry",
+              "description": "description: \"Discover providers and modules from the Terraform Registry.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-workspaces",
+              "description": "description: \"Manage HCP Terraform (Terraform Cloud/Enterprise) workspaces.\"",
+              "invocable": true
+            },
+            {
+              "name": "threejs-network-viz",
+              "description": "**Version**: 1.0.0",
+              "invocable": true
+            },
+            {
+              "name": "token-tracker",
+              "description": "description: \"Track and display token consumption and cost for every NetClaw interaction.\"",
+              "invocable": true
+            },
+            {
+              "name": "twilio-daily-briefing",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-emergency-call",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-inbound-voice",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-outbound-call",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twitter-check",
+              "description": "**Purpose**: Quick invocation to check mentions and respond to #netclaw threads.",
+              "invocable": true
+            },
+            {
+              "name": "twitter-heartbeat",
+              "description": "**Purpose**: Autonomous periodic tweeting AND mention monitoring to maintain NetClaw's Twitter presence with CCIE-level network engineering content.",
+              "invocable": true
+            },
+            {
+              "name": "twitter-respond",
+              "description": "**Skill ID**: twitter-respond",
+              "invocable": true
+            },
+            {
+              "name": "twitter-share",
+              "description": "**Purpose**: Manual tweet posting with content guardrails and human approval flow.",
+              "invocable": true
+            },
+            {
+              "name": "ue5-network-viz",
+              "description": "description: \"3D network topology visualization and interactive digital twin in Unreal Engine 5.8 via the built-in UE5 MCP server.\"",
+              "invocable": true
+            },
+            {
+              "name": "uml-diagram",
+              "description": "description: \"UML and diagram generation via Kroki \u2014 class, sequence, activity, state, component, deployment, network, ER, C4, Mermaid, D2, Graphviz, BPMN, 27+ types. Use when generating a network dia",
+              "invocable": true
+            },
+            {
+              "name": "vault-mounts",
+              "description": "description: \"Discover and manage HashiCorp Vault secret engine mounts.\"",
+              "invocable": true
+            },
+            {
+              "name": "vault-pki",
+              "description": "description: \"Manage HashiCorp Vault PKI certificate infrastructure.\"",
+              "invocable": true
+            },
+            {
+              "name": "vault-secrets",
+              "description": "description: \"Manage HashiCorp Vault KV secrets with strict value protection.\"",
+              "invocable": true
+            },
+            {
+              "name": "webex-incident-workflow",
+              "description": "description: \"Manage network incident response workflows in Cisco WebEx - incident spaces, status updates, escalation, resolution tracking, and post-incident review coordination. Use when declaring a ",
+              "invocable": true
+            },
+            {
+              "name": "webex-network-alerts",
+              "description": "description: \"Format and deliver network alerts, health warnings, and critical notifications via Cisco WebEx with Adaptive Cards, markdown formatting, and file attachments. Use when sending alerts to ",
+              "invocable": true
+            },
+            {
+              "name": "webex-report-delivery",
+              "description": "description: \"Deliver formatted network reports, audit results, topology diagrams, and compliance documentation to WebEx spaces with Adaptive Cards and markdown formatting. Use when posting a health c",
+              "invocable": true
+            },
+            {
+              "name": "webex-user-context",
+              "description": "description: \"Leverage WebEx user profiles, presence status, and workspace context to personalize responses, route escalations, and coordinate team operations. Use when checking who is available, rout",
+              "invocable": true
+            },
+            {
+              "name": "webex-voice-interface",
+              "description": "description: \"Respond to WebEx voice clips with both text and an MP3 voice reply using edge-tts. Voice IN is already handled by OpenClaw transcription. Use when a user sends a voice message in WebEx, ",
+              "invocable": true
+            },
+            {
+              "name": "wikipedia-research",
+              "description": "description: \"Research networking protocols, standards history, and technology context via Wikipedia - OSPF, BGP, MPLS, 802.1X, VXLAN, and more. Use when looking up protocol background, researching ho",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-identity",
+              "description": "description: \"Manage users, groups, departments, and identity provider configurations.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-insights",
+              "description": "description: \"Access analytics, threat intelligence, and security event data.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zdx",
+              "description": "description: \"Monitor digital experience scores, user performance, and application health.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zia",
+              "description": "description: \"Manage Zscaler Internet Access firewall rules, URL filtering, DLP, and security policies.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zpa",
+              "description": "description: \"Manage Zscaler Private Access applications, segments, policies, and connectors.\"",
+              "invocable": true
+            }
+          ],
+          "mcp_servers": [
+            {
+              "name": "forward-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "suzieq-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "batfish-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gnmi-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "azure-network-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gitlab-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chrome-devtools-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chrome-devtools-mcp-visible",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "jenkins-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "atlassian-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gns3-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "prisma-sdwan-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "datadog-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "pagerduty-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "splunk-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "infrahub-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "terraform-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "vault-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "zscaler-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-dns-analytics",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-security",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-zerotrust",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-analytics",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-workers",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "blender-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aruba-cx-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "devnet-content-search",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-golden-config-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-routing-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-management",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-management-logs",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-threat-prevention",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-https-inspection",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-harmony-sase",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-reputation-service",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-quantum-gw-cli",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-gw-connection-analysis",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-threat-emulation",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-quantum-gaia",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-documentation",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-spark-management",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-cpinfo-analysis",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-argos-erm",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-policy-insights",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "claroty-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twitter-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twilio-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twilio-voice-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "unreal-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "sketchfab-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "n2n-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "rag-mcp",
+              "tools": [],
+              "invocable_tools": []
+            }
+          ],
+          "badges": [
+            "Azure",
+            "Batfish",
+            "Check Point",
+            "Forward",
+            "GNS3",
+            "Nautobot",
+            "SuzieQ",
+            "gNMI"
+          ],
+          "posture": {
+            "mode": "testing",
+            "state": "unknown",
+            "summary": "testing",
+            "controls": {}
+          },
+          "llm": {
+            "primary_model": "anthropic/claude-sonnet-4-6",
+            "guarded": false
+          }
+        },
+        "received_at": "2026-07-18T17:04:37Z",
+        "stale": true
+      },
+      "channel_state": "unreachable",
+      "last_seen": 0,
+      "endpoint_updated_at": null,
+      "in_flight_tasks": [],
+      "endpoint": null
+    },
+    {
+      "identity": "as65007-8.8.8.8",
+      "display_name": "Hermes",
+      "state": "severed",
+      "chat_enabled": false,
+      "inventory_version": null,
+      "inventory_received_at": null,
+      "stale": null,
+      "inventory": null,
+      "channel_state": "unknown",
+      "last_seen": 0,
+      "endpoint_updated_at": null,
+      "in_flight_tasks": [],
+      "endpoint": null
+    },
+    {
+      "identity": "as65008-8.8.8.8",
+      "display_name": "Hermes",
+      "state": "federated",
+      "chat_enabled": false,
+      "inventory_version": 3,
+      "inventory_received_at": "2026-07-23T00:34:20Z",
+      "stale": true,
+      "inventory": {
+        "inventory": {
+          "identity": "as65008-8.8.8.8",
+          "issued_at": "2026-07-23T00:34:13Z",
+          "version": 3,
+          "skills": [
+            {
+              "name": "aap-automation",
+              "description": "description: \"Red Hat Ansible Automation Platform \u2014 inventory management, job template execution, project SCM sync, ad-hoc commands, host management, Galaxy content discovery. Use when automating infr",
+              "invocable": true
+            },
+            {
+              "name": "aap-eda",
+              "description": "description: \"Event-Driven Ansible (EDA) \u2014 activation lifecycle, rulebook management, decision environments, event stream monitoring. Use when managing event-driven automation triggers, enabling/disab",
+              "invocable": true
+            },
+            {
+              "name": "aap-lint",
+              "description": "description: \"ansible-lint playbook and role validation \u2014 syntax checking, best practice enforcement, project-wide analysis, rule filtering. Use when validating Ansible playbooks, checking code qualit",
+              "invocable": true
+            },
+            {
+              "name": "aci-change-deploy",
+              "description": "description: \"Safe ACI policy change deployment - ServiceNow CR lifecycle, pre/post-change fault baselines, APIC policy application, automatic rollback on fault delta, and GAIT audit trail. Use when d",
+              "invocable": true
+            },
+            {
+              "name": "aci-fabric-audit",
+              "description": "description: \"Comprehensive Cisco ACI fabric health audit - node status, tenant/VRF/BD/EPG policy review, contract analysis, fault triage, and endpoint learning verification. Use when auditing ACI fab",
+              "invocable": true
+            },
+            {
+              "name": "arista-cvp",
+              "description": "description: \"Arista CloudVision Portal (CVP) automation via REST API \u2014 device inventory, events, connectivity monitoring, tag management (4 tools). Use when managing Arista devices, checking CloudVis",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-config",
+              "description": "description: \"View and manage Aruba CX switch configurations, perform ISSU upgrades, and firmware operations\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-interfaces",
+              "description": "description: \"Monitor Aruba CX switch interface status, LLDP neighbors, and optical transceiver health\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-switching",
+              "description": "description: \"View and manage Aruba CX switch VLANs and MAC address tables for Layer 2 operations\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-system",
+              "description": "description: \"Discover Aruba CX switch system information, firmware versions, and VSF topology\"",
+              "invocable": true
+            },
+            {
+              "name": "atlassian-itsm",
+              "description": "description: IT Service Management workflows using Jira for issue tracking and Confluence for documentation",
+              "invocable": true
+            },
+            {
+              "name": "aws-architecture-diagram",
+              "description": "description: \"AWS architecture diagrams \u2014 generate visual network topology diagrams from live AWS infrastructure. Use when drawing AWS network diagrams, visualizing VPCs, mapping Transit Gateway topol",
+              "invocable": true
+            },
+            {
+              "name": "aws-cloud-monitoring",
+              "description": "description: \"AWS CloudWatch monitoring \u2014 metrics, alarms, log queries, VPC flow log analysis, network performance. Use when checking AWS alarms, analyzing VPC flow logs, investigating network latency",
+              "invocable": true
+            },
+            {
+              "name": "aws-cost-ops",
+              "description": "description: \"AWS Cost Explorer \u2014 spending analysis, service breakdowns, forecasts, cost anomalies. Use when analyzing AWS spending, investigating cost spikes, reviewing network cost drivers like NAT ",
+              "invocable": true
+            },
+            {
+              "name": "aws-network-ops",
+              "description": "description: \"AWS cloud networking \u2014 VPC, Transit Gateway, Cloud WAN, VPN, Network Firewall, ENI, flow logs. Use when auditing AWS VPCs, troubleshooting connectivity between EC2 instances, checking Tr",
+              "invocable": true
+            },
+            {
+              "name": "aws-security-audit",
+              "description": "description: \"AWS security auditing \u2014 IAM users/roles/policies, CloudTrail API events, security posture analysis. Use when auditing IAM permissions, investigating security incidents, checking MFA comp",
+              "invocable": true
+            },
+            {
+              "name": "azure-network-ops",
+              "description": "description: \"Azure cloud networking -- VNets, NSGs, ExpressRoute, VPN Gateways, Azure Firewalls, Load Balancers, Application Gateways, Route Tables, Network Watcher, Private Endpoints, DNS zones. Use",
+              "invocable": true
+            },
+            {
+              "name": "azure-security-audit",
+              "description": "description: \"Azure NSG compliance auditing and security posture assessment. CIS Azure Foundations Benchmark rules, effective security rule analysis, orphaned NSG detection. Use when auditing Azure NS",
+              "invocable": true
+            },
+            {
+              "name": "batfish-config-analysis",
+              "description": "description: \"Batfish network configuration analysis -- pre-deployment validation, reachability testing, ACL/firewall tracing, differential analysis, compliance checking. Use when validating configs b",
+              "invocable": true
+            },
+            {
+              "name": "blender-3d-viz",
+              "description": "description: \"Create 3D network topology visualizations in Blender from CDP/LLDP neighbor data\"",
+              "invocable": true
+            },
+            {
+              "name": "browser-gui-inspect",
+              "description": "description: \"Controller-agnostic browser automation and inspection \u2014 navigate, read, click, fill, and capture network traffic on any web GUI using a persistent, manually-authenticated Chrome profile.",
+              "invocable": true
+            },
+            {
+              "name": "browser-viz-verify",
+              "description": "description: \"Verifies that a NetClaw-generated visualization HTML file (three.js, canvas, drawio, UML, markmap) actually renders correctly \u2014 screenshot, console-error check, and an optional Lighthous",
+              "invocable": true
+            },
+            {
+              "name": "canvas-network-viz",
+              "description": "description: \"Canvas/A2UI inline network visualizations \u2014 topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards rendered directly in the Ope",
+              "invocable": true
+            },
+            {
+              "name": "catc-client-ops",
+              "description": "description: \"Catalyst Center client operations and monitoring - list/filter wired and wireless clients, detailed client lookup by MAC, client count analytics, time-based analysis, SSID and band filte",
+              "invocable": true
+            },
+            {
+              "name": "catc-inventory",
+              "description": "description: \"Catalyst Center device inventory and site management - list/filter devices by hostname, IP, platform, family, role, reachability; view site hierarchy; get interface details per device; d",
+              "invocable": true
+            },
+            {
+              "name": "catc-troubleshoot",
+              "description": "description: \"Catalyst Center troubleshooting workflows - device unreachable investigation, client connectivity issues, interface down analysis, site-wide outage triage, wireless roaming problems, int",
+              "invocable": true
+            },
+            {
+              "name": "checkpoint",
+              "description": "A comprehensive skill for interacting with Check Point enterprise security infrastructure through 15 MCP servers.",
+              "invocable": true
+            },
+            {
+              "name": "clab-lab-management",
+              "description": "description: \"ContainerLab network lab lifecycle management \u2014 authenticate, list, deploy, inspect, execute commands on, and destroy containerized network labs via the ContainerLab API. Use when deploy",
+              "invocable": true
+            },
+            {
+              "name": "claroty-asset-inventory",
+              "description": "description: \"Discover and classify OT / IoT / IoMT assets via Claroty xDome. List devices by site, Purdue level, and device purpose; assign Purdue layers and custom attributes; cross-reference with N",
+              "invocable": true
+            },
+            {
+              "name": "claroty-ot-topology",
+              "description": "description: \"Render Claroty xDome OT / IoT communication maps and zone segmentation as inline Canvas/A2UI topology, draw.io diagrams, and timeline summaries.\"",
+              "invocable": true
+            },
+            {
+              "name": "claroty-risk-triage",
+              "description": "description: \"Triage Claroty xDome alerts and vulnerabilities, compute blast radius, correlate with NVD CVE data, and drive ITSM-gated workflow actions (acknowledge, label, assign, set relevance).\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-analytics",
+              "description": "description: \"Access Cloudflare traffic analytics, logs, and Radar global Internet insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-dns",
+              "description": "description: \"Manage Cloudflare DNS zones and records with analytics insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-security",
+              "description": "description: \"Monitor Cloudflare WAF, firewall events, audit logs, and threat intelligence.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-workers",
+              "description": "description: \"Monitor Cloudflare Workers deployments, bindings, and build insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-zerotrust",
+              "description": "description: \"Inspect Cloudflare Zero Trust access applications, policies, tunnels, and CASB findings.\"",
+              "invocable": true
+            },
+            {
+              "name": "cml-admin",
+              "description": "description: \"CML administration \u2014 user/group management, system info, licensing, resource monitoring. Use when creating CML users, checking license status, monitoring CML server resources, or auditin",
+              "invocable": true
+            },
+            {
+              "name": "cml-lab-lifecycle",
+              "description": "description: \"Cisco CML lab lifecycle management \u2014 create, start, stop, wipe, delete, clone, import/export labs. Use when building a network lab, starting or stopping a CML lab, cloning a topology, or",
+              "invocable": true
+            },
+            {
+              "name": "cml-node-operations",
+              "description": "description: \"CML node operations \u2014 start, stop, console access, CLI execution, config management, node details. Use when starting or stopping a CML node, running show commands on a lab router, settin",
+              "invocable": true
+            },
+            {
+              "name": "cml-packet-capture",
+              "description": "description: \"CML packet capture \u2014 start, stop, download pcaps from CML lab links, integrate with Packet Buddy for analysis. Use when capturing packets in a CML lab, troubleshooting BGP or OSPF with p",
+              "invocable": true
+            },
+            {
+              "name": "cml-topology-builder",
+              "description": "description: \"Build CML topologies \u2014 add nodes, create interfaces, wire links, set link conditioning, add annotations. Use when building a network topology in CML, adding routers or switches to a lab,",
+              "invocable": true
+            },
+            {
+              "name": "datadog-apm",
+              "description": "description: \"Analyze distributed traces and service performance in Datadog APM.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-incidents",
+              "description": "description: \"Manage incidents in Datadog Incident Management.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-logs",
+              "description": "description: \"Search and analyze logs in Datadog Log Management.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-metrics",
+              "description": "description: \"Query metrics and explore dashboards in Datadog.\"",
+              "invocable": true
+            },
+            {
+              "name": "defenseclaw-ops",
+              "description": "description: Manage DefenseClaw enterprise security - scan components, manage tool permissions, view alerts, configure guardrails",
+              "invocable": true
+            },
+            {
+              "name": "desktop-gui-inspect",
+              "description": "description: \"Full-desktop automation for targets that have no browser and no API at all \u2014 a legacy Java-based NMS client, a vendor's Windows-only configuration utility, a terminal emulator with no sc",
+              "invocable": true
+            },
+            {
+              "name": "devnet-catalyst-search",
+              "description": "description: Search Cisco Catalyst Center API documentation for device management and policy automation",
+              "invocable": true
+            },
+            {
+              "name": "devnet-meraki-search",
+              "description": "description: Search Cisco Meraki API documentation and lookup specific operations",
+              "invocable": true
+            },
+            {
+              "name": "drawio-diagram",
+              "description": "description: \"Generate draw.io network diagrams \u2014 native .drawio files with CLI export (PNG/SVG/PDF), plus browser-based Mermaid/XML/CSV via MCP server. Use when creating network topology diagrams, ge",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-build",
+              "description": "description: Build or rewire EVE-NG lab topology. Use when creating or deleting virtual networks, connecting node interfaces to networks, inspecting topology links, checking interface mappings, or lis",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-design",
+              "description": "description: Design EVE-NG lab topology and coordinate the design workflow. Use when the user asks for lab design, architecture advice, topology planning, design review, or a build plan, especially wh",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-discovery",
+              "description": "description: Gather missing requirements for EVE-NG topology design. Use when the request is vague or incomplete, when you need discovery questions, defaults, trade-off framing, image recommendations,",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-validation",
+              "description": "description: Validate EVE-NG topology designs and enforce final delivery structure. Use when reviewing a design, checking build readiness, producing the final design output, building an implementation",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-config-ops",
+              "description": "description: Manage EVE-NG startup configurations stored in lab files. Use when exporting configs natively into the lab, reading embedded startup configs, pushing startup config before boot, clearing ",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-console-ops",
+              "description": "description: Execute live CLI commands on running EVE-NG nodes over telnet console. Use when running show commands, making live config changes, verifying protocol state, testing connectivity, checking",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-lab-management",
+              "description": "description: Manage EVE-NG labs and platform inventory. Use when listing labs, checking lab metadata, creating or deleting labs, importing or exporting lab archives, checking EVE-NG health or auth, or",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-node-operations",
+              "description": "description: Manage EVE-NG node lifecycle. Use when listing nodes, checking runtime state, creating or deleting nodes, starting or stopping nodes or whole labs, verifying node details, or wiping node ",
+              "invocable": true
+            },
+            {
+              "name": "evpn-vxlan-fabric",
+              "description": "description: \"EVPN/VXLAN fabric audit and troubleshooting \u2014 VTEPs, VNIs, route types, multihoming, underlay/overlay validation. Use when troubleshooting VXLAN overlay reachability, auditing leaf-spine",
+              "invocable": true
+            },
+            {
+              "name": "f5-config-mgmt",
+              "description": "description: \"F5 BIG-IP configuration management - safe change workflow with baseline capture, planning, creation/update/deletion of virtual servers, pools, iRules, and profiles with full verification",
+              "invocable": true
+            },
+            {
+              "name": "f5-health-check",
+              "description": "description: \"F5 BIG-IP health monitoring - virtual server status, pool member health, log analysis, performance statistics, and systematic health assessment. Use when checking F5 load balancer health",
+              "invocable": true
+            },
+            {
+              "name": "f5-troubleshoot",
+              "description": "description: \"F5 BIG-IP troubleshooting - virtual server failures, pool member health, connection issues, SSL/TLS problems, iRule errors, persistence issues, and performance degradation. Use when a VI",
+              "invocable": true
+            },
+            {
+              "name": "fmc-firewall-ops",
+              "description": "description: \"Cisco Secure Firewall FMC \u2014 access policy search, rule inspection, FTD device targeting, multi-FMC profile management. Use when searching firewall rules by IP or FQDN, checking if host A",
+              "invocable": true
+            },
+            {
+              "name": "fortimanager-ops",
+              "description": "description: \"FortiManager operations \u2014 ADOM inventory, policy package review, object search, install preview, and compliance workflows. Use when auditing FortiGate firewall policies, reviewing ADOM p",
+              "invocable": true
+            },
+            {
+              "name": "forward",
+              "description": "description: Forward snapshot assurance, path search, app-aware path search, NQE, checks, vulnerabilities, diffs, configuration, lifecycle, collection, and topology workflows through the upstream forw",
+              "invocable": true
+            },
+            {
+              "name": "fwrule-analyzer",
+              "description": "description: \"Multi-vendor firewall rule analysis \u2014 overlap detection, shadowing, conflict identification, duplication checking across PAN-OS, ASA, FTD, IOS/IOS-XE, IOS-XR, Check Point, SRX, Junos, No",
+              "invocable": true
+            },
+            {
+              "name": "gait-session-tracking",
+              "description": "description: \"GAIT session lifecycle management - branch creation, turn recording, audit logging for every NetClaw operation. Use when starting a new NetClaw session, recording a health check or confi",
+              "invocable": true
+            },
+            {
+              "name": "gcp-cloud-logging",
+              "description": "description: \"Google Cloud Logging \u2014 log search, VPC flow logs, firewall logs, audit logs, log buckets and views. Use when searching GCP logs, investigating denied VPC flow traffic, checking who delet",
+              "invocable": true
+            },
+            {
+              "name": "gcp-cloud-monitoring",
+              "description": "description: \"Google Cloud Monitoring \u2014 time series metrics, alert policies, active alerts, metric discovery. Use when checking GCP network performance, investigating firing alerts, querying VM CPU or",
+              "invocable": true
+            },
+            {
+              "name": "gcp-compute-ops",
+              "description": "description: \"Google Cloud Compute Engine \u2014 VM instances, disks, templates, instance groups, reservations, project discovery. Use when listing GCP VMs, troubleshooting a Compute Engine instance, check",
+              "invocable": true
+            },
+            {
+              "name": "github-ops",
+              "description": "description: \"GitHub repository operations \u2014 issues, PRs, code search, and config-as-code workflows. Use when creating a GitHub issue for a network finding, opening a pull request for a config change,",
+              "invocable": true
+            },
+            {
+              "name": "gitlab-devops",
+              "description": "description: \"GitLab DevOps operations \u2014 issues, merge requests, CI/CD pipelines, repository browsing, labels, milestones, releases, and wiki management. Use when querying GitLab project status, monit",
+              "invocable": true
+            },
+            {
+              "name": "gnmi-telemetry",
+              "description": "description: \"gNMI streaming telemetry operations for multi-vendor network devices. Query device state via structured YANG model paths, subscribe to real-time telemetry streams, apply ITSM-gated confi",
+              "invocable": true
+            },
+            {
+              "name": "gns3-link-management",
+              "description": "description: \"Manage GNS3 links - connect/disconnect node interfaces, isolate nodes\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-node-operations",
+              "description": "description: \"Manage GNS3 nodes - add from templates, start/stop/suspend/reload, console access\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-packet-capture",
+              "description": "description: \"Capture network traffic on GNS3 links - start/stop captures, retrieve PCAP data\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-project-lifecycle",
+              "description": "description: \"Manage GNS3 network lab projects - create, open, close, delete, clone, export/import\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-snapshot-ops",
+              "description": "description: \"Manage GNS3 project snapshots - create, restore, delete for safe experimentation\"",
+              "invocable": true
+            },
+            {
+              "name": "grafana-observability",
+              "description": "description: \"Grafana observability platform \u2014 dashboards, Prometheus PromQL, Loki LogQL, alerting, incidents, OnCall schedules, annotations, datasource queries, panel rendering (75+ tools). Use when ",
+              "invocable": true
+            },
+            {
+              "name": "gtrace-ip-enrichment",
+              "description": "description: \"IP address enrichment \u2014 ASN ownership lookup, geolocation (city/region/country/coordinates), and reverse DNS resolution. Use when identifying who owns an IP address, locating an IP geogr",
+              "invocable": true
+            },
+            {
+              "name": "gtrace-path-analysis",
+              "description": "description: \"Network path tracing and monitoring \u2014 traceroute with MPLS/ECMP/NAT detection, continuous MTR monitoring, and distributed GlobalPing probes from 500+ worldwide locations. Use when tracin",
+              "invocable": true
+            },
+            {
+              "name": "humanrail-escalation",
+              "description": "description: \"Human-in-the-loop escalation via HumanRail \u2014 route low-confidence agent decisions, pre-destructive operation approvals, and ambiguous incident tickets to real human engineers. Human answ",
+              "invocable": true
+            },
+            {
+              "name": "infoblox-ddi",
+              "description": "description: \"Infoblox DDI operations \u2014 DNS zones/records, DHCP scopes and leases, IPAM networks and address utilization. Use when checking DNS records, validating IPAM address allocation, investigati",
+              "invocable": true
+            },
+            {
+              "name": "infrahub-sot",
+              "description": "description: \"OpsMill Infrahub \u2014 infrastructure source of truth with schema-driven nodes, GraphQL queries, and branch-isolated changes. Use when querying Infrahub for device/IPAM inventory, browsing i",
+              "invocable": true
+            },
+            {
+              "name": "ipfabric",
+              "description": "**Skill**: `/ipfabric`",
+              "invocable": true
+            },
+            {
+              "name": "ipfix-receiver",
+              "description": "description: \"Receive and query IPFIX and NetFlow flow records from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "ise-incident-response",
+              "description": "description: \"Rapid ISE endpoint investigation and quarantine workflow - endpoint lookup, auth history, posture review, human-authorized quarantine, ServiceNow Security Incident. Use when a SOC alert ",
+              "invocable": true
+            },
+            {
+              "name": "ise-posture-audit",
+              "description": "description: \"Cisco ISE posture and policy audit - authorization rules, posture compliance, profiling gaps, TrustSec SGT matrix, active session health. Use when running a periodic ISE compliance audit",
+              "invocable": true
+            },
+            {
+              "name": "itential-automation",
+              "description": "description: \"Itential Automation Platform (IAP) \u2014 network automation orchestration, device configuration management, compliance enforcement, workflow execution, golden config, lifecycle management, a",
+              "invocable": true
+            },
+            {
+              "name": "jenkins-cicd",
+              "description": "description: Jenkins CI/CD pipeline management \u2014 monitor builds, trigger pipelines, analyze logs, and track SCM changes for network automation workflows.",
+              "invocable": true
+            },
+            {
+              "name": "junos-network",
+              "description": "description: \"Juniper JunOS device automation via PyEZ/NETCONF \u2014 CLI execution, configuration management, Jinja2 template rendering, device facts, batch operations, config diff and rollback comparison",
+              "invocable": true
+            },
+            {
+              "name": "kubeshark-traffic",
+              "description": "description: \"Kubeshark Kubernetes traffic analysis \u2014 L4/L7 deep packet inspection, TLS decryption, pcap export, flow analysis, service mapping (6 tools). Use when capturing Kubernetes pod traffic, de",
+              "invocable": true
+            },
+            {
+              "name": "markmap-viz",
+              "description": "description: \"Create interactive mind map visualizations from markdown - network inventory, OSPF areas, BGP topology, security audit results. Use when visualizing network topology as a mind map, creat",
+              "invocable": true
+            },
+            {
+              "name": "memory",
+              "description": "**Purpose**: Provide persistent context across NetClaw sessions through structured facts, semantic search, and entity relationships.",
+              "invocable": true
+            },
+            {
+              "name": "mempalace",
+              "description": "description: \"MemPalace AI memory \u2014 persistent memory across sessions. Search past decisions, store architecture choices, track temporal network facts via knowledge graph, navigate cross-domain connec",
+              "invocable": true
+            },
+            {
+              "name": "meraki-monitoring",
+              "description": "description: \"Cisco Meraki Monitoring & Diagnostics \u2014 live ping, cable test, LED blink, wake-on-LAN, camera analytics, config change tracking. Use when running ping tests from Meraki devices, troubles",
+              "invocable": true
+            },
+            {
+              "name": "meraki-network-ops",
+              "description": "description: \"Cisco Meraki Dashboard \u2014 organization inventory, network management, device lifecycle, client discovery, action batches. Use when listing Meraki devices, managing networks, checking devi",
+              "invocable": true
+            },
+            {
+              "name": "meraki-security-appliance",
+              "description": "description: \"Cisco Meraki Security Appliance (MX) \u2014 firewall rules, site-to-site VPN, content filtering, traffic shaping, security events. Use when auditing Meraki MX firewall rules, troubleshooting ",
+              "invocable": true
+            },
+            {
+              "name": "meraki-switch-ops",
+              "description": "description: \"Cisco Meraki Switching \u2014 port configuration, VLANs, port status, ACLs, QoS rules, port cycling. Use when configuring Meraki switch ports, creating VLANs, checking port status and PoE, tr",
+              "invocable": true
+            },
+            {
+              "name": "meraki-wireless-ops",
+              "description": "description: \"Cisco Meraki Wireless \u2014 SSID management, RF profiles, channel utilization, signal quality, client connectivity events. Use when managing Meraki SSIDs, troubleshooting WiFi connectivity, ",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-files",
+              "description": "description: \"Manage files on OneDrive and SharePoint via Microsoft Graph API - upload, download, list, search, and organize network documentation and artifacts. Use when uploading reports to SharePoi",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-teams",
+              "description": "description: \"Send notifications and reports to Microsoft Teams channels via Graph API - alert delivery, report posting, incident updates, and diagram sharing. Use when posting health alerts to Teams,",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-visio",
+              "description": "description: \"Generate and manage Visio network diagrams on SharePoint via Microsoft Graph API - create topology diagrams from CDP/LLDP discovery, update existing diagrams, export to PDF. Use when cre",
+              "invocable": true
+            },
+            {
+              "name": "n2n-federation",
+              "description": "description: Federate your NetClaw with other NetClaw operators over the BGP mesh \u2014 exchange capability inventories and ask your claw what a peer can do. (US1; remote invocation and chat land in later",
+              "invocable": true
+            },
+            {
+              "name": "nautobot-sot",
+              "description": "description: \"Nautobot IPAM & source of truth \u2014 IP address queries, prefix lookups, VRF/tenant/site filtering, IPAM search, connection testing. Use when looking up IP addresses in Nautobot, checking s",
+              "invocable": true
+            },
+            {
+              "name": "netbox-reconcile",
+              "description": "description: \"Reconcile NetBox source of truth against live network state - detect IP drift, missing interfaces, undocumented links, cable mismatches, VLAN mismatches, and ticket discrepancies in Serv",
+              "invocable": true
+            },
+            {
+              "name": "nmap-network-scan",
+              "description": "description: \"Host discovery and port scanning using nmap \u2014 ICMP/ARP host discovery, SYN/TCP/UDP port scanning with scope enforcement and audit logging. Use when discovering live hosts on a subnet, sc",
+              "invocable": true
+            },
+            {
+              "name": "nmap-scan-management",
+              "description": "description: \"Custom nmap scans with arbitrary flags, plus scan history retrieval and management. Use when running nmap with custom flags, reviewing past scan results, comparing before/after scans, or",
+              "invocable": true
+            },
+            {
+              "name": "nmap-service-detection",
+              "description": "description: \"Service fingerprinting, OS detection, NSE script execution, and vulnerability scanning using nmap MCP. Use when identifying services on open ports, fingerprinting OS versions, running NS",
+              "invocable": true
+            },
+            {
+              "name": "nso-device-ops",
+              "description": "description: \"Cisco NSO device operations \u2014 config retrieval, state inspection, sync, platform info, NED IDs, device groups. Use when retrieving device configs from NSO, checking sync status, pulling ",
+              "invocable": true
+            },
+            {
+              "name": "nso-service-mgmt",
+              "description": "description: \"Cisco NSO service management \u2014 discover service types, list service instances, orchestrate network services. Use when listing NSO services, checking service health, auditing deployed ser",
+              "invocable": true
+            },
+            {
+              "name": "nvd-cve",
+              "description": "description: \"Search the National Vulnerability Database for CVEs - find vulnerabilities by keyword or ID, get CVSS scores, weaknesses, affected configurations, and remediation references. Use when lo",
+              "invocable": true
+            },
+            {
+              "name": "packet-analysis",
+              "description": "description: \"Analyze network packet captures (.pcap/.pcapng) using Packet Buddy MCP. Use when opening a pcap file, inspecting packet captures, troubleshooting network traffic, analyzing retransmissio",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-incidents",
+              "description": "description: \"Manage and investigate incidents in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-oncall",
+              "description": "description: \"Manage on-call schedules and escalation policies in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-orchestration",
+              "description": "description: \"Manage event orchestration and routing rules in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-services",
+              "description": "description: \"Manage service catalog and service health in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "paloalto-panorama",
+              "description": "description: \"Palo Alto Panorama operations \u2014 device groups, templates, security policy search, NAT review, commit status, and audit workflows. Use when searching Palo Alto firewall rules, checking if",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-apps",
+              "description": "description: \"View Prisma SD-WAN application definitions for policy visibility\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-config",
+              "description": "description: \"Inspect Prisma SD-WAN interfaces, routing (BGP, static), policies, and security zones\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-status",
+              "description": "description: \"Monitor Prisma SD-WAN element health, software versions, events, and alarms\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-topology",
+              "description": "description: \"Discover Prisma SD-WAN sites, ION elements, machines, and network topology\"",
+              "invocable": true
+            },
+            {
+              "name": "prometheus-monitoring",
+              "description": "description: \"Prometheus monitoring \u2014 PromQL instant/range queries, metric discovery, metadata, scrape target health, system health checks (6 tools). Use when querying Prometheus metrics, checking scr",
+              "invocable": true
+            },
+            {
+              "name": "protocol-participation",
+              "description": "description: \"Live BGP and OSPF control-plane participation \u2014 peer with real routers, inject/withdraw routes, query RIB/LSDB, adjust metrics, GRE tunnel status. Use when injecting or withdrawing BGP r",
+              "invocable": true
+            },
+            {
+              "name": "pyats-asa-firewall",
+              "description": "description: \"Cisco ASA firewall operations via pyATS \u2014 VPN sessions, failover state, interfaces, routing, service policies, resource usage, AnyConnect monitoring. Use when checking ASA failover statu",
+              "invocable": true
+            },
+            {
+              "name": "pyats-config-mgmt",
+              "description": "description: \"Network change management - pre-change baselines, configuration deployment, post-change verification, rollback procedures, and compliance validation. Use when pushing config to a device,",
+              "invocable": true
+            },
+            {
+              "name": "pyats-dynamic-test",
+              "description": "description: \"Generate and execute deterministic pyATS aetest validation scripts - interface state, OSPF neighbors, BGP paths, ping matrices, and custom compliance tests. Use when writing a network te",
+              "invocable": true
+            },
+            {
+              "name": "pyats-f5-ltm",
+              "description": "description: \"F5 BIG-IP LTM/GTM operations via pyATS iControl REST \u2014 virtual servers, pools, nodes, monitors, profiles, iRules, persistence, GTM wide IPs, DNS, data groups. Use when checking F5 virtua",
+              "invocable": true
+            },
+            {
+              "name": "pyats-f5-platform",
+              "description": "description: \"F5 BIG-IP platform operations via pyATS iControl REST \u2014 system, networking, HA/CM, auth, analytics, security, APM, live-update, ADC certs, file management. Use when checking BIG-IP syste",
+              "invocable": true
+            },
+            {
+              "name": "pyats-health-check",
+              "description": "description: \"Comprehensive network device health monitoring - CPU, memory, interfaces, hardware, NTP, logging, environment, and uptime analysis. Use when running a device health check, monitoring CPU",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-interfaces",
+              "description": "description: \"JunOS interface operations via pyATS \u2014 physical/logical interfaces, LACP, CoS, LLDP, ARP, BFD, IPv6 neighbors, traffic monitoring, optics diagnostics. Use when checking Juniper interface",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-routing",
+              "description": "description: \"JunOS routing operations via pyATS \u2014 OSPF/OSPFv3, BGP, route table, MPLS/LDP/RSVP, TED, PFE, ping, traceroute across Juniper devices. Use when checking Juniper OSPF neighbors, viewing BG",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-system",
+              "description": "description: \"JunOS system operations via pyATS \u2014 chassis health, hardware inventory, system info, NTP, SNMP, files/logs, firewall counters, DDoS protection, services accounting. Use when checking Jun",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-network",
+              "description": "description: \"Linux host network operations via pyATS \u2014 interface configuration, routing tables, network connections, and multi-table route inspection across fleet hosts. Use when checking Linux inter",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-system",
+              "description": "description: \"Linux host system operations via pyATS \u2014 process monitoring, filesystem inspection, Docker container stats, package/tool verification across fleet hosts. Use when checking running proces",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-vmware",
+              "description": "description: \"VMware ESXi host operations via pyATS \u2014 VM inventory, snapshot management, hypervisor inspection across ESXi hosts in the testbed. Use when listing VMs on ESXi, checking snapshot age, au",
+              "invocable": true
+            },
+            {
+              "name": "pyats-network",
+              "description": "description: \"Network device automation via pyATS - run show commands, ping, apply config, learn config/logging, list devices, run Linux commands, execute dynamic tests on Cisco IOS-XE/NX-OS devices. ",
+              "invocable": true
+            },
+            {
+              "name": "pyats-parallel-ops",
+              "description": "description: \"Fleet-wide parallel device operations - concurrent health checks, config audits, routing snapshots, severity-sorted reporting, and failure-isolated multi-device automation. Use when chec",
+              "invocable": true
+            },
+            {
+              "name": "pyats-routing",
+              "description": "description: \"CCIE-level routing protocol analysis - OSPF, BGP, EIGRP, IS-IS, static routes, RIB/FIB verification, redistribution audit, and convergence validation. Use when analyzing routing tables, ",
+              "invocable": true
+            },
+            {
+              "name": "pyats-security",
+              "description": "description: \"Network security audit - ACLs, AAA, control plane policing, management plane hardening, encryption, port security, and CIS benchmark checks. Use when auditing device security posture, ch",
+              "invocable": true
+            },
+            {
+              "name": "pyats-topology",
+              "description": "description: \"Network topology discovery via CDP/LLDP neighbors, ARP tables, routing peers, and interface mapping to build complete network maps. Use when mapping the network, building a diagram, disc",
+              "invocable": true
+            },
+            {
+              "name": "pyats-troubleshoot",
+              "description": "description: \"Systematic network troubleshooting - connectivity, routing, interface, protocol, and performance issues using structured OSI-layer and divide-and-conquer methodology. Use when something ",
+              "invocable": true
+            },
+            {
+              "name": "radkit-remote-access",
+              "description": "description: \"Cisco RADKit \u2014 cloud-relayed remote device access, CLI execution, SNMP polling, device inventory discovery, attribute inspection. Use when accessing remote network devices through a clou",
+              "invocable": true
+            },
+            {
+              "name": "rag",
+              "description": "**Purpose**: Give NetClaw a fully offline, user-curated document knowledge base \u2014 vendor guides, standards (RFC/IEEE/vendor), customer design documents, install guides \u2014 with agentic retrieval, mandat",
+              "invocable": true
+            },
+            {
+              "name": "rfc-lookup",
+              "description": "description: \"Search and retrieve IETF RFC documents - lookup by number, search by keyword, extract sections. Use when looking up an RFC, checking protocol specifications, verifying standards complian",
+              "invocable": true
+            },
+            {
+              "name": "sdwan-ops",
+              "description": "description: \"Cisco SD-WAN vManage read-only operations \u2014 fabric devices, WAN Edge inventory, templates, policies, alarms, events, interface stats, BFD sessions, OMP routes, control connections, runni",
+              "invocable": true
+            },
+            {
+              "name": "servicenow-change-workflow",
+              "description": "description: \"Full ITSM-gated change lifecycle - CR creation, pre-change incident validation, approval gate, execution via pyats-config-mgmt, post-change verification, and closure with GAIT audit trai",
+              "invocable": true
+            },
+            {
+              "name": "slack-incident-workflow",
+              "description": "description: \"Manage network incident response workflows in Slack - incident channels, status updates, escalation, resolution tracking, and post-incident review coordination. Use when declaring a netw",
+              "invocable": true
+            },
+            {
+              "name": "slack-network-alerts",
+              "description": "description: \"Format and deliver network alerts, health warnings, and critical notifications via Slack with rich formatting, reactions, and file attachments. Use when sending alerts to Slack, posting ",
+              "invocable": true
+            },
+            {
+              "name": "slack-report-delivery",
+              "description": "description: \"Deliver formatted network reports, audit results, topology diagrams, and compliance documentation to Slack channels with rich Block Kit formatting. Use when posting a health check report",
+              "invocable": true
+            },
+            {
+              "name": "slack-user-context",
+              "description": "description: \"Leverage Slack user profiles, presence, DND status, and workspace context to personalize responses, route escalations, and coordinate team operations. Use when checking who is on-call, r",
+              "invocable": true
+            },
+            {
+              "name": "slack-voice-interface",
+              "description": "description: \"Respond to Slack voice clips with both text and an MP3 voice reply using edge-tts. Voice IN is already handled by OpenClaw transcription. Use when a user sends a voice message in Slack, ",
+              "invocable": true
+            },
+            {
+              "name": "snmptrap-receiver",
+              "description": "description: \"Receive and query SNMP traps from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-indexes",
+              "description": "description: \"Discover and inspect Splunk indexes and configuration.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-saved",
+              "description": "description: \"Manage and run saved searches in Splunk.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-search",
+              "description": "description: \"Execute and validate SPL (Search Processing Language) queries.\"",
+              "invocable": true
+            },
+            {
+              "name": "subnet-calculator",
+              "description": "description: \"IPv4 and IPv6 subnet calculator - CIDR breakdown, usable hosts, previous/next subnets, address classification, VLSM planning, and dual-stack analysis. Use when calculating subnets, figur",
+              "invocable": true
+            },
+            {
+              "name": "suzieq-observability",
+              "description": "description: \"SuzieQ network observability \u2014 query current and historical network state, run validation assertions, get summary statistics, trace forwarding paths, and discover unique values across 20",
+              "invocable": true
+            },
+            {
+              "name": "syslog-receiver",
+              "description": "description: \"Receive and query syslog messages from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "te-network-monitoring",
+              "description": "description: \"Cisco ThousandEyes \u2014 test management, agent inventory, test results, dashboards, path visualization, user/account management. Use when checking ThousandEyes test results, viewing network",
+              "invocable": true
+            },
+            {
+              "name": "te-path-analysis",
+              "description": "description: \"Cisco ThousandEyes \u2014 path visualization, BGP route analysis, outage investigation, instant tests, endpoint agent diagnostics. Use when tracing network paths hop-by-hop, investigating why",
+              "invocable": true
+            },
+            {
+              "name": "telemetry-ops",
+              "description": "description: \"Comprehensive network telemetry and event collection across multiple protocols.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-operations",
+              "description": "description: \"Execute local Terraform operations with ServiceNow change control.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-registry",
+              "description": "description: \"Discover providers and modules from the Terraform Registry.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-workspaces",
+              "description": "description: \"Manage HCP Terraform (Terraform Cloud/Enterprise) workspaces.\"",
+              "invocable": true
+            },
+            {
+              "name": "threejs-network-viz",
+              "description": "**Version**: 1.0.0",
+              "invocable": true
+            },
+            {
+              "name": "token-tracker",
+              "description": "description: \"Track and display token consumption and cost for every NetClaw interaction.\"",
+              "invocable": true
+            },
+            {
+              "name": "twilio-daily-briefing",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-emergency-call",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-inbound-voice",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-outbound-call",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twitter-check",
+              "description": "**Purpose**: Quick invocation to check mentions and respond to #netclaw threads.",
+              "invocable": true
+            },
+            {
+              "name": "twitter-heartbeat",
+              "description": "**Purpose**: Autonomous periodic tweeting AND mention monitoring to maintain NetClaw's Twitter presence with CCIE-level network engineering content.",
+              "invocable": true
+            },
+            {
+              "name": "twitter-respond",
+              "description": "**Skill ID**: twitter-respond",
+              "invocable": true
+            },
+            {
+              "name": "twitter-share",
+              "description": "**Purpose**: Manual tweet posting with content guardrails and human approval flow.",
+              "invocable": true
+            },
+            {
+              "name": "ue5-network-viz",
+              "description": "description: \"3D network topology visualization and interactive digital twin in Unreal Engine 5.8 via the built-in UE5 MCP server.\"",
+              "invocable": true
+            },
+            {
+              "name": "uml-diagram",
+              "description": "description: \"UML and diagram generation via Kroki \u2014 class, sequence, activity, state, component, deployment, network, ER, C4, Mermaid, D2, Graphviz, BPMN, 27+ types. Use when generating a network dia",
+              "invocable": true
+            },
+            {
+              "name": "vault-mounts",
+              "description": "description: \"Discover and manage HashiCorp Vault secret engine mounts.\"",
+              "invocable": true
+            },
+            {
+              "name": "vault-pki",
+              "description": "description: \"Manage HashiCorp Vault PKI certificate infrastructure.\"",
+              "invocable": true
+            },
+            {
+              "name": "vault-secrets",
+              "description": "description: \"Manage HashiCorp Vault KV secrets with strict value protection.\"",
+              "invocable": true
+            },
+            {
+              "name": "webex-incident-workflow",
+              "description": "description: \"Manage network incident response workflows in Cisco WebEx - incident spaces, status updates, escalation, resolution tracking, and post-incident review coordination. Use when declaring a ",
+              "invocable": true
+            },
+            {
+              "name": "webex-network-alerts",
+              "description": "description: \"Format and deliver network alerts, health warnings, and critical notifications via Cisco WebEx with Adaptive Cards, markdown formatting, and file attachments. Use when sending alerts to ",
+              "invocable": true
+            },
+            {
+              "name": "webex-report-delivery",
+              "description": "description: \"Deliver formatted network reports, audit results, topology diagrams, and compliance documentation to WebEx spaces with Adaptive Cards and markdown formatting. Use when posting a health c",
+              "invocable": true
+            },
+            {
+              "name": "webex-user-context",
+              "description": "description: \"Leverage WebEx user profiles, presence status, and workspace context to personalize responses, route escalations, and coordinate team operations. Use when checking who is available, rout",
+              "invocable": true
+            },
+            {
+              "name": "webex-voice-interface",
+              "description": "description: \"Respond to WebEx voice clips with both text and an MP3 voice reply using edge-tts. Voice IN is already handled by OpenClaw transcription. Use when a user sends a voice message in WebEx, ",
+              "invocable": true
+            },
+            {
+              "name": "wikipedia-research",
+              "description": "description: \"Research networking protocols, standards history, and technology context via Wikipedia - OSPF, BGP, MPLS, 802.1X, VXLAN, and more. Use when looking up protocol background, researching ho",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-identity",
+              "description": "description: \"Manage users, groups, departments, and identity provider configurations.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-insights",
+              "description": "description: \"Access analytics, threat intelligence, and security event data.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zdx",
+              "description": "description: \"Monitor digital experience scores, user performance, and application health.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zia",
+              "description": "description: \"Manage Zscaler Internet Access firewall rules, URL filtering, DLP, and security policies.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zpa",
+              "description": "description: \"Manage Zscaler Private Access applications, segments, policies, and connectors.\"",
+              "invocable": true
+            }
+          ],
+          "mcp_servers": [
+            {
+              "name": "forward-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "suzieq-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "batfish-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gnmi-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "azure-network-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gitlab-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chrome-devtools-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chrome-devtools-mcp-visible",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "jenkins-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "atlassian-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gns3-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "prisma-sdwan-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "datadog-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "pagerduty-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "splunk-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "infrahub-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "terraform-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "vault-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "zscaler-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-dns-analytics",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-security",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-zerotrust",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-analytics",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-workers",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "blender-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aruba-cx-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "devnet-content-search",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-golden-config-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-routing-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-management",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-management-logs",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-threat-prevention",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-https-inspection",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-harmony-sase",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-reputation-service",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-quantum-gw-cli",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-gw-connection-analysis",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-threat-emulation",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-quantum-gaia",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-documentation",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-spark-management",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-cpinfo-analysis",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-argos-erm",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-policy-insights",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "claroty-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twitter-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twilio-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twilio-voice-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "unreal-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "sketchfab-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "n2n-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "rag-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cml-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nso-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "itential-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "prometheus-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "grafana-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "meraki-magic-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "radkit-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "junos-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "arista-cvp-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cisco-fmc-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "thousandeyes-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "github-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-network-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-cloudwatch-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-iam-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-cloudtrail-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-cost-explorer-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-diagram-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-compute-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-monitoring-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-logging-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-resource-manager-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "thousandeyes-official-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "kubeshark-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "uml-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "protocol-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "ollama-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "fwrule-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-ansible-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-eda-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-lint-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-docs-mcp",
+              "tools": [],
+              "invocable_tools": []
+            }
+          ],
+          "knowledge": [],
+          "badges": [
+            "AWS",
+            "Azure",
+            "Batfish",
+            "CML",
+            "Check Point",
+            "Forward",
+            "GNS3",
+            "Meraki",
+            "Nautobot",
+            "SuzieQ",
+            "gNMI"
+          ],
+          "posture": {
+            "mode": "testing",
+            "state": "unknown",
+            "summary": "testing",
+            "controls": {}
+          },
+          "llm": {
+            "primary_model": null,
+            "guarded": false
+          }
+        },
+        "received_at": "2026-07-23T00:34:20Z",
+        "stale": true
+      },
+      "channel_state": "unreachable",
+      "last_seen": 0,
+      "endpoint_updated_at": null,
+      "in_flight_tasks": [],
+      "endpoint": null
+    },
+    {
+      "identity": "as65099-10.255.255.1",
+      "display_name": "Byrn",
+      "state": "federated",
+      "chat_enabled": true,
+      "inventory_version": 18,
+      "inventory_received_at": "2026-07-25T16:43:51Z",
+      "stale": true,
+      "inventory": {
+        "inventory": {
+          "identity": "as65099-10.255.255.1",
+          "issued_at": "2026-07-25T16:43:48Z",
+          "version": 18,
+          "skills": [
+            {
+              "name": "aap-automation",
+              "description": "description: \"Red Hat Ansible Automation Platform \u2014 inventory management, job template execution, project SCM sync, ad-hoc commands, host management, Galaxy content discovery. Use when automating infr",
+              "invocable": true
+            },
+            {
+              "name": "aap-eda",
+              "description": "description: \"Event-Driven Ansible (EDA) \u2014 activation lifecycle, rulebook management, decision environments, event stream monitoring. Use when managing event-driven automation triggers, enabling/disab",
+              "invocable": true
+            },
+            {
+              "name": "aap-lint",
+              "description": "description: \"ansible-lint playbook and role validation \u2014 syntax checking, best practice enforcement, project-wide analysis, rule filtering. Use when validating Ansible playbooks, checking code qualit",
+              "invocable": true
+            },
+            {
+              "name": "aci-change-deploy",
+              "description": "description: \"Safe ACI policy change deployment - ServiceNow CR lifecycle, pre/post-change fault baselines, APIC policy application, automatic rollback on fault delta, and GAIT audit trail. Use when d",
+              "invocable": true
+            },
+            {
+              "name": "aci-fabric-audit",
+              "description": "description: \"Comprehensive Cisco ACI fabric health audit - node status, tenant/VRF/BD/EPG policy review, contract analysis, fault triage, and endpoint learning verification. Use when auditing ACI fab",
+              "invocable": true
+            },
+            {
+              "name": "alert-triage",
+              "description": "description: \"Investigate alerts from the home/edge observability stack via adapters (firewall, wireless, SoT). Receives enriched alert context (device name, IP, platform, role) from the alert receive",
+              "invocable": true
+            },
+            {
+              "name": "arista-cvp",
+              "description": "description: \"Arista CloudVision Portal (CVP) automation via REST API \u2014 device inventory, events, connectivity monitoring, tag management (4 tools). Use when managing Arista devices, checking CloudVis",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-config",
+              "description": "description: \"View and manage Aruba CX switch configurations, perform ISSU upgrades, and firmware operations\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-interfaces",
+              "description": "description: \"Monitor Aruba CX switch interface status, LLDP neighbors, and optical transceiver health\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-switching",
+              "description": "description: \"View and manage Aruba CX switch VLANs and MAC address tables for Layer 2 operations\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-system",
+              "description": "description: \"Discover Aruba CX switch system information, firmware versions, and VSF topology\"",
+              "invocable": true
+            },
+            {
+              "name": "atlassian-itsm",
+              "description": "description: IT Service Management workflows using Jira for issue tracking and Confluence for documentation",
+              "invocable": true
+            },
+            {
+              "name": "aws-architecture-diagram",
+              "description": "description: \"AWS architecture diagrams \u2014 generate visual network topology diagrams from live AWS infrastructure. Use when drawing AWS network diagrams, visualizing VPCs, mapping Transit Gateway topol",
+              "invocable": true
+            },
+            {
+              "name": "aws-cloud-monitoring",
+              "description": "description: \"AWS CloudWatch monitoring \u2014 metrics, alarms, log queries, VPC flow log analysis, network performance. Use when checking AWS alarms, analyzing VPC flow logs, investigating network latency",
+              "invocable": true
+            },
+            {
+              "name": "aws-cost-ops",
+              "description": "description: \"AWS Cost Explorer \u2014 spending analysis, service breakdowns, forecasts, cost anomalies. Use when analyzing AWS spending, investigating cost spikes, reviewing network cost drivers like NAT ",
+              "invocable": true
+            },
+            {
+              "name": "aws-network-ops",
+              "description": "description: \"AWS cloud networking \u2014 VPC, Transit Gateway, Cloud WAN, VPN, Network Firewall, ENI, flow logs. Use when auditing AWS VPCs, troubleshooting connectivity between EC2 instances, checking Tr",
+              "invocable": true
+            },
+            {
+              "name": "aws-security-audit",
+              "description": "description: \"AWS security auditing \u2014 IAM users/roles/policies, CloudTrail API events, security posture analysis. Use when auditing IAM permissions, investigating security incidents, checking MFA comp",
+              "invocable": true
+            },
+            {
+              "name": "azure-network-ops",
+              "description": "description: \"Azure cloud networking -- VNets, NSGs, ExpressRoute, VPN Gateways, Azure Firewalls, Load Balancers, Application Gateways, Route Tables, Network Watcher, Private Endpoints, DNS zones. Use",
+              "invocable": true
+            },
+            {
+              "name": "azure-security-audit",
+              "description": "description: \"Azure NSG compliance auditing and security posture assessment. CIS Azure Foundations Benchmark rules, effective security rule analysis, orphaned NSG detection. Use when auditing Azure NS",
+              "invocable": true
+            },
+            {
+              "name": "batfish-config-analysis",
+              "description": "description: \"Batfish network configuration analysis -- pre-deployment validation, reachability testing, ACL/firewall tracing, differential analysis, compliance checking. Use when validating configs b",
+              "invocable": true
+            },
+            {
+              "name": "blender-3d-viz",
+              "description": "description: \"Create 3D network topology visualizations in Blender from CDP/LLDP neighbor data\"",
+              "invocable": true
+            },
+            {
+              "name": "browser-gui-inspect",
+              "description": "description: \"Controller-agnostic browser automation and inspection \u2014 navigate, read, click, fill, and capture network traffic on any web GUI using a persistent, manually-authenticated Chrome profile.",
+              "invocable": true
+            },
+            {
+              "name": "browser-viz-verify",
+              "description": "description: \"Verifies that a NetClaw-generated visualization HTML file (three.js, canvas, drawio, UML, markmap) actually renders correctly \u2014 screenshot, console-error check, and an optional Lighthous",
+              "invocable": true
+            },
+            {
+              "name": "canvas-network-viz",
+              "description": "description: \"Canvas/A2UI inline network visualizations \u2014 topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards rendered directly in the Ope",
+              "invocable": true
+            },
+            {
+              "name": "catc-client-ops",
+              "description": "description: \"Catalyst Center client operations and monitoring - list/filter wired and wireless clients, detailed client lookup by MAC, client count analytics, time-based analysis, SSID and band filte",
+              "invocable": true
+            },
+            {
+              "name": "catc-inventory",
+              "description": "description: \"Catalyst Center device inventory and site management - list/filter devices by hostname, IP, platform, family, role, reachability; view site hierarchy; get interface details per device; d",
+              "invocable": true
+            },
+            {
+              "name": "catc-troubleshoot",
+              "description": "description: \"Catalyst Center troubleshooting workflows - device unreachable investigation, client connectivity issues, interface down analysis, site-wide outage triage, wireless roaming problems, int",
+              "invocable": true
+            },
+            {
+              "name": "checkpoint",
+              "description": "A comprehensive skill for interacting with Check Point enterprise security infrastructure through 15 MCP servers.",
+              "invocable": true
+            },
+            {
+              "name": "clab-lab-management",
+              "description": "description: \"ContainerLab network lab lifecycle management \u2014 authenticate, list, deploy, inspect, execute commands on, and destroy containerized network labs via the ContainerLab API. Use when deploy",
+              "invocable": true
+            },
+            {
+              "name": "claroty-asset-inventory",
+              "description": "description: \"Discover and classify OT / IoT / IoMT assets via Claroty xDome. List devices by site, Purdue level, and device purpose; assign Purdue layers and custom attributes; cross-reference with N",
+              "invocable": true
+            },
+            {
+              "name": "claroty-ot-topology",
+              "description": "description: \"Render Claroty xDome OT / IoT communication maps and zone segmentation as inline Canvas/A2UI topology, draw.io diagrams, and timeline summaries.\"",
+              "invocable": true
+            },
+            {
+              "name": "claroty-risk-triage",
+              "description": "description: \"Triage Claroty xDome alerts and vulnerabilities, compute blast radius, correlate with NVD CVE data, and drive ITSM-gated workflow actions (acknowledge, label, assign, set relevance).\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-analytics",
+              "description": "description: \"Access Cloudflare traffic analytics, logs, and Radar global Internet insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-dns",
+              "description": "description: \"Manage Cloudflare DNS zones and records with analytics insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-security",
+              "description": "description: \"Monitor Cloudflare WAF, firewall events, audit logs, and threat intelligence.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-workers",
+              "description": "description: \"Monitor Cloudflare Workers deployments, bindings, and build insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-zerotrust",
+              "description": "description: \"Inspect Cloudflare Zero Trust access applications, policies, tunnels, and CASB findings.\"",
+              "invocable": true
+            },
+            {
+              "name": "cml-admin",
+              "description": "description: \"CML administration \u2014 user/group management, system info, licensing, resource monitoring. Use when creating CML users, checking license status, monitoring CML server resources, or auditin",
+              "invocable": true
+            },
+            {
+              "name": "cml-lab-lifecycle",
+              "description": "description: \"Cisco CML lab lifecycle management \u2014 create, start, stop, wipe, delete, clone, import/export labs. Use when building a network lab, starting or stopping a CML lab, cloning a topology, or",
+              "invocable": true
+            },
+            {
+              "name": "cml-node-operations",
+              "description": "description: \"CML node operations \u2014 start, stop, console access, CLI execution, config management, node details. Use when starting or stopping a CML node, running show commands on a lab router, settin",
+              "invocable": true
+            },
+            {
+              "name": "cml-packet-capture",
+              "description": "description: \"CML packet capture \u2014 start, stop, download pcaps from CML lab links, integrate with Packet Buddy for analysis. Use when capturing packets in a CML lab, troubleshooting BGP or OSPF with p",
+              "invocable": true
+            },
+            {
+              "name": "cml-topology-builder",
+              "description": "description: \"Build CML topologies \u2014 add nodes, create interfaces, wire links, set link conditioning, add annotations. Use when building a network topology in CML, adding routers or switches to a lab,",
+              "invocable": true
+            },
+            {
+              "name": "datadog-apm",
+              "description": "description: \"Analyze distributed traces and service performance in Datadog APM.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-incidents",
+              "description": "description: \"Manage incidents in Datadog Incident Management.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-logs",
+              "description": "description: \"Search and analyze logs in Datadog Log Management.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-metrics",
+              "description": "description: \"Query metrics and explore dashboards in Datadog.\"",
+              "invocable": true
+            },
+            {
+              "name": "defenseclaw-ops",
+              "description": "description: Manage DefenseClaw enterprise security - scan components, manage tool permissions, view alerts, configure guardrails",
+              "invocable": true
+            },
+            {
+              "name": "demo-lab-setup",
+              "description": "Deploy the byrn-baker/Nautobot-Workshop environment end-to-end. Fully autonomous \u2014 validate each step before proceeding, no user input required except at session checkpoints.",
+              "invocable": true
+            },
+            {
+              "name": "desktop-gui-inspect",
+              "description": "description: \"Full-desktop automation for targets that have no browser and no API at all \u2014 a legacy Java-based NMS client, a vendor's Windows-only configuration utility, a terminal emulator with no sc",
+              "invocable": true
+            },
+            {
+              "name": "devnet-catalyst-search",
+              "description": "description: Search Cisco Catalyst Center API documentation for device management and policy automation",
+              "invocable": true
+            },
+            {
+              "name": "devnet-meraki-search",
+              "description": "description: Search Cisco Meraki API documentation and lookup specific operations",
+              "invocable": true
+            },
+            {
+              "name": "domain-expert-delegation",
+              "description": "description: \"Offload structured workloads (config generation, design validation, GraphQL building, state summarization, context compression) to local or cloud LLM providers via the ollama-mcp server.",
+              "invocable": true
+            },
+            {
+              "name": "drawio-diagram",
+              "description": "description: \"Generate draw.io network diagrams \u2014 native .drawio files with CLI export (PNG/SVG/PDF), plus browser-based Mermaid/XML/CSV via MCP server. Use when creating network topology diagrams, ge",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-build",
+              "description": "description: Build or rewire EVE-NG lab topology. Use when creating or deleting virtual networks, connecting node interfaces to networks, inspecting topology links, checking interface mappings, or lis",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-design",
+              "description": "description: Design EVE-NG lab topology and coordinate the design workflow. Use when the user asks for lab design, architecture advice, topology planning, design review, or a build plan, especially wh",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-discovery",
+              "description": "description: Gather missing requirements for EVE-NG topology design. Use when the request is vague or incomplete, when you need discovery questions, defaults, trade-off framing, image recommendations,",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-validation",
+              "description": "description: Validate EVE-NG topology designs and enforce final delivery structure. Use when reviewing a design, checking build readiness, producing the final design output, building an implementation",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-config-ops",
+              "description": "description: Manage EVE-NG startup configurations stored in lab files. Use when exporting configs natively into the lab, reading embedded startup configs, pushing startup config before boot, clearing ",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-console-ops",
+              "description": "description: Execute live CLI commands on running EVE-NG nodes over telnet console. Use when running show commands, making live config changes, verifying protocol state, testing connectivity, checking",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-lab-management",
+              "description": "description: Manage EVE-NG labs and platform inventory. Use when listing labs, checking lab metadata, creating or deleting labs, importing or exporting lab archives, checking EVE-NG health or auth, or",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-node-operations",
+              "description": "description: Manage EVE-NG node lifecycle. Use when listing nodes, checking runtime state, creating or deleting nodes, starting or stopping nodes or whole labs, verifying node details, or wiping node ",
+              "invocable": true
+            },
+            {
+              "name": "evpn-vxlan-fabric",
+              "description": "description: \"EVPN/VXLAN fabric audit and troubleshooting \u2014 VTEPs, VNIs, route types, multihoming, underlay/overlay validation. Use when troubleshooting VXLAN overlay reachability, auditing leaf-spine",
+              "invocable": true
+            },
+            {
+              "name": "f5-config-mgmt",
+              "description": "description: \"F5 BIG-IP configuration management - safe change workflow with baseline capture, planning, creation/update/deletion of virtual servers, pools, iRules, and profiles with full verification",
+              "invocable": true
+            },
+            {
+              "name": "f5-health-check",
+              "description": "description: \"F5 BIG-IP health monitoring - virtual server status, pool member health, log analysis, performance statistics, and systematic health assessment. Use when checking F5 load balancer health",
+              "invocable": true
+            },
+            {
+              "name": "f5-troubleshoot",
+              "description": "description: \"F5 BIG-IP troubleshooting - virtual server failures, pool member health, connection issues, SSL/TLS problems, iRule errors, persistence issues, and performance degradation. Use when a VI",
+              "invocable": true
+            },
+            {
+              "name": "fmc-firewall-ops",
+              "description": "description: \"Cisco Secure Firewall FMC \u2014 access policy search, rule inspection, FTD device targeting, multi-FMC profile management. Use when searching firewall rules by IP or FQDN, checking if host A",
+              "invocable": true
+            },
+            {
+              "name": "fortimanager-ops",
+              "description": "description: \"FortiManager operations \u2014 ADOM inventory, policy package review, object search, install preview, and compliance workflows. Use when auditing FortiGate firewall policies, reviewing ADOM p",
+              "invocable": true
+            },
+            {
+              "name": "forward",
+              "description": "description: Forward snapshot assurance, path search, app-aware path search, NQE, checks, vulnerabilities, diffs, configuration, lifecycle, collection, and topology workflows through the upstream forw",
+              "invocable": true
+            },
+            {
+              "name": "fwrule-analyzer",
+              "description": "description: \"Multi-vendor firewall rule analysis \u2014 overlap detection, shadowing, conflict identification, duplication checking across PAN-OS, ASA, FTD, IOS/IOS-XE, IOS-XR, Check Point, SRX, Junos, No",
+              "invocable": true
+            },
+            {
+              "name": "gait-session-tracking",
+              "description": "description: \"GAIT session lifecycle management - branch creation, turn recording, audit logging for every NetClaw operation. Use when starting a new NetClaw session, recording a health check or confi",
+              "invocable": true
+            },
+            {
+              "name": "gcp-cloud-logging",
+              "description": "description: \"Google Cloud Logging \u2014 log search, VPC flow logs, firewall logs, audit logs, log buckets and views. Use when searching GCP logs, investigating denied VPC flow traffic, checking who delet",
+              "invocable": true
+            },
+            {
+              "name": "gcp-cloud-monitoring",
+              "description": "description: \"Google Cloud Monitoring \u2014 time series metrics, alert policies, active alerts, metric discovery. Use when checking GCP network performance, investigating firing alerts, querying VM CPU or",
+              "invocable": true
+            },
+            {
+              "name": "gcp-compute-ops",
+              "description": "description: \"Google Cloud Compute Engine \u2014 VM instances, disks, templates, instance groups, reservations, project discovery. Use when listing GCP VMs, troubleshooting a Compute Engine instance, check",
+              "invocable": true
+            },
+            {
+              "name": "github-ops",
+              "description": "description: \"GitHub repository operations \u2014 issues, PRs, code search, and config-as-code workflows. Use when creating a GitHub issue for a network finding, opening a pull request for a config change,",
+              "invocable": true
+            },
+            {
+              "name": "gitlab-devops",
+              "description": "description: \"GitLab DevOps operations \u2014 issues, merge requests, CI/CD pipelines, repository browsing, labels, milestones, releases, and wiki management. Use when querying GitLab project status, monit",
+              "invocable": true
+            },
+            {
+              "name": "gnmi-telemetry",
+              "description": "description: \"gNMI streaming telemetry operations for multi-vendor network devices. Query device state via structured YANG model paths, subscribe to real-time telemetry streams, apply ITSM-gated confi",
+              "invocable": true
+            },
+            {
+              "name": "gns3-link-management",
+              "description": "description: \"Manage GNS3 links - connect/disconnect node interfaces, isolate nodes\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-node-operations",
+              "description": "description: \"Manage GNS3 nodes - add from templates, start/stop/suspend/reload, console access\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-packet-capture",
+              "description": "description: \"Capture network traffic on GNS3 links - start/stop captures, retrieve PCAP data\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-project-lifecycle",
+              "description": "description: \"Manage GNS3 network lab projects - create, open, close, delete, clone, export/import\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-snapshot-ops",
+              "description": "description: \"Manage GNS3 project snapshots - create, restore, delete for safe experimentation\"",
+              "invocable": true
+            },
+            {
+              "name": "golden-config-bootstrap",
+              "description": "Interactively set up the Nautobot Golden Config plugin from scratch. This is a conversational workflow \u2014 the agent guides the user through analyzing their running configs, designing compliance feature",
+              "invocable": true
+            },
+            {
+              "name": "grafana-observability",
+              "description": "description: \"Grafana observability platform \u2014 dashboards, Prometheus PromQL, Loki LogQL, alerting, incidents, OnCall schedules, annotations, datasource queries, panel rendering (75+ tools). Use when ",
+              "invocable": true
+            },
+            {
+              "name": "gtrace-ip-enrichment",
+              "description": "description: \"IP address enrichment \u2014 ASN ownership lookup, geolocation (city/region/country/coordinates), and reverse DNS resolution. Use when identifying who owns an IP address, locating an IP geogr",
+              "invocable": true
+            },
+            {
+              "name": "gtrace-path-analysis",
+              "description": "description: \"Network path tracing and monitoring \u2014 traceroute with MPLS/ECMP/NAT detection, continuous MTR monitoring, and distributed GlobalPing probes from 500+ worldwide locations. Use when tracin",
+              "invocable": true
+            },
+            {
+              "name": "humanrail-escalation",
+              "description": "description: \"Human-in-the-loop escalation via HumanRail \u2014 route low-confidence agent decisions, pre-destructive operation approvals, and ambiguous incident tickets to real human engineers. Human answ",
+              "invocable": true
+            },
+            {
+              "name": "infoblox-ddi",
+              "description": "description: \"Infoblox DDI operations \u2014 DNS zones/records, DHCP scopes and leases, IPAM networks and address utilization. Use when checking DNS records, validating IPAM address allocation, investigati",
+              "invocable": true
+            },
+            {
+              "name": "infrahub-sot",
+              "description": "description: \"OpsMill Infrahub \u2014 infrastructure source of truth with schema-driven nodes, GraphQL queries, and branch-isolated changes. Use when querying Infrahub for device/IPAM inventory, browsing i",
+              "invocable": true
+            },
+            {
+              "name": "intent-reconcile",
+              "description": "description: \"Reconcile live network devices to Nautobot intent, with a human approval gate over Discord. Triggered by a Nautobot webhook (device interface change) or by an approval/denial reply. Prop",
+              "invocable": true
+            },
+            {
+              "name": "ipfabric",
+              "description": "**Skill**: `/ipfabric`",
+              "invocable": true
+            },
+            {
+              "name": "ipfix-receiver",
+              "description": "description: \"Receive and query IPFIX and NetFlow flow records from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "ise-incident-response",
+              "description": "description: \"Rapid ISE endpoint investigation and quarantine workflow - endpoint lookup, auth history, posture review, human-authorized quarantine, ServiceNow Security Incident. Use when a SOC alert ",
+              "invocable": true
+            },
+            {
+              "name": "ise-posture-audit",
+              "description": "description: \"Cisco ISE posture and policy audit - authorization rules, posture compliance, profiling gaps, TrustSec SGT matrix, active session health. Use when running a periodic ISE compliance audit",
+              "invocable": true
+            },
+            {
+              "name": "isp-sla-claim",
+              "description": "description: \"Draft ISP service credit claims after WAN outages. Gathers evidence from Prometheus, pfSense, and dpinger logs to prove the outage was ISP-side (not CPE). Produces a ready-to-send email ",
+              "invocable": true
+            },
+            {
+              "name": "itential-automation",
+              "description": "description: \"Itential Automation Platform (IAP) \u2014 network automation orchestration, device configuration management, compliance enforcement, workflow execution, golden config, lifecycle management, a",
+              "invocable": true
+            },
+            {
+              "name": "jenkins-cicd",
+              "description": "description: Jenkins CI/CD pipeline management \u2014 monitor builds, trigger pipelines, analyze logs, and track SCM changes for network automation workflows.",
+              "invocable": true
+            },
+            {
+              "name": "junos-network",
+              "description": "description: \"Juniper JunOS device automation via PyEZ/NETCONF \u2014 CLI execution, configuration management, Jinja2 template rendering, device facts, batch operations, config diff and rollback comparison",
+              "invocable": true
+            },
+            {
+              "name": "kubeshark-traffic",
+              "description": "description: \"Kubeshark Kubernetes traffic analysis \u2014 L4/L7 deep packet inspection, TLS decryption, pcap export, flow analysis, service mapping (6 tools). Use when capturing Kubernetes pod traffic, de",
+              "invocable": true
+            },
+            {
+              "name": "lab-troubleshoot",
+              "description": "description: \"Detect and diagnose network failures by correlating observability metrics (Grafana/Prometheus), syslog (Loki), and live device state (pyATS). Use when investigating connectivity issues, ",
+              "invocable": true
+            },
+            {
+              "name": "markmap-viz",
+              "description": "description: \"Create interactive mind map visualizations from markdown - network inventory, OSPF areas, BGP topology, security audit results. Use when visualizing network topology as a mind map, creat",
+              "invocable": true
+            },
+            {
+              "name": "memory",
+              "description": "**Purpose**: Provide persistent context across NetClaw sessions through structured facts, semantic search, and entity relationships.",
+              "invocable": true
+            },
+            {
+              "name": "memory-management",
+              "description": "description: \"Record and recall network facts, decisions, and session context using hybrid structured + semantic memory\"",
+              "invocable": true
+            },
+            {
+              "name": "mempalace",
+              "description": "description: \"MemPalace AI memory \u2014 persistent memory across sessions. Search past decisions, store architecture choices, track temporal network facts via knowledge graph, navigate cross-domain connec",
+              "invocable": true
+            },
+            {
+              "name": "meraki-monitoring",
+              "description": "description: \"Cisco Meraki Monitoring & Diagnostics \u2014 live ping, cable test, LED blink, wake-on-LAN, camera analytics, config change tracking. Use when running ping tests from Meraki devices, troubles",
+              "invocable": true
+            },
+            {
+              "name": "meraki-network-ops",
+              "description": "description: \"Cisco Meraki Dashboard \u2014 organization inventory, network management, device lifecycle, client discovery, action batches. Use when listing Meraki devices, managing networks, checking devi",
+              "invocable": true
+            },
+            {
+              "name": "meraki-security-appliance",
+              "description": "description: \"Cisco Meraki Security Appliance (MX) \u2014 firewall rules, site-to-site VPN, content filtering, traffic shaping, security events. Use when auditing Meraki MX firewall rules, troubleshooting ",
+              "invocable": true
+            },
+            {
+              "name": "meraki-switch-ops",
+              "description": "description: \"Cisco Meraki Switching \u2014 port configuration, VLANs, port status, ACLs, QoS rules, port cycling. Use when configuring Meraki switch ports, creating VLANs, checking port status and PoE, tr",
+              "invocable": true
+            },
+            {
+              "name": "meraki-wireless-ops",
+              "description": "description: \"Cisco Meraki Wireless \u2014 SSID management, RF profiles, channel utilization, signal quality, client connectivity events. Use when managing Meraki SSIDs, troubleshooting WiFi connectivity, ",
+              "invocable": true
+            },
+            {
+              "name": "monitoring-onboard",
+              "description": "description: \"Configure network devices to send telemetry to the existing observability stack. Supports pfSense, Cisco IOS/IOS-XE switches, Proxmox hosts, and Linux servers. Generates Prometheus scrap",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-files",
+              "description": "description: \"Manage files on OneDrive and SharePoint via Microsoft Graph API - upload, download, list, search, and organize network documentation and artifacts. Use when uploading reports to SharePoi",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-teams",
+              "description": "description: \"Send notifications and reports to Microsoft Teams channels via Graph API - alert delivery, report posting, incident updates, and diagram sharing. Use when posting health alerts to Teams,",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-visio",
+              "description": "description: \"Generate and manage Visio network diagrams on SharePoint via Microsoft Graph API - create topology diagrams from CDP/LLDP discovery, update existing diagrams, export to PDF. Use when cre",
+              "invocable": true
+            },
+            {
+              "name": "n2n-federation",
+              "description": "description: Federate your NetClaw with other NetClaw operators over the BGP mesh \u2014 exchange capability inventories and ask your claw what a peer can do. (US1; remote invocation and chat land in later",
+              "invocable": true
+            },
+            {
+              "name": "nautobot-dev-setup",
+              "description": "Deploy a Nautobot development instance using the official `nautobot/nautobot-docker-compose` repository.",
+              "invocable": true
+            },
+            {
+              "name": "nautobot-sot",
+              "description": "description: \"Nautobot IPAM & source of truth \u2014 IP address queries, prefix lookups, VRF/tenant/site filtering, IPAM search, connection testing. Use when looking up IP addresses in Nautobot, checking s",
+              "invocable": true
+            },
+            {
+              "name": "netbox-reconcile",
+              "description": "description: \"Reconcile NetBox source of truth against live network state - detect IP drift, missing interfaces, undocumented links, cable mismatches, VLAN mismatches, and ticket discrepancies in Serv",
+              "invocable": true
+            },
+            {
+              "name": "nmap-network-scan",
+              "description": "description: \"Host discovery and port scanning using nmap \u2014 ICMP/ARP host discovery, SYN/TCP/UDP port scanning with scope enforcement and audit logging. Use when discovering live hosts on a subnet, sc",
+              "invocable": true
+            },
+            {
+              "name": "nmap-scan-management",
+              "description": "description: \"Custom nmap scans with arbitrary flags, plus scan history retrieval and management. Use when running nmap with custom flags, reviewing past scan results, comparing before/after scans, or",
+              "invocable": true
+            },
+            {
+              "name": "nmap-service-detection",
+              "description": "description: \"Service fingerprinting, OS detection, NSE script execution, and vulnerability scanning using nmap MCP. Use when identifying services on open ports, fingerprinting OS versions, running NS",
+              "invocable": true
+            },
+            {
+              "name": "nso-device-ops",
+              "description": "description: \"Cisco NSO device operations \u2014 config retrieval, state inspection, sync, platform info, NED IDs, device groups. Use when retrieving device configs from NSO, checking sync status, pulling ",
+              "invocable": true
+            },
+            {
+              "name": "nso-service-mgmt",
+              "description": "description: \"Cisco NSO service management \u2014 discover service types, list service instances, orchestrate network services. Use when listing NSO services, checking service health, auditing deployed ser",
+              "invocable": true
+            },
+            {
+              "name": "nvd-cve",
+              "description": "description: \"Search the National Vulnerability Database for CVEs - find vulnerabilities by keyword or ID, get CVSS scores, weaknesses, affected configurations, and remediation references. Use when lo",
+              "invocable": true
+            },
+            {
+              "name": "packet-analysis",
+              "description": "description: \"Analyze network packet captures (.pcap/.pcapng) using Packet Buddy MCP. Use when opening a pcap file, inspecting packet captures, troubleshooting network traffic, analyzing retransmissio",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-incidents",
+              "description": "description: \"Manage and investigate incidents in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-oncall",
+              "description": "description: \"Manage on-call schedules and escalation policies in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-orchestration",
+              "description": "description: \"Manage event orchestration and routing rules in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-services",
+              "description": "description: \"Manage service catalog and service health in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "paloalto-panorama",
+              "description": "description: \"Palo Alto Panorama operations \u2014 device groups, templates, security policy search, NAT review, commit status, and audit workflows. Use when searching Palo Alto firewall rules, checking if",
+              "invocable": true
+            },
+            {
+              "name": "pfsense-threat-intel",
+              "description": "version: 2.0.0",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-apps",
+              "description": "description: \"View Prisma SD-WAN application definitions for policy visibility\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-config",
+              "description": "description: \"Inspect Prisma SD-WAN interfaces, routing (BGP, static), policies, and security zones\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-status",
+              "description": "description: \"Monitor Prisma SD-WAN element health, software versions, events, and alarms\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-topology",
+              "description": "description: \"Discover Prisma SD-WAN sites, ION elements, machines, and network topology\"",
+              "invocable": true
+            },
+            {
+              "name": "prometheus-monitoring",
+              "description": "description: \"Prometheus monitoring \u2014 PromQL instant/range queries, metric discovery, metadata, scrape target health, system health checks (6 tools). Use when querying Prometheus metrics, checking scr",
+              "invocable": true
+            },
+            {
+              "name": "protocol-participation",
+              "description": "description: \"Live BGP and OSPF control-plane participation \u2014 peer with real routers, inject/withdraw routes, query RIB/LSDB, adjust metrics, GRE tunnel status. Use when injecting or withdrawing BGP r",
+              "invocable": true
+            },
+            {
+              "name": "pyats-asa-firewall",
+              "description": "description: \"Cisco ASA firewall operations via pyATS \u2014 VPN sessions, failover state, interfaces, routing, service policies, resource usage, AnyConnect monitoring. Use when checking ASA failover statu",
+              "invocable": true
+            },
+            {
+              "name": "pyats-config-mgmt",
+              "description": "description: \"Network change management - pre-change baselines, configuration deployment, post-change verification, rollback procedures, and compliance validation. Use when pushing config to a device,",
+              "invocable": true
+            },
+            {
+              "name": "pyats-dynamic-test",
+              "description": "description: \"Generate and execute deterministic pyATS aetest validation scripts - interface state, OSPF neighbors, BGP paths, ping matrices, and custom compliance tests. Use when writing a network te",
+              "invocable": true
+            },
+            {
+              "name": "pyats-f5-ltm",
+              "description": "description: \"F5 BIG-IP LTM/GTM operations via pyATS iControl REST \u2014 virtual servers, pools, nodes, monitors, profiles, iRules, persistence, GTM wide IPs, DNS, data groups. Use when checking F5 virtua",
+              "invocable": true
+            },
+            {
+              "name": "pyats-f5-platform",
+              "description": "description: \"F5 BIG-IP platform operations via pyATS iControl REST \u2014 system, networking, HA/CM, auth, analytics, security, APM, live-update, ADC certs, file management. Use when checking BIG-IP syste",
+              "invocable": true
+            },
+            {
+              "name": "pyats-health-check",
+              "description": "description: \"Comprehensive network device health monitoring - CPU, memory, interfaces, hardware, NTP, logging, environment, and uptime analysis. Use when running a device health check, monitoring CPU",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-interfaces",
+              "description": "description: \"JunOS interface operations via pyATS \u2014 physical/logical interfaces, LACP, CoS, LLDP, ARP, BFD, IPv6 neighbors, traffic monitoring, optics diagnostics. Use when checking Juniper interface",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-routing",
+              "description": "description: \"JunOS routing operations via pyATS \u2014 OSPF/OSPFv3, BGP, route table, MPLS/LDP/RSVP, TED, PFE, ping, traceroute across Juniper devices. Use when checking Juniper OSPF neighbors, viewing BG",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-system",
+              "description": "description: \"JunOS system operations via pyATS \u2014 chassis health, hardware inventory, system info, NTP, SNMP, files/logs, firewall counters, DDoS protection, services accounting. Use when checking Jun",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-network",
+              "description": "description: \"Linux host network operations via pyATS \u2014 interface configuration, routing tables, network connections, and multi-table route inspection across fleet hosts. Use when checking Linux inter",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-system",
+              "description": "description: \"Linux host system operations via pyATS \u2014 process monitoring, filesystem inspection, Docker container stats, package/tool verification across fleet hosts. Use when checking running proces",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-vmware",
+              "description": "description: \"VMware ESXi host operations via pyATS \u2014 VM inventory, snapshot management, hypervisor inspection across ESXi hosts in the testbed. Use when listing VMs on ESXi, checking snapshot age, au",
+              "invocable": true
+            },
+            {
+              "name": "pyats-network",
+              "description": "description: \"Network device automation via pyATS - run show commands, ping, apply config, learn config/logging, list devices, run Linux commands, execute dynamic tests on Cisco IOS-XE/NX-OS devices. ",
+              "invocable": true
+            },
+            {
+              "name": "pyats-parallel-ops",
+              "description": "description: \"Fleet-wide parallel device operations - concurrent health checks, config audits, routing snapshots, severity-sorted reporting, and failure-isolated multi-device automation. Use when chec",
+              "invocable": true
+            },
+            {
+              "name": "pyats-routing",
+              "description": "description: \"CCIE-level routing protocol analysis - OSPF, BGP, EIGRP, IS-IS, static routes, RIB/FIB verification, redistribution audit, and convergence validation. Use when analyzing routing tables, ",
+              "invocable": true
+            },
+            {
+              "name": "pyats-security",
+              "description": "description: \"Network security audit - ACLs, AAA, control plane policing, management plane hardening, encryption, port security, and CIS benchmark checks. Use when auditing device security posture, ch",
+              "invocable": true
+            },
+            {
+              "name": "pyats-topology",
+              "description": "description: \"Network topology discovery via CDP/LLDP neighbors, ARP tables, routing peers, and interface mapping to build complete network maps. Use when mapping the network, building a diagram, disc",
+              "invocable": true
+            },
+            {
+              "name": "pyats-troubleshoot",
+              "description": "description: \"Systematic network troubleshooting - connectivity, routing, interface, protocol, and performance issues using structured OSI-layer and divide-and-conquer methodology. Use when something ",
+              "invocable": true
+            },
+            {
+              "name": "radkit-remote-access",
+              "description": "description: \"Cisco RADKit \u2014 cloud-relayed remote device access, CLI execution, SNMP polling, device inventory discovery, attribute inspection. Use when accessing remote network devices through a clou",
+              "invocable": true
+            },
+            {
+              "name": "rag",
+              "description": "**Purpose**: Give NetClaw a fully offline, user-curated document knowledge base \u2014 vendor guides, standards (RFC/IEEE/vendor), customer design documents, install guides \u2014 with agentic retrieval, mandat",
+              "invocable": true
+            },
+            {
+              "name": "rfc-lookup",
+              "description": "description: \"Search and retrieve IETF RFC documents - lookup by number, search by keyword, extract sections. Use when looking up an RFC, checking protocol specifications, verifying standards complian",
+              "invocable": true
+            },
+            {
+              "name": "sdwan-ops",
+              "description": "description: \"Cisco SD-WAN vManage read-only operations \u2014 fabric devices, WAN Edge inventory, templates, policies, alarms, events, interface stats, BFD sessions, OMP routes, control connections, runni",
+              "invocable": true
+            },
+            {
+              "name": "servicenow-change-workflow",
+              "description": "description: \"Full ITSM-gated change lifecycle - CR creation, pre-change incident validation, approval gate, execution via pyats-config-mgmt, post-change verification, and closure with GAIT audit trai",
+              "invocable": true
+            },
+            {
+              "name": "slack-incident-workflow",
+              "description": "description: \"Manage network incident response workflows in Slack - incident channels, status updates, escalation, resolution tracking, and post-incident review coordination. Use when declaring a netw",
+              "invocable": true
+            },
+            {
+              "name": "slack-network-alerts",
+              "description": "description: \"Format and deliver network alerts, health warnings, and critical notifications via Slack with rich formatting, reactions, and file attachments. Use when sending alerts to Slack, posting ",
+              "invocable": true
+            },
+            {
+              "name": "slack-report-delivery",
+              "description": "description: \"Deliver formatted network reports, audit results, topology diagrams, and compliance documentation to Slack channels with rich Block Kit formatting. Use when posting a health check report",
+              "invocable": true
+            },
+            {
+              "name": "slack-user-context",
+              "description": "description: \"Leverage Slack user profiles, presence, DND status, and workspace context to personalize responses, route escalations, and coordinate team operations. Use when checking who is on-call, r",
+              "invocable": true
+            },
+            {
+              "name": "slack-voice-interface",
+              "description": "description: \"Respond to Slack voice clips with both text and an MP3 voice reply using edge-tts. Voice IN is already handled by OpenClaw transcription. Use when a user sends a voice message in Slack, ",
+              "invocable": true
+            },
+            {
+              "name": "snmptrap-receiver",
+              "description": "description: \"Receive and query SNMP traps from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-indexes",
+              "description": "description: \"Discover and inspect Splunk indexes and configuration.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-saved",
+              "description": "description: \"Manage and run saved searches in Splunk.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-search",
+              "description": "description: \"Execute and validate SPL (Search Processing Language) queries.\"",
+              "invocable": true
+            },
+            {
+              "name": "subnet-calculator",
+              "description": "description: \"IPv4 and IPv6 subnet calculator - CIDR breakdown, usable hosts, previous/next subnets, address classification, VLSM planning, and dual-stack analysis. Use when calculating subnets, figur",
+              "invocable": true
+            },
+            {
+              "name": "suzieq-observability",
+              "description": "description: \"SuzieQ network observability \u2014 query current and historical network state, run validation assertions, get summary statistics, trace forwarding paths, and discover unique values across 20",
+              "invocable": true
+            },
+            {
+              "name": "syslog-receiver",
+              "description": "description: \"Receive and query syslog messages from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "te-network-monitoring",
+              "description": "description: \"Cisco ThousandEyes \u2014 test management, agent inventory, test results, dashboards, path visualization, user/account management. Use when checking ThousandEyes test results, viewing network",
+              "invocable": true
+            },
+            {
+              "name": "te-path-analysis",
+              "description": "description: \"Cisco ThousandEyes \u2014 path visualization, BGP route analysis, outage investigation, instant tests, endpoint agent diagnostics. Use when tracing network paths hop-by-hop, investigating why",
+              "invocable": true
+            },
+            {
+              "name": "telemetry-ops",
+              "description": "description: \"Comprehensive network telemetry and event collection across multiple protocols.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-operations",
+              "description": "description: \"Execute local Terraform operations with ServiceNow change control.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-registry",
+              "description": "description: \"Discover providers and modules from the Terraform Registry.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-workspaces",
+              "description": "description: \"Manage HCP Terraform (Terraform Cloud/Enterprise) workspaces.\"",
+              "invocable": true
+            },
+            {
+              "name": "threejs-network-viz",
+              "description": "**Version**: 1.0.0",
+              "invocable": true
+            },
+            {
+              "name": "token-tracker",
+              "description": "description: \"Track and display token consumption and cost for every NetClaw interaction.\"",
+              "invocable": true
+            },
+            {
+              "name": "twilio-daily-briefing",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-emergency-call",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-inbound-voice",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-outbound-call",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twitter-check",
+              "description": "**Purpose**: Quick invocation to check mentions and respond to #netclaw threads.",
+              "invocable": true
+            },
+            {
+              "name": "twitter-heartbeat",
+              "description": "**Purpose**: Autonomous periodic tweeting AND mention monitoring to maintain NetClaw's Twitter presence with CCIE-level network engineering content.",
+              "invocable": true
+            },
+            {
+              "name": "twitter-respond",
+              "description": "**Skill ID**: twitter-respond",
+              "invocable": true
+            },
+            {
+              "name": "twitter-share",
+              "description": "**Purpose**: Manual tweet posting with content guardrails and human approval flow.",
+              "invocable": true
+            },
+            {
+              "name": "ue5-network-viz",
+              "description": "description: \"3D network topology visualization and interactive digital twin in Unreal Engine 5.8 via the built-in UE5 MCP server.\"",
+              "invocable": true
+            },
+            {
+              "name": "uml-diagram",
+              "description": "description: \"UML and diagram generation via Kroki \u2014 class, sequence, activity, state, component, deployment, network, ER, C4, Mermaid, D2, Graphviz, BPMN, 27+ types. Use when generating a network dia",
+              "invocable": true
+            },
+            {
+              "name": "vault-mounts",
+              "description": "description: \"Discover and manage HashiCorp Vault secret engine mounts.\"",
+              "invocable": true
+            },
+            {
+              "name": "vault-pki",
+              "description": "description: \"Manage HashiCorp Vault PKI certificate infrastructure.\"",
+              "invocable": true
+            },
+            {
+              "name": "vault-secrets",
+              "description": "description: \"Manage HashiCorp Vault KV secrets with strict value protection.\"",
+              "invocable": true
+            },
+            {
+              "name": "webex-incident-workflow",
+              "description": "description: \"Manage network incident response workflows in Cisco WebEx - incident spaces, status updates, escalation, resolution tracking, and post-incident review coordination. Use when declaring a ",
+              "invocable": true
+            },
+            {
+              "name": "webex-network-alerts",
+              "description": "description: \"Format and deliver network alerts, health warnings, and critical notifications via Cisco WebEx with Adaptive Cards, markdown formatting, and file attachments. Use when sending alerts to ",
+              "invocable": true
+            },
+            {
+              "name": "webex-report-delivery",
+              "description": "description: \"Deliver formatted network reports, audit results, topology diagrams, and compliance documentation to WebEx spaces with Adaptive Cards and markdown formatting. Use when posting a health c",
+              "invocable": true
+            },
+            {
+              "name": "webex-user-context",
+              "description": "description: \"Leverage WebEx user profiles, presence status, and workspace context to personalize responses, route escalations, and coordinate team operations. Use when checking who is available, rout",
+              "invocable": true
+            },
+            {
+              "name": "webex-voice-interface",
+              "description": "description: \"Respond to WebEx voice clips with both text and an MP3 voice reply using edge-tts. Voice IN is already handled by OpenClaw transcription. Use when a user sends a voice message in WebEx, ",
+              "invocable": true
+            },
+            {
+              "name": "wifi-diagnosis",
+              "description": "description: \"Diagnose Wi-Fi and internet connectivity using Home / Network Guardian observability. Prefer adapter metrics (UniFi Integration exporter first; other wireless vendors via stubs later). A",
+              "invocable": true
+            },
+            {
+              "name": "wikipedia-research",
+              "description": "description: \"Research networking protocols, standards history, and technology context via Wikipedia - OSPF, BGP, MPLS, 802.1X, VXLAN, and more. Use when looking up protocol background, researching ho",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-identity",
+              "description": "description: \"Manage users, groups, departments, and identity provider configurations.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-insights",
+              "description": "description: \"Access analytics, threat intelligence, and security event data.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zdx",
+              "description": "description: \"Monitor digital experience scores, user performance, and application health.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zia",
+              "description": "description: \"Manage Zscaler Internet Access firewall rules, URL filtering, DLP, and security policies.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zpa",
+              "description": "description: \"Manage Zscaler Private Access applications, segments, policies, and connectors.\"",
+              "invocable": true
+            }
+          ],
+          "mcp_servers": [
+            {
+              "name": "forward-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "suzieq-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "batfish-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gnmi-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "azure-network-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gitlab-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chrome-devtools-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chrome-devtools-mcp-visible",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "jenkins-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "atlassian-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gns3-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "prisma-sdwan-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "datadog-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "pagerduty-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "splunk-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "infrahub-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "terraform-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "vault-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "zscaler-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-dns-analytics",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-security",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-zerotrust",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-analytics",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-workers",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "blender-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aruba-cx-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "devnet-content-search",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-golden-config-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-routing-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-management",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-management-logs",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-threat-prevention",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-https-inspection",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-harmony-sase",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-reputation-service",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-quantum-gw-cli",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-gw-connection-analysis",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-threat-emulation",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-quantum-gaia",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-documentation",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-spark-management",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-cpinfo-analysis",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-argos-erm",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-policy-insights",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "claroty-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twitter-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twilio-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twilio-voice-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "unreal-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "sketchfab-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "pfsense-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "unifi-network",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "n2n-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "rag-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cml-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nso-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "itential-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "prometheus-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "grafana-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "meraki-magic-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "radkit-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "junos-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "arista-cvp-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cisco-fmc-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "thousandeyes-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "github-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-network-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-cloudwatch-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-iam-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-cloudtrail-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-cost-explorer-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-diagram-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-compute-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-monitoring-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-logging-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-resource-manager-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "thousandeyes-official-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "kubeshark-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "uml-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "protocol-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "ollama-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "fwrule-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-ansible-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-eda-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-lint-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-docs-mcp",
+              "tools": [],
+              "invocable_tools": []
+            }
+          ],
+          "knowledge": [
+            {
+              "collection_id": "knowledge:documents",
+              "name": "Knowledge: documents",
+              "description": "Knowledge collection 'documents': VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches); VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches) - Preface [Cisco Catalyst 9200 Series Switches] - Cisco; VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches) - Configuring VTP [Cisco Catalyst 9200 Series Switches] - Cisco; VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches) - Configuring VLANs [Cisco Catalyst 9200 Series Switches] - Cisco; VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches) - Configuring Voice VLANs [Cisco Catalyst 9200 Series Switches] - Cisco; VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches) - Configuring VLAN Trunks [Cisco Catalyst 9200 Series Switches] - Cisco; VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches) - Configuring Private VLANs [Cisco Catalyst 9200 Series Switches] - Cisco; VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches) - Configuring Wired Dynamic PVLAN [Cisco Catalyst 9200 Series Switches] - Cisco; Quantum Fiber Internet Subscriber Agreement; Documentation crawl; UniFi Network API 10.4.57 OpenAPI (customer, vendor).",
+              "tags": [
+                "customer",
+                "vendor"
+              ],
+              "doc_count": 11,
+              "page_count": 127,
+              "chunk_count": 744,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_WifiDegraded24GHz-Basement-AP---deeper-investigation-with-radio-details_2026-07-24T134400Z",
+              "name": "Knowledge: snapshot_WifiDegraded24GHz-Basement-AP---deeper-investigation-with-radio-details_2026-07-24T134400Z",
+              "description": "Knowledge collection 'snapshot_WifiDegraded24GHz-Basement-AP---deeper-investigation-with-radio-details_2026-07-24T134400Z': WifiDegraded24GHz-Basement-AP---deeper-investigation-with-radio-details (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 3,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_WifiDegraded24GHz_2026-07-24T185304Z",
+              "name": "Knowledge: snapshot_WifiDegraded24GHz_2026-07-24T185304Z",
+              "description": "Knowledge collection 'snapshot_WifiDegraded24GHz_2026-07-24T185304Z': WifiDegraded24GHz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 2,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_convergence-pipe-test-seed_2026-07-24T121341Z",
+              "name": "Knowledge: snapshot_convergence-pipe-test-seed_2026-07-24T121341Z",
+              "description": "Knowledge collection 'snapshot_convergence-pipe-test-seed_2026-07-24T121341Z': convergence-pipe-test-seed (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_convergencepipetest_2026-07-24T121655Z",
+              "name": "Knowledge: snapshot_convergencepipetest_2026-07-24T121655Z",
+              "description": "Knowledge collection 'snapshot_convergencepipetest_2026-07-24T121655Z': convergencepipetest (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_convergencepipetest_2026-07-24T121702Z",
+              "name": "Knowledge: snapshot_convergencepipetest_2026-07-24T121702Z",
+              "description": "Knowledge collection 'snapshot_convergencepipetest_2026-07-24T121702Z': convergencepipetest (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 3,
+              "page_count": 0,
+              "chunk_count": 3,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_convergencepipetest_2026-07-24T121917Z",
+              "name": "Knowledge: snapshot_convergencepipetest_2026-07-24T121917Z",
+              "description": "Knowledge collection 'snapshot_convergencepipetest_2026-07-24T121917Z': convergencepipetest (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_homeapidown_2026-07-24T170417Z",
+              "name": "Knowledge: snapshot_homeapidown_2026-07-24T170417Z",
+              "description": "Knowledge collection 'snapshot_homeapidown_2026-07-24T170417Z': homeapidown (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_homeapidown_2026-07-24T171230Z",
+              "name": "Knowledge: snapshot_homeapidown_2026-07-24T171230Z",
+              "description": "Knowledge collection 'snapshot_homeapidown_2026-07-24T171230Z': homeapidown (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_pfsensewanportscan_2026-07-25T005621Z",
+              "name": "Knowledge: snapshot_pfsensewanportscan_2026-07-25T005621Z",
+              "description": "Knowledge collection 'snapshot_pfsensewanportscan_2026-07-25T005621Z': pfsensewanportscan (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_pfsensewanportscan_2026-07-25T005845Z",
+              "name": "Knowledge: snapshot_pfsensewanportscan_2026-07-25T005845Z",
+              "description": "Knowledge collection 'snapshot_pfsensewanportscan_2026-07-25T005845Z': pfsensewanportscan (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_pfsensewanportscan_2026-07-25T043143Z",
+              "name": "Knowledge: snapshot_pfsensewanportscan_2026-07-25T043143Z",
+              "description": "Knowledge collection 'snapshot_pfsensewanportscan_2026-07-25T043143Z': pfsensewanportscan (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_pfsensewanportscan_2026-07-25T043546Z",
+              "name": "Knowledge: snapshot_pfsensewanportscan_2026-07-25T043546Z",
+              "description": "Knowledge collection 'snapshot_pfsensewanportscan_2026-07-25T043546Z': pfsensewanportscan (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_pfsensewanportscan_2026-07-25T074523Z",
+              "name": "Knowledge: snapshot_pfsensewanportscan_2026-07-25T074523Z",
+              "description": "Knowledge collection 'snapshot_pfsensewanportscan_2026-07-25T074523Z': pfsensewanportscan (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_unifiexporterdown_2026-07-24T170725Z",
+              "name": "Knowledge: snapshot_unifiexporterdown_2026-07-24T170725Z",
+              "description": "Knowledge collection 'snapshot_unifiexporterdown_2026-07-24T170725Z': unifiexporterdown (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_unifiexporterdown_2026-07-24T171619Z",
+              "name": "Knowledge: snapshot_unifiexporterdown_2026-07-24T171619Z",
+              "description": "Knowledge collection 'snapshot_unifiexporterdown_2026-07-24T171619Z': unifiexporterdown (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T121702Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T121702Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T121702Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 2,
+              "page_count": 0,
+              "chunk_count": 2,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T122809Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T122809Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T122809Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T122817Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T122817Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T122817Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T133706Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T133706Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T133706Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T133758Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T133758Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T133758Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T135212Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T135212Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T135212Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T141656Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T141656Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T141656Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T144758Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T144758Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T144758Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T145315Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T145315Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T145315Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T145349Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T145349Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T145349Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T182206Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T182206Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T182206Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T182249Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T182249Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T182249Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-25T065417Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-25T065417Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-25T065417Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-25T065439Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-25T065439Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-25T065439Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded5ghz_2026-07-24T234412Z",
+              "name": "Knowledge: snapshot_wifidegraded5ghz_2026-07-24T234412Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded5ghz_2026-07-24T234412Z': wifidegraded5ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded5ghz_2026-07-24T235329Z",
+              "name": "Knowledge: snapshot_wifidegraded5ghz_2026-07-24T235329Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded5ghz_2026-07-24T235329Z': wifidegraded5ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            }
+          ],
+          "badges": [
+            "AWS",
+            "Azure",
+            "Batfish",
+            "CML",
+            "Check Point",
+            "Forward",
+            "GNS3",
+            "Meraki",
+            "Nautobot",
+            "SuzieQ",
+            "gNMI"
+          ],
+          "posture": {
+            "mode": "testing",
+            "state": "testing",
+            "summary": "testing",
+            "controls": {
+              "sandbox": true,
+              "model-guard": false,
+              "audit": true
+            }
+          },
+          "llm": {
+            "primary_model": "ollama/deepseek-v4-flash:cloud",
+            "guarded": false,
+            "note": "Border reasoning model; member claws run their own per-specialty tiered models"
+          }
+        },
+        "received_at": "2026-07-25T16:43:51Z",
+        "stale": true
+      },
+      "channel_state": "unreachable",
+      "last_seen": 0,
+      "endpoint_updated_at": null,
+      "in_flight_tasks": [],
+      "endpoint": null
+    }
+  ],
+  "approvals": [],
+  "risk": {
+    "role": "border",
+    "risk_name": "johns-risk",
+    "description": null,
+    "enabled_stacks": "both",
+    "self_member_id": null,
+    "member_count": 102,
+    "members_active": 10
+  },
+  "members": [
+    {
+      "member_id": "johns-risk/scale-000",
+      "display_name": "scale-000",
+      "profile": "aap",
+      "state": "active",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "aap-automation",
+        "aap-eda",
+        "aap-lint"
+      ],
+      "live": true,
+      "heartbeat_age_s": 5
+    },
+    {
+      "member_id": "johns-risk/scale-001",
+      "display_name": "scale-001",
+      "profile": "aci",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "aci-change-deploy",
+        "aci-fabric-audit"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-002",
+      "display_name": "scale-002",
+      "profile": "azure",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "azure-network-ops",
+        "azure-security-audit"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-003",
+      "display_name": "scale-003",
+      "profile": "batfish",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "batfish-config-analysis"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-004",
+      "display_name": "scale-004",
+      "profile": "catalyst-center",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "catc-client-ops",
+        "catc-inventory",
+        "catc-troubleshoot"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-005",
+      "display_name": "scale-005",
+      "profile": "cml",
+      "state": "provisioned",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 5,
+      "skills": [
+        "cml-topology-builder",
+        "cml-node-operations",
+        "cml-packet-capture",
+        "cml-lab-lifecycle",
+        "cml-admin"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-006",
+      "display_name": "scale-006",
+      "profile": "containerlab",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "clab-lab-management"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-007",
+      "display_name": "scale-007",
+      "profile": "f5",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "f5-config-mgmt",
+        "f5-health-check",
+        "f5-troubleshoot"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-008",
+      "display_name": "scale-008",
+      "profile": "fortimanager",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "fortimanager-ops"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-009",
+      "display_name": "scale-009",
+      "profile": "forward",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "forward"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-010",
+      "display_name": "scale-010",
+      "profile": "fwrule",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "fwrule-analyzer"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-011",
+      "display_name": "scale-011",
+      "profile": "github",
+      "state": "provisioned",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "github-ops"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-012",
+      "display_name": "scale-012",
+      "profile": "gtrace",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "gtrace-ip-enrichment",
+        "gtrace-path-analysis"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-013",
+      "display_name": "scale-013",
+      "profile": "infoblox",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "infoblox-ddi"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-014",
+      "display_name": "scale-014",
+      "profile": "ipfabric",
+      "state": "provisioned",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "ipfabric"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-015",
+      "display_name": "scale-015",
+      "profile": "ise",
+      "state": "unreachable",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "ise-incident-response",
+        "ise-posture-audit"
+      ],
+      "live": false,
+      "heartbeat_age_s": 99999
+    },
+    {
+      "member_id": "johns-risk/scale-016",
+      "display_name": "scale-016",
+      "profile": "itential",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "itential-automation"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-017",
+      "display_name": "scale-017",
+      "profile": "netbox",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "netbox-reconcile"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-018",
+      "display_name": "scale-018",
+      "profile": "nmap",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "nmap-network-scan",
+        "nmap-scan-management",
+        "nmap-service-detection"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-019",
+      "display_name": "scale-019",
+      "profile": "nso",
+      "state": "active",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "nso-device-ops",
+        "nso-service-mgmt"
+      ],
+      "live": true,
+      "heartbeat_age_s": 5
+    },
+    {
+      "member_id": "johns-risk/scale-020",
+      "display_name": "scale-020",
+      "profile": "nvd",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "nvd-cve"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-021",
+      "display_name": "scale-021",
+      "profile": "packet",
+      "state": "active",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "kubeshark-traffic",
+        "packet-analysis"
+      ],
+      "live": true,
+      "heartbeat_age_s": 5
+    },
+    {
+      "member_id": "johns-risk/scale-022",
+      "display_name": "scale-022",
+      "profile": "paloalto",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "fmc-firewall-ops",
+        "paloalto-panorama"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-023",
+      "display_name": "scale-023",
+      "profile": "pyats",
+      "state": "unreachable",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 18,
+      "skills": [
+        "pyats-parallel-ops",
+        "pyats-health-check",
+        "pyats-troubleshoot",
+        "pyats-linux-system",
+        "pyats-f5-ltm",
+        "pyats-security",
+        "pyats-junos-interfaces",
+        "pyats-linux-network",
+        "pyats-junos-system",
+        "pyats-junos-routing",
+        "pyats-f5-platform",
+        "pyats-dynamic-test",
+        "pyats-network",
+        "pyats-asa-firewall",
+        "pyats-config-mgmt",
+        "pyats-routing",
+        "pyats-linux-vmware",
+        "pyats-topology"
+      ],
+      "live": false,
+      "heartbeat_age_s": 99999
+    },
+    {
+      "member_id": "johns-risk/scale-024",
+      "display_name": "scale-024",
+      "profile": "sdwan",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 5,
+      "skills": [
+        "prisma-sdwan-apps",
+        "prisma-sdwan-config",
+        "prisma-sdwan-status",
+        "prisma-sdwan-topology",
+        "sdwan-ops"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-025",
+      "display_name": "scale-025",
+      "profile": "suzieq",
+      "state": "unreachable",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "suzieq-observability"
+      ],
+      "live": false,
+      "heartbeat_age_s": 99999
+    },
+    {
+      "member_id": "johns-risk/scale-026",
+      "display_name": "scale-026",
+      "profile": "viz",
+      "state": "provisioned",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 8,
+      "skills": [
+        "ue5-network-viz",
+        "blender-3d-viz",
+        "threejs-network-viz",
+        "drawio-diagram",
+        "markmap-viz",
+        "canvas-network-viz",
+        "uml-diagram",
+        "aws-architecture-diagram"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-027",
+      "display_name": "scale-027",
+      "profile": "aap",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "aap-automation",
+        "aap-eda",
+        "aap-lint"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-028",
+      "display_name": "scale-028",
+      "profile": "aci",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "aci-change-deploy",
+        "aci-fabric-audit"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-029",
+      "display_name": "scale-029",
+      "profile": "azure",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "azure-network-ops",
+        "azure-security-audit"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-030",
+      "display_name": "scale-030",
+      "profile": "batfish",
+      "state": "active",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "batfish-config-analysis"
+      ],
+      "live": false,
+      "heartbeat_age_s": 300
+    },
+    {
+      "member_id": "johns-risk/scale-031",
+      "display_name": "scale-031",
+      "profile": "catalyst-center",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "catc-client-ops",
+        "catc-inventory",
+        "catc-troubleshoot"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-032",
+      "display_name": "scale-032",
+      "profile": "cml",
+      "state": "provisioned",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 5,
+      "skills": [
+        "cml-topology-builder",
+        "cml-node-operations",
+        "cml-packet-capture",
+        "cml-lab-lifecycle",
+        "cml-admin"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-033",
+      "display_name": "scale-033",
+      "profile": "containerlab",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "clab-lab-management"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-034",
+      "display_name": "scale-034",
+      "profile": "f5",
+      "state": "active",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "f5-config-mgmt",
+        "f5-health-check",
+        "f5-troubleshoot"
+      ],
+      "live": false,
+      "heartbeat_age_s": 300
+    },
+    {
+      "member_id": "johns-risk/scale-035",
+      "display_name": "scale-035",
+      "profile": "fortimanager",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "fortimanager-ops"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-036",
+      "display_name": "scale-036",
+      "profile": "forward",
+      "state": "unreachable",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "forward"
+      ],
+      "live": false,
+      "heartbeat_age_s": 99999
+    },
+    {
+      "member_id": "johns-risk/scale-037",
+      "display_name": "scale-037",
+      "profile": "fwrule",
+      "state": "active",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "fwrule-analyzer"
+      ],
+      "live": true,
+      "heartbeat_age_s": 5
+    },
+    {
+      "member_id": "johns-risk/scale-038",
+      "display_name": "scale-038",
+      "profile": "github",
+      "state": "provisioned",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "github-ops"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-039",
+      "display_name": "scale-039",
+      "profile": "gtrace",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "gtrace-ip-enrichment",
+        "gtrace-path-analysis"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-040",
+      "display_name": "scale-040",
+      "profile": "infoblox",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "infoblox-ddi"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-041",
+      "display_name": "scale-041",
+      "profile": "ipfabric",
+      "state": "active",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "ipfabric"
+      ],
+      "live": false,
+      "heartbeat_age_s": 300
+    },
+    {
+      "member_id": "johns-risk/scale-042",
+      "display_name": "scale-042",
+      "profile": "ise",
+      "state": "active",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "ise-incident-response",
+        "ise-posture-audit"
+      ],
+      "live": true,
+      "heartbeat_age_s": 5
+    },
+    {
+      "member_id": "johns-risk/scale-043",
+      "display_name": "scale-043",
+      "profile": "itential",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "itential-automation"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-044",
+      "display_name": "scale-044",
+      "profile": "netbox",
+      "state": "active",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "netbox-reconcile"
+      ],
+      "live": true,
+      "heartbeat_age_s": 5
+    },
+    {
+      "member_id": "johns-risk/scale-045",
+      "display_name": "scale-045",
+      "profile": "nmap",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "nmap-network-scan",
+        "nmap-scan-management",
+        "nmap-service-detection"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-046",
+      "display_name": "scale-046",
+      "profile": "nso",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "nso-device-ops",
+        "nso-service-mgmt"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-047",
+      "display_name": "scale-047",
+      "profile": "nvd",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "nvd-cve"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-048",
+      "display_name": "scale-048",
+      "profile": "packet",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "kubeshark-traffic",
+        "packet-analysis"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-049",
+      "display_name": "scale-049",
+      "profile": "paloalto",
+      "state": "unreachable",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "fmc-firewall-ops",
+        "paloalto-panorama"
+      ],
+      "live": false,
+      "heartbeat_age_s": 99999
+    },
+    {
+      "member_id": "johns-risk/scale-050",
+      "display_name": "scale-050",
+      "profile": "pyats",
+      "state": "provisioned",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 18,
+      "skills": [
+        "pyats-parallel-ops",
+        "pyats-health-check",
+        "pyats-troubleshoot",
+        "pyats-linux-system",
+        "pyats-f5-ltm",
+        "pyats-security",
+        "pyats-junos-interfaces",
+        "pyats-linux-network",
+        "pyats-junos-system",
+        "pyats-junos-routing",
+        "pyats-f5-platform",
+        "pyats-dynamic-test",
+        "pyats-network",
+        "pyats-asa-firewall",
+        "pyats-config-mgmt",
+        "pyats-routing",
+        "pyats-linux-vmware",
+        "pyats-topology"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-051",
+      "display_name": "scale-051",
+      "profile": "sdwan",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 5,
+      "skills": [
+        "prisma-sdwan-apps",
+        "prisma-sdwan-config",
+        "prisma-sdwan-status",
+        "prisma-sdwan-topology",
+        "sdwan-ops"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-052",
+      "display_name": "scale-052",
+      "profile": "suzieq",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "suzieq-observability"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-053",
+      "display_name": "scale-053",
+      "profile": "viz",
+      "state": "active",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 8,
+      "skills": [
+        "ue5-network-viz",
+        "blender-3d-viz",
+        "threejs-network-viz",
+        "drawio-diagram",
+        "markmap-viz",
+        "canvas-network-viz",
+        "uml-diagram",
+        "aws-architecture-diagram"
+      ],
+      "live": true,
+      "heartbeat_age_s": 5
+    },
+    {
+      "member_id": "johns-risk/scale-054",
+      "display_name": "scale-054",
+      "profile": "aap",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "aap-automation",
+        "aap-eda",
+        "aap-lint"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-055",
+      "display_name": "scale-055",
+      "profile": "aci",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "aci-change-deploy",
+        "aci-fabric-audit"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-056",
+      "display_name": "scale-056",
+      "profile": "azure",
+      "state": "active",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "azure-network-ops",
+        "azure-security-audit"
+      ],
+      "live": true,
+      "heartbeat_age_s": 5
+    },
+    {
+      "member_id": "johns-risk/scale-057",
+      "display_name": "scale-057",
+      "profile": "batfish",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "batfish-config-analysis"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-058",
+      "display_name": "scale-058",
+      "profile": "catalyst-center",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "catc-client-ops",
+        "catc-inventory",
+        "catc-troubleshoot"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-059",
+      "display_name": "scale-059",
+      "profile": "cml",
+      "state": "provisioned",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 5,
+      "skills": [
+        "cml-topology-builder",
+        "cml-node-operations",
+        "cml-packet-capture",
+        "cml-lab-lifecycle",
+        "cml-admin"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-060",
+      "display_name": "scale-060",
+      "profile": "containerlab",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "clab-lab-management"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-061",
+      "display_name": "scale-061",
+      "profile": "f5",
+      "state": "active",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "f5-config-mgmt",
+        "f5-health-check",
+        "f5-troubleshoot"
+      ],
+      "live": false,
+      "heartbeat_age_s": 300
+    },
+    {
+      "member_id": "johns-risk/scale-062",
+      "display_name": "scale-062",
+      "profile": "fortimanager",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "fortimanager-ops"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-063",
+      "display_name": "scale-063",
+      "profile": "forward",
+      "state": "unreachable",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "forward"
+      ],
+      "live": false,
+      "heartbeat_age_s": 99999
+    },
+    {
+      "member_id": "johns-risk/scale-064",
+      "display_name": "scale-064",
+      "profile": "fwrule",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "fwrule-analyzer"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-065",
+      "display_name": "scale-065",
+      "profile": "github",
+      "state": "active",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "github-ops"
+      ],
+      "live": false,
+      "heartbeat_age_s": 300
+    },
+    {
+      "member_id": "johns-risk/scale-066",
+      "display_name": "scale-066",
+      "profile": "gtrace",
+      "state": "active",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "gtrace-ip-enrichment",
+        "gtrace-path-analysis"
+      ],
+      "live": false,
+      "heartbeat_age_s": 300
+    },
+    {
+      "member_id": "johns-risk/scale-067",
+      "display_name": "scale-067",
+      "profile": "infoblox",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "infoblox-ddi"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-068",
+      "display_name": "scale-068",
+      "profile": "ipfabric",
+      "state": "active",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "ipfabric"
+      ],
+      "live": true,
+      "heartbeat_age_s": 5
+    },
+    {
+      "member_id": "johns-risk/scale-069",
+      "display_name": "scale-069",
+      "profile": "ise",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "ise-incident-response",
+        "ise-posture-audit"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-070",
+      "display_name": "scale-070",
+      "profile": "itential",
+      "state": "unreachable",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "itential-automation"
+      ],
+      "live": false,
+      "heartbeat_age_s": 99999
+    },
+    {
+      "member_id": "johns-risk/scale-071",
+      "display_name": "scale-071",
+      "profile": "netbox",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "netbox-reconcile"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-072",
+      "display_name": "scale-072",
+      "profile": "nmap",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "nmap-network-scan",
+        "nmap-scan-management",
+        "nmap-service-detection"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-073",
+      "display_name": "scale-073",
+      "profile": "nso",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "nso-device-ops",
+        "nso-service-mgmt"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-074",
+      "display_name": "scale-074",
+      "profile": "nvd",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "nvd-cve"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-075",
+      "display_name": "scale-075",
+      "profile": "packet",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "kubeshark-traffic",
+        "packet-analysis"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-076",
+      "display_name": "scale-076",
+      "profile": "paloalto",
+      "state": "active",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "fmc-firewall-ops",
+        "paloalto-panorama"
+      ],
+      "live": false,
+      "heartbeat_age_s": 300
+    },
+    {
+      "member_id": "johns-risk/scale-077",
+      "display_name": "scale-077",
+      "profile": "pyats",
+      "state": "provisioned",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 18,
+      "skills": [
+        "pyats-parallel-ops",
+        "pyats-health-check",
+        "pyats-troubleshoot",
+        "pyats-linux-system",
+        "pyats-f5-ltm",
+        "pyats-security",
+        "pyats-junos-interfaces",
+        "pyats-linux-network",
+        "pyats-junos-system",
+        "pyats-junos-routing",
+        "pyats-f5-platform",
+        "pyats-dynamic-test",
+        "pyats-network",
+        "pyats-asa-firewall",
+        "pyats-config-mgmt",
+        "pyats-routing",
+        "pyats-linux-vmware",
+        "pyats-topology"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-078",
+      "display_name": "scale-078",
+      "profile": "sdwan",
+      "state": "unreachable",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 5,
+      "skills": [
+        "prisma-sdwan-apps",
+        "prisma-sdwan-config",
+        "prisma-sdwan-status",
+        "prisma-sdwan-topology",
+        "sdwan-ops"
+      ],
+      "live": false,
+      "heartbeat_age_s": 99999
+    },
+    {
+      "member_id": "johns-risk/scale-079",
+      "display_name": "scale-079",
+      "profile": "suzieq",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "suzieq-observability"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-080",
+      "display_name": "scale-080",
+      "profile": "viz",
+      "state": "provisioned",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 8,
+      "skills": [
+        "ue5-network-viz",
+        "blender-3d-viz",
+        "threejs-network-viz",
+        "drawio-diagram",
+        "markmap-viz",
+        "canvas-network-viz",
+        "uml-diagram",
+        "aws-architecture-diagram"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-081",
+      "display_name": "scale-081",
+      "profile": "aap",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "aap-automation",
+        "aap-eda",
+        "aap-lint"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-082",
+      "display_name": "scale-082",
+      "profile": "aci",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "aci-change-deploy",
+        "aci-fabric-audit"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-083",
+      "display_name": "scale-083",
+      "profile": "azure",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "azure-network-ops",
+        "azure-security-audit"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-084",
+      "display_name": "scale-084",
+      "profile": "batfish",
+      "state": "active",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "batfish-config-analysis"
+      ],
+      "live": false,
+      "heartbeat_age_s": 300
+    },
+    {
+      "member_id": "johns-risk/scale-085",
+      "display_name": "scale-085",
+      "profile": "catalyst-center",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "catc-client-ops",
+        "catc-inventory",
+        "catc-troubleshoot"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-086",
+      "display_name": "scale-086",
+      "profile": "cml",
+      "state": "provisioned",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 5,
+      "skills": [
+        "cml-topology-builder",
+        "cml-node-operations",
+        "cml-packet-capture",
+        "cml-lab-lifecycle",
+        "cml-admin"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-087",
+      "display_name": "scale-087",
+      "profile": "containerlab",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "clab-lab-management"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-088",
+      "display_name": "scale-088",
+      "profile": "f5",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "f5-config-mgmt",
+        "f5-health-check",
+        "f5-troubleshoot"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-089",
+      "display_name": "scale-089",
+      "profile": "fortimanager",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "fortimanager-ops"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-090",
+      "display_name": "scale-090",
+      "profile": "forward",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "forward"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-091",
+      "display_name": "scale-091",
+      "profile": "fwrule",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "fwrule-analyzer"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-092",
+      "display_name": "scale-092",
+      "profile": "github",
+      "state": "active",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "github-ops"
+      ],
+      "live": false,
+      "heartbeat_age_s": 300
+    },
+    {
+      "member_id": "johns-risk/scale-093",
+      "display_name": "scale-093",
+      "profile": "gtrace",
+      "state": "unreachable",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "gtrace-ip-enrichment",
+        "gtrace-path-analysis"
+      ],
+      "live": false,
+      "heartbeat_age_s": 99999
+    },
+    {
+      "member_id": "johns-risk/scale-094",
+      "display_name": "scale-094",
+      "profile": "infoblox",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "infoblox-ddi"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-095",
+      "display_name": "scale-095",
+      "profile": "ipfabric",
+      "state": "provisioned",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "ipfabric"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-096",
+      "display_name": "scale-096",
+      "profile": "ise",
+      "state": "active",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "ise-incident-response",
+        "ise-posture-audit"
+      ],
+      "live": false,
+      "heartbeat_age_s": 300
+    },
+    {
+      "member_id": "johns-risk/scale-097",
+      "display_name": "scale-097",
+      "profile": "itential",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "itential-automation"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-098",
+      "display_name": "scale-098",
+      "profile": "netbox",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "netbox-reconcile"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/scale-099",
+      "display_name": "scale-099",
+      "profile": "nmap",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "nmap-network-scan",
+        "nmap-scan-management",
+        "nmap-service-detection"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "risk/1785077389894",
+      "display_name": null,
+      "profile": null,
+      "state": "unreachable",
+      "transport_binding": "edge-ws",
+      "node_type": "edge",
+      "specialty_count": 3,
+      "skills": [
+        "camera.capture",
+        "camera.record_video",
+        "audio.record"
+      ],
+      "live": false,
+      "heartbeat_age_s": 1742.2
+    },
+    {
+      "member_id": "risk/1785078347014",
+      "display_name": null,
+      "profile": null,
+      "state": "active",
+      "transport_binding": "edge-ws",
+      "node_type": "edge",
+      "specialty_count": 3,
+      "skills": [
+        "camera.capture",
+        "camera.record_video",
+        "audio.record"
+      ],
+      "live": true,
+      "heartbeat_age_s": 13.3
+    }
+  ],
+  "posture": {
+    "mode": "production",
+    "state": "enforced",
+    "controls": [
+      {
+        "name": "sandbox",
+        "kind": "containment",
+        "available": true,
+        "detail": "",
+        "probed_at": 1785179850.0359924
+      },
+      {
+        "name": "model-guard",
+        "kind": "containment",
+        "available": true,
+        "detail": "",
+        "probed_at": 1785179850.0359924
+      },
+      {
+        "name": "audit",
+        "kind": "audit",
+        "available": true,
+        "detail": "",
+        "probed_at": 1785179850.0359924
+      }
+    ],
+    "missing": [],
+    "strict_all": false,
+    "model": {
+      "primary": "anthropic/claude-opus-5",
+      "guarded": false
+    },
+    "channel_security": {
+      "mode": "on",
+      "by_trust_model": {
+        "legacy": 2,
+        "pinned": 3
+      },
+      "degraded": 2,
+      "amber": 0,
+      "red": 0,
+      "renewals_failing": 0,
+      "pq_mode": "opportunistic",
+      "pq_available": false,
+      "ech_available": false,
+      "channels_kex": []
+    },
+    "computed_at": 1785179850.0363233,
+    "summary": "production \u2014 enforced"
+  },
+  "gait": [
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 471,
+      "ts": "2026-07-27T18:57:50Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/cml",
+      "target": "cml-admin",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 470,
+      "ts": "2026-07-27T18:48:10Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 469,
+      "ts": "2026-07-27T18:35:43Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/cml",
+      "target": "cml-lab-lifecycle",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 468,
+      "ts": "2026-07-27T18:31:49Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/cml",
+      "target": "cml-lab-lifecycle",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 467,
+      "ts": "2026-07-27T18:30:32Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 466,
+      "ts": "2026-07-27T18:27:59Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 465,
+      "ts": "2026-07-27T18:03:35Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 464,
+      "ts": "2026-07-27T17:57:48Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 463,
+      "ts": "2026-07-27T17:33:32Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 462,
+      "ts": "2026-07-27T17:27:57Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 461,
+      "ts": "2026-07-27T17:21:48Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 460,
+      "ts": "2026-07-27T17:17:27Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 459,
+      "ts": "2026-07-27T17:03:31Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 458,
+      "ts": "2026-07-27T16:57:43Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 457,
+      "ts": "2026-07-27T16:33:30Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 456,
+      "ts": "2026-07-27T16:27:43Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 455,
+      "ts": "2026-07-27T16:03:36Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 454,
+      "ts": "2026-07-27T15:57:52Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 453,
+      "ts": "2026-07-27T15:33:32Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 452,
+      "ts": "2026-07-27T15:27:49Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 451,
+      "ts": "2026-07-27T15:03:35Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 450,
+      "ts": "2026-07-27T14:58:19Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 449,
+      "ts": "2026-07-27T14:33:08Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 448,
+      "ts": "2026-07-27T14:27:20Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 447,
+      "ts": "2026-07-27T14:03:24Z"
+    }
+  ],
+  "replicationJobs": [],
+  "edgeNodes": [
+    {
+      "member_id": "risk/1785077389894",
+      "display_name": null,
+      "profile": null,
+      "state": "unreachable",
+      "transport_binding": "edge-ws",
+      "node_type": "edge",
+      "specialty_count": 3,
+      "skills": [
+        "camera.capture",
+        "camera.record_video",
+        "audio.record"
+      ],
+      "live": false,
+      "heartbeat_age_s": 1742.2
+    },
+    {
+      "member_id": "risk/1785078347014",
+      "display_name": null,
+      "profile": null,
+      "state": "active",
+      "transport_binding": "edge-ws",
+      "node_type": "edge",
+      "specialty_count": 3,
+      "skills": [
+        "camera.capture",
+        "camera.record_video",
+        "audio.record"
+      ],
+      "live": true,
+      "heartbeat_age_s": 13.3
+    }
+  ],
+  "recentPushes": [
+    {
+      "id": 440,
+      "direction": "outbound",
+      "peer_identity": "risk/1785077389894",
+      "target_type": "edge_push",
+      "target_name": "text",
+      "request_id": null,
+      "decision": "pushed",
+      "outcome": "success",
+      "requested_at": "2026-07-26T21:01:23Z",
+      "completed_at": "2026-07-26T21:01:23Z",
+      "result_ref": null,
+      "gait_ref": null,
+      "channel_kind": "in2n",
+      "linked_record_id": null
+    },
+    {
+      "id": 423,
+      "direction": "outbound",
+      "peer_identity": "risk/1785077389894",
+      "target_type": "edge_push",
+      "target_name": "text",
+      "request_id": null,
+      "decision": "pushed",
+      "outcome": "success",
+      "requested_at": "2026-07-26T16:20:00Z",
+      "completed_at": "2026-07-26T16:20:00Z",
+      "result_ref": null,
+      "gait_ref": null,
+      "channel_kind": "in2n",
+      "linked_record_id": null
+    }
+  ],
+  "generatedAt": "2026-07-27T19:17:32.063Z"
+}

--- a/specs/072-hud-2-org-chart/fixtures/single.json
+++ b/specs/072-hud-2-org-chart/fixtures/single.json
@@ -1,0 +1,382 @@
+{
+  "available": true,
+  "identity": "as65001-4.4.4.4",
+  "peers": [],
+  "approvals": [],
+  "risk": {
+    "role": "border",
+    "risk_name": "johns-risk",
+    "description": null,
+    "enabled_stacks": "both",
+    "self_member_id": null,
+    "member_count": 29,
+    "members_active": 6
+  },
+  "members": [
+    {
+      "member_id": "johns-risk/cml",
+      "display_name": "cml",
+      "profile": "cml",
+      "state": "active",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 5,
+      "skills": [
+        "cml-topology-builder",
+        "cml-node-operations",
+        "cml-packet-capture",
+        "cml-lab-lifecycle",
+        "cml-admin"
+      ],
+      "live": true,
+      "heartbeat_age_s": null
+    }
+  ],
+  "posture": {
+    "mode": "production",
+    "state": "enforced",
+    "controls": [
+      {
+        "name": "sandbox",
+        "kind": "containment",
+        "available": true,
+        "detail": "",
+        "probed_at": 1785179850.0359924
+      },
+      {
+        "name": "model-guard",
+        "kind": "containment",
+        "available": true,
+        "detail": "",
+        "probed_at": 1785179850.0359924
+      },
+      {
+        "name": "audit",
+        "kind": "audit",
+        "available": true,
+        "detail": "",
+        "probed_at": 1785179850.0359924
+      }
+    ],
+    "missing": [],
+    "strict_all": false,
+    "model": {
+      "primary": "anthropic/claude-opus-5",
+      "guarded": false
+    },
+    "channel_security": {
+      "mode": "on",
+      "by_trust_model": {
+        "legacy": 2,
+        "pinned": 3
+      },
+      "degraded": 2,
+      "amber": 0,
+      "red": 0,
+      "renewals_failing": 0,
+      "pq_mode": "opportunistic",
+      "pq_available": false,
+      "ech_available": false,
+      "channels_kex": []
+    },
+    "computed_at": 1785179850.0363233,
+    "summary": "production \u2014 enforced"
+  },
+  "gait": [
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 471,
+      "ts": "2026-07-27T18:57:50Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/cml",
+      "target": "cml-admin",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 470,
+      "ts": "2026-07-27T18:48:10Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 469,
+      "ts": "2026-07-27T18:35:43Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/cml",
+      "target": "cml-lab-lifecycle",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 468,
+      "ts": "2026-07-27T18:31:49Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/cml",
+      "target": "cml-lab-lifecycle",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 467,
+      "ts": "2026-07-27T18:30:32Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 466,
+      "ts": "2026-07-27T18:27:59Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 465,
+      "ts": "2026-07-27T18:03:35Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 464,
+      "ts": "2026-07-27T17:57:48Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 463,
+      "ts": "2026-07-27T17:33:32Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 462,
+      "ts": "2026-07-27T17:27:57Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 461,
+      "ts": "2026-07-27T17:21:48Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 460,
+      "ts": "2026-07-27T17:17:27Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 459,
+      "ts": "2026-07-27T17:03:31Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 458,
+      "ts": "2026-07-27T16:57:43Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 457,
+      "ts": "2026-07-27T16:33:30Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 456,
+      "ts": "2026-07-27T16:27:43Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 455,
+      "ts": "2026-07-27T16:03:36Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 454,
+      "ts": "2026-07-27T15:57:52Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 453,
+      "ts": "2026-07-27T15:33:32Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 452,
+      "ts": "2026-07-27T15:27:49Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 451,
+      "ts": "2026-07-27T15:03:35Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 450,
+      "ts": "2026-07-27T14:58:19Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 449,
+      "ts": "2026-07-27T14:33:08Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 448,
+      "ts": "2026-07-27T14:27:20Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 447,
+      "ts": "2026-07-27T14:03:24Z"
+    }
+  ],
+  "replicationJobs": [],
+  "edgeNodes": [
+    {
+      "member_id": "risk/1785077389894",
+      "display_name": null,
+      "profile": null,
+      "state": "unreachable",
+      "transport_binding": "edge-ws",
+      "node_type": "edge",
+      "specialty_count": 3,
+      "skills": [
+        "camera.capture",
+        "camera.record_video",
+        "audio.record"
+      ],
+      "live": false,
+      "heartbeat_age_s": 1742.2
+    },
+    {
+      "member_id": "risk/1785078347014",
+      "display_name": null,
+      "profile": null,
+      "state": "active",
+      "transport_binding": "edge-ws",
+      "node_type": "edge",
+      "specialty_count": 3,
+      "skills": [
+        "camera.capture",
+        "camera.record_video",
+        "audio.record"
+      ],
+      "live": true,
+      "heartbeat_age_s": 13.3
+    }
+  ],
+  "recentPushes": [
+    {
+      "id": 440,
+      "direction": "outbound",
+      "peer_identity": "risk/1785077389894",
+      "target_type": "edge_push",
+      "target_name": "text",
+      "request_id": null,
+      "decision": "pushed",
+      "outcome": "success",
+      "requested_at": "2026-07-26T21:01:23Z",
+      "completed_at": "2026-07-26T21:01:23Z",
+      "result_ref": null,
+      "gait_ref": null,
+      "channel_kind": "in2n",
+      "linked_record_id": null
+    },
+    {
+      "id": 423,
+      "direction": "outbound",
+      "peer_identity": "risk/1785077389894",
+      "target_type": "edge_push",
+      "target_name": "text",
+      "request_id": null,
+      "decision": "pushed",
+      "outcome": "success",
+      "requested_at": "2026-07-26T16:20:00Z",
+      "completed_at": "2026-07-26T16:20:00Z",
+      "result_ref": null,
+      "gait_ref": null,
+      "channel_kind": "in2n",
+      "linked_record_id": null
+    }
+  ],
+  "generatedAt": "2026-07-27T19:17:32.063Z"
+}

--- a/specs/072-hud-2-org-chart/fixtures/uncategorised.json
+++ b/specs/072-hud-2-org-chart/fixtures/uncategorised.json
@@ -1,0 +1,5423 @@
+{
+  "available": true,
+  "identity": "as65001-4.4.4.4",
+  "peers": [
+    {
+      "identity": "as65003-3.3.3.3",
+      "display_name": "AB",
+      "state": "federated",
+      "chat_enabled": false,
+      "inventory_version": null,
+      "inventory_received_at": null,
+      "stale": null,
+      "inventory": null,
+      "channel_state": "unknown",
+      "last_seen": 0,
+      "endpoint_updated_at": null,
+      "in_flight_tasks": [],
+      "endpoint": null
+    },
+    {
+      "identity": "as65007-7.7.7.7",
+      "display_name": "Nicholas",
+      "state": "federated",
+      "chat_enabled": true,
+      "inventory_version": 1,
+      "inventory_received_at": "2026-07-18T17:04:37Z",
+      "stale": true,
+      "inventory": {
+        "inventory": {
+          "identity": "as65007-7.7.7.7",
+          "issued_at": "2026-07-18T17:04:36Z",
+          "version": 1,
+          "skills": [
+            {
+              "name": "aap-automation",
+              "description": "description: \"Red Hat Ansible Automation Platform \u2014 inventory management, job template execution, project SCM sync, ad-hoc commands, host management, Galaxy content discovery. Use when automating infr",
+              "invocable": true
+            },
+            {
+              "name": "aap-eda",
+              "description": "description: \"Event-Driven Ansible (EDA) \u2014 activation lifecycle, rulebook management, decision environments, event stream monitoring. Use when managing event-driven automation triggers, enabling/disab",
+              "invocable": true
+            },
+            {
+              "name": "aap-lint",
+              "description": "description: \"ansible-lint playbook and role validation \u2014 syntax checking, best practice enforcement, project-wide analysis, rule filtering. Use when validating Ansible playbooks, checking code qualit",
+              "invocable": true
+            },
+            {
+              "name": "aci-change-deploy",
+              "description": "description: \"Safe ACI policy change deployment - ServiceNow CR lifecycle, pre/post-change fault baselines, APIC policy application, automatic rollback on fault delta, and GAIT audit trail. Use when d",
+              "invocable": true
+            },
+            {
+              "name": "aci-fabric-audit",
+              "description": "description: \"Comprehensive Cisco ACI fabric health audit - node status, tenant/VRF/BD/EPG policy review, contract analysis, fault triage, and endpoint learning verification. Use when auditing ACI fab",
+              "invocable": true
+            },
+            {
+              "name": "arista-cvp",
+              "description": "description: \"Arista CloudVision Portal (CVP) automation via REST API \u2014 device inventory, events, connectivity monitoring, tag management (4 tools). Use when managing Arista devices, checking CloudVis",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-config",
+              "description": "description: \"View and manage Aruba CX switch configurations, perform ISSU upgrades, and firmware operations\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-interfaces",
+              "description": "description: \"Monitor Aruba CX switch interface status, LLDP neighbors, and optical transceiver health\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-switching",
+              "description": "description: \"View and manage Aruba CX switch VLANs and MAC address tables for Layer 2 operations\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-system",
+              "description": "description: \"Discover Aruba CX switch system information, firmware versions, and VSF topology\"",
+              "invocable": true
+            },
+            {
+              "name": "atlassian-itsm",
+              "description": "description: IT Service Management workflows using Jira for issue tracking and Confluence for documentation",
+              "invocable": true
+            },
+            {
+              "name": "aws-architecture-diagram",
+              "description": "description: \"AWS architecture diagrams \u2014 generate visual network topology diagrams from live AWS infrastructure. Use when drawing AWS network diagrams, visualizing VPCs, mapping Transit Gateway topol",
+              "invocable": true
+            },
+            {
+              "name": "aws-cloud-monitoring",
+              "description": "description: \"AWS CloudWatch monitoring \u2014 metrics, alarms, log queries, VPC flow log analysis, network performance. Use when checking AWS alarms, analyzing VPC flow logs, investigating network latency",
+              "invocable": true
+            },
+            {
+              "name": "aws-cost-ops",
+              "description": "description: \"AWS Cost Explorer \u2014 spending analysis, service breakdowns, forecasts, cost anomalies. Use when analyzing AWS spending, investigating cost spikes, reviewing network cost drivers like NAT ",
+              "invocable": true
+            },
+            {
+              "name": "aws-network-ops",
+              "description": "description: \"AWS cloud networking \u2014 VPC, Transit Gateway, Cloud WAN, VPN, Network Firewall, ENI, flow logs. Use when auditing AWS VPCs, troubleshooting connectivity between EC2 instances, checking Tr",
+              "invocable": true
+            },
+            {
+              "name": "aws-security-audit",
+              "description": "description: \"AWS security auditing \u2014 IAM users/roles/policies, CloudTrail API events, security posture analysis. Use when auditing IAM permissions, investigating security incidents, checking MFA comp",
+              "invocable": true
+            },
+            {
+              "name": "azure-network-ops",
+              "description": "description: \"Azure cloud networking -- VNets, NSGs, ExpressRoute, VPN Gateways, Azure Firewalls, Load Balancers, Application Gateways, Route Tables, Network Watcher, Private Endpoints, DNS zones. Use",
+              "invocable": true
+            },
+            {
+              "name": "azure-security-audit",
+              "description": "description: \"Azure NSG compliance auditing and security posture assessment. CIS Azure Foundations Benchmark rules, effective security rule analysis, orphaned NSG detection. Use when auditing Azure NS",
+              "invocable": true
+            },
+            {
+              "name": "batfish-config-analysis",
+              "description": "description: \"Batfish network configuration analysis -- pre-deployment validation, reachability testing, ACL/firewall tracing, differential analysis, compliance checking. Use when validating configs b",
+              "invocable": true
+            },
+            {
+              "name": "blender-3d-viz",
+              "description": "description: \"Create 3D network topology visualizations in Blender from CDP/LLDP neighbor data\"",
+              "invocable": true
+            },
+            {
+              "name": "browser-gui-inspect",
+              "description": "description: \"Controller-agnostic browser automation and inspection \u2014 navigate, read, click, fill, and capture network traffic on any web GUI using a persistent, manually-authenticated Chrome profile.",
+              "invocable": true
+            },
+            {
+              "name": "browser-viz-verify",
+              "description": "description: \"Verifies that a NetClaw-generated visualization HTML file (three.js, canvas, drawio, UML, markmap) actually renders correctly \u2014 screenshot, console-error check, and an optional Lighthous",
+              "invocable": true
+            },
+            {
+              "name": "canvas-network-viz",
+              "description": "description: \"Canvas/A2UI inline network visualizations \u2014 topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards rendered directly in the Ope",
+              "invocable": true
+            },
+            {
+              "name": "catc-client-ops",
+              "description": "description: \"Catalyst Center client operations and monitoring - list/filter wired and wireless clients, detailed client lookup by MAC, client count analytics, time-based analysis, SSID and band filte",
+              "invocable": true
+            },
+            {
+              "name": "catc-inventory",
+              "description": "description: \"Catalyst Center device inventory and site management - list/filter devices by hostname, IP, platform, family, role, reachability; view site hierarchy; get interface details per device; d",
+              "invocable": true
+            },
+            {
+              "name": "catc-troubleshoot",
+              "description": "description: \"Catalyst Center troubleshooting workflows - device unreachable investigation, client connectivity issues, interface down analysis, site-wide outage triage, wireless roaming problems, int",
+              "invocable": true
+            },
+            {
+              "name": "checkpoint",
+              "description": "A comprehensive skill for interacting with Check Point enterprise security infrastructure through 15 MCP servers.",
+              "invocable": true
+            },
+            {
+              "name": "clab-lab-management",
+              "description": "description: \"ContainerLab network lab lifecycle management \u2014 authenticate, list, deploy, inspect, execute commands on, and destroy containerized network labs via the ContainerLab API. Use when deploy",
+              "invocable": true
+            },
+            {
+              "name": "claroty-asset-inventory",
+              "description": "description: \"Discover and classify OT / IoT / IoMT assets via Claroty xDome. List devices by site, Purdue level, and device purpose; assign Purdue layers and custom attributes; cross-reference with N",
+              "invocable": true
+            },
+            {
+              "name": "claroty-ot-topology",
+              "description": "description: \"Render Claroty xDome OT / IoT communication maps and zone segmentation as inline Canvas/A2UI topology, draw.io diagrams, and timeline summaries.\"",
+              "invocable": true
+            },
+            {
+              "name": "claroty-risk-triage",
+              "description": "description: \"Triage Claroty xDome alerts and vulnerabilities, compute blast radius, correlate with NVD CVE data, and drive ITSM-gated workflow actions (acknowledge, label, assign, set relevance).\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-analytics",
+              "description": "description: \"Access Cloudflare traffic analytics, logs, and Radar global Internet insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-dns",
+              "description": "description: \"Manage Cloudflare DNS zones and records with analytics insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-security",
+              "description": "description: \"Monitor Cloudflare WAF, firewall events, audit logs, and threat intelligence.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-workers",
+              "description": "description: \"Monitor Cloudflare Workers deployments, bindings, and build insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-zerotrust",
+              "description": "description: \"Inspect Cloudflare Zero Trust access applications, policies, tunnels, and CASB findings.\"",
+              "invocable": true
+            },
+            {
+              "name": "cml-admin",
+              "description": "description: \"CML administration \u2014 user/group management, system info, licensing, resource monitoring. Use when creating CML users, checking license status, monitoring CML server resources, or auditin",
+              "invocable": true
+            },
+            {
+              "name": "cml-lab-lifecycle",
+              "description": "description: \"Cisco CML lab lifecycle management \u2014 create, start, stop, wipe, delete, clone, import/export labs. Use when building a network lab, starting or stopping a CML lab, cloning a topology, or",
+              "invocable": true
+            },
+            {
+              "name": "cml-node-operations",
+              "description": "description: \"CML node operations \u2014 start, stop, console access, CLI execution, config management, node details. Use when starting or stopping a CML node, running show commands on a lab router, settin",
+              "invocable": true
+            },
+            {
+              "name": "cml-packet-capture",
+              "description": "description: \"CML packet capture \u2014 start, stop, download pcaps from CML lab links, integrate with Packet Buddy for analysis. Use when capturing packets in a CML lab, troubleshooting BGP or OSPF with p",
+              "invocable": true
+            },
+            {
+              "name": "cml-topology-builder",
+              "description": "description: \"Build CML topologies \u2014 add nodes, create interfaces, wire links, set link conditioning, add annotations. Use when building a network topology in CML, adding routers or switches to a lab,",
+              "invocable": true
+            },
+            {
+              "name": "datadog-apm",
+              "description": "description: \"Analyze distributed traces and service performance in Datadog APM.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-incidents",
+              "description": "description: \"Manage incidents in Datadog Incident Management.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-logs",
+              "description": "description: \"Search and analyze logs in Datadog Log Management.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-metrics",
+              "description": "description: \"Query metrics and explore dashboards in Datadog.\"",
+              "invocable": true
+            },
+            {
+              "name": "defenseclaw-ops",
+              "description": "description: Manage DefenseClaw enterprise security - scan components, manage tool permissions, view alerts, configure guardrails",
+              "invocable": true
+            },
+            {
+              "name": "desktop-gui-inspect",
+              "description": "description: \"Full-desktop automation for targets that have no browser and no API at all \u2014 a legacy Java-based NMS client, a vendor's Windows-only configuration utility, a terminal emulator with no sc",
+              "invocable": true
+            },
+            {
+              "name": "devnet-catalyst-search",
+              "description": "description: Search Cisco Catalyst Center API documentation for device management and policy automation",
+              "invocable": true
+            },
+            {
+              "name": "devnet-meraki-search",
+              "description": "description: Search Cisco Meraki API documentation and lookup specific operations",
+              "invocable": true
+            },
+            {
+              "name": "drawio-diagram",
+              "description": "description: \"Generate draw.io network diagrams \u2014 native .drawio files with CLI export (PNG/SVG/PDF), plus browser-based Mermaid/XML/CSV via MCP server. Use when creating network topology diagrams, ge",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-build",
+              "description": "description: Build or rewire EVE-NG lab topology. Use when creating or deleting virtual networks, connecting node interfaces to networks, inspecting topology links, checking interface mappings, or lis",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-design",
+              "description": "description: Design EVE-NG lab topology and coordinate the design workflow. Use when the user asks for lab design, architecture advice, topology planning, design review, or a build plan, especially wh",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-discovery",
+              "description": "description: Gather missing requirements for EVE-NG topology design. Use when the request is vague or incomplete, when you need discovery questions, defaults, trade-off framing, image recommendations,",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-validation",
+              "description": "description: Validate EVE-NG topology designs and enforce final delivery structure. Use when reviewing a design, checking build readiness, producing the final design output, building an implementation",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-config-ops",
+              "description": "description: Manage EVE-NG startup configurations stored in lab files. Use when exporting configs natively into the lab, reading embedded startup configs, pushing startup config before boot, clearing ",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-console-ops",
+              "description": "description: Execute live CLI commands on running EVE-NG nodes over telnet console. Use when running show commands, making live config changes, verifying protocol state, testing connectivity, checking",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-lab-management",
+              "description": "description: Manage EVE-NG labs and platform inventory. Use when listing labs, checking lab metadata, creating or deleting labs, importing or exporting lab archives, checking EVE-NG health or auth, or",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-node-operations",
+              "description": "description: Manage EVE-NG node lifecycle. Use when listing nodes, checking runtime state, creating or deleting nodes, starting or stopping nodes or whole labs, verifying node details, or wiping node ",
+              "invocable": true
+            },
+            {
+              "name": "evpn-vxlan-fabric",
+              "description": "description: \"EVPN/VXLAN fabric audit and troubleshooting \u2014 VTEPs, VNIs, route types, multihoming, underlay/overlay validation. Use when troubleshooting VXLAN overlay reachability, auditing leaf-spine",
+              "invocable": true
+            },
+            {
+              "name": "f5-config-mgmt",
+              "description": "description: \"F5 BIG-IP configuration management - safe change workflow with baseline capture, planning, creation/update/deletion of virtual servers, pools, iRules, and profiles with full verification",
+              "invocable": true
+            },
+            {
+              "name": "f5-health-check",
+              "description": "description: \"F5 BIG-IP health monitoring - virtual server status, pool member health, log analysis, performance statistics, and systematic health assessment. Use when checking F5 load balancer health",
+              "invocable": true
+            },
+            {
+              "name": "f5-troubleshoot",
+              "description": "description: \"F5 BIG-IP troubleshooting - virtual server failures, pool member health, connection issues, SSL/TLS problems, iRule errors, persistence issues, and performance degradation. Use when a VI",
+              "invocable": true
+            },
+            {
+              "name": "fmc-firewall-ops",
+              "description": "description: \"Cisco Secure Firewall FMC \u2014 access policy search, rule inspection, FTD device targeting, multi-FMC profile management. Use when searching firewall rules by IP or FQDN, checking if host A",
+              "invocable": true
+            },
+            {
+              "name": "fortimanager-ops",
+              "description": "description: \"FortiManager operations \u2014 ADOM inventory, policy package review, object search, install preview, and compliance workflows. Use when auditing FortiGate firewall policies, reviewing ADOM p",
+              "invocable": true
+            },
+            {
+              "name": "forward",
+              "description": "description: Forward snapshot assurance, path search, app-aware path search, NQE, checks, vulnerabilities, diffs, configuration, lifecycle, collection, and topology workflows through the upstream forw",
+              "invocable": true
+            },
+            {
+              "name": "fwrule-analyzer",
+              "description": "description: \"Multi-vendor firewall rule analysis \u2014 overlap detection, shadowing, conflict identification, duplication checking across PAN-OS, ASA, FTD, IOS/IOS-XE, IOS-XR, Check Point, SRX, Junos, No",
+              "invocable": true
+            },
+            {
+              "name": "gait-session-tracking",
+              "description": "description: \"GAIT session lifecycle management - branch creation, turn recording, audit logging for every NetClaw operation. Use when starting a new NetClaw session, recording a health check or confi",
+              "invocable": true
+            },
+            {
+              "name": "gcp-cloud-logging",
+              "description": "description: \"Google Cloud Logging \u2014 log search, VPC flow logs, firewall logs, audit logs, log buckets and views. Use when searching GCP logs, investigating denied VPC flow traffic, checking who delet",
+              "invocable": true
+            },
+            {
+              "name": "gcp-cloud-monitoring",
+              "description": "description: \"Google Cloud Monitoring \u2014 time series metrics, alert policies, active alerts, metric discovery. Use when checking GCP network performance, investigating firing alerts, querying VM CPU or",
+              "invocable": true
+            },
+            {
+              "name": "gcp-compute-ops",
+              "description": "description: \"Google Cloud Compute Engine \u2014 VM instances, disks, templates, instance groups, reservations, project discovery. Use when listing GCP VMs, troubleshooting a Compute Engine instance, check",
+              "invocable": true
+            },
+            {
+              "name": "github-ops",
+              "description": "description: \"GitHub repository operations \u2014 issues, PRs, code search, and config-as-code workflows. Use when creating a GitHub issue for a network finding, opening a pull request for a config change,",
+              "invocable": true
+            },
+            {
+              "name": "gitlab-devops",
+              "description": "description: \"GitLab DevOps operations \u2014 issues, merge requests, CI/CD pipelines, repository browsing, labels, milestones, releases, and wiki management. Use when querying GitLab project status, monit",
+              "invocable": true
+            },
+            {
+              "name": "gnmi-telemetry",
+              "description": "description: \"gNMI streaming telemetry operations for multi-vendor network devices. Query device state via structured YANG model paths, subscribe to real-time telemetry streams, apply ITSM-gated confi",
+              "invocable": true
+            },
+            {
+              "name": "gns3-link-management",
+              "description": "description: \"Manage GNS3 links - connect/disconnect node interfaces, isolate nodes\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-node-operations",
+              "description": "description: \"Manage GNS3 nodes - add from templates, start/stop/suspend/reload, console access\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-packet-capture",
+              "description": "description: \"Capture network traffic on GNS3 links - start/stop captures, retrieve PCAP data\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-project-lifecycle",
+              "description": "description: \"Manage GNS3 network lab projects - create, open, close, delete, clone, export/import\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-snapshot-ops",
+              "description": "description: \"Manage GNS3 project snapshots - create, restore, delete for safe experimentation\"",
+              "invocable": true
+            },
+            {
+              "name": "grafana-observability",
+              "description": "description: \"Grafana observability platform \u2014 dashboards, Prometheus PromQL, Loki LogQL, alerting, incidents, OnCall schedules, annotations, datasource queries, panel rendering (75+ tools). Use when ",
+              "invocable": true
+            },
+            {
+              "name": "gtrace-ip-enrichment",
+              "description": "description: \"IP address enrichment \u2014 ASN ownership lookup, geolocation (city/region/country/coordinates), and reverse DNS resolution. Use when identifying who owns an IP address, locating an IP geogr",
+              "invocable": true
+            },
+            {
+              "name": "gtrace-path-analysis",
+              "description": "description: \"Network path tracing and monitoring \u2014 traceroute with MPLS/ECMP/NAT detection, continuous MTR monitoring, and distributed GlobalPing probes from 500+ worldwide locations. Use when tracin",
+              "invocable": true
+            },
+            {
+              "name": "humanrail-escalation",
+              "description": "description: \"Human-in-the-loop escalation via HumanRail \u2014 route low-confidence agent decisions, pre-destructive operation approvals, and ambiguous incident tickets to real human engineers. Human answ",
+              "invocable": true
+            },
+            {
+              "name": "infoblox-ddi",
+              "description": "description: \"Infoblox DDI operations \u2014 DNS zones/records, DHCP scopes and leases, IPAM networks and address utilization. Use when checking DNS records, validating IPAM address allocation, investigati",
+              "invocable": true
+            },
+            {
+              "name": "infrahub-sot",
+              "description": "description: \"OpsMill Infrahub \u2014 infrastructure source of truth with schema-driven nodes, GraphQL queries, and branch-isolated changes. Use when querying Infrahub for device/IPAM inventory, browsing i",
+              "invocable": true
+            },
+            {
+              "name": "ipfabric",
+              "description": "**Skill**: `/ipfabric`",
+              "invocable": true
+            },
+            {
+              "name": "ipfix-receiver",
+              "description": "description: \"Receive and query IPFIX and NetFlow flow records from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "ise-incident-response",
+              "description": "description: \"Rapid ISE endpoint investigation and quarantine workflow - endpoint lookup, auth history, posture review, human-authorized quarantine, ServiceNow Security Incident. Use when a SOC alert ",
+              "invocable": true
+            },
+            {
+              "name": "ise-posture-audit",
+              "description": "description: \"Cisco ISE posture and policy audit - authorization rules, posture compliance, profiling gaps, TrustSec SGT matrix, active session health. Use when running a periodic ISE compliance audit",
+              "invocable": true
+            },
+            {
+              "name": "itential-automation",
+              "description": "description: \"Itential Automation Platform (IAP) \u2014 network automation orchestration, device configuration management, compliance enforcement, workflow execution, golden config, lifecycle management, a",
+              "invocable": true
+            },
+            {
+              "name": "jenkins-cicd",
+              "description": "description: Jenkins CI/CD pipeline management \u2014 monitor builds, trigger pipelines, analyze logs, and track SCM changes for network automation workflows.",
+              "invocable": true
+            },
+            {
+              "name": "junos-network",
+              "description": "description: \"Juniper JunOS device automation via PyEZ/NETCONF \u2014 CLI execution, configuration management, Jinja2 template rendering, device facts, batch operations, config diff and rollback comparison",
+              "invocable": true
+            },
+            {
+              "name": "kubeshark-traffic",
+              "description": "description: \"Kubeshark Kubernetes traffic analysis \u2014 L4/L7 deep packet inspection, TLS decryption, pcap export, flow analysis, service mapping (6 tools). Use when capturing Kubernetes pod traffic, de",
+              "invocable": true
+            },
+            {
+              "name": "markmap-viz",
+              "description": "description: \"Create interactive mind map visualizations from markdown - network inventory, OSPF areas, BGP topology, security audit results. Use when visualizing network topology as a mind map, creat",
+              "invocable": true
+            },
+            {
+              "name": "memory",
+              "description": "**Purpose**: Provide persistent context across NetClaw sessions through structured facts, semantic search, and entity relationships.",
+              "invocable": true
+            },
+            {
+              "name": "mempalace",
+              "description": "description: \"MemPalace AI memory \u2014 persistent memory across sessions. Search past decisions, store architecture choices, track temporal network facts via knowledge graph, navigate cross-domain connec",
+              "invocable": true
+            },
+            {
+              "name": "meraki-monitoring",
+              "description": "description: \"Cisco Meraki Monitoring & Diagnostics \u2014 live ping, cable test, LED blink, wake-on-LAN, camera analytics, config change tracking. Use when running ping tests from Meraki devices, troubles",
+              "invocable": true
+            },
+            {
+              "name": "meraki-network-ops",
+              "description": "description: \"Cisco Meraki Dashboard \u2014 organization inventory, network management, device lifecycle, client discovery, action batches. Use when listing Meraki devices, managing networks, checking devi",
+              "invocable": true
+            },
+            {
+              "name": "meraki-security-appliance",
+              "description": "description: \"Cisco Meraki Security Appliance (MX) \u2014 firewall rules, site-to-site VPN, content filtering, traffic shaping, security events. Use when auditing Meraki MX firewall rules, troubleshooting ",
+              "invocable": true
+            },
+            {
+              "name": "meraki-switch-ops",
+              "description": "description: \"Cisco Meraki Switching \u2014 port configuration, VLANs, port status, ACLs, QoS rules, port cycling. Use when configuring Meraki switch ports, creating VLANs, checking port status and PoE, tr",
+              "invocable": true
+            },
+            {
+              "name": "meraki-wireless-ops",
+              "description": "description: \"Cisco Meraki Wireless \u2014 SSID management, RF profiles, channel utilization, signal quality, client connectivity events. Use when managing Meraki SSIDs, troubleshooting WiFi connectivity, ",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-files",
+              "description": "description: \"Manage files on OneDrive and SharePoint via Microsoft Graph API - upload, download, list, search, and organize network documentation and artifacts. Use when uploading reports to SharePoi",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-teams",
+              "description": "description: \"Send notifications and reports to Microsoft Teams channels via Graph API - alert delivery, report posting, incident updates, and diagram sharing. Use when posting health alerts to Teams,",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-visio",
+              "description": "description: \"Generate and manage Visio network diagrams on SharePoint via Microsoft Graph API - create topology diagrams from CDP/LLDP discovery, update existing diagrams, export to PDF. Use when cre",
+              "invocable": true
+            },
+            {
+              "name": "n2n-federation",
+              "description": "description: Federate your NetClaw with other NetClaw operators over the BGP mesh \u2014 exchange capability inventories and ask your claw what a peer can do. (US1; remote invocation and chat land in later",
+              "invocable": true
+            },
+            {
+              "name": "nautobot-sot",
+              "description": "description: \"Nautobot IPAM & source of truth \u2014 IP address queries, prefix lookups, VRF/tenant/site filtering, IPAM search, connection testing. Use when looking up IP addresses in Nautobot, checking s",
+              "invocable": true
+            },
+            {
+              "name": "netbox-reconcile",
+              "description": "description: \"Reconcile NetBox source of truth against live network state - detect IP drift, missing interfaces, undocumented links, cable mismatches, VLAN mismatches, and ticket discrepancies in Serv",
+              "invocable": true
+            },
+            {
+              "name": "nmap-network-scan",
+              "description": "description: \"Host discovery and port scanning using nmap \u2014 ICMP/ARP host discovery, SYN/TCP/UDP port scanning with scope enforcement and audit logging. Use when discovering live hosts on a subnet, sc",
+              "invocable": true
+            },
+            {
+              "name": "nmap-scan-management",
+              "description": "description: \"Custom nmap scans with arbitrary flags, plus scan history retrieval and management. Use when running nmap with custom flags, reviewing past scan results, comparing before/after scans, or",
+              "invocable": true
+            },
+            {
+              "name": "nmap-service-detection",
+              "description": "description: \"Service fingerprinting, OS detection, NSE script execution, and vulnerability scanning using nmap MCP. Use when identifying services on open ports, fingerprinting OS versions, running NS",
+              "invocable": true
+            },
+            {
+              "name": "nso-device-ops",
+              "description": "description: \"Cisco NSO device operations \u2014 config retrieval, state inspection, sync, platform info, NED IDs, device groups. Use when retrieving device configs from NSO, checking sync status, pulling ",
+              "invocable": true
+            },
+            {
+              "name": "nso-service-mgmt",
+              "description": "description: \"Cisco NSO service management \u2014 discover service types, list service instances, orchestrate network services. Use when listing NSO services, checking service health, auditing deployed ser",
+              "invocable": true
+            },
+            {
+              "name": "nvd-cve",
+              "description": "description: \"Search the National Vulnerability Database for CVEs - find vulnerabilities by keyword or ID, get CVSS scores, weaknesses, affected configurations, and remediation references. Use when lo",
+              "invocable": true
+            },
+            {
+              "name": "packet-analysis",
+              "description": "description: \"Analyze network packet captures (.pcap/.pcapng) using Packet Buddy MCP. Use when opening a pcap file, inspecting packet captures, troubleshooting network traffic, analyzing retransmissio",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-incidents",
+              "description": "description: \"Manage and investigate incidents in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-oncall",
+              "description": "description: \"Manage on-call schedules and escalation policies in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-orchestration",
+              "description": "description: \"Manage event orchestration and routing rules in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-services",
+              "description": "description: \"Manage service catalog and service health in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "paloalto-panorama",
+              "description": "description: \"Palo Alto Panorama operations \u2014 device groups, templates, security policy search, NAT review, commit status, and audit workflows. Use when searching Palo Alto firewall rules, checking if",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-apps",
+              "description": "description: \"View Prisma SD-WAN application definitions for policy visibility\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-config",
+              "description": "description: \"Inspect Prisma SD-WAN interfaces, routing (BGP, static), policies, and security zones\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-status",
+              "description": "description: \"Monitor Prisma SD-WAN element health, software versions, events, and alarms\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-topology",
+              "description": "description: \"Discover Prisma SD-WAN sites, ION elements, machines, and network topology\"",
+              "invocable": true
+            },
+            {
+              "name": "prometheus-monitoring",
+              "description": "description: \"Prometheus monitoring \u2014 PromQL instant/range queries, metric discovery, metadata, scrape target health, system health checks (6 tools). Use when querying Prometheus metrics, checking scr",
+              "invocable": true
+            },
+            {
+              "name": "protocol-participation",
+              "description": "description: \"Live BGP and OSPF control-plane participation \u2014 peer with real routers, inject/withdraw routes, query RIB/LSDB, adjust metrics, GRE tunnel status. Use when injecting or withdrawing BGP r",
+              "invocable": true
+            },
+            {
+              "name": "pyats-asa-firewall",
+              "description": "description: \"Cisco ASA firewall operations via pyATS \u2014 VPN sessions, failover state, interfaces, routing, service policies, resource usage, AnyConnect monitoring. Use when checking ASA failover statu",
+              "invocable": true
+            },
+            {
+              "name": "pyats-config-mgmt",
+              "description": "description: \"Network change management - pre-change baselines, configuration deployment, post-change verification, rollback procedures, and compliance validation. Use when pushing config to a device,",
+              "invocable": true
+            },
+            {
+              "name": "pyats-dynamic-test",
+              "description": "description: \"Generate and execute deterministic pyATS aetest validation scripts - interface state, OSPF neighbors, BGP paths, ping matrices, and custom compliance tests. Use when writing a network te",
+              "invocable": true
+            },
+            {
+              "name": "pyats-f5-ltm",
+              "description": "description: \"F5 BIG-IP LTM/GTM operations via pyATS iControl REST \u2014 virtual servers, pools, nodes, monitors, profiles, iRules, persistence, GTM wide IPs, DNS, data groups. Use when checking F5 virtua",
+              "invocable": true
+            },
+            {
+              "name": "pyats-f5-platform",
+              "description": "description: \"F5 BIG-IP platform operations via pyATS iControl REST \u2014 system, networking, HA/CM, auth, analytics, security, APM, live-update, ADC certs, file management. Use when checking BIG-IP syste",
+              "invocable": true
+            },
+            {
+              "name": "pyats-health-check",
+              "description": "description: \"Comprehensive network device health monitoring - CPU, memory, interfaces, hardware, NTP, logging, environment, and uptime analysis. Use when running a device health check, monitoring CPU",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-interfaces",
+              "description": "description: \"JunOS interface operations via pyATS \u2014 physical/logical interfaces, LACP, CoS, LLDP, ARP, BFD, IPv6 neighbors, traffic monitoring, optics diagnostics. Use when checking Juniper interface",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-routing",
+              "description": "description: \"JunOS routing operations via pyATS \u2014 OSPF/OSPFv3, BGP, route table, MPLS/LDP/RSVP, TED, PFE, ping, traceroute across Juniper devices. Use when checking Juniper OSPF neighbors, viewing BG",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-system",
+              "description": "description: \"JunOS system operations via pyATS \u2014 chassis health, hardware inventory, system info, NTP, SNMP, files/logs, firewall counters, DDoS protection, services accounting. Use when checking Jun",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-network",
+              "description": "description: \"Linux host network operations via pyATS \u2014 interface configuration, routing tables, network connections, and multi-table route inspection across fleet hosts. Use when checking Linux inter",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-system",
+              "description": "description: \"Linux host system operations via pyATS \u2014 process monitoring, filesystem inspection, Docker container stats, package/tool verification across fleet hosts. Use when checking running proces",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-vmware",
+              "description": "description: \"VMware ESXi host operations via pyATS \u2014 VM inventory, snapshot management, hypervisor inspection across ESXi hosts in the testbed. Use when listing VMs on ESXi, checking snapshot age, au",
+              "invocable": true
+            },
+            {
+              "name": "pyats-network",
+              "description": "description: \"Network device automation via pyATS - run show commands, ping, apply config, learn config/logging, list devices, run Linux commands, execute dynamic tests on Cisco IOS-XE/NX-OS devices. ",
+              "invocable": true
+            },
+            {
+              "name": "pyats-parallel-ops",
+              "description": "description: \"Fleet-wide parallel device operations - concurrent health checks, config audits, routing snapshots, severity-sorted reporting, and failure-isolated multi-device automation. Use when chec",
+              "invocable": true
+            },
+            {
+              "name": "pyats-routing",
+              "description": "description: \"CCIE-level routing protocol analysis - OSPF, BGP, EIGRP, IS-IS, static routes, RIB/FIB verification, redistribution audit, and convergence validation. Use when analyzing routing tables, ",
+              "invocable": true
+            },
+            {
+              "name": "pyats-security",
+              "description": "description: \"Network security audit - ACLs, AAA, control plane policing, management plane hardening, encryption, port security, and CIS benchmark checks. Use when auditing device security posture, ch",
+              "invocable": true
+            },
+            {
+              "name": "pyats-topology",
+              "description": "description: \"Network topology discovery via CDP/LLDP neighbors, ARP tables, routing peers, and interface mapping to build complete network maps. Use when mapping the network, building a diagram, disc",
+              "invocable": true
+            },
+            {
+              "name": "pyats-troubleshoot",
+              "description": "description: \"Systematic network troubleshooting - connectivity, routing, interface, protocol, and performance issues using structured OSI-layer and divide-and-conquer methodology. Use when something ",
+              "invocable": true
+            },
+            {
+              "name": "radkit-remote-access",
+              "description": "description: \"Cisco RADKit \u2014 cloud-relayed remote device access, CLI execution, SNMP polling, device inventory discovery, attribute inspection. Use when accessing remote network devices through a clou",
+              "invocable": true
+            },
+            {
+              "name": "rag",
+              "description": "**Purpose**: Give NetClaw a fully offline, user-curated document knowledge base \u2014 vendor guides, standards (RFC/IEEE/vendor), customer design documents, install guides \u2014 with agentic retrieval, mandat",
+              "invocable": true
+            },
+            {
+              "name": "rfc-lookup",
+              "description": "description: \"Search and retrieve IETF RFC documents - lookup by number, search by keyword, extract sections. Use when looking up an RFC, checking protocol specifications, verifying standards complian",
+              "invocable": true
+            },
+            {
+              "name": "sdwan-ops",
+              "description": "description: \"Cisco SD-WAN vManage read-only operations \u2014 fabric devices, WAN Edge inventory, templates, policies, alarms, events, interface stats, BFD sessions, OMP routes, control connections, runni",
+              "invocable": true
+            },
+            {
+              "name": "servicenow-change-workflow",
+              "description": "description: \"Full ITSM-gated change lifecycle - CR creation, pre-change incident validation, approval gate, execution via pyats-config-mgmt, post-change verification, and closure with GAIT audit trai",
+              "invocable": true
+            },
+            {
+              "name": "slack-incident-workflow",
+              "description": "description: \"Manage network incident response workflows in Slack - incident channels, status updates, escalation, resolution tracking, and post-incident review coordination. Use when declaring a netw",
+              "invocable": true
+            },
+            {
+              "name": "slack-network-alerts",
+              "description": "description: \"Format and deliver network alerts, health warnings, and critical notifications via Slack with rich formatting, reactions, and file attachments. Use when sending alerts to Slack, posting ",
+              "invocable": true
+            },
+            {
+              "name": "slack-report-delivery",
+              "description": "description: \"Deliver formatted network reports, audit results, topology diagrams, and compliance documentation to Slack channels with rich Block Kit formatting. Use when posting a health check report",
+              "invocable": true
+            },
+            {
+              "name": "slack-user-context",
+              "description": "description: \"Leverage Slack user profiles, presence, DND status, and workspace context to personalize responses, route escalations, and coordinate team operations. Use when checking who is on-call, r",
+              "invocable": true
+            },
+            {
+              "name": "slack-voice-interface",
+              "description": "description: \"Respond to Slack voice clips with both text and an MP3 voice reply using edge-tts. Voice IN is already handled by OpenClaw transcription. Use when a user sends a voice message in Slack, ",
+              "invocable": true
+            },
+            {
+              "name": "snmptrap-receiver",
+              "description": "description: \"Receive and query SNMP traps from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-indexes",
+              "description": "description: \"Discover and inspect Splunk indexes and configuration.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-saved",
+              "description": "description: \"Manage and run saved searches in Splunk.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-search",
+              "description": "description: \"Execute and validate SPL (Search Processing Language) queries.\"",
+              "invocable": true
+            },
+            {
+              "name": "subnet-calculator",
+              "description": "description: \"IPv4 and IPv6 subnet calculator - CIDR breakdown, usable hosts, previous/next subnets, address classification, VLSM planning, and dual-stack analysis. Use when calculating subnets, figur",
+              "invocable": true
+            },
+            {
+              "name": "suzieq-observability",
+              "description": "description: \"SuzieQ network observability \u2014 query current and historical network state, run validation assertions, get summary statistics, trace forwarding paths, and discover unique values across 20",
+              "invocable": true
+            },
+            {
+              "name": "syslog-receiver",
+              "description": "description: \"Receive and query syslog messages from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "te-network-monitoring",
+              "description": "description: \"Cisco ThousandEyes \u2014 test management, agent inventory, test results, dashboards, path visualization, user/account management. Use when checking ThousandEyes test results, viewing network",
+              "invocable": true
+            },
+            {
+              "name": "te-path-analysis",
+              "description": "description: \"Cisco ThousandEyes \u2014 path visualization, BGP route analysis, outage investigation, instant tests, endpoint agent diagnostics. Use when tracing network paths hop-by-hop, investigating why",
+              "invocable": true
+            },
+            {
+              "name": "telemetry-ops",
+              "description": "description: \"Comprehensive network telemetry and event collection across multiple protocols.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-operations",
+              "description": "description: \"Execute local Terraform operations with ServiceNow change control.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-registry",
+              "description": "description: \"Discover providers and modules from the Terraform Registry.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-workspaces",
+              "description": "description: \"Manage HCP Terraform (Terraform Cloud/Enterprise) workspaces.\"",
+              "invocable": true
+            },
+            {
+              "name": "threejs-network-viz",
+              "description": "**Version**: 1.0.0",
+              "invocable": true
+            },
+            {
+              "name": "token-tracker",
+              "description": "description: \"Track and display token consumption and cost for every NetClaw interaction.\"",
+              "invocable": true
+            },
+            {
+              "name": "twilio-daily-briefing",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-emergency-call",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-inbound-voice",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-outbound-call",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twitter-check",
+              "description": "**Purpose**: Quick invocation to check mentions and respond to #netclaw threads.",
+              "invocable": true
+            },
+            {
+              "name": "twitter-heartbeat",
+              "description": "**Purpose**: Autonomous periodic tweeting AND mention monitoring to maintain NetClaw's Twitter presence with CCIE-level network engineering content.",
+              "invocable": true
+            },
+            {
+              "name": "twitter-respond",
+              "description": "**Skill ID**: twitter-respond",
+              "invocable": true
+            },
+            {
+              "name": "twitter-share",
+              "description": "**Purpose**: Manual tweet posting with content guardrails and human approval flow.",
+              "invocable": true
+            },
+            {
+              "name": "ue5-network-viz",
+              "description": "description: \"3D network topology visualization and interactive digital twin in Unreal Engine 5.8 via the built-in UE5 MCP server.\"",
+              "invocable": true
+            },
+            {
+              "name": "uml-diagram",
+              "description": "description: \"UML and diagram generation via Kroki \u2014 class, sequence, activity, state, component, deployment, network, ER, C4, Mermaid, D2, Graphviz, BPMN, 27+ types. Use when generating a network dia",
+              "invocable": true
+            },
+            {
+              "name": "vault-mounts",
+              "description": "description: \"Discover and manage HashiCorp Vault secret engine mounts.\"",
+              "invocable": true
+            },
+            {
+              "name": "vault-pki",
+              "description": "description: \"Manage HashiCorp Vault PKI certificate infrastructure.\"",
+              "invocable": true
+            },
+            {
+              "name": "vault-secrets",
+              "description": "description: \"Manage HashiCorp Vault KV secrets with strict value protection.\"",
+              "invocable": true
+            },
+            {
+              "name": "webex-incident-workflow",
+              "description": "description: \"Manage network incident response workflows in Cisco WebEx - incident spaces, status updates, escalation, resolution tracking, and post-incident review coordination. Use when declaring a ",
+              "invocable": true
+            },
+            {
+              "name": "webex-network-alerts",
+              "description": "description: \"Format and deliver network alerts, health warnings, and critical notifications via Cisco WebEx with Adaptive Cards, markdown formatting, and file attachments. Use when sending alerts to ",
+              "invocable": true
+            },
+            {
+              "name": "webex-report-delivery",
+              "description": "description: \"Deliver formatted network reports, audit results, topology diagrams, and compliance documentation to WebEx spaces with Adaptive Cards and markdown formatting. Use when posting a health c",
+              "invocable": true
+            },
+            {
+              "name": "webex-user-context",
+              "description": "description: \"Leverage WebEx user profiles, presence status, and workspace context to personalize responses, route escalations, and coordinate team operations. Use when checking who is available, rout",
+              "invocable": true
+            },
+            {
+              "name": "webex-voice-interface",
+              "description": "description: \"Respond to WebEx voice clips with both text and an MP3 voice reply using edge-tts. Voice IN is already handled by OpenClaw transcription. Use when a user sends a voice message in WebEx, ",
+              "invocable": true
+            },
+            {
+              "name": "wikipedia-research",
+              "description": "description: \"Research networking protocols, standards history, and technology context via Wikipedia - OSPF, BGP, MPLS, 802.1X, VXLAN, and more. Use when looking up protocol background, researching ho",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-identity",
+              "description": "description: \"Manage users, groups, departments, and identity provider configurations.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-insights",
+              "description": "description: \"Access analytics, threat intelligence, and security event data.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zdx",
+              "description": "description: \"Monitor digital experience scores, user performance, and application health.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zia",
+              "description": "description: \"Manage Zscaler Internet Access firewall rules, URL filtering, DLP, and security policies.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zpa",
+              "description": "description: \"Manage Zscaler Private Access applications, segments, policies, and connectors.\"",
+              "invocable": true
+            }
+          ],
+          "mcp_servers": [
+            {
+              "name": "forward-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "suzieq-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "batfish-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gnmi-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "azure-network-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gitlab-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chrome-devtools-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chrome-devtools-mcp-visible",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "jenkins-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "atlassian-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gns3-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "prisma-sdwan-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "datadog-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "pagerduty-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "splunk-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "infrahub-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "terraform-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "vault-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "zscaler-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-dns-analytics",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-security",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-zerotrust",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-analytics",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-workers",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "blender-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aruba-cx-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "devnet-content-search",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-golden-config-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-routing-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-management",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-management-logs",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-threat-prevention",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-https-inspection",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-harmony-sase",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-reputation-service",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-quantum-gw-cli",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-gw-connection-analysis",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-threat-emulation",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-quantum-gaia",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-documentation",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-spark-management",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-cpinfo-analysis",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-argos-erm",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-policy-insights",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "claroty-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twitter-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twilio-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twilio-voice-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "unreal-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "sketchfab-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "n2n-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "rag-mcp",
+              "tools": [],
+              "invocable_tools": []
+            }
+          ],
+          "badges": [
+            "Azure",
+            "Batfish",
+            "Check Point",
+            "Forward",
+            "GNS3",
+            "Nautobot",
+            "SuzieQ",
+            "gNMI"
+          ],
+          "posture": {
+            "mode": "testing",
+            "state": "unknown",
+            "summary": "testing",
+            "controls": {}
+          },
+          "llm": {
+            "primary_model": "anthropic/claude-sonnet-4-6",
+            "guarded": false
+          }
+        },
+        "received_at": "2026-07-18T17:04:37Z",
+        "stale": true
+      },
+      "channel_state": "unreachable",
+      "last_seen": 0,
+      "endpoint_updated_at": null,
+      "in_flight_tasks": [],
+      "endpoint": null
+    },
+    {
+      "identity": "as65007-8.8.8.8",
+      "display_name": "Hermes",
+      "state": "severed",
+      "chat_enabled": false,
+      "inventory_version": null,
+      "inventory_received_at": null,
+      "stale": null,
+      "inventory": null,
+      "channel_state": "unknown",
+      "last_seen": 0,
+      "endpoint_updated_at": null,
+      "in_flight_tasks": [],
+      "endpoint": null
+    },
+    {
+      "identity": "as65008-8.8.8.8",
+      "display_name": "Hermes",
+      "state": "federated",
+      "chat_enabled": false,
+      "inventory_version": 3,
+      "inventory_received_at": "2026-07-23T00:34:20Z",
+      "stale": true,
+      "inventory": {
+        "inventory": {
+          "identity": "as65008-8.8.8.8",
+          "issued_at": "2026-07-23T00:34:13Z",
+          "version": 3,
+          "skills": [
+            {
+              "name": "aap-automation",
+              "description": "description: \"Red Hat Ansible Automation Platform \u2014 inventory management, job template execution, project SCM sync, ad-hoc commands, host management, Galaxy content discovery. Use when automating infr",
+              "invocable": true
+            },
+            {
+              "name": "aap-eda",
+              "description": "description: \"Event-Driven Ansible (EDA) \u2014 activation lifecycle, rulebook management, decision environments, event stream monitoring. Use when managing event-driven automation triggers, enabling/disab",
+              "invocable": true
+            },
+            {
+              "name": "aap-lint",
+              "description": "description: \"ansible-lint playbook and role validation \u2014 syntax checking, best practice enforcement, project-wide analysis, rule filtering. Use when validating Ansible playbooks, checking code qualit",
+              "invocable": true
+            },
+            {
+              "name": "aci-change-deploy",
+              "description": "description: \"Safe ACI policy change deployment - ServiceNow CR lifecycle, pre/post-change fault baselines, APIC policy application, automatic rollback on fault delta, and GAIT audit trail. Use when d",
+              "invocable": true
+            },
+            {
+              "name": "aci-fabric-audit",
+              "description": "description: \"Comprehensive Cisco ACI fabric health audit - node status, tenant/VRF/BD/EPG policy review, contract analysis, fault triage, and endpoint learning verification. Use when auditing ACI fab",
+              "invocable": true
+            },
+            {
+              "name": "arista-cvp",
+              "description": "description: \"Arista CloudVision Portal (CVP) automation via REST API \u2014 device inventory, events, connectivity monitoring, tag management (4 tools). Use when managing Arista devices, checking CloudVis",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-config",
+              "description": "description: \"View and manage Aruba CX switch configurations, perform ISSU upgrades, and firmware operations\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-interfaces",
+              "description": "description: \"Monitor Aruba CX switch interface status, LLDP neighbors, and optical transceiver health\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-switching",
+              "description": "description: \"View and manage Aruba CX switch VLANs and MAC address tables for Layer 2 operations\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-system",
+              "description": "description: \"Discover Aruba CX switch system information, firmware versions, and VSF topology\"",
+              "invocable": true
+            },
+            {
+              "name": "atlassian-itsm",
+              "description": "description: IT Service Management workflows using Jira for issue tracking and Confluence for documentation",
+              "invocable": true
+            },
+            {
+              "name": "aws-architecture-diagram",
+              "description": "description: \"AWS architecture diagrams \u2014 generate visual network topology diagrams from live AWS infrastructure. Use when drawing AWS network diagrams, visualizing VPCs, mapping Transit Gateway topol",
+              "invocable": true
+            },
+            {
+              "name": "aws-cloud-monitoring",
+              "description": "description: \"AWS CloudWatch monitoring \u2014 metrics, alarms, log queries, VPC flow log analysis, network performance. Use when checking AWS alarms, analyzing VPC flow logs, investigating network latency",
+              "invocable": true
+            },
+            {
+              "name": "aws-cost-ops",
+              "description": "description: \"AWS Cost Explorer \u2014 spending analysis, service breakdowns, forecasts, cost anomalies. Use when analyzing AWS spending, investigating cost spikes, reviewing network cost drivers like NAT ",
+              "invocable": true
+            },
+            {
+              "name": "aws-network-ops",
+              "description": "description: \"AWS cloud networking \u2014 VPC, Transit Gateway, Cloud WAN, VPN, Network Firewall, ENI, flow logs. Use when auditing AWS VPCs, troubleshooting connectivity between EC2 instances, checking Tr",
+              "invocable": true
+            },
+            {
+              "name": "aws-security-audit",
+              "description": "description: \"AWS security auditing \u2014 IAM users/roles/policies, CloudTrail API events, security posture analysis. Use when auditing IAM permissions, investigating security incidents, checking MFA comp",
+              "invocable": true
+            },
+            {
+              "name": "azure-network-ops",
+              "description": "description: \"Azure cloud networking -- VNets, NSGs, ExpressRoute, VPN Gateways, Azure Firewalls, Load Balancers, Application Gateways, Route Tables, Network Watcher, Private Endpoints, DNS zones. Use",
+              "invocable": true
+            },
+            {
+              "name": "azure-security-audit",
+              "description": "description: \"Azure NSG compliance auditing and security posture assessment. CIS Azure Foundations Benchmark rules, effective security rule analysis, orphaned NSG detection. Use when auditing Azure NS",
+              "invocable": true
+            },
+            {
+              "name": "batfish-config-analysis",
+              "description": "description: \"Batfish network configuration analysis -- pre-deployment validation, reachability testing, ACL/firewall tracing, differential analysis, compliance checking. Use when validating configs b",
+              "invocable": true
+            },
+            {
+              "name": "blender-3d-viz",
+              "description": "description: \"Create 3D network topology visualizations in Blender from CDP/LLDP neighbor data\"",
+              "invocable": true
+            },
+            {
+              "name": "browser-gui-inspect",
+              "description": "description: \"Controller-agnostic browser automation and inspection \u2014 navigate, read, click, fill, and capture network traffic on any web GUI using a persistent, manually-authenticated Chrome profile.",
+              "invocable": true
+            },
+            {
+              "name": "browser-viz-verify",
+              "description": "description: \"Verifies that a NetClaw-generated visualization HTML file (three.js, canvas, drawio, UML, markmap) actually renders correctly \u2014 screenshot, console-error check, and an optional Lighthous",
+              "invocable": true
+            },
+            {
+              "name": "canvas-network-viz",
+              "description": "description: \"Canvas/A2UI inline network visualizations \u2014 topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards rendered directly in the Ope",
+              "invocable": true
+            },
+            {
+              "name": "catc-client-ops",
+              "description": "description: \"Catalyst Center client operations and monitoring - list/filter wired and wireless clients, detailed client lookup by MAC, client count analytics, time-based analysis, SSID and band filte",
+              "invocable": true
+            },
+            {
+              "name": "catc-inventory",
+              "description": "description: \"Catalyst Center device inventory and site management - list/filter devices by hostname, IP, platform, family, role, reachability; view site hierarchy; get interface details per device; d",
+              "invocable": true
+            },
+            {
+              "name": "catc-troubleshoot",
+              "description": "description: \"Catalyst Center troubleshooting workflows - device unreachable investigation, client connectivity issues, interface down analysis, site-wide outage triage, wireless roaming problems, int",
+              "invocable": true
+            },
+            {
+              "name": "checkpoint",
+              "description": "A comprehensive skill for interacting with Check Point enterprise security infrastructure through 15 MCP servers.",
+              "invocable": true
+            },
+            {
+              "name": "clab-lab-management",
+              "description": "description: \"ContainerLab network lab lifecycle management \u2014 authenticate, list, deploy, inspect, execute commands on, and destroy containerized network labs via the ContainerLab API. Use when deploy",
+              "invocable": true
+            },
+            {
+              "name": "claroty-asset-inventory",
+              "description": "description: \"Discover and classify OT / IoT / IoMT assets via Claroty xDome. List devices by site, Purdue level, and device purpose; assign Purdue layers and custom attributes; cross-reference with N",
+              "invocable": true
+            },
+            {
+              "name": "claroty-ot-topology",
+              "description": "description: \"Render Claroty xDome OT / IoT communication maps and zone segmentation as inline Canvas/A2UI topology, draw.io diagrams, and timeline summaries.\"",
+              "invocable": true
+            },
+            {
+              "name": "claroty-risk-triage",
+              "description": "description: \"Triage Claroty xDome alerts and vulnerabilities, compute blast radius, correlate with NVD CVE data, and drive ITSM-gated workflow actions (acknowledge, label, assign, set relevance).\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-analytics",
+              "description": "description: \"Access Cloudflare traffic analytics, logs, and Radar global Internet insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-dns",
+              "description": "description: \"Manage Cloudflare DNS zones and records with analytics insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-security",
+              "description": "description: \"Monitor Cloudflare WAF, firewall events, audit logs, and threat intelligence.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-workers",
+              "description": "description: \"Monitor Cloudflare Workers deployments, bindings, and build insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-zerotrust",
+              "description": "description: \"Inspect Cloudflare Zero Trust access applications, policies, tunnels, and CASB findings.\"",
+              "invocable": true
+            },
+            {
+              "name": "cml-admin",
+              "description": "description: \"CML administration \u2014 user/group management, system info, licensing, resource monitoring. Use when creating CML users, checking license status, monitoring CML server resources, or auditin",
+              "invocable": true
+            },
+            {
+              "name": "cml-lab-lifecycle",
+              "description": "description: \"Cisco CML lab lifecycle management \u2014 create, start, stop, wipe, delete, clone, import/export labs. Use when building a network lab, starting or stopping a CML lab, cloning a topology, or",
+              "invocable": true
+            },
+            {
+              "name": "cml-node-operations",
+              "description": "description: \"CML node operations \u2014 start, stop, console access, CLI execution, config management, node details. Use when starting or stopping a CML node, running show commands on a lab router, settin",
+              "invocable": true
+            },
+            {
+              "name": "cml-packet-capture",
+              "description": "description: \"CML packet capture \u2014 start, stop, download pcaps from CML lab links, integrate with Packet Buddy for analysis. Use when capturing packets in a CML lab, troubleshooting BGP or OSPF with p",
+              "invocable": true
+            },
+            {
+              "name": "cml-topology-builder",
+              "description": "description: \"Build CML topologies \u2014 add nodes, create interfaces, wire links, set link conditioning, add annotations. Use when building a network topology in CML, adding routers or switches to a lab,",
+              "invocable": true
+            },
+            {
+              "name": "datadog-apm",
+              "description": "description: \"Analyze distributed traces and service performance in Datadog APM.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-incidents",
+              "description": "description: \"Manage incidents in Datadog Incident Management.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-logs",
+              "description": "description: \"Search and analyze logs in Datadog Log Management.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-metrics",
+              "description": "description: \"Query metrics and explore dashboards in Datadog.\"",
+              "invocable": true
+            },
+            {
+              "name": "defenseclaw-ops",
+              "description": "description: Manage DefenseClaw enterprise security - scan components, manage tool permissions, view alerts, configure guardrails",
+              "invocable": true
+            },
+            {
+              "name": "desktop-gui-inspect",
+              "description": "description: \"Full-desktop automation for targets that have no browser and no API at all \u2014 a legacy Java-based NMS client, a vendor's Windows-only configuration utility, a terminal emulator with no sc",
+              "invocable": true
+            },
+            {
+              "name": "devnet-catalyst-search",
+              "description": "description: Search Cisco Catalyst Center API documentation for device management and policy automation",
+              "invocable": true
+            },
+            {
+              "name": "devnet-meraki-search",
+              "description": "description: Search Cisco Meraki API documentation and lookup specific operations",
+              "invocable": true
+            },
+            {
+              "name": "drawio-diagram",
+              "description": "description: \"Generate draw.io network diagrams \u2014 native .drawio files with CLI export (PNG/SVG/PDF), plus browser-based Mermaid/XML/CSV via MCP server. Use when creating network topology diagrams, ge",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-build",
+              "description": "description: Build or rewire EVE-NG lab topology. Use when creating or deleting virtual networks, connecting node interfaces to networks, inspecting topology links, checking interface mappings, or lis",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-design",
+              "description": "description: Design EVE-NG lab topology and coordinate the design workflow. Use when the user asks for lab design, architecture advice, topology planning, design review, or a build plan, especially wh",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-discovery",
+              "description": "description: Gather missing requirements for EVE-NG topology design. Use when the request is vague or incomplete, when you need discovery questions, defaults, trade-off framing, image recommendations,",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-validation",
+              "description": "description: Validate EVE-NG topology designs and enforce final delivery structure. Use when reviewing a design, checking build readiness, producing the final design output, building an implementation",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-config-ops",
+              "description": "description: Manage EVE-NG startup configurations stored in lab files. Use when exporting configs natively into the lab, reading embedded startup configs, pushing startup config before boot, clearing ",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-console-ops",
+              "description": "description: Execute live CLI commands on running EVE-NG nodes over telnet console. Use when running show commands, making live config changes, verifying protocol state, testing connectivity, checking",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-lab-management",
+              "description": "description: Manage EVE-NG labs and platform inventory. Use when listing labs, checking lab metadata, creating or deleting labs, importing or exporting lab archives, checking EVE-NG health or auth, or",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-node-operations",
+              "description": "description: Manage EVE-NG node lifecycle. Use when listing nodes, checking runtime state, creating or deleting nodes, starting or stopping nodes or whole labs, verifying node details, or wiping node ",
+              "invocable": true
+            },
+            {
+              "name": "evpn-vxlan-fabric",
+              "description": "description: \"EVPN/VXLAN fabric audit and troubleshooting \u2014 VTEPs, VNIs, route types, multihoming, underlay/overlay validation. Use when troubleshooting VXLAN overlay reachability, auditing leaf-spine",
+              "invocable": true
+            },
+            {
+              "name": "f5-config-mgmt",
+              "description": "description: \"F5 BIG-IP configuration management - safe change workflow with baseline capture, planning, creation/update/deletion of virtual servers, pools, iRules, and profiles with full verification",
+              "invocable": true
+            },
+            {
+              "name": "f5-health-check",
+              "description": "description: \"F5 BIG-IP health monitoring - virtual server status, pool member health, log analysis, performance statistics, and systematic health assessment. Use when checking F5 load balancer health",
+              "invocable": true
+            },
+            {
+              "name": "f5-troubleshoot",
+              "description": "description: \"F5 BIG-IP troubleshooting - virtual server failures, pool member health, connection issues, SSL/TLS problems, iRule errors, persistence issues, and performance degradation. Use when a VI",
+              "invocable": true
+            },
+            {
+              "name": "fmc-firewall-ops",
+              "description": "description: \"Cisco Secure Firewall FMC \u2014 access policy search, rule inspection, FTD device targeting, multi-FMC profile management. Use when searching firewall rules by IP or FQDN, checking if host A",
+              "invocable": true
+            },
+            {
+              "name": "fortimanager-ops",
+              "description": "description: \"FortiManager operations \u2014 ADOM inventory, policy package review, object search, install preview, and compliance workflows. Use when auditing FortiGate firewall policies, reviewing ADOM p",
+              "invocable": true
+            },
+            {
+              "name": "forward",
+              "description": "description: Forward snapshot assurance, path search, app-aware path search, NQE, checks, vulnerabilities, diffs, configuration, lifecycle, collection, and topology workflows through the upstream forw",
+              "invocable": true
+            },
+            {
+              "name": "fwrule-analyzer",
+              "description": "description: \"Multi-vendor firewall rule analysis \u2014 overlap detection, shadowing, conflict identification, duplication checking across PAN-OS, ASA, FTD, IOS/IOS-XE, IOS-XR, Check Point, SRX, Junos, No",
+              "invocable": true
+            },
+            {
+              "name": "gait-session-tracking",
+              "description": "description: \"GAIT session lifecycle management - branch creation, turn recording, audit logging for every NetClaw operation. Use when starting a new NetClaw session, recording a health check or confi",
+              "invocable": true
+            },
+            {
+              "name": "gcp-cloud-logging",
+              "description": "description: \"Google Cloud Logging \u2014 log search, VPC flow logs, firewall logs, audit logs, log buckets and views. Use when searching GCP logs, investigating denied VPC flow traffic, checking who delet",
+              "invocable": true
+            },
+            {
+              "name": "gcp-cloud-monitoring",
+              "description": "description: \"Google Cloud Monitoring \u2014 time series metrics, alert policies, active alerts, metric discovery. Use when checking GCP network performance, investigating firing alerts, querying VM CPU or",
+              "invocable": true
+            },
+            {
+              "name": "gcp-compute-ops",
+              "description": "description: \"Google Cloud Compute Engine \u2014 VM instances, disks, templates, instance groups, reservations, project discovery. Use when listing GCP VMs, troubleshooting a Compute Engine instance, check",
+              "invocable": true
+            },
+            {
+              "name": "github-ops",
+              "description": "description: \"GitHub repository operations \u2014 issues, PRs, code search, and config-as-code workflows. Use when creating a GitHub issue for a network finding, opening a pull request for a config change,",
+              "invocable": true
+            },
+            {
+              "name": "gitlab-devops",
+              "description": "description: \"GitLab DevOps operations \u2014 issues, merge requests, CI/CD pipelines, repository browsing, labels, milestones, releases, and wiki management. Use when querying GitLab project status, monit",
+              "invocable": true
+            },
+            {
+              "name": "gnmi-telemetry",
+              "description": "description: \"gNMI streaming telemetry operations for multi-vendor network devices. Query device state via structured YANG model paths, subscribe to real-time telemetry streams, apply ITSM-gated confi",
+              "invocable": true
+            },
+            {
+              "name": "gns3-link-management",
+              "description": "description: \"Manage GNS3 links - connect/disconnect node interfaces, isolate nodes\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-node-operations",
+              "description": "description: \"Manage GNS3 nodes - add from templates, start/stop/suspend/reload, console access\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-packet-capture",
+              "description": "description: \"Capture network traffic on GNS3 links - start/stop captures, retrieve PCAP data\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-project-lifecycle",
+              "description": "description: \"Manage GNS3 network lab projects - create, open, close, delete, clone, export/import\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-snapshot-ops",
+              "description": "description: \"Manage GNS3 project snapshots - create, restore, delete for safe experimentation\"",
+              "invocable": true
+            },
+            {
+              "name": "grafana-observability",
+              "description": "description: \"Grafana observability platform \u2014 dashboards, Prometheus PromQL, Loki LogQL, alerting, incidents, OnCall schedules, annotations, datasource queries, panel rendering (75+ tools). Use when ",
+              "invocable": true
+            },
+            {
+              "name": "gtrace-ip-enrichment",
+              "description": "description: \"IP address enrichment \u2014 ASN ownership lookup, geolocation (city/region/country/coordinates), and reverse DNS resolution. Use when identifying who owns an IP address, locating an IP geogr",
+              "invocable": true
+            },
+            {
+              "name": "gtrace-path-analysis",
+              "description": "description: \"Network path tracing and monitoring \u2014 traceroute with MPLS/ECMP/NAT detection, continuous MTR monitoring, and distributed GlobalPing probes from 500+ worldwide locations. Use when tracin",
+              "invocable": true
+            },
+            {
+              "name": "humanrail-escalation",
+              "description": "description: \"Human-in-the-loop escalation via HumanRail \u2014 route low-confidence agent decisions, pre-destructive operation approvals, and ambiguous incident tickets to real human engineers. Human answ",
+              "invocable": true
+            },
+            {
+              "name": "infoblox-ddi",
+              "description": "description: \"Infoblox DDI operations \u2014 DNS zones/records, DHCP scopes and leases, IPAM networks and address utilization. Use when checking DNS records, validating IPAM address allocation, investigati",
+              "invocable": true
+            },
+            {
+              "name": "infrahub-sot",
+              "description": "description: \"OpsMill Infrahub \u2014 infrastructure source of truth with schema-driven nodes, GraphQL queries, and branch-isolated changes. Use when querying Infrahub for device/IPAM inventory, browsing i",
+              "invocable": true
+            },
+            {
+              "name": "ipfabric",
+              "description": "**Skill**: `/ipfabric`",
+              "invocable": true
+            },
+            {
+              "name": "ipfix-receiver",
+              "description": "description: \"Receive and query IPFIX and NetFlow flow records from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "ise-incident-response",
+              "description": "description: \"Rapid ISE endpoint investigation and quarantine workflow - endpoint lookup, auth history, posture review, human-authorized quarantine, ServiceNow Security Incident. Use when a SOC alert ",
+              "invocable": true
+            },
+            {
+              "name": "ise-posture-audit",
+              "description": "description: \"Cisco ISE posture and policy audit - authorization rules, posture compliance, profiling gaps, TrustSec SGT matrix, active session health. Use when running a periodic ISE compliance audit",
+              "invocable": true
+            },
+            {
+              "name": "itential-automation",
+              "description": "description: \"Itential Automation Platform (IAP) \u2014 network automation orchestration, device configuration management, compliance enforcement, workflow execution, golden config, lifecycle management, a",
+              "invocable": true
+            },
+            {
+              "name": "jenkins-cicd",
+              "description": "description: Jenkins CI/CD pipeline management \u2014 monitor builds, trigger pipelines, analyze logs, and track SCM changes for network automation workflows.",
+              "invocable": true
+            },
+            {
+              "name": "junos-network",
+              "description": "description: \"Juniper JunOS device automation via PyEZ/NETCONF \u2014 CLI execution, configuration management, Jinja2 template rendering, device facts, batch operations, config diff and rollback comparison",
+              "invocable": true
+            },
+            {
+              "name": "kubeshark-traffic",
+              "description": "description: \"Kubeshark Kubernetes traffic analysis \u2014 L4/L7 deep packet inspection, TLS decryption, pcap export, flow analysis, service mapping (6 tools). Use when capturing Kubernetes pod traffic, de",
+              "invocable": true
+            },
+            {
+              "name": "markmap-viz",
+              "description": "description: \"Create interactive mind map visualizations from markdown - network inventory, OSPF areas, BGP topology, security audit results. Use when visualizing network topology as a mind map, creat",
+              "invocable": true
+            },
+            {
+              "name": "memory",
+              "description": "**Purpose**: Provide persistent context across NetClaw sessions through structured facts, semantic search, and entity relationships.",
+              "invocable": true
+            },
+            {
+              "name": "mempalace",
+              "description": "description: \"MemPalace AI memory \u2014 persistent memory across sessions. Search past decisions, store architecture choices, track temporal network facts via knowledge graph, navigate cross-domain connec",
+              "invocable": true
+            },
+            {
+              "name": "meraki-monitoring",
+              "description": "description: \"Cisco Meraki Monitoring & Diagnostics \u2014 live ping, cable test, LED blink, wake-on-LAN, camera analytics, config change tracking. Use when running ping tests from Meraki devices, troubles",
+              "invocable": true
+            },
+            {
+              "name": "meraki-network-ops",
+              "description": "description: \"Cisco Meraki Dashboard \u2014 organization inventory, network management, device lifecycle, client discovery, action batches. Use when listing Meraki devices, managing networks, checking devi",
+              "invocable": true
+            },
+            {
+              "name": "meraki-security-appliance",
+              "description": "description: \"Cisco Meraki Security Appliance (MX) \u2014 firewall rules, site-to-site VPN, content filtering, traffic shaping, security events. Use when auditing Meraki MX firewall rules, troubleshooting ",
+              "invocable": true
+            },
+            {
+              "name": "meraki-switch-ops",
+              "description": "description: \"Cisco Meraki Switching \u2014 port configuration, VLANs, port status, ACLs, QoS rules, port cycling. Use when configuring Meraki switch ports, creating VLANs, checking port status and PoE, tr",
+              "invocable": true
+            },
+            {
+              "name": "meraki-wireless-ops",
+              "description": "description: \"Cisco Meraki Wireless \u2014 SSID management, RF profiles, channel utilization, signal quality, client connectivity events. Use when managing Meraki SSIDs, troubleshooting WiFi connectivity, ",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-files",
+              "description": "description: \"Manage files on OneDrive and SharePoint via Microsoft Graph API - upload, download, list, search, and organize network documentation and artifacts. Use when uploading reports to SharePoi",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-teams",
+              "description": "description: \"Send notifications and reports to Microsoft Teams channels via Graph API - alert delivery, report posting, incident updates, and diagram sharing. Use when posting health alerts to Teams,",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-visio",
+              "description": "description: \"Generate and manage Visio network diagrams on SharePoint via Microsoft Graph API - create topology diagrams from CDP/LLDP discovery, update existing diagrams, export to PDF. Use when cre",
+              "invocable": true
+            },
+            {
+              "name": "n2n-federation",
+              "description": "description: Federate your NetClaw with other NetClaw operators over the BGP mesh \u2014 exchange capability inventories and ask your claw what a peer can do. (US1; remote invocation and chat land in later",
+              "invocable": true
+            },
+            {
+              "name": "nautobot-sot",
+              "description": "description: \"Nautobot IPAM & source of truth \u2014 IP address queries, prefix lookups, VRF/tenant/site filtering, IPAM search, connection testing. Use when looking up IP addresses in Nautobot, checking s",
+              "invocable": true
+            },
+            {
+              "name": "netbox-reconcile",
+              "description": "description: \"Reconcile NetBox source of truth against live network state - detect IP drift, missing interfaces, undocumented links, cable mismatches, VLAN mismatches, and ticket discrepancies in Serv",
+              "invocable": true
+            },
+            {
+              "name": "nmap-network-scan",
+              "description": "description: \"Host discovery and port scanning using nmap \u2014 ICMP/ARP host discovery, SYN/TCP/UDP port scanning with scope enforcement and audit logging. Use when discovering live hosts on a subnet, sc",
+              "invocable": true
+            },
+            {
+              "name": "nmap-scan-management",
+              "description": "description: \"Custom nmap scans with arbitrary flags, plus scan history retrieval and management. Use when running nmap with custom flags, reviewing past scan results, comparing before/after scans, or",
+              "invocable": true
+            },
+            {
+              "name": "nmap-service-detection",
+              "description": "description: \"Service fingerprinting, OS detection, NSE script execution, and vulnerability scanning using nmap MCP. Use when identifying services on open ports, fingerprinting OS versions, running NS",
+              "invocable": true
+            },
+            {
+              "name": "nso-device-ops",
+              "description": "description: \"Cisco NSO device operations \u2014 config retrieval, state inspection, sync, platform info, NED IDs, device groups. Use when retrieving device configs from NSO, checking sync status, pulling ",
+              "invocable": true
+            },
+            {
+              "name": "nso-service-mgmt",
+              "description": "description: \"Cisco NSO service management \u2014 discover service types, list service instances, orchestrate network services. Use when listing NSO services, checking service health, auditing deployed ser",
+              "invocable": true
+            },
+            {
+              "name": "nvd-cve",
+              "description": "description: \"Search the National Vulnerability Database for CVEs - find vulnerabilities by keyword or ID, get CVSS scores, weaknesses, affected configurations, and remediation references. Use when lo",
+              "invocable": true
+            },
+            {
+              "name": "packet-analysis",
+              "description": "description: \"Analyze network packet captures (.pcap/.pcapng) using Packet Buddy MCP. Use when opening a pcap file, inspecting packet captures, troubleshooting network traffic, analyzing retransmissio",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-incidents",
+              "description": "description: \"Manage and investigate incidents in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-oncall",
+              "description": "description: \"Manage on-call schedules and escalation policies in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-orchestration",
+              "description": "description: \"Manage event orchestration and routing rules in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-services",
+              "description": "description: \"Manage service catalog and service health in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "paloalto-panorama",
+              "description": "description: \"Palo Alto Panorama operations \u2014 device groups, templates, security policy search, NAT review, commit status, and audit workflows. Use when searching Palo Alto firewall rules, checking if",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-apps",
+              "description": "description: \"View Prisma SD-WAN application definitions for policy visibility\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-config",
+              "description": "description: \"Inspect Prisma SD-WAN interfaces, routing (BGP, static), policies, and security zones\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-status",
+              "description": "description: \"Monitor Prisma SD-WAN element health, software versions, events, and alarms\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-topology",
+              "description": "description: \"Discover Prisma SD-WAN sites, ION elements, machines, and network topology\"",
+              "invocable": true
+            },
+            {
+              "name": "prometheus-monitoring",
+              "description": "description: \"Prometheus monitoring \u2014 PromQL instant/range queries, metric discovery, metadata, scrape target health, system health checks (6 tools). Use when querying Prometheus metrics, checking scr",
+              "invocable": true
+            },
+            {
+              "name": "protocol-participation",
+              "description": "description: \"Live BGP and OSPF control-plane participation \u2014 peer with real routers, inject/withdraw routes, query RIB/LSDB, adjust metrics, GRE tunnel status. Use when injecting or withdrawing BGP r",
+              "invocable": true
+            },
+            {
+              "name": "pyats-asa-firewall",
+              "description": "description: \"Cisco ASA firewall operations via pyATS \u2014 VPN sessions, failover state, interfaces, routing, service policies, resource usage, AnyConnect monitoring. Use when checking ASA failover statu",
+              "invocable": true
+            },
+            {
+              "name": "pyats-config-mgmt",
+              "description": "description: \"Network change management - pre-change baselines, configuration deployment, post-change verification, rollback procedures, and compliance validation. Use when pushing config to a device,",
+              "invocable": true
+            },
+            {
+              "name": "pyats-dynamic-test",
+              "description": "description: \"Generate and execute deterministic pyATS aetest validation scripts - interface state, OSPF neighbors, BGP paths, ping matrices, and custom compliance tests. Use when writing a network te",
+              "invocable": true
+            },
+            {
+              "name": "pyats-f5-ltm",
+              "description": "description: \"F5 BIG-IP LTM/GTM operations via pyATS iControl REST \u2014 virtual servers, pools, nodes, monitors, profiles, iRules, persistence, GTM wide IPs, DNS, data groups. Use when checking F5 virtua",
+              "invocable": true
+            },
+            {
+              "name": "pyats-f5-platform",
+              "description": "description: \"F5 BIG-IP platform operations via pyATS iControl REST \u2014 system, networking, HA/CM, auth, analytics, security, APM, live-update, ADC certs, file management. Use when checking BIG-IP syste",
+              "invocable": true
+            },
+            {
+              "name": "pyats-health-check",
+              "description": "description: \"Comprehensive network device health monitoring - CPU, memory, interfaces, hardware, NTP, logging, environment, and uptime analysis. Use when running a device health check, monitoring CPU",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-interfaces",
+              "description": "description: \"JunOS interface operations via pyATS \u2014 physical/logical interfaces, LACP, CoS, LLDP, ARP, BFD, IPv6 neighbors, traffic monitoring, optics diagnostics. Use when checking Juniper interface",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-routing",
+              "description": "description: \"JunOS routing operations via pyATS \u2014 OSPF/OSPFv3, BGP, route table, MPLS/LDP/RSVP, TED, PFE, ping, traceroute across Juniper devices. Use when checking Juniper OSPF neighbors, viewing BG",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-system",
+              "description": "description: \"JunOS system operations via pyATS \u2014 chassis health, hardware inventory, system info, NTP, SNMP, files/logs, firewall counters, DDoS protection, services accounting. Use when checking Jun",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-network",
+              "description": "description: \"Linux host network operations via pyATS \u2014 interface configuration, routing tables, network connections, and multi-table route inspection across fleet hosts. Use when checking Linux inter",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-system",
+              "description": "description: \"Linux host system operations via pyATS \u2014 process monitoring, filesystem inspection, Docker container stats, package/tool verification across fleet hosts. Use when checking running proces",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-vmware",
+              "description": "description: \"VMware ESXi host operations via pyATS \u2014 VM inventory, snapshot management, hypervisor inspection across ESXi hosts in the testbed. Use when listing VMs on ESXi, checking snapshot age, au",
+              "invocable": true
+            },
+            {
+              "name": "pyats-network",
+              "description": "description: \"Network device automation via pyATS - run show commands, ping, apply config, learn config/logging, list devices, run Linux commands, execute dynamic tests on Cisco IOS-XE/NX-OS devices. ",
+              "invocable": true
+            },
+            {
+              "name": "pyats-parallel-ops",
+              "description": "description: \"Fleet-wide parallel device operations - concurrent health checks, config audits, routing snapshots, severity-sorted reporting, and failure-isolated multi-device automation. Use when chec",
+              "invocable": true
+            },
+            {
+              "name": "pyats-routing",
+              "description": "description: \"CCIE-level routing protocol analysis - OSPF, BGP, EIGRP, IS-IS, static routes, RIB/FIB verification, redistribution audit, and convergence validation. Use when analyzing routing tables, ",
+              "invocable": true
+            },
+            {
+              "name": "pyats-security",
+              "description": "description: \"Network security audit - ACLs, AAA, control plane policing, management plane hardening, encryption, port security, and CIS benchmark checks. Use when auditing device security posture, ch",
+              "invocable": true
+            },
+            {
+              "name": "pyats-topology",
+              "description": "description: \"Network topology discovery via CDP/LLDP neighbors, ARP tables, routing peers, and interface mapping to build complete network maps. Use when mapping the network, building a diagram, disc",
+              "invocable": true
+            },
+            {
+              "name": "pyats-troubleshoot",
+              "description": "description: \"Systematic network troubleshooting - connectivity, routing, interface, protocol, and performance issues using structured OSI-layer and divide-and-conquer methodology. Use when something ",
+              "invocable": true
+            },
+            {
+              "name": "radkit-remote-access",
+              "description": "description: \"Cisco RADKit \u2014 cloud-relayed remote device access, CLI execution, SNMP polling, device inventory discovery, attribute inspection. Use when accessing remote network devices through a clou",
+              "invocable": true
+            },
+            {
+              "name": "rag",
+              "description": "**Purpose**: Give NetClaw a fully offline, user-curated document knowledge base \u2014 vendor guides, standards (RFC/IEEE/vendor), customer design documents, install guides \u2014 with agentic retrieval, mandat",
+              "invocable": true
+            },
+            {
+              "name": "rfc-lookup",
+              "description": "description: \"Search and retrieve IETF RFC documents - lookup by number, search by keyword, extract sections. Use when looking up an RFC, checking protocol specifications, verifying standards complian",
+              "invocable": true
+            },
+            {
+              "name": "sdwan-ops",
+              "description": "description: \"Cisco SD-WAN vManage read-only operations \u2014 fabric devices, WAN Edge inventory, templates, policies, alarms, events, interface stats, BFD sessions, OMP routes, control connections, runni",
+              "invocable": true
+            },
+            {
+              "name": "servicenow-change-workflow",
+              "description": "description: \"Full ITSM-gated change lifecycle - CR creation, pre-change incident validation, approval gate, execution via pyats-config-mgmt, post-change verification, and closure with GAIT audit trai",
+              "invocable": true
+            },
+            {
+              "name": "slack-incident-workflow",
+              "description": "description: \"Manage network incident response workflows in Slack - incident channels, status updates, escalation, resolution tracking, and post-incident review coordination. Use when declaring a netw",
+              "invocable": true
+            },
+            {
+              "name": "slack-network-alerts",
+              "description": "description: \"Format and deliver network alerts, health warnings, and critical notifications via Slack with rich formatting, reactions, and file attachments. Use when sending alerts to Slack, posting ",
+              "invocable": true
+            },
+            {
+              "name": "slack-report-delivery",
+              "description": "description: \"Deliver formatted network reports, audit results, topology diagrams, and compliance documentation to Slack channels with rich Block Kit formatting. Use when posting a health check report",
+              "invocable": true
+            },
+            {
+              "name": "slack-user-context",
+              "description": "description: \"Leverage Slack user profiles, presence, DND status, and workspace context to personalize responses, route escalations, and coordinate team operations. Use when checking who is on-call, r",
+              "invocable": true
+            },
+            {
+              "name": "slack-voice-interface",
+              "description": "description: \"Respond to Slack voice clips with both text and an MP3 voice reply using edge-tts. Voice IN is already handled by OpenClaw transcription. Use when a user sends a voice message in Slack, ",
+              "invocable": true
+            },
+            {
+              "name": "snmptrap-receiver",
+              "description": "description: \"Receive and query SNMP traps from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-indexes",
+              "description": "description: \"Discover and inspect Splunk indexes and configuration.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-saved",
+              "description": "description: \"Manage and run saved searches in Splunk.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-search",
+              "description": "description: \"Execute and validate SPL (Search Processing Language) queries.\"",
+              "invocable": true
+            },
+            {
+              "name": "subnet-calculator",
+              "description": "description: \"IPv4 and IPv6 subnet calculator - CIDR breakdown, usable hosts, previous/next subnets, address classification, VLSM planning, and dual-stack analysis. Use when calculating subnets, figur",
+              "invocable": true
+            },
+            {
+              "name": "suzieq-observability",
+              "description": "description: \"SuzieQ network observability \u2014 query current and historical network state, run validation assertions, get summary statistics, trace forwarding paths, and discover unique values across 20",
+              "invocable": true
+            },
+            {
+              "name": "syslog-receiver",
+              "description": "description: \"Receive and query syslog messages from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "te-network-monitoring",
+              "description": "description: \"Cisco ThousandEyes \u2014 test management, agent inventory, test results, dashboards, path visualization, user/account management. Use when checking ThousandEyes test results, viewing network",
+              "invocable": true
+            },
+            {
+              "name": "te-path-analysis",
+              "description": "description: \"Cisco ThousandEyes \u2014 path visualization, BGP route analysis, outage investigation, instant tests, endpoint agent diagnostics. Use when tracing network paths hop-by-hop, investigating why",
+              "invocable": true
+            },
+            {
+              "name": "telemetry-ops",
+              "description": "description: \"Comprehensive network telemetry and event collection across multiple protocols.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-operations",
+              "description": "description: \"Execute local Terraform operations with ServiceNow change control.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-registry",
+              "description": "description: \"Discover providers and modules from the Terraform Registry.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-workspaces",
+              "description": "description: \"Manage HCP Terraform (Terraform Cloud/Enterprise) workspaces.\"",
+              "invocable": true
+            },
+            {
+              "name": "threejs-network-viz",
+              "description": "**Version**: 1.0.0",
+              "invocable": true
+            },
+            {
+              "name": "token-tracker",
+              "description": "description: \"Track and display token consumption and cost for every NetClaw interaction.\"",
+              "invocable": true
+            },
+            {
+              "name": "twilio-daily-briefing",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-emergency-call",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-inbound-voice",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-outbound-call",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twitter-check",
+              "description": "**Purpose**: Quick invocation to check mentions and respond to #netclaw threads.",
+              "invocable": true
+            },
+            {
+              "name": "twitter-heartbeat",
+              "description": "**Purpose**: Autonomous periodic tweeting AND mention monitoring to maintain NetClaw's Twitter presence with CCIE-level network engineering content.",
+              "invocable": true
+            },
+            {
+              "name": "twitter-respond",
+              "description": "**Skill ID**: twitter-respond",
+              "invocable": true
+            },
+            {
+              "name": "twitter-share",
+              "description": "**Purpose**: Manual tweet posting with content guardrails and human approval flow.",
+              "invocable": true
+            },
+            {
+              "name": "ue5-network-viz",
+              "description": "description: \"3D network topology visualization and interactive digital twin in Unreal Engine 5.8 via the built-in UE5 MCP server.\"",
+              "invocable": true
+            },
+            {
+              "name": "uml-diagram",
+              "description": "description: \"UML and diagram generation via Kroki \u2014 class, sequence, activity, state, component, deployment, network, ER, C4, Mermaid, D2, Graphviz, BPMN, 27+ types. Use when generating a network dia",
+              "invocable": true
+            },
+            {
+              "name": "vault-mounts",
+              "description": "description: \"Discover and manage HashiCorp Vault secret engine mounts.\"",
+              "invocable": true
+            },
+            {
+              "name": "vault-pki",
+              "description": "description: \"Manage HashiCorp Vault PKI certificate infrastructure.\"",
+              "invocable": true
+            },
+            {
+              "name": "vault-secrets",
+              "description": "description: \"Manage HashiCorp Vault KV secrets with strict value protection.\"",
+              "invocable": true
+            },
+            {
+              "name": "webex-incident-workflow",
+              "description": "description: \"Manage network incident response workflows in Cisco WebEx - incident spaces, status updates, escalation, resolution tracking, and post-incident review coordination. Use when declaring a ",
+              "invocable": true
+            },
+            {
+              "name": "webex-network-alerts",
+              "description": "description: \"Format and deliver network alerts, health warnings, and critical notifications via Cisco WebEx with Adaptive Cards, markdown formatting, and file attachments. Use when sending alerts to ",
+              "invocable": true
+            },
+            {
+              "name": "webex-report-delivery",
+              "description": "description: \"Deliver formatted network reports, audit results, topology diagrams, and compliance documentation to WebEx spaces with Adaptive Cards and markdown formatting. Use when posting a health c",
+              "invocable": true
+            },
+            {
+              "name": "webex-user-context",
+              "description": "description: \"Leverage WebEx user profiles, presence status, and workspace context to personalize responses, route escalations, and coordinate team operations. Use when checking who is available, rout",
+              "invocable": true
+            },
+            {
+              "name": "webex-voice-interface",
+              "description": "description: \"Respond to WebEx voice clips with both text and an MP3 voice reply using edge-tts. Voice IN is already handled by OpenClaw transcription. Use when a user sends a voice message in WebEx, ",
+              "invocable": true
+            },
+            {
+              "name": "wikipedia-research",
+              "description": "description: \"Research networking protocols, standards history, and technology context via Wikipedia - OSPF, BGP, MPLS, 802.1X, VXLAN, and more. Use when looking up protocol background, researching ho",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-identity",
+              "description": "description: \"Manage users, groups, departments, and identity provider configurations.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-insights",
+              "description": "description: \"Access analytics, threat intelligence, and security event data.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zdx",
+              "description": "description: \"Monitor digital experience scores, user performance, and application health.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zia",
+              "description": "description: \"Manage Zscaler Internet Access firewall rules, URL filtering, DLP, and security policies.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zpa",
+              "description": "description: \"Manage Zscaler Private Access applications, segments, policies, and connectors.\"",
+              "invocable": true
+            }
+          ],
+          "mcp_servers": [
+            {
+              "name": "forward-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "suzieq-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "batfish-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gnmi-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "azure-network-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gitlab-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chrome-devtools-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chrome-devtools-mcp-visible",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "jenkins-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "atlassian-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gns3-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "prisma-sdwan-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "datadog-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "pagerduty-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "splunk-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "infrahub-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "terraform-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "vault-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "zscaler-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-dns-analytics",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-security",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-zerotrust",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-analytics",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-workers",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "blender-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aruba-cx-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "devnet-content-search",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-golden-config-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-routing-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-management",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-management-logs",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-threat-prevention",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-https-inspection",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-harmony-sase",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-reputation-service",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-quantum-gw-cli",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-gw-connection-analysis",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-threat-emulation",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-quantum-gaia",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-documentation",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-spark-management",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-cpinfo-analysis",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-argos-erm",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-policy-insights",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "claroty-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twitter-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twilio-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twilio-voice-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "unreal-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "sketchfab-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "n2n-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "rag-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cml-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nso-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "itential-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "prometheus-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "grafana-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "meraki-magic-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "radkit-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "junos-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "arista-cvp-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cisco-fmc-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "thousandeyes-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "github-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-network-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-cloudwatch-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-iam-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-cloudtrail-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-cost-explorer-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-diagram-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-compute-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-monitoring-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-logging-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-resource-manager-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "thousandeyes-official-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "kubeshark-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "uml-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "protocol-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "ollama-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "fwrule-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-ansible-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-eda-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-lint-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-docs-mcp",
+              "tools": [],
+              "invocable_tools": []
+            }
+          ],
+          "knowledge": [],
+          "badges": [
+            "AWS",
+            "Azure",
+            "Batfish",
+            "CML",
+            "Check Point",
+            "Forward",
+            "GNS3",
+            "Meraki",
+            "Nautobot",
+            "SuzieQ",
+            "gNMI"
+          ],
+          "posture": {
+            "mode": "testing",
+            "state": "unknown",
+            "summary": "testing",
+            "controls": {}
+          },
+          "llm": {
+            "primary_model": null,
+            "guarded": false
+          }
+        },
+        "received_at": "2026-07-23T00:34:20Z",
+        "stale": true
+      },
+      "channel_state": "unreachable",
+      "last_seen": 0,
+      "endpoint_updated_at": null,
+      "in_flight_tasks": [],
+      "endpoint": null
+    },
+    {
+      "identity": "as65099-10.255.255.1",
+      "display_name": "Byrn",
+      "state": "federated",
+      "chat_enabled": true,
+      "inventory_version": 18,
+      "inventory_received_at": "2026-07-25T16:43:51Z",
+      "stale": true,
+      "inventory": {
+        "inventory": {
+          "identity": "as65099-10.255.255.1",
+          "issued_at": "2026-07-25T16:43:48Z",
+          "version": 18,
+          "skills": [
+            {
+              "name": "aap-automation",
+              "description": "description: \"Red Hat Ansible Automation Platform \u2014 inventory management, job template execution, project SCM sync, ad-hoc commands, host management, Galaxy content discovery. Use when automating infr",
+              "invocable": true
+            },
+            {
+              "name": "aap-eda",
+              "description": "description: \"Event-Driven Ansible (EDA) \u2014 activation lifecycle, rulebook management, decision environments, event stream monitoring. Use when managing event-driven automation triggers, enabling/disab",
+              "invocable": true
+            },
+            {
+              "name": "aap-lint",
+              "description": "description: \"ansible-lint playbook and role validation \u2014 syntax checking, best practice enforcement, project-wide analysis, rule filtering. Use when validating Ansible playbooks, checking code qualit",
+              "invocable": true
+            },
+            {
+              "name": "aci-change-deploy",
+              "description": "description: \"Safe ACI policy change deployment - ServiceNow CR lifecycle, pre/post-change fault baselines, APIC policy application, automatic rollback on fault delta, and GAIT audit trail. Use when d",
+              "invocable": true
+            },
+            {
+              "name": "aci-fabric-audit",
+              "description": "description: \"Comprehensive Cisco ACI fabric health audit - node status, tenant/VRF/BD/EPG policy review, contract analysis, fault triage, and endpoint learning verification. Use when auditing ACI fab",
+              "invocable": true
+            },
+            {
+              "name": "alert-triage",
+              "description": "description: \"Investigate alerts from the home/edge observability stack via adapters (firewall, wireless, SoT). Receives enriched alert context (device name, IP, platform, role) from the alert receive",
+              "invocable": true
+            },
+            {
+              "name": "arista-cvp",
+              "description": "description: \"Arista CloudVision Portal (CVP) automation via REST API \u2014 device inventory, events, connectivity monitoring, tag management (4 tools). Use when managing Arista devices, checking CloudVis",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-config",
+              "description": "description: \"View and manage Aruba CX switch configurations, perform ISSU upgrades, and firmware operations\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-interfaces",
+              "description": "description: \"Monitor Aruba CX switch interface status, LLDP neighbors, and optical transceiver health\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-switching",
+              "description": "description: \"View and manage Aruba CX switch VLANs and MAC address tables for Layer 2 operations\"",
+              "invocable": true
+            },
+            {
+              "name": "aruba-cx-system",
+              "description": "description: \"Discover Aruba CX switch system information, firmware versions, and VSF topology\"",
+              "invocable": true
+            },
+            {
+              "name": "atlassian-itsm",
+              "description": "description: IT Service Management workflows using Jira for issue tracking and Confluence for documentation",
+              "invocable": true
+            },
+            {
+              "name": "aws-architecture-diagram",
+              "description": "description: \"AWS architecture diagrams \u2014 generate visual network topology diagrams from live AWS infrastructure. Use when drawing AWS network diagrams, visualizing VPCs, mapping Transit Gateway topol",
+              "invocable": true
+            },
+            {
+              "name": "aws-cloud-monitoring",
+              "description": "description: \"AWS CloudWatch monitoring \u2014 metrics, alarms, log queries, VPC flow log analysis, network performance. Use when checking AWS alarms, analyzing VPC flow logs, investigating network latency",
+              "invocable": true
+            },
+            {
+              "name": "aws-cost-ops",
+              "description": "description: \"AWS Cost Explorer \u2014 spending analysis, service breakdowns, forecasts, cost anomalies. Use when analyzing AWS spending, investigating cost spikes, reviewing network cost drivers like NAT ",
+              "invocable": true
+            },
+            {
+              "name": "aws-network-ops",
+              "description": "description: \"AWS cloud networking \u2014 VPC, Transit Gateway, Cloud WAN, VPN, Network Firewall, ENI, flow logs. Use when auditing AWS VPCs, troubleshooting connectivity between EC2 instances, checking Tr",
+              "invocable": true
+            },
+            {
+              "name": "aws-security-audit",
+              "description": "description: \"AWS security auditing \u2014 IAM users/roles/policies, CloudTrail API events, security posture analysis. Use when auditing IAM permissions, investigating security incidents, checking MFA comp",
+              "invocable": true
+            },
+            {
+              "name": "azure-network-ops",
+              "description": "description: \"Azure cloud networking -- VNets, NSGs, ExpressRoute, VPN Gateways, Azure Firewalls, Load Balancers, Application Gateways, Route Tables, Network Watcher, Private Endpoints, DNS zones. Use",
+              "invocable": true
+            },
+            {
+              "name": "azure-security-audit",
+              "description": "description: \"Azure NSG compliance auditing and security posture assessment. CIS Azure Foundations Benchmark rules, effective security rule analysis, orphaned NSG detection. Use when auditing Azure NS",
+              "invocable": true
+            },
+            {
+              "name": "batfish-config-analysis",
+              "description": "description: \"Batfish network configuration analysis -- pre-deployment validation, reachability testing, ACL/firewall tracing, differential analysis, compliance checking. Use when validating configs b",
+              "invocable": true
+            },
+            {
+              "name": "blender-3d-viz",
+              "description": "description: \"Create 3D network topology visualizations in Blender from CDP/LLDP neighbor data\"",
+              "invocable": true
+            },
+            {
+              "name": "browser-gui-inspect",
+              "description": "description: \"Controller-agnostic browser automation and inspection \u2014 navigate, read, click, fill, and capture network traffic on any web GUI using a persistent, manually-authenticated Chrome profile.",
+              "invocable": true
+            },
+            {
+              "name": "browser-viz-verify",
+              "description": "description: \"Verifies that a NetClaw-generated visualization HTML file (three.js, canvas, drawio, UML, markmap) actually renders correctly \u2014 screenshot, console-error check, and an optional Lighthous",
+              "invocable": true
+            },
+            {
+              "name": "canvas-network-viz",
+              "description": "description: \"Canvas/A2UI inline network visualizations \u2014 topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards rendered directly in the Ope",
+              "invocable": true
+            },
+            {
+              "name": "catc-client-ops",
+              "description": "description: \"Catalyst Center client operations and monitoring - list/filter wired and wireless clients, detailed client lookup by MAC, client count analytics, time-based analysis, SSID and band filte",
+              "invocable": true
+            },
+            {
+              "name": "catc-inventory",
+              "description": "description: \"Catalyst Center device inventory and site management - list/filter devices by hostname, IP, platform, family, role, reachability; view site hierarchy; get interface details per device; d",
+              "invocable": true
+            },
+            {
+              "name": "catc-troubleshoot",
+              "description": "description: \"Catalyst Center troubleshooting workflows - device unreachable investigation, client connectivity issues, interface down analysis, site-wide outage triage, wireless roaming problems, int",
+              "invocable": true
+            },
+            {
+              "name": "checkpoint",
+              "description": "A comprehensive skill for interacting with Check Point enterprise security infrastructure through 15 MCP servers.",
+              "invocable": true
+            },
+            {
+              "name": "clab-lab-management",
+              "description": "description: \"ContainerLab network lab lifecycle management \u2014 authenticate, list, deploy, inspect, execute commands on, and destroy containerized network labs via the ContainerLab API. Use when deploy",
+              "invocable": true
+            },
+            {
+              "name": "claroty-asset-inventory",
+              "description": "description: \"Discover and classify OT / IoT / IoMT assets via Claroty xDome. List devices by site, Purdue level, and device purpose; assign Purdue layers and custom attributes; cross-reference with N",
+              "invocable": true
+            },
+            {
+              "name": "claroty-ot-topology",
+              "description": "description: \"Render Claroty xDome OT / IoT communication maps and zone segmentation as inline Canvas/A2UI topology, draw.io diagrams, and timeline summaries.\"",
+              "invocable": true
+            },
+            {
+              "name": "claroty-risk-triage",
+              "description": "description: \"Triage Claroty xDome alerts and vulnerabilities, compute blast radius, correlate with NVD CVE data, and drive ITSM-gated workflow actions (acknowledge, label, assign, set relevance).\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-analytics",
+              "description": "description: \"Access Cloudflare traffic analytics, logs, and Radar global Internet insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-dns",
+              "description": "description: \"Manage Cloudflare DNS zones and records with analytics insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-security",
+              "description": "description: \"Monitor Cloudflare WAF, firewall events, audit logs, and threat intelligence.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-workers",
+              "description": "description: \"Monitor Cloudflare Workers deployments, bindings, and build insights.\"",
+              "invocable": true
+            },
+            {
+              "name": "cloudflare-zerotrust",
+              "description": "description: \"Inspect Cloudflare Zero Trust access applications, policies, tunnels, and CASB findings.\"",
+              "invocable": true
+            },
+            {
+              "name": "cml-admin",
+              "description": "description: \"CML administration \u2014 user/group management, system info, licensing, resource monitoring. Use when creating CML users, checking license status, monitoring CML server resources, or auditin",
+              "invocable": true
+            },
+            {
+              "name": "cml-lab-lifecycle",
+              "description": "description: \"Cisco CML lab lifecycle management \u2014 create, start, stop, wipe, delete, clone, import/export labs. Use when building a network lab, starting or stopping a CML lab, cloning a topology, or",
+              "invocable": true
+            },
+            {
+              "name": "cml-node-operations",
+              "description": "description: \"CML node operations \u2014 start, stop, console access, CLI execution, config management, node details. Use when starting or stopping a CML node, running show commands on a lab router, settin",
+              "invocable": true
+            },
+            {
+              "name": "cml-packet-capture",
+              "description": "description: \"CML packet capture \u2014 start, stop, download pcaps from CML lab links, integrate with Packet Buddy for analysis. Use when capturing packets in a CML lab, troubleshooting BGP or OSPF with p",
+              "invocable": true
+            },
+            {
+              "name": "cml-topology-builder",
+              "description": "description: \"Build CML topologies \u2014 add nodes, create interfaces, wire links, set link conditioning, add annotations. Use when building a network topology in CML, adding routers or switches to a lab,",
+              "invocable": true
+            },
+            {
+              "name": "datadog-apm",
+              "description": "description: \"Analyze distributed traces and service performance in Datadog APM.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-incidents",
+              "description": "description: \"Manage incidents in Datadog Incident Management.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-logs",
+              "description": "description: \"Search and analyze logs in Datadog Log Management.\"",
+              "invocable": true
+            },
+            {
+              "name": "datadog-metrics",
+              "description": "description: \"Query metrics and explore dashboards in Datadog.\"",
+              "invocable": true
+            },
+            {
+              "name": "defenseclaw-ops",
+              "description": "description: Manage DefenseClaw enterprise security - scan components, manage tool permissions, view alerts, configure guardrails",
+              "invocable": true
+            },
+            {
+              "name": "demo-lab-setup",
+              "description": "Deploy the byrn-baker/Nautobot-Workshop environment end-to-end. Fully autonomous \u2014 validate each step before proceeding, no user input required except at session checkpoints.",
+              "invocable": true
+            },
+            {
+              "name": "desktop-gui-inspect",
+              "description": "description: \"Full-desktop automation for targets that have no browser and no API at all \u2014 a legacy Java-based NMS client, a vendor's Windows-only configuration utility, a terminal emulator with no sc",
+              "invocable": true
+            },
+            {
+              "name": "devnet-catalyst-search",
+              "description": "description: Search Cisco Catalyst Center API documentation for device management and policy automation",
+              "invocable": true
+            },
+            {
+              "name": "devnet-meraki-search",
+              "description": "description: Search Cisco Meraki API documentation and lookup specific operations",
+              "invocable": true
+            },
+            {
+              "name": "domain-expert-delegation",
+              "description": "description: \"Offload structured workloads (config generation, design validation, GraphQL building, state summarization, context compression) to local or cloud LLM providers via the ollama-mcp server.",
+              "invocable": true
+            },
+            {
+              "name": "drawio-diagram",
+              "description": "description: \"Generate draw.io network diagrams \u2014 native .drawio files with CLI export (PNG/SVG/PDF), plus browser-based Mermaid/XML/CSV via MCP server. Use when creating network topology diagrams, ge",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-build",
+              "description": "description: Build or rewire EVE-NG lab topology. Use when creating or deleting virtual networks, connecting node interfaces to networks, inspecting topology links, checking interface mappings, or lis",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-design",
+              "description": "description: Design EVE-NG lab topology and coordinate the design workflow. Use when the user asks for lab design, architecture advice, topology planning, design review, or a build plan, especially wh",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-discovery",
+              "description": "description: Gather missing requirements for EVE-NG topology design. Use when the request is vague or incomplete, when you need discovery questions, defaults, trade-off framing, image recommendations,",
+              "invocable": true
+            },
+            {
+              "name": "eve-lab-topology-validation",
+              "description": "description: Validate EVE-NG topology designs and enforce final delivery structure. Use when reviewing a design, checking build readiness, producing the final design output, building an implementation",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-config-ops",
+              "description": "description: Manage EVE-NG startup configurations stored in lab files. Use when exporting configs natively into the lab, reading embedded startup configs, pushing startup config before boot, clearing ",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-console-ops",
+              "description": "description: Execute live CLI commands on running EVE-NG nodes over telnet console. Use when running show commands, making live config changes, verifying protocol state, testing connectivity, checking",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-lab-management",
+              "description": "description: Manage EVE-NG labs and platform inventory. Use when listing labs, checking lab metadata, creating or deleting labs, importing or exporting lab archives, checking EVE-NG health or auth, or",
+              "invocable": true
+            },
+            {
+              "name": "eve-ng-node-operations",
+              "description": "description: Manage EVE-NG node lifecycle. Use when listing nodes, checking runtime state, creating or deleting nodes, starting or stopping nodes or whole labs, verifying node details, or wiping node ",
+              "invocable": true
+            },
+            {
+              "name": "evpn-vxlan-fabric",
+              "description": "description: \"EVPN/VXLAN fabric audit and troubleshooting \u2014 VTEPs, VNIs, route types, multihoming, underlay/overlay validation. Use when troubleshooting VXLAN overlay reachability, auditing leaf-spine",
+              "invocable": true
+            },
+            {
+              "name": "f5-config-mgmt",
+              "description": "description: \"F5 BIG-IP configuration management - safe change workflow with baseline capture, planning, creation/update/deletion of virtual servers, pools, iRules, and profiles with full verification",
+              "invocable": true
+            },
+            {
+              "name": "f5-health-check",
+              "description": "description: \"F5 BIG-IP health monitoring - virtual server status, pool member health, log analysis, performance statistics, and systematic health assessment. Use when checking F5 load balancer health",
+              "invocable": true
+            },
+            {
+              "name": "f5-troubleshoot",
+              "description": "description: \"F5 BIG-IP troubleshooting - virtual server failures, pool member health, connection issues, SSL/TLS problems, iRule errors, persistence issues, and performance degradation. Use when a VI",
+              "invocable": true
+            },
+            {
+              "name": "fmc-firewall-ops",
+              "description": "description: \"Cisco Secure Firewall FMC \u2014 access policy search, rule inspection, FTD device targeting, multi-FMC profile management. Use when searching firewall rules by IP or FQDN, checking if host A",
+              "invocable": true
+            },
+            {
+              "name": "fortimanager-ops",
+              "description": "description: \"FortiManager operations \u2014 ADOM inventory, policy package review, object search, install preview, and compliance workflows. Use when auditing FortiGate firewall policies, reviewing ADOM p",
+              "invocable": true
+            },
+            {
+              "name": "forward",
+              "description": "description: Forward snapshot assurance, path search, app-aware path search, NQE, checks, vulnerabilities, diffs, configuration, lifecycle, collection, and topology workflows through the upstream forw",
+              "invocable": true
+            },
+            {
+              "name": "fwrule-analyzer",
+              "description": "description: \"Multi-vendor firewall rule analysis \u2014 overlap detection, shadowing, conflict identification, duplication checking across PAN-OS, ASA, FTD, IOS/IOS-XE, IOS-XR, Check Point, SRX, Junos, No",
+              "invocable": true
+            },
+            {
+              "name": "gait-session-tracking",
+              "description": "description: \"GAIT session lifecycle management - branch creation, turn recording, audit logging for every NetClaw operation. Use when starting a new NetClaw session, recording a health check or confi",
+              "invocable": true
+            },
+            {
+              "name": "gcp-cloud-logging",
+              "description": "description: \"Google Cloud Logging \u2014 log search, VPC flow logs, firewall logs, audit logs, log buckets and views. Use when searching GCP logs, investigating denied VPC flow traffic, checking who delet",
+              "invocable": true
+            },
+            {
+              "name": "gcp-cloud-monitoring",
+              "description": "description: \"Google Cloud Monitoring \u2014 time series metrics, alert policies, active alerts, metric discovery. Use when checking GCP network performance, investigating firing alerts, querying VM CPU or",
+              "invocable": true
+            },
+            {
+              "name": "gcp-compute-ops",
+              "description": "description: \"Google Cloud Compute Engine \u2014 VM instances, disks, templates, instance groups, reservations, project discovery. Use when listing GCP VMs, troubleshooting a Compute Engine instance, check",
+              "invocable": true
+            },
+            {
+              "name": "github-ops",
+              "description": "description: \"GitHub repository operations \u2014 issues, PRs, code search, and config-as-code workflows. Use when creating a GitHub issue for a network finding, opening a pull request for a config change,",
+              "invocable": true
+            },
+            {
+              "name": "gitlab-devops",
+              "description": "description: \"GitLab DevOps operations \u2014 issues, merge requests, CI/CD pipelines, repository browsing, labels, milestones, releases, and wiki management. Use when querying GitLab project status, monit",
+              "invocable": true
+            },
+            {
+              "name": "gnmi-telemetry",
+              "description": "description: \"gNMI streaming telemetry operations for multi-vendor network devices. Query device state via structured YANG model paths, subscribe to real-time telemetry streams, apply ITSM-gated confi",
+              "invocable": true
+            },
+            {
+              "name": "gns3-link-management",
+              "description": "description: \"Manage GNS3 links - connect/disconnect node interfaces, isolate nodes\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-node-operations",
+              "description": "description: \"Manage GNS3 nodes - add from templates, start/stop/suspend/reload, console access\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-packet-capture",
+              "description": "description: \"Capture network traffic on GNS3 links - start/stop captures, retrieve PCAP data\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-project-lifecycle",
+              "description": "description: \"Manage GNS3 network lab projects - create, open, close, delete, clone, export/import\"",
+              "invocable": true
+            },
+            {
+              "name": "gns3-snapshot-ops",
+              "description": "description: \"Manage GNS3 project snapshots - create, restore, delete for safe experimentation\"",
+              "invocable": true
+            },
+            {
+              "name": "golden-config-bootstrap",
+              "description": "Interactively set up the Nautobot Golden Config plugin from scratch. This is a conversational workflow \u2014 the agent guides the user through analyzing their running configs, designing compliance feature",
+              "invocable": true
+            },
+            {
+              "name": "grafana-observability",
+              "description": "description: \"Grafana observability platform \u2014 dashboards, Prometheus PromQL, Loki LogQL, alerting, incidents, OnCall schedules, annotations, datasource queries, panel rendering (75+ tools). Use when ",
+              "invocable": true
+            },
+            {
+              "name": "gtrace-ip-enrichment",
+              "description": "description: \"IP address enrichment \u2014 ASN ownership lookup, geolocation (city/region/country/coordinates), and reverse DNS resolution. Use when identifying who owns an IP address, locating an IP geogr",
+              "invocable": true
+            },
+            {
+              "name": "gtrace-path-analysis",
+              "description": "description: \"Network path tracing and monitoring \u2014 traceroute with MPLS/ECMP/NAT detection, continuous MTR monitoring, and distributed GlobalPing probes from 500+ worldwide locations. Use when tracin",
+              "invocable": true
+            },
+            {
+              "name": "humanrail-escalation",
+              "description": "description: \"Human-in-the-loop escalation via HumanRail \u2014 route low-confidence agent decisions, pre-destructive operation approvals, and ambiguous incident tickets to real human engineers. Human answ",
+              "invocable": true
+            },
+            {
+              "name": "infoblox-ddi",
+              "description": "description: \"Infoblox DDI operations \u2014 DNS zones/records, DHCP scopes and leases, IPAM networks and address utilization. Use when checking DNS records, validating IPAM address allocation, investigati",
+              "invocable": true
+            },
+            {
+              "name": "infrahub-sot",
+              "description": "description: \"OpsMill Infrahub \u2014 infrastructure source of truth with schema-driven nodes, GraphQL queries, and branch-isolated changes. Use when querying Infrahub for device/IPAM inventory, browsing i",
+              "invocable": true
+            },
+            {
+              "name": "intent-reconcile",
+              "description": "description: \"Reconcile live network devices to Nautobot intent, with a human approval gate over Discord. Triggered by a Nautobot webhook (device interface change) or by an approval/denial reply. Prop",
+              "invocable": true
+            },
+            {
+              "name": "ipfabric",
+              "description": "**Skill**: `/ipfabric`",
+              "invocable": true
+            },
+            {
+              "name": "ipfix-receiver",
+              "description": "description: \"Receive and query IPFIX and NetFlow flow records from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "ise-incident-response",
+              "description": "description: \"Rapid ISE endpoint investigation and quarantine workflow - endpoint lookup, auth history, posture review, human-authorized quarantine, ServiceNow Security Incident. Use when a SOC alert ",
+              "invocable": true
+            },
+            {
+              "name": "ise-posture-audit",
+              "description": "description: \"Cisco ISE posture and policy audit - authorization rules, posture compliance, profiling gaps, TrustSec SGT matrix, active session health. Use when running a periodic ISE compliance audit",
+              "invocable": true
+            },
+            {
+              "name": "isp-sla-claim",
+              "description": "description: \"Draft ISP service credit claims after WAN outages. Gathers evidence from Prometheus, pfSense, and dpinger logs to prove the outage was ISP-side (not CPE). Produces a ready-to-send email ",
+              "invocable": true
+            },
+            {
+              "name": "itential-automation",
+              "description": "description: \"Itential Automation Platform (IAP) \u2014 network automation orchestration, device configuration management, compliance enforcement, workflow execution, golden config, lifecycle management, a",
+              "invocable": true
+            },
+            {
+              "name": "jenkins-cicd",
+              "description": "description: Jenkins CI/CD pipeline management \u2014 monitor builds, trigger pipelines, analyze logs, and track SCM changes for network automation workflows.",
+              "invocable": true
+            },
+            {
+              "name": "junos-network",
+              "description": "description: \"Juniper JunOS device automation via PyEZ/NETCONF \u2014 CLI execution, configuration management, Jinja2 template rendering, device facts, batch operations, config diff and rollback comparison",
+              "invocable": true
+            },
+            {
+              "name": "kubeshark-traffic",
+              "description": "description: \"Kubeshark Kubernetes traffic analysis \u2014 L4/L7 deep packet inspection, TLS decryption, pcap export, flow analysis, service mapping (6 tools). Use when capturing Kubernetes pod traffic, de",
+              "invocable": true
+            },
+            {
+              "name": "lab-troubleshoot",
+              "description": "description: \"Detect and diagnose network failures by correlating observability metrics (Grafana/Prometheus), syslog (Loki), and live device state (pyATS). Use when investigating connectivity issues, ",
+              "invocable": true
+            },
+            {
+              "name": "markmap-viz",
+              "description": "description: \"Create interactive mind map visualizations from markdown - network inventory, OSPF areas, BGP topology, security audit results. Use when visualizing network topology as a mind map, creat",
+              "invocable": true
+            },
+            {
+              "name": "memory",
+              "description": "**Purpose**: Provide persistent context across NetClaw sessions through structured facts, semantic search, and entity relationships.",
+              "invocable": true
+            },
+            {
+              "name": "memory-management",
+              "description": "description: \"Record and recall network facts, decisions, and session context using hybrid structured + semantic memory\"",
+              "invocable": true
+            },
+            {
+              "name": "mempalace",
+              "description": "description: \"MemPalace AI memory \u2014 persistent memory across sessions. Search past decisions, store architecture choices, track temporal network facts via knowledge graph, navigate cross-domain connec",
+              "invocable": true
+            },
+            {
+              "name": "meraki-monitoring",
+              "description": "description: \"Cisco Meraki Monitoring & Diagnostics \u2014 live ping, cable test, LED blink, wake-on-LAN, camera analytics, config change tracking. Use when running ping tests from Meraki devices, troubles",
+              "invocable": true
+            },
+            {
+              "name": "meraki-network-ops",
+              "description": "description: \"Cisco Meraki Dashboard \u2014 organization inventory, network management, device lifecycle, client discovery, action batches. Use when listing Meraki devices, managing networks, checking devi",
+              "invocable": true
+            },
+            {
+              "name": "meraki-security-appliance",
+              "description": "description: \"Cisco Meraki Security Appliance (MX) \u2014 firewall rules, site-to-site VPN, content filtering, traffic shaping, security events. Use when auditing Meraki MX firewall rules, troubleshooting ",
+              "invocable": true
+            },
+            {
+              "name": "meraki-switch-ops",
+              "description": "description: \"Cisco Meraki Switching \u2014 port configuration, VLANs, port status, ACLs, QoS rules, port cycling. Use when configuring Meraki switch ports, creating VLANs, checking port status and PoE, tr",
+              "invocable": true
+            },
+            {
+              "name": "meraki-wireless-ops",
+              "description": "description: \"Cisco Meraki Wireless \u2014 SSID management, RF profiles, channel utilization, signal quality, client connectivity events. Use when managing Meraki SSIDs, troubleshooting WiFi connectivity, ",
+              "invocable": true
+            },
+            {
+              "name": "monitoring-onboard",
+              "description": "description: \"Configure network devices to send telemetry to the existing observability stack. Supports pfSense, Cisco IOS/IOS-XE switches, Proxmox hosts, and Linux servers. Generates Prometheus scrap",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-files",
+              "description": "description: \"Manage files on OneDrive and SharePoint via Microsoft Graph API - upload, download, list, search, and organize network documentation and artifacts. Use when uploading reports to SharePoi",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-teams",
+              "description": "description: \"Send notifications and reports to Microsoft Teams channels via Graph API - alert delivery, report posting, incident updates, and diagram sharing. Use when posting health alerts to Teams,",
+              "invocable": true
+            },
+            {
+              "name": "msgraph-visio",
+              "description": "description: \"Generate and manage Visio network diagrams on SharePoint via Microsoft Graph API - create topology diagrams from CDP/LLDP discovery, update existing diagrams, export to PDF. Use when cre",
+              "invocable": true
+            },
+            {
+              "name": "n2n-federation",
+              "description": "description: Federate your NetClaw with other NetClaw operators over the BGP mesh \u2014 exchange capability inventories and ask your claw what a peer can do. (US1; remote invocation and chat land in later",
+              "invocable": true
+            },
+            {
+              "name": "nautobot-dev-setup",
+              "description": "Deploy a Nautobot development instance using the official `nautobot/nautobot-docker-compose` repository.",
+              "invocable": true
+            },
+            {
+              "name": "nautobot-sot",
+              "description": "description: \"Nautobot IPAM & source of truth \u2014 IP address queries, prefix lookups, VRF/tenant/site filtering, IPAM search, connection testing. Use when looking up IP addresses in Nautobot, checking s",
+              "invocable": true
+            },
+            {
+              "name": "netbox-reconcile",
+              "description": "description: \"Reconcile NetBox source of truth against live network state - detect IP drift, missing interfaces, undocumented links, cable mismatches, VLAN mismatches, and ticket discrepancies in Serv",
+              "invocable": true
+            },
+            {
+              "name": "nmap-network-scan",
+              "description": "description: \"Host discovery and port scanning using nmap \u2014 ICMP/ARP host discovery, SYN/TCP/UDP port scanning with scope enforcement and audit logging. Use when discovering live hosts on a subnet, sc",
+              "invocable": true
+            },
+            {
+              "name": "nmap-scan-management",
+              "description": "description: \"Custom nmap scans with arbitrary flags, plus scan history retrieval and management. Use when running nmap with custom flags, reviewing past scan results, comparing before/after scans, or",
+              "invocable": true
+            },
+            {
+              "name": "nmap-service-detection",
+              "description": "description: \"Service fingerprinting, OS detection, NSE script execution, and vulnerability scanning using nmap MCP. Use when identifying services on open ports, fingerprinting OS versions, running NS",
+              "invocable": true
+            },
+            {
+              "name": "nso-device-ops",
+              "description": "description: \"Cisco NSO device operations \u2014 config retrieval, state inspection, sync, platform info, NED IDs, device groups. Use when retrieving device configs from NSO, checking sync status, pulling ",
+              "invocable": true
+            },
+            {
+              "name": "nso-service-mgmt",
+              "description": "description: \"Cisco NSO service management \u2014 discover service types, list service instances, orchestrate network services. Use when listing NSO services, checking service health, auditing deployed ser",
+              "invocable": true
+            },
+            {
+              "name": "nvd-cve",
+              "description": "description: \"Search the National Vulnerability Database for CVEs - find vulnerabilities by keyword or ID, get CVSS scores, weaknesses, affected configurations, and remediation references. Use when lo",
+              "invocable": true
+            },
+            {
+              "name": "packet-analysis",
+              "description": "description: \"Analyze network packet captures (.pcap/.pcapng) using Packet Buddy MCP. Use when opening a pcap file, inspecting packet captures, troubleshooting network traffic, analyzing retransmissio",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-incidents",
+              "description": "description: \"Manage and investigate incidents in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-oncall",
+              "description": "description: \"Manage on-call schedules and escalation policies in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-orchestration",
+              "description": "description: \"Manage event orchestration and routing rules in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "pagerduty-services",
+              "description": "description: \"Manage service catalog and service health in PagerDuty.\"",
+              "invocable": true
+            },
+            {
+              "name": "paloalto-panorama",
+              "description": "description: \"Palo Alto Panorama operations \u2014 device groups, templates, security policy search, NAT review, commit status, and audit workflows. Use when searching Palo Alto firewall rules, checking if",
+              "invocable": true
+            },
+            {
+              "name": "pfsense-threat-intel",
+              "description": "version: 2.0.0",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-apps",
+              "description": "description: \"View Prisma SD-WAN application definitions for policy visibility\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-config",
+              "description": "description: \"Inspect Prisma SD-WAN interfaces, routing (BGP, static), policies, and security zones\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-status",
+              "description": "description: \"Monitor Prisma SD-WAN element health, software versions, events, and alarms\"",
+              "invocable": true
+            },
+            {
+              "name": "prisma-sdwan-topology",
+              "description": "description: \"Discover Prisma SD-WAN sites, ION elements, machines, and network topology\"",
+              "invocable": true
+            },
+            {
+              "name": "prometheus-monitoring",
+              "description": "description: \"Prometheus monitoring \u2014 PromQL instant/range queries, metric discovery, metadata, scrape target health, system health checks (6 tools). Use when querying Prometheus metrics, checking scr",
+              "invocable": true
+            },
+            {
+              "name": "protocol-participation",
+              "description": "description: \"Live BGP and OSPF control-plane participation \u2014 peer with real routers, inject/withdraw routes, query RIB/LSDB, adjust metrics, GRE tunnel status. Use when injecting or withdrawing BGP r",
+              "invocable": true
+            },
+            {
+              "name": "pyats-asa-firewall",
+              "description": "description: \"Cisco ASA firewall operations via pyATS \u2014 VPN sessions, failover state, interfaces, routing, service policies, resource usage, AnyConnect monitoring. Use when checking ASA failover statu",
+              "invocable": true
+            },
+            {
+              "name": "pyats-config-mgmt",
+              "description": "description: \"Network change management - pre-change baselines, configuration deployment, post-change verification, rollback procedures, and compliance validation. Use when pushing config to a device,",
+              "invocable": true
+            },
+            {
+              "name": "pyats-dynamic-test",
+              "description": "description: \"Generate and execute deterministic pyATS aetest validation scripts - interface state, OSPF neighbors, BGP paths, ping matrices, and custom compliance tests. Use when writing a network te",
+              "invocable": true
+            },
+            {
+              "name": "pyats-f5-ltm",
+              "description": "description: \"F5 BIG-IP LTM/GTM operations via pyATS iControl REST \u2014 virtual servers, pools, nodes, monitors, profiles, iRules, persistence, GTM wide IPs, DNS, data groups. Use when checking F5 virtua",
+              "invocable": true
+            },
+            {
+              "name": "pyats-f5-platform",
+              "description": "description: \"F5 BIG-IP platform operations via pyATS iControl REST \u2014 system, networking, HA/CM, auth, analytics, security, APM, live-update, ADC certs, file management. Use when checking BIG-IP syste",
+              "invocable": true
+            },
+            {
+              "name": "pyats-health-check",
+              "description": "description: \"Comprehensive network device health monitoring - CPU, memory, interfaces, hardware, NTP, logging, environment, and uptime analysis. Use when running a device health check, monitoring CPU",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-interfaces",
+              "description": "description: \"JunOS interface operations via pyATS \u2014 physical/logical interfaces, LACP, CoS, LLDP, ARP, BFD, IPv6 neighbors, traffic monitoring, optics diagnostics. Use when checking Juniper interface",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-routing",
+              "description": "description: \"JunOS routing operations via pyATS \u2014 OSPF/OSPFv3, BGP, route table, MPLS/LDP/RSVP, TED, PFE, ping, traceroute across Juniper devices. Use when checking Juniper OSPF neighbors, viewing BG",
+              "invocable": true
+            },
+            {
+              "name": "pyats-junos-system",
+              "description": "description: \"JunOS system operations via pyATS \u2014 chassis health, hardware inventory, system info, NTP, SNMP, files/logs, firewall counters, DDoS protection, services accounting. Use when checking Jun",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-network",
+              "description": "description: \"Linux host network operations via pyATS \u2014 interface configuration, routing tables, network connections, and multi-table route inspection across fleet hosts. Use when checking Linux inter",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-system",
+              "description": "description: \"Linux host system operations via pyATS \u2014 process monitoring, filesystem inspection, Docker container stats, package/tool verification across fleet hosts. Use when checking running proces",
+              "invocable": true
+            },
+            {
+              "name": "pyats-linux-vmware",
+              "description": "description: \"VMware ESXi host operations via pyATS \u2014 VM inventory, snapshot management, hypervisor inspection across ESXi hosts in the testbed. Use when listing VMs on ESXi, checking snapshot age, au",
+              "invocable": true
+            },
+            {
+              "name": "pyats-network",
+              "description": "description: \"Network device automation via pyATS - run show commands, ping, apply config, learn config/logging, list devices, run Linux commands, execute dynamic tests on Cisco IOS-XE/NX-OS devices. ",
+              "invocable": true
+            },
+            {
+              "name": "pyats-parallel-ops",
+              "description": "description: \"Fleet-wide parallel device operations - concurrent health checks, config audits, routing snapshots, severity-sorted reporting, and failure-isolated multi-device automation. Use when chec",
+              "invocable": true
+            },
+            {
+              "name": "pyats-routing",
+              "description": "description: \"CCIE-level routing protocol analysis - OSPF, BGP, EIGRP, IS-IS, static routes, RIB/FIB verification, redistribution audit, and convergence validation. Use when analyzing routing tables, ",
+              "invocable": true
+            },
+            {
+              "name": "pyats-security",
+              "description": "description: \"Network security audit - ACLs, AAA, control plane policing, management plane hardening, encryption, port security, and CIS benchmark checks. Use when auditing device security posture, ch",
+              "invocable": true
+            },
+            {
+              "name": "pyats-topology",
+              "description": "description: \"Network topology discovery via CDP/LLDP neighbors, ARP tables, routing peers, and interface mapping to build complete network maps. Use when mapping the network, building a diagram, disc",
+              "invocable": true
+            },
+            {
+              "name": "pyats-troubleshoot",
+              "description": "description: \"Systematic network troubleshooting - connectivity, routing, interface, protocol, and performance issues using structured OSI-layer and divide-and-conquer methodology. Use when something ",
+              "invocable": true
+            },
+            {
+              "name": "radkit-remote-access",
+              "description": "description: \"Cisco RADKit \u2014 cloud-relayed remote device access, CLI execution, SNMP polling, device inventory discovery, attribute inspection. Use when accessing remote network devices through a clou",
+              "invocable": true
+            },
+            {
+              "name": "rag",
+              "description": "**Purpose**: Give NetClaw a fully offline, user-curated document knowledge base \u2014 vendor guides, standards (RFC/IEEE/vendor), customer design documents, install guides \u2014 with agentic retrieval, mandat",
+              "invocable": true
+            },
+            {
+              "name": "rfc-lookup",
+              "description": "description: \"Search and retrieve IETF RFC documents - lookup by number, search by keyword, extract sections. Use when looking up an RFC, checking protocol specifications, verifying standards complian",
+              "invocable": true
+            },
+            {
+              "name": "sdwan-ops",
+              "description": "description: \"Cisco SD-WAN vManage read-only operations \u2014 fabric devices, WAN Edge inventory, templates, policies, alarms, events, interface stats, BFD sessions, OMP routes, control connections, runni",
+              "invocable": true
+            },
+            {
+              "name": "servicenow-change-workflow",
+              "description": "description: \"Full ITSM-gated change lifecycle - CR creation, pre-change incident validation, approval gate, execution via pyats-config-mgmt, post-change verification, and closure with GAIT audit trai",
+              "invocable": true
+            },
+            {
+              "name": "slack-incident-workflow",
+              "description": "description: \"Manage network incident response workflows in Slack - incident channels, status updates, escalation, resolution tracking, and post-incident review coordination. Use when declaring a netw",
+              "invocable": true
+            },
+            {
+              "name": "slack-network-alerts",
+              "description": "description: \"Format and deliver network alerts, health warnings, and critical notifications via Slack with rich formatting, reactions, and file attachments. Use when sending alerts to Slack, posting ",
+              "invocable": true
+            },
+            {
+              "name": "slack-report-delivery",
+              "description": "description: \"Deliver formatted network reports, audit results, topology diagrams, and compliance documentation to Slack channels with rich Block Kit formatting. Use when posting a health check report",
+              "invocable": true
+            },
+            {
+              "name": "slack-user-context",
+              "description": "description: \"Leverage Slack user profiles, presence, DND status, and workspace context to personalize responses, route escalations, and coordinate team operations. Use when checking who is on-call, r",
+              "invocable": true
+            },
+            {
+              "name": "slack-voice-interface",
+              "description": "description: \"Respond to Slack voice clips with both text and an MP3 voice reply using edge-tts. Voice IN is already handled by OpenClaw transcription. Use when a user sends a voice message in Slack, ",
+              "invocable": true
+            },
+            {
+              "name": "snmptrap-receiver",
+              "description": "description: \"Receive and query SNMP traps from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-indexes",
+              "description": "description: \"Discover and inspect Splunk indexes and configuration.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-saved",
+              "description": "description: \"Manage and run saved searches in Splunk.\"",
+              "invocable": true
+            },
+            {
+              "name": "splunk-search",
+              "description": "description: \"Execute and validate SPL (Search Processing Language) queries.\"",
+              "invocable": true
+            },
+            {
+              "name": "subnet-calculator",
+              "description": "description: \"IPv4 and IPv6 subnet calculator - CIDR breakdown, usable hosts, previous/next subnets, address classification, VLSM planning, and dual-stack analysis. Use when calculating subnets, figur",
+              "invocable": true
+            },
+            {
+              "name": "suzieq-observability",
+              "description": "description: \"SuzieQ network observability \u2014 query current and historical network state, run validation assertions, get summary statistics, trace forwarding paths, and discover unique values across 20",
+              "invocable": true
+            },
+            {
+              "name": "syslog-receiver",
+              "description": "description: \"Receive and query syslog messages from network devices via UDP.\"",
+              "invocable": true
+            },
+            {
+              "name": "te-network-monitoring",
+              "description": "description: \"Cisco ThousandEyes \u2014 test management, agent inventory, test results, dashboards, path visualization, user/account management. Use when checking ThousandEyes test results, viewing network",
+              "invocable": true
+            },
+            {
+              "name": "te-path-analysis",
+              "description": "description: \"Cisco ThousandEyes \u2014 path visualization, BGP route analysis, outage investigation, instant tests, endpoint agent diagnostics. Use when tracing network paths hop-by-hop, investigating why",
+              "invocable": true
+            },
+            {
+              "name": "telemetry-ops",
+              "description": "description: \"Comprehensive network telemetry and event collection across multiple protocols.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-operations",
+              "description": "description: \"Execute local Terraform operations with ServiceNow change control.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-registry",
+              "description": "description: \"Discover providers and modules from the Terraform Registry.\"",
+              "invocable": true
+            },
+            {
+              "name": "terraform-workspaces",
+              "description": "description: \"Manage HCP Terraform (Terraform Cloud/Enterprise) workspaces.\"",
+              "invocable": true
+            },
+            {
+              "name": "threejs-network-viz",
+              "description": "**Version**: 1.0.0",
+              "invocable": true
+            },
+            {
+              "name": "token-tracker",
+              "description": "description: \"Track and display token consumption and cost for every NetClaw interaction.\"",
+              "invocable": true
+            },
+            {
+              "name": "twilio-daily-briefing",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-emergency-call",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-inbound-voice",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twilio-outbound-call",
+              "description": "**Feature**: 042-twilio-voice-mcp",
+              "invocable": true
+            },
+            {
+              "name": "twitter-check",
+              "description": "**Purpose**: Quick invocation to check mentions and respond to #netclaw threads.",
+              "invocable": true
+            },
+            {
+              "name": "twitter-heartbeat",
+              "description": "**Purpose**: Autonomous periodic tweeting AND mention monitoring to maintain NetClaw's Twitter presence with CCIE-level network engineering content.",
+              "invocable": true
+            },
+            {
+              "name": "twitter-respond",
+              "description": "**Skill ID**: twitter-respond",
+              "invocable": true
+            },
+            {
+              "name": "twitter-share",
+              "description": "**Purpose**: Manual tweet posting with content guardrails and human approval flow.",
+              "invocable": true
+            },
+            {
+              "name": "ue5-network-viz",
+              "description": "description: \"3D network topology visualization and interactive digital twin in Unreal Engine 5.8 via the built-in UE5 MCP server.\"",
+              "invocable": true
+            },
+            {
+              "name": "uml-diagram",
+              "description": "description: \"UML and diagram generation via Kroki \u2014 class, sequence, activity, state, component, deployment, network, ER, C4, Mermaid, D2, Graphviz, BPMN, 27+ types. Use when generating a network dia",
+              "invocable": true
+            },
+            {
+              "name": "vault-mounts",
+              "description": "description: \"Discover and manage HashiCorp Vault secret engine mounts.\"",
+              "invocable": true
+            },
+            {
+              "name": "vault-pki",
+              "description": "description: \"Manage HashiCorp Vault PKI certificate infrastructure.\"",
+              "invocable": true
+            },
+            {
+              "name": "vault-secrets",
+              "description": "description: \"Manage HashiCorp Vault KV secrets with strict value protection.\"",
+              "invocable": true
+            },
+            {
+              "name": "webex-incident-workflow",
+              "description": "description: \"Manage network incident response workflows in Cisco WebEx - incident spaces, status updates, escalation, resolution tracking, and post-incident review coordination. Use when declaring a ",
+              "invocable": true
+            },
+            {
+              "name": "webex-network-alerts",
+              "description": "description: \"Format and deliver network alerts, health warnings, and critical notifications via Cisco WebEx with Adaptive Cards, markdown formatting, and file attachments. Use when sending alerts to ",
+              "invocable": true
+            },
+            {
+              "name": "webex-report-delivery",
+              "description": "description: \"Deliver formatted network reports, audit results, topology diagrams, and compliance documentation to WebEx spaces with Adaptive Cards and markdown formatting. Use when posting a health c",
+              "invocable": true
+            },
+            {
+              "name": "webex-user-context",
+              "description": "description: \"Leverage WebEx user profiles, presence status, and workspace context to personalize responses, route escalations, and coordinate team operations. Use when checking who is available, rout",
+              "invocable": true
+            },
+            {
+              "name": "webex-voice-interface",
+              "description": "description: \"Respond to WebEx voice clips with both text and an MP3 voice reply using edge-tts. Voice IN is already handled by OpenClaw transcription. Use when a user sends a voice message in WebEx, ",
+              "invocable": true
+            },
+            {
+              "name": "wifi-diagnosis",
+              "description": "description: \"Diagnose Wi-Fi and internet connectivity using Home / Network Guardian observability. Prefer adapter metrics (UniFi Integration exporter first; other wireless vendors via stubs later). A",
+              "invocable": true
+            },
+            {
+              "name": "wikipedia-research",
+              "description": "description: \"Research networking protocols, standards history, and technology context via Wikipedia - OSPF, BGP, MPLS, 802.1X, VXLAN, and more. Use when looking up protocol background, researching ho",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-identity",
+              "description": "description: \"Manage users, groups, departments, and identity provider configurations.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-insights",
+              "description": "description: \"Access analytics, threat intelligence, and security event data.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zdx",
+              "description": "description: \"Monitor digital experience scores, user performance, and application health.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zia",
+              "description": "description: \"Manage Zscaler Internet Access firewall rules, URL filtering, DLP, and security policies.\"",
+              "invocable": true
+            },
+            {
+              "name": "zscaler-zpa",
+              "description": "description: \"Manage Zscaler Private Access applications, segments, policies, and connectors.\"",
+              "invocable": true
+            }
+          ],
+          "mcp_servers": [
+            {
+              "name": "forward-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "suzieq-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "batfish-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gnmi-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "azure-network-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gitlab-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chrome-devtools-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chrome-devtools-mcp-visible",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "jenkins-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "atlassian-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gns3-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "prisma-sdwan-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "datadog-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "pagerduty-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "splunk-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "infrahub-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "terraform-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "vault-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "zscaler-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-dns-analytics",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-security",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-zerotrust",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-analytics",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cloudflare-workers",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "blender-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aruba-cx-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "devnet-content-search",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-golden-config-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nautobot-routing-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-management",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-management-logs",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-threat-prevention",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-https-inspection",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-harmony-sase",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-reputation-service",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-quantum-gw-cli",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-gw-connection-analysis",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-threat-emulation",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-quantum-gaia",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-documentation",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-spark-management",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-cpinfo-analysis",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-argos-erm",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "chkp-policy-insights",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "claroty-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twitter-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twilio-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "twilio-voice-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "unreal-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "sketchfab-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "pfsense-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "unifi-network",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "n2n-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "rag-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cml-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "nso-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "itential-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "prometheus-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "grafana-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "meraki-magic-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "radkit-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "junos-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "arista-cvp-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "cisco-fmc-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "thousandeyes-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "github-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-network-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-cloudwatch-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-iam-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-cloudtrail-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-cost-explorer-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aws-diagram-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-compute-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-monitoring-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-logging-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "gcp-resource-manager-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "thousandeyes-official-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "kubeshark-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "uml-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "protocol-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "ollama-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "fwrule-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-ansible-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-eda-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-lint-mcp",
+              "tools": [],
+              "invocable_tools": []
+            },
+            {
+              "name": "aap-docs-mcp",
+              "tools": [],
+              "invocable_tools": []
+            }
+          ],
+          "knowledge": [
+            {
+              "collection_id": "knowledge:documents",
+              "name": "Knowledge: documents",
+              "description": "Knowledge collection 'documents': VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches); VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches) - Preface [Cisco Catalyst 9200 Series Switches] - Cisco; VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches) - Configuring VTP [Cisco Catalyst 9200 Series Switches] - Cisco; VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches) - Configuring VLANs [Cisco Catalyst 9200 Series Switches] - Cisco; VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches) - Configuring Voice VLANs [Cisco Catalyst 9200 Series Switches] - Cisco; VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches) - Configuring VLAN Trunks [Cisco Catalyst 9200 Series Switches] - Cisco; VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches) - Configuring Private VLANs [Cisco Catalyst 9200 Series Switches] - Cisco; VLAN Configuration Guide, Cisco IOS XE 17.16.x (Catalyst 9200 Switches) - Configuring Wired Dynamic PVLAN [Cisco Catalyst 9200 Series Switches] - Cisco; Quantum Fiber Internet Subscriber Agreement; Documentation crawl; UniFi Network API 10.4.57 OpenAPI (customer, vendor).",
+              "tags": [
+                "customer",
+                "vendor"
+              ],
+              "doc_count": 11,
+              "page_count": 127,
+              "chunk_count": 744,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_WifiDegraded24GHz-Basement-AP---deeper-investigation-with-radio-details_2026-07-24T134400Z",
+              "name": "Knowledge: snapshot_WifiDegraded24GHz-Basement-AP---deeper-investigation-with-radio-details_2026-07-24T134400Z",
+              "description": "Knowledge collection 'snapshot_WifiDegraded24GHz-Basement-AP---deeper-investigation-with-radio-details_2026-07-24T134400Z': WifiDegraded24GHz-Basement-AP---deeper-investigation-with-radio-details (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 3,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_WifiDegraded24GHz_2026-07-24T185304Z",
+              "name": "Knowledge: snapshot_WifiDegraded24GHz_2026-07-24T185304Z",
+              "description": "Knowledge collection 'snapshot_WifiDegraded24GHz_2026-07-24T185304Z': WifiDegraded24GHz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 2,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_convergence-pipe-test-seed_2026-07-24T121341Z",
+              "name": "Knowledge: snapshot_convergence-pipe-test-seed_2026-07-24T121341Z",
+              "description": "Knowledge collection 'snapshot_convergence-pipe-test-seed_2026-07-24T121341Z': convergence-pipe-test-seed (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_convergencepipetest_2026-07-24T121655Z",
+              "name": "Knowledge: snapshot_convergencepipetest_2026-07-24T121655Z",
+              "description": "Knowledge collection 'snapshot_convergencepipetest_2026-07-24T121655Z': convergencepipetest (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_convergencepipetest_2026-07-24T121702Z",
+              "name": "Knowledge: snapshot_convergencepipetest_2026-07-24T121702Z",
+              "description": "Knowledge collection 'snapshot_convergencepipetest_2026-07-24T121702Z': convergencepipetest (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 3,
+              "page_count": 0,
+              "chunk_count": 3,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_convergencepipetest_2026-07-24T121917Z",
+              "name": "Knowledge: snapshot_convergencepipetest_2026-07-24T121917Z",
+              "description": "Knowledge collection 'snapshot_convergencepipetest_2026-07-24T121917Z': convergencepipetest (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_homeapidown_2026-07-24T170417Z",
+              "name": "Knowledge: snapshot_homeapidown_2026-07-24T170417Z",
+              "description": "Knowledge collection 'snapshot_homeapidown_2026-07-24T170417Z': homeapidown (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_homeapidown_2026-07-24T171230Z",
+              "name": "Knowledge: snapshot_homeapidown_2026-07-24T171230Z",
+              "description": "Knowledge collection 'snapshot_homeapidown_2026-07-24T171230Z': homeapidown (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_pfsensewanportscan_2026-07-25T005621Z",
+              "name": "Knowledge: snapshot_pfsensewanportscan_2026-07-25T005621Z",
+              "description": "Knowledge collection 'snapshot_pfsensewanportscan_2026-07-25T005621Z': pfsensewanportscan (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_pfsensewanportscan_2026-07-25T005845Z",
+              "name": "Knowledge: snapshot_pfsensewanportscan_2026-07-25T005845Z",
+              "description": "Knowledge collection 'snapshot_pfsensewanportscan_2026-07-25T005845Z': pfsensewanportscan (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_pfsensewanportscan_2026-07-25T043143Z",
+              "name": "Knowledge: snapshot_pfsensewanportscan_2026-07-25T043143Z",
+              "description": "Knowledge collection 'snapshot_pfsensewanportscan_2026-07-25T043143Z': pfsensewanportscan (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_pfsensewanportscan_2026-07-25T043546Z",
+              "name": "Knowledge: snapshot_pfsensewanportscan_2026-07-25T043546Z",
+              "description": "Knowledge collection 'snapshot_pfsensewanportscan_2026-07-25T043546Z': pfsensewanportscan (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_pfsensewanportscan_2026-07-25T074523Z",
+              "name": "Knowledge: snapshot_pfsensewanportscan_2026-07-25T074523Z",
+              "description": "Knowledge collection 'snapshot_pfsensewanportscan_2026-07-25T074523Z': pfsensewanportscan (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_unifiexporterdown_2026-07-24T170725Z",
+              "name": "Knowledge: snapshot_unifiexporterdown_2026-07-24T170725Z",
+              "description": "Knowledge collection 'snapshot_unifiexporterdown_2026-07-24T170725Z': unifiexporterdown (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_unifiexporterdown_2026-07-24T171619Z",
+              "name": "Knowledge: snapshot_unifiexporterdown_2026-07-24T171619Z",
+              "description": "Knowledge collection 'snapshot_unifiexporterdown_2026-07-24T171619Z': unifiexporterdown (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T121702Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T121702Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T121702Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 2,
+              "page_count": 0,
+              "chunk_count": 2,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T122809Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T122809Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T122809Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T122817Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T122817Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T122817Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T133706Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T133706Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T133706Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T133758Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T133758Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T133758Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T135212Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T135212Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T135212Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T141656Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T141656Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T141656Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T144758Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T144758Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T144758Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T145315Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T145315Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T145315Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T145349Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T145349Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T145349Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T182206Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T182206Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T182206Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-24T182249Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-24T182249Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-24T182249Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-25T065417Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-25T065417Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-25T065417Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded24ghz_2026-07-25T065439Z",
+              "name": "Knowledge: snapshot_wifidegraded24ghz_2026-07-25T065439Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded24ghz_2026-07-25T065439Z': wifidegraded24ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded5ghz_2026-07-24T234412Z",
+              "name": "Knowledge: snapshot_wifidegraded5ghz_2026-07-24T234412Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded5ghz_2026-07-24T234412Z': wifidegraded5ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            },
+            {
+              "collection_id": "knowledge:snapshot_wifidegraded5ghz_2026-07-24T235329Z",
+              "name": "Knowledge: snapshot_wifidegraded5ghz_2026-07-24T235329Z",
+              "description": "Knowledge collection 'snapshot_wifidegraded5ghz_2026-07-24T235329Z': wifidegraded5ghz (other).",
+              "tags": [
+                "other"
+              ],
+              "doc_count": 1,
+              "page_count": 0,
+              "chunk_count": 1,
+              "retrieval": "n2n/knowledge/query",
+              "embedding_model": "BAAI/bge-small-en-v1.5"
+            }
+          ],
+          "badges": [
+            "AWS",
+            "Azure",
+            "Batfish",
+            "CML",
+            "Check Point",
+            "Forward",
+            "GNS3",
+            "Meraki",
+            "Nautobot",
+            "SuzieQ",
+            "gNMI"
+          ],
+          "posture": {
+            "mode": "testing",
+            "state": "testing",
+            "summary": "testing",
+            "controls": {
+              "sandbox": true,
+              "model-guard": false,
+              "audit": true
+            }
+          },
+          "llm": {
+            "primary_model": "ollama/deepseek-v4-flash:cloud",
+            "guarded": false,
+            "note": "Border reasoning model; member claws run their own per-specialty tiered models"
+          }
+        },
+        "received_at": "2026-07-25T16:43:51Z",
+        "stale": true
+      },
+      "channel_state": "unreachable",
+      "last_seen": 0,
+      "endpoint_updated_at": null,
+      "in_flight_tasks": [],
+      "endpoint": null
+    }
+  ],
+  "approvals": [],
+  "risk": {
+    "role": "border",
+    "risk_name": "johns-risk",
+    "description": null,
+    "enabled_stacks": "both",
+    "self_member_id": null,
+    "member_count": 29,
+    "members_active": 6
+  },
+  "members": [
+    {
+      "member_id": "johns-risk/aap",
+      "display_name": "aap",
+      "profile": "aap",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "zzz-nonexistent-skill-0"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/aci",
+      "display_name": "aci",
+      "profile": "aci",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "zzz-nonexistent-skill-1"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/azure",
+      "display_name": "azure",
+      "profile": "azure",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "zzz-nonexistent-skill-2"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/batfish",
+      "display_name": "batfish",
+      "profile": "batfish",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "zzz-nonexistent-skill-3"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/catalyst-center",
+      "display_name": "catalyst-center",
+      "profile": "catalyst-center",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "zzz-nonexistent-skill-4"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/cml",
+      "display_name": "cml",
+      "profile": "cml",
+      "state": "active",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 5,
+      "skills": [
+        "zzz-nonexistent-skill-5"
+      ],
+      "live": true,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/containerlab",
+      "display_name": "containerlab",
+      "profile": "containerlab",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "zzz-nonexistent-skill-6"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/f5",
+      "display_name": "f5",
+      "profile": "f5",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "zzz-nonexistent-skill-7"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/fortimanager",
+      "display_name": "fortimanager",
+      "profile": "fortimanager",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "zzz-nonexistent-skill-8"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/forward",
+      "display_name": "forward",
+      "profile": "forward",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "zzz-nonexistent-skill-9"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/fwrule",
+      "display_name": "fwrule",
+      "profile": "fwrule",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "zzz-nonexistent-skill-10"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/github",
+      "display_name": "github",
+      "profile": "github",
+      "state": "active",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "zzz-nonexistent-skill-11"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/gtrace",
+      "display_name": "gtrace",
+      "profile": "gtrace",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "zzz-nonexistent-skill-12"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/infoblox",
+      "display_name": "infoblox",
+      "profile": "infoblox",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "zzz-nonexistent-skill-13"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/ipfabric",
+      "display_name": "ipfabric",
+      "profile": "ipfabric",
+      "state": "active",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "zzz-nonexistent-skill-14"
+      ],
+      "live": true,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/ise",
+      "display_name": "ise",
+      "profile": "ise",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "zzz-nonexistent-skill-15"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/itential",
+      "display_name": "itential",
+      "profile": "itential",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "zzz-nonexistent-skill-16"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/netbox",
+      "display_name": "netbox",
+      "profile": "netbox",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "zzz-nonexistent-skill-17"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/nmap",
+      "display_name": "nmap",
+      "profile": "nmap",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 3,
+      "skills": [
+        "zzz-nonexistent-skill-18"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/nso",
+      "display_name": "nso",
+      "profile": "nso",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "zzz-nonexistent-skill-19"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/nvd",
+      "display_name": "nvd",
+      "profile": "nvd",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "zzz-nonexistent-skill-20"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/packet",
+      "display_name": "packet",
+      "profile": "packet",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "zzz-nonexistent-skill-21"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/paloalto",
+      "display_name": "paloalto",
+      "profile": "paloalto",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 2,
+      "skills": [
+        "zzz-nonexistent-skill-22"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/pyats",
+      "display_name": "pyats",
+      "profile": "pyats",
+      "state": "active",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 18,
+      "skills": [
+        "zzz-nonexistent-skill-23"
+      ],
+      "live": true,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/sdwan",
+      "display_name": "sdwan",
+      "profile": "sdwan",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 5,
+      "skills": [
+        "zzz-nonexistent-skill-24"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/suzieq",
+      "display_name": "suzieq",
+      "profile": "suzieq",
+      "state": "provisioned",
+      "transport_binding": null,
+      "node_type": "agent",
+      "specialty_count": 1,
+      "skills": [
+        "zzz-nonexistent-skill-25"
+      ],
+      "live": false,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "johns-risk/viz",
+      "display_name": "viz",
+      "profile": "viz",
+      "state": "active",
+      "transport_binding": "distributed",
+      "node_type": "agent",
+      "specialty_count": 8,
+      "skills": [
+        "zzz-nonexistent-skill-26"
+      ],
+      "live": true,
+      "heartbeat_age_s": null
+    },
+    {
+      "member_id": "risk/1785077389894",
+      "display_name": null,
+      "profile": null,
+      "state": "unreachable",
+      "transport_binding": "edge-ws",
+      "node_type": "edge",
+      "specialty_count": 3,
+      "skills": [
+        "zzz-nonexistent-skill-27"
+      ],
+      "live": false,
+      "heartbeat_age_s": 1742.2
+    },
+    {
+      "member_id": "risk/1785078347014",
+      "display_name": null,
+      "profile": null,
+      "state": "active",
+      "transport_binding": "edge-ws",
+      "node_type": "edge",
+      "specialty_count": 3,
+      "skills": [
+        "zzz-nonexistent-skill-28"
+      ],
+      "live": true,
+      "heartbeat_age_s": 13.3
+    }
+  ],
+  "posture": {
+    "mode": "production",
+    "state": "enforced",
+    "controls": [
+      {
+        "name": "sandbox",
+        "kind": "containment",
+        "available": true,
+        "detail": "",
+        "probed_at": 1785179850.0359924
+      },
+      {
+        "name": "model-guard",
+        "kind": "containment",
+        "available": true,
+        "detail": "",
+        "probed_at": 1785179850.0359924
+      },
+      {
+        "name": "audit",
+        "kind": "audit",
+        "available": true,
+        "detail": "",
+        "probed_at": 1785179850.0359924
+      }
+    ],
+    "missing": [],
+    "strict_all": false,
+    "model": {
+      "primary": "anthropic/claude-opus-5",
+      "guarded": false
+    },
+    "channel_security": {
+      "mode": "on",
+      "by_trust_model": {
+        "legacy": 2,
+        "pinned": 3
+      },
+      "degraded": 2,
+      "amber": 0,
+      "red": 0,
+      "renewals_failing": 0,
+      "pq_mode": "opportunistic",
+      "pq_available": false,
+      "ech_available": false,
+      "channels_kex": []
+    },
+    "computed_at": 1785179850.0363233,
+    "summary": "production \u2014 enforced"
+  },
+  "gait": [
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 471,
+      "ts": "2026-07-27T18:57:50Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/cml",
+      "target": "cml-admin",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 470,
+      "ts": "2026-07-27T18:48:10Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 469,
+      "ts": "2026-07-27T18:35:43Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/cml",
+      "target": "cml-lab-lifecycle",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 468,
+      "ts": "2026-07-27T18:31:49Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/cml",
+      "target": "cml-lab-lifecycle",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 467,
+      "ts": "2026-07-27T18:30:32Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 466,
+      "ts": "2026-07-27T18:27:59Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 465,
+      "ts": "2026-07-27T18:03:35Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 464,
+      "ts": "2026-07-27T17:57:48Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 463,
+      "ts": "2026-07-27T17:33:32Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 462,
+      "ts": "2026-07-27T17:27:57Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 461,
+      "ts": "2026-07-27T17:21:48Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 460,
+      "ts": "2026-07-27T17:17:27Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 459,
+      "ts": "2026-07-27T17:03:31Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 458,
+      "ts": "2026-07-27T16:57:43Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 457,
+      "ts": "2026-07-27T16:33:30Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 456,
+      "ts": "2026-07-27T16:27:43Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 455,
+      "ts": "2026-07-27T16:03:36Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 454,
+      "ts": "2026-07-27T15:57:52Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 453,
+      "ts": "2026-07-27T15:33:32Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 452,
+      "ts": "2026-07-27T15:27:49Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 451,
+      "ts": "2026-07-27T15:03:35Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 450,
+      "ts": "2026-07-27T14:58:19Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 449,
+      "ts": "2026-07-27T14:33:08Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 448,
+      "ts": "2026-07-27T14:27:20Z"
+    },
+    {
+      "event": "delegation",
+      "actor": "johns-risk/border",
+      "subject": "johns-risk/pyats",
+      "target": "pyats-health-check",
+      "channel_kind": "in2n",
+      "sqlite_row_id": 447,
+      "ts": "2026-07-27T14:03:24Z"
+    }
+  ],
+  "replicationJobs": [],
+  "edgeNodes": [
+    {
+      "member_id": "risk/1785077389894",
+      "display_name": null,
+      "profile": null,
+      "state": "unreachable",
+      "transport_binding": "edge-ws",
+      "node_type": "edge",
+      "specialty_count": 3,
+      "skills": [
+        "camera.capture",
+        "camera.record_video",
+        "audio.record"
+      ],
+      "live": false,
+      "heartbeat_age_s": 1742.2
+    },
+    {
+      "member_id": "risk/1785078347014",
+      "display_name": null,
+      "profile": null,
+      "state": "active",
+      "transport_binding": "edge-ws",
+      "node_type": "edge",
+      "specialty_count": 3,
+      "skills": [
+        "camera.capture",
+        "camera.record_video",
+        "audio.record"
+      ],
+      "live": true,
+      "heartbeat_age_s": 13.3
+    }
+  ],
+  "recentPushes": [
+    {
+      "id": 440,
+      "direction": "outbound",
+      "peer_identity": "risk/1785077389894",
+      "target_type": "edge_push",
+      "target_name": "text",
+      "request_id": null,
+      "decision": "pushed",
+      "outcome": "success",
+      "requested_at": "2026-07-26T21:01:23Z",
+      "completed_at": "2026-07-26T21:01:23Z",
+      "result_ref": null,
+      "gait_ref": null,
+      "channel_kind": "in2n",
+      "linked_record_id": null
+    },
+    {
+      "id": 423,
+      "direction": "outbound",
+      "peer_identity": "risk/1785077389894",
+      "target_type": "edge_push",
+      "target_name": "text",
+      "request_id": null,
+      "decision": "pushed",
+      "outcome": "success",
+      "requested_at": "2026-07-26T16:20:00Z",
+      "completed_at": "2026-07-26T16:20:00Z",
+      "result_ref": null,
+      "gait_ref": null,
+      "channel_kind": "in2n",
+      "linked_record_id": null
+    }
+  ],
+  "generatedAt": "2026-07-27T19:17:32.063Z"
+}

--- a/specs/072-hud-2-org-chart/plan.md
+++ b/specs/072-hud-2-org-chart/plan.md
@@ -1,0 +1,190 @@
+# Implementation Plan: HUD 2.0 — Top-Down Trust Org Chart
+
+**Branch**: `072-hud-2-org-chart` | **Date**: 2026-07-27 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/072-hud-2-org-chart/spec.md`
+
+## Summary
+
+Replace the HUD's orbiting-cores scene with a planar, top-down trust org chart:
+eN2N peers in an external band north of an explicit trust boundary, the Border
+on the centre line, iN2N members below grouped into derived categories, and
+mobile edges in their own lane at the boundary. Chat and the right-hand detail
+panel are untouched.
+
+The technical approach turns on one decision from Phase 0 (R1): **split pure
+layout logic from three.js rendering**. Category derivation, health
+classification, ordering, dedup and position maths become dependency-free
+modules unit-tested with `node:test`; only genuinely perceptual criteria
+(greyscale separability, fault-finding time, frame rate) need a browser. That is
+what makes a 64-requirement visual spec falsifiable rather than "looks right".
+
+Two supporting decisions: the camera becomes orthographic with rotation disabled
+(R7) — the actual cure for "hard to navigate", more than the theme is — and the
+scene sheds two entire populations (integrations, devices) that were being drawn
+over the trust topology (FR-030).
+
+## Technical Context
+
+**Language/Version**: JavaScript ES2022 (ESM), Node 22+ for tooling
+**Primary Dependencies**: three.js `^0.170.0` (existing), `OrbitControls`,
+`CSS2DRenderer`, postprocessing chain, gsap `^3.12.5`, vite `^5.4.0`. **No new
+runtime dependencies.**
+**Storage**: N/A — stateless client; all state from `/api/n2n` and `/api/graph`
+**Testing**: `node:test` (built-in, zero new dependencies) for pure logic;
+`chrome-devtools-mcp` (already vendored, feature 048) for perceptual and
+performance verification
+**Target Platform**: Chromium-family browser, desktop
+**Project Type**: Web frontend (single package, `ui/netclaw-visual/`)
+**Performance Goals**: 60 fps sustained on a discrete GPU at 100 members /
+~25 categories / 5 expanded (FR-029b); never slower than HUD 1.0 on identical
+data (FR-029c)
+**Constraints**: No new runtime dependency; no server change; no widening of the
+HUD's API surface (FR-019); chat and right-hand panel behaviour unchanged
+(FR-016/017/018)
+**Scale/Scope**: ~100 members, ~25 categories, ~10 peers, ~10 edge nodes, all
+simultaneously visible without virtualisation
+
+## Constitution Check
+
+*GATE: evaluated before Phase 0 and re-evaluated after Phase 1.*
+
+| Principle | Applies? | Assessment |
+|---|---|---|
+| I. Safety-First Operations | No | Read-only visualisation; issues no device commands |
+| II. Read-Before-Write | No | No writes of any kind |
+| III. ITSM-Gated Changes | No | Not a production device change |
+| IV. Immutable Audit Trail | Partial | The HUD is a viewer, not an operator, and performs no auditable operation. `/api/chat` does, and is explicitly untouched (FR-016) |
+| V. MCP-Native Integration | No | No new capability; consumes existing endpoints |
+| VI. Multi-Vendor Neutrality | **Yes — PASS** | FR-006 forbids a hardcoded member list; categories derive from the shipped integration catalog, so no vendor is privileged |
+| VII. Skill Modularity | Analogous — PASS | R1's pure/render split applies the same decomposition principle to UI code |
+| VIII. Verify After Every Change | **Yes — PASS** | SC-001..013; FR-029c is an explicit regression guard |
+| IX. Security by Default | **Yes — PASS** | FR-019 forbids widening the API surface. No new endpoint, no new privilege |
+| X. Observability | Partial | Client-side; no new signals. Recorded as Deferred during clarify |
+| XI. Full-Stack Artifact Coherence | **Yes — PARTIAL** | Not a new MCP/skill/integration, so catalog and installer entries do not apply. `ui/netclaw-visual/README.md` **MUST** be updated |
+| XII. Documentation-as-Code | **Yes — PASS** | README update is a tracked task, not an afterthought |
+| XIII. Credential Safety | **Yes — see violation below** | This feature adds no credential handling |
+| XIV. Human-in-the-Loop | No | No external communication |
+| XV. Backwards Compatibility | **Yes — PASS** | Layout-only hard replace. FR-016/017/018 preserve chat and panel; FR-030d keeps `/api/graph` alive for retained renderers; no shared interface changes |
+| XVI. Spec-Driven Development | **Yes — PASS** | spec → 2× clarify → plan → tasks → analyze → implement |
+| XVII. Milestone Documentation | Deferred | Post-merge decision, not a gate |
+
+**Gate result: PASS.** No unjustified violations.
+
+### Pre-existing constitutional violation (out of scope, recorded)
+
+**Principle XIII (Credential Safety) is currently violated by the HUD**, prior to
+and independently of this feature. `ui/netclaw-visual/server.js:1088`
+(`GET /api/env/:integrationId`) returns unmasked credential values;
+`server.js:17` applies `cors()` with no origin allowlist; `server.js:1789` binds
+`0.0.0.0` while logging `localhost`. Confirmed live: device enable passwords, a
+NetBox token, a ServiceNow password and a GitHub PAT are all retrievable over
+unauthenticated HTTP.
+
+This feature **must not compound it** (FR-019) and does not touch that surface.
+The operator has been informed and elected to review it separately; the finding
+is written up at `~/netclaw-reports/SECURITY-hud-credential-exposure.md`.
+
+It is recorded here because a constitution check that silently passed over a
+live Principle XIII violation *in the very file being edited* would be
+dishonest.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/072-hud-2-org-chart/
+├── plan.md              # This file
+├── research.md          # Phase 0 — 8 decisions, all unknowns resolved
+├── data-model.md        # Phase 1
+├── quickstart.md        # Phase 1
+├── contracts/
+│   └── layout-contract.md    # Phase 1 — pure-layout module contract
+├── fixtures/                 # Phase 1 — synthetic /api/n2n payloads (R4)
+│   ├── empty.json
+│   ├── single.json
+│   ├── live-29.json
+│   ├── scale-100.json
+│   └── uncategorised.json
+└── tasks.md             # Phase 2 (/speckit.tasks — not created here)
+```
+
+### Source Code (repository root)
+
+```text
+ui/netclaw-visual/
+├── server.js                    # UNCHANGED (FR-019; see violation note above)
+├── index.html                   # #search retargeted (FR-031); legend added (FR-009c)
+└── src/
+    ├── main.js                  # Scene wiring. Orbit layout REMOVED (FR-026/027);
+    │                            #   materials, ribbons, labels, picking, polling
+    │                            #   and every panel renderer PRESERVED (FR-028)
+    ├── orgchart/                # NEW — pure logic, imports NOTHING from three.js
+    │   ├── categorize.js        #   member -> integration -> category (FR-006/006a)
+    │   ├── categorize.test.js
+    │   ├── health.js            #   HOT/WARM/COLD/FAULT + 900s threshold (FR-008/008a)
+    │   ├── health.test.js
+    │   ├── normalize.js         #   peer dedup (FR-014), label fallback (FR-015)
+    │   ├── normalize.test.js
+    │   ├── ordering.js          #   heat-then-size, computed once (FR-006b/034)
+    │   ├── ordering.test.js
+    │   ├── layout.js            #   bands, category columns, row packing (R6)
+    │   └── layout.test.js
+    ├── orgchart-render/         # NEW — three.js only, consumes orgchart/ output
+    │   ├── bands.js             #   3 bands + trust boundary (FR-001/002)
+    │   ├── nodes.js             #   instanced node geometry (FR-029a)
+    │   ├── links.js             #   6 link styles (FR-010/011)
+    │   ├── expansion.js         #   tool expand/collapse (FR-020..025)
+    │   ├── camera.js            #   orthographic, rotation locked (FR-012/013)
+    │   └── a11y.js              #   DOM overlay, keyboard, SR labels (FR-032)
+    └── panels/                  # UNCHANGED
+```
+
+**Structure decision.** A single web frontend package; no backend change. The
+`orgchart/` ÷ `orgchart-render/` split is load-bearing, not cosmetic — it is
+what makes R1's testing strategy possible. `orgchart/` must stay importable in
+bare Node with no WebGL context, enforced by its tests running under
+`node --test` with no DOM.
+
+## Complexity Tracking
+
+| Item | Why it is not over-engineering |
+|---|---|
+| Two new directories rather than editing `main.js` in place | `main.js` is 132 KB. FR-026 mandates a hard replace of the layout; doing that inside one file makes the diff unreviewable and leaves no seam for tests |
+| Five committed fixtures | SC-006 is a product-generality claim ("renders sensibly for a deployment it has never seen"). One deployment cannot evidence it, and 100-member performance cannot be measured on a 29-member Border |
+| A11y DOM overlay | FR-032. A WebGL canvas exposes no focusable elements; there is no lighter mechanism. Reuses the `CSS2DRenderer` layer already present |
+| `node:test` rather than no tests | The spec makes numeric claims (100 members, 900 s, 60 fps, four states) that rot silently without regression coverage |
+
+**Rejected as unnecessary:** `d3-hierarchy` (the graph is two levels deep),
+force-directed layout (non-deterministic, would violate FR-034), vitest (the
+code under test imports nothing), Playwright (`chrome-devtools-mcp` already
+vendored), any server-side change (FR-019).
+
+## Post-Design Constitution Re-Check
+
+Re-evaluated after Phase 1 artifacts. **Still PASS**, with two observations:
+
+- **Principle VI strengthened by the design.** `categorize.js` takes the
+  integration catalog as an *argument* rather than importing it, so the
+  vendor-neutrality guarantee is testable — `categorize.test.js` proves the same
+  code produces different, correct charts for different catalogs.
+- **Principle XV risk concentrated in one place.** The only realistic way this
+  feature breaks something else is FR-030d (deleting scene builders whose
+  `/api/graph` payload a panel renderer still reads). R5 verified the dependency
+  by reading the source rather than assuming; it becomes a discrete task with
+  its own verification step rather than a line in a larger deletion.
+
+No new violations introduced by the design.
+
+## Phase 2 preview
+
+`/speckit.tasks` will decompose along the structure above. Expected ordering:
+fixtures → pure modules with tests → render modules → camera → a11y → deletion
+of the orbit and integration/device populations → README → verification against
+SC-001..013. Deletions land **after** the replacement works, so the branch never
+sits in a state where neither layout functions.
+
+---
+
+*Phase 0 complete: [research.md](./research.md) — 8 decisions, no NEEDS CLARIFICATION remaining.*
+*Phase 1 complete: [data-model.md](./data-model.md), [contracts/layout-contract.md](./contracts/layout-contract.md), [quickstart.md](./quickstart.md).*

--- a/specs/072-hud-2-org-chart/plan.md
+++ b/specs/072-hud-2-org-chart/plan.md
@@ -113,6 +113,7 @@ specs/072-hud-2-org-chart/
 
 ```text
 ui/netclaw-visual/
+├── package.json                 # +"test" script only (research R2)
 ├── server.js                    # UNCHANGED (FR-019; see violation note above)
 ├── index.html                   # #search retargeted (FR-031); legend added (FR-009c)
 └── src/

--- a/specs/072-hud-2-org-chart/quickstart.md
+++ b/specs/072-hud-2-org-chart/quickstart.md
@@ -1,0 +1,72 @@
+# Quickstart: HUD 2.0
+
+Feature: `072-hud-2-org-chart` · Phase 1
+
+## Run the HUD
+
+```bash
+cd ui/netclaw-visual
+npm install          # only if node_modules is absent
+npm run dev          # express API :3001 + vite :5173
+```
+
+> **Security note.** The HUD's API binds `0.0.0.0` and serves credentials
+> unauthenticated (Principle XIII violation, pre-existing, out of scope for this
+> feature — see plan.md). Do not run `npm run dev` on an untrusted network while
+> that remains unfixed.
+
+## Run the tests
+
+```bash
+cd ui/netclaw-visual
+npm test             # node --test src/   (no browser, no GPU, no new deps)
+```
+
+Every module under `src/orgchart/` is pure and dependency-free, so the suite is
+fast and runs anywhere Node runs. If a test fails with a three.js or `document`
+error, an import has crossed the boundary the contract forbids — that is the
+enforcement mechanism, not an accident.
+
+## Work against a fixture instead of the live Border
+
+The live Border has 29 members and can't exercise the 100-member ceiling
+(FR-029) or the empty first-run state (FR-033):
+
+```bash
+HUD_FIXTURE=specs/072-hud-2-org-chart/fixtures/scale-100.json npm run dev
+```
+
+| Fixture | Exercises |
+|---|---|
+| `empty.json` | FR-033 first-run — bands, boundary, CTAs, no data |
+| `single.json` | Degenerate single-member chart |
+| `live-29.json` | Snapshot of the real Border (regression baseline) |
+| `scale-100.json` | FR-029 ceiling + FR-029b frame rate |
+| `uncategorised.json` | FR-006a — every member matches no prefix |
+
+## Verify the perceptual criteria
+
+Pure logic is covered by `npm test`. These need a real browser
+(`chrome-devtools-mcp`, already vendored — no install):
+
+| Check | How |
+|---|---|
+| SC-007 greyscale | Screenshot → greyscale filter → four states still separable |
+| SC-007a fault-find | `uncategorised.json` + 1 FAULT among 25 COLD; time to locate < 5 s |
+| SC-009 keyboard | Tab/arrows/Enter reach and operate every node, no pointer |
+| SC-010 reduced motion | Emulate `prefers-reduced-motion`, re-run SC-007 |
+| SC-011 stability | Node coordinates, first frame vs 30 min later — must be identical |
+| SC-013 frame rate | Performance trace on `scale-100.json`, 5 expanded, during pan/zoom |
+
+## Definition of done
+
+1. `npm test` green.
+2. All five fixtures render without overlap or blank labels.
+3. Chat and the right-hand panel behave exactly as on `main` — diff behaviour,
+   don't eyeball it (SC-005).
+4. `/api/graph` still fetched; `renderSidebar` and `renderMetrics` still work
+   (FR-030d — the single most likely way this feature breaks something else).
+5. No orbit code remains (FR-027), and no integration/device scene objects
+   (FR-030c).
+6. `ui/netclaw-visual/README.md` updated (Constitution XI/XII).
+7. `git grep` finds no member name hardcoded in layout code (SC-006).

--- a/specs/072-hud-2-org-chart/research.md
+++ b/specs/072-hud-2-org-chart/research.md
@@ -1,0 +1,207 @@
+# Phase 0 Research: HUD 2.0 — Top-Down Trust Org Chart
+
+Feature: `072-hud-2-org-chart` · Date: 2026-07-27
+
+Resolves every NEEDS CLARIFICATION in the plan's Technical Context.
+
+---
+
+## R1. How is a *visual* specification tested when no JS test framework exists?
+
+**Finding.** `ui/netclaw-visual/package.json` has four scripts (`dev`, `server`,
+`build`, `preview`) and **no test framework** — no vitest, jest, playwright,
+cypress or puppeteer. Every test in the repo is Python/pytest. The 13 success
+criteria in this spec are largely perceptual ("identifiable within 2 seconds",
+"distinguishable in greyscale", "located in under 5 seconds").
+
+**Decision.** Split the feature into two testable halves, and make the split an
+architectural requirement rather than a testing afterthought:
+
+1. **Pure logic — unit tested, no browser, no GPU.** Category derivation, health
+   classification, dedup, label fallback, ordering, and band/row position math
+   are all pure functions of the `/api/n2n` payload. Extracted into modules that
+   **import nothing from three.js**, they are testable as plain data-in/data-out.
+   This covers the majority of the spec's falsifiable content: FR-006, 006a,
+   006b, 008, 008a, 014, 015, 029a, 034, 034b.
+2. **Perceptual / runtime — verified in a real browser.** Everything that only
+   exists once pixels are drawn: FR-009a/b, 012, 013, 029b/c, 032, 033 and
+   SC-001..013.
+
+**Rationale.** Without this split, a WebGL scene is effectively untestable and
+the 64 requirements degrade into "looks right to me". With it, the numeric and
+structural requirements get real regression tests, and human judgement is
+reserved for genuinely perceptual claims.
+
+**Alternatives considered.**
+- *Test through the rendered scene only* — rejected: slow, flaky, needs a GPU in
+  CI, and cannot isolate a layout maths bug from a material bug.
+- *Skip automated testing* — rejected: the spec makes falsifiable numeric claims
+  (100 members, 60 fps, 900 s threshold, four states) that would silently rot.
+
+---
+
+## R2. Which test runner, given Constitution XV (dependency isolation)?
+
+**Decision.** **Node's built-in `node:test`** (`node --test`), zero new
+dependencies. Test files as `src/**/*.test.js`, run via a new
+`"test": "node --test src/"` script.
+
+**Rationale.** The pure-logic modules from R1 import nothing but plain JS, so
+none of vitest's value (vite resolution, ESM/CJS interop, `three/addons`
+aliasing, browser mode) is actually needed. Node 25 is installed and ships
+`node:test` with ESM support. Constitution XV requires new dependencies to be
+isolated and non-conflicting; the cheapest way to satisfy that is not to add
+one. This also matches the repo's established stdlib-only tooling convention
+(`scripts/*.py` are Python-stdlib only by policy).
+
+**Alternatives considered.**
+- *vitest* — the ecosystem default and better DX, and it would integrate with
+  the existing vite 5 config. Rejected only because the code under test is
+  deliberately dependency-free; adding a runner to test functions that import
+  nothing is unjustified weight. **Revisit if** rendering-layer tests are ever
+  wanted, where vite resolution would genuinely pay for itself.
+- *pytest via a JS bridge* — rejected as absurd for this purpose.
+
+---
+
+## R3. How are the perceptual and performance criteria verified?
+
+**Finding.** `chrome-devtools-mcp` is registered in the repo template
+(`config/openclaw.json`, both headless and visible variants, from feature 048)
+but is **not** in the live `~/.openclaw/openclaw.json`. It runs on demand via
+`npx -y chrome-devtools-mcp@latest` with no install step.
+
+**Decision.** Use it as the verification harness for the perceptual half:
+
+| Criterion | Method |
+|---|---|
+| SC-007 greyscale | Screenshot, apply a greyscale filter, confirm four states remain separable |
+| SC-007a fault-find < 5 s | Seeded fixture (1 FAULT among 25 COLD), human timing |
+| SC-009 keyboard | Drive Tab/arrows/Enter, assert focus lands on every node |
+| SC-010 reduced motion | Emulate `prefers-reduced-motion`, re-run SC-007 |
+| SC-011 position stability | Capture node coordinates first frame vs last, diff |
+| SC-013 60 fps / regression | DevTools performance trace at the FR-029 ceiling |
+
+**Rationale.** It is already vendored, needs no new dependency, and gives
+screenshots, CDP emulation (including `prefers-reduced-motion`) and performance
+traces from one tool. Registering it live is a one-line config change and is
+**not** required for the feature to ship — it is a developer-workflow step.
+
+**Alternatives considered.** Playwright (a new dependency covering the same
+ground); manual verification only (rejected — SC-011 and SC-013 are numeric and
+would never actually be checked).
+
+---
+
+## R4. Synthetic fixtures — how are 100 members and first-run tested?
+
+**Finding.** The live Border has 29 members, 4 peers and 2 edges. The spec
+requires correctness at ~100 members / ~25 categories (FR-029) and on an empty
+first-run install (FR-033). Neither state can be produced from live data, and
+`SC-006` explicitly demands validation against Borders the code has never seen.
+
+**Decision.** Commit synthetic `/api/n2n` fixtures under
+`specs/072-hud-2-org-chart/fixtures/`: `empty.json` (no risk/members/peers),
+`single.json` (1 member), `live-29.json` (a captured snapshot of today's real
+Border), `scale-100.json` (100 members / ~25 categories), and
+`uncategorised.json` (members matching no integration prefix). Pure-logic tests
+run against all five; the dev server gains a documented way to serve a fixture
+instead of live data.
+
+**Rationale.** SC-006 is a product-generality claim and cannot be honoured by
+testing one deployment. Fixtures make the claim falsifiable and let the 100-node
+performance target be exercised before anyone has that many claws.
+
+**Alternatives considered.** Generating members procedurally at runtime
+(rejected — FR-033c forbids synthetic topologies reaching the real UI, and a
+fixture file is easier to reason about than a generator).
+
+---
+
+## R5. Does removing the scene populations break the panel? (FR-030d)
+
+**Finding — confirmed by reading the source, not assumed.** `renderSidebar(graph)`
+and `renderMetrics(graph)` both consume the `/api/graph` payload, and
+`fetchGraph()` supplies it. FR-030 removes the *scene objects* built from that
+payload (`buildIntegrations`, `buildDevices`, `createSkillSprites`,
+`computeDendritePositions`, `createDendriteMaterial`, `lightIntegration`,
+`lightDevice`) but the payload itself still has consumers.
+
+**Decision.** Keep `fetchGraph()` and the `/api/graph` request. Delete only the
+scene-construction functions and the integration/device branches of
+`applyFilters()`. `state.integrations` and `state.devices` must be re-examined
+individually: any field still read by a retained panel renderer stays.
+
+**Rationale.** This is the highest-risk part of a hard replace — deleting a
+fetch whose data a panel still needs would breach FR-017/FR-018 and only surface
+at runtime. Making it an explicit, verified step rather than an assumption.
+
+---
+
+## R6. Layout algorithm
+
+**Decision.** Deterministic banded row-packing. Three fixed bands on the XY
+plane (external / border / internal); the internal band packs category columns
+left→right, wrapping to a new row when width is exceeded; members stack
+vertically within their column. Order is computed **once** per session (FR-034).
+No force simulation, no tidy-tree.
+
+**Rationale.** The graph is depth-2 by construction (Border → category →
+member) — every member is depth-1 from the Border, as measured in the spec.
+Reingold–Tilford and force-directed layouts both solve problems this graph does
+not have, and force simulation would actively violate FR-034's position
+stability.
+
+**Alternatives considered.** `d3-hierarchy` (a new dependency for a tree that is
+two levels deep); force-directed (non-deterministic, contradicts FR-034).
+
+---
+
+## R7. Camera model (FR-012 / FR-013)
+
+**Decision.** `THREE.OrthographicCamera` with `OrbitControls` configured as
+`enableRotate = false`, pan and zoom retained, and zoom clamped. The existing
+`CSS2DRenderer` label layer is kept and doubles as the accessibility DOM overlay
+required by FR-032.
+
+**Rationale.** Orthographic makes equal-tier siblings render at equal size,
+which is the property that makes a chart read as a chart (FR-013), and it
+removes the perspective foreshortening that currently makes the far side of the
+orbit unreadable. `OrbitControls` is already imported and supports rotation
+lockout, so no control library is added or replaced.
+
+**Alternatives considered.** Perspective with compensating per-tier scale
+(FR-013's fallback — more maths, worse result); `MapControls` (a second control
+addon for behaviour `OrbitControls` already provides).
+
+---
+
+## R8. `prefers-reduced-motion` vs the four-state encoding (FR-032c)
+
+**Decision.** Motion is a **redundant** channel, never a load-bearing one. Each
+of HOT/WARM/COLD/FAULT is separable by form and colour temperature alone; motion
+is added on top for HOT and FAULT only. Under reduced motion, animation is
+suppressed and the encoding is unaffected.
+
+**Rationale.** FR-009a asks for multi-channel encoding and FR-032c requires the
+encoding to survive motion suppression. The only way to satisfy both is for
+motion to be additive. Designing it as redundant from the start also means
+SC-007 (greyscale) and SC-010 (reduced motion) test the same underlying
+property rather than two separate mechanisms.
+
+---
+
+## Resolved unknowns
+
+| Unknown | Resolution |
+|---|---|
+| Testing approach for a visual feature | R1 — pure/perceptual split, made architectural |
+| Test runner | R2 — `node:test`, zero new dependencies |
+| Perceptual + perf verification | R3 — `chrome-devtools-mcp`, already vendored |
+| Fixtures for scale and first-run | R4 — five committed `/api/n2n` fixtures |
+| Panel breakage risk from FR-030 | R5 — keep `fetchGraph()`, delete scene builders only |
+| Layout algorithm | R6 — deterministic banded row-packing |
+| Camera | R7 — orthographic, rotation disabled |
+| Reduced motion vs health encoding | R8 — motion is redundant, never load-bearing |
+
+**No NEEDS CLARIFICATION remain.**

--- a/specs/072-hud-2-org-chart/spec.md
+++ b/specs/072-hud-2-org-chart/spec.md
@@ -123,6 +123,36 @@ edges in their own lane at the boundary line.
 - Q: Should a member's tools be visible? → A: Yes, via per-node expand/collapse
   (FR-020).
 
+### Session 2026-07-27 (clarify, pass 2)
+
+- Q: FR-020 (expand tools) and US3/AC1 (click selects → detail panel) both claim
+  the click. Which gesture does what? → A: **Click = select** (invokes
+  `setDetail`, panel unchanged); **expand is a dedicated affordance** on the
+  node (chevron/`+`). Two independent, separately discoverable actions. See
+  FR-020a.
+
+- Q: What accessibility scope does HUD 2.0 carry? → A: **Keyboard + screen
+  reader via a DOM overlay** — every node focusable and labelled, arrow/tab
+  traversal, Enter selects, expand affordance reachable. Reuses the existing
+  CSS2D layer. Full WCAG AA conformance is out of scope. See FR-032.
+
+- Q: FR-029b's "interactive frame rate on the reference machine" is undefined.
+  What is the target? → A: **60 fps sustained on a discrete GPU** at the FR-029
+  ceiling. A relative regression guard (never slower than HUD 1.0 on identical
+  data) applies alongside it. See FR-029b/029c.
+
+- Q: A fresh install has no risk, no members and no peers — and FR-030 removes
+  the integration/device populations. What does a first-run HUD 2.0 render?
+  → A: **Structure always visible.** Bands and the trust boundary render even
+  when empty, each with an empty state and a short CTA. See FR-033.
+
+- Q: FR-006b orders categories by heat, but the HUD polls continuously — so a
+  claw changing state would re-rank its category and re-pack the whole chart,
+  contradicting the spatial-memory principle behind FR-022/FR-031a. Live
+  re-sort or stable order? → A: **Stable within session.** Order is computed
+  once at load; live updates change appearance only. See FR-006b (amended) and
+  FR-034.
+
 ### Session 2026-07-27 (clarify)
 
 - Q: Migration strategy — hard replace the orbit layout, coexist behind a view
@@ -295,11 +325,14 @@ jump or reframe.
 
 - **FR-006b**: The layout MUST adapt to however many categories a deployment
   yields — 1 to N — with column packing and wrapping. It MUST NOT assume a
-  fixed set. Categories MUST be ordered **by heat first, then by size**: groups
-  containing live members lead, so the handful of hot claws are always the most
-  prominent thing on screen regardless of how many cold categories exist. On
+  fixed set. Categories are ordered **by heat first, then by size**, so the
+  handful of hot claws lead regardless of how many cold categories exist. On
   this deployment that places Labs, Device Automation, Visualization and
   Uncategorised (the 4 hot groups) ahead of 18 cold ones.
+
+  **This ordering is computed once per session, at load — never live.** See
+  FR-034; heat ordering helps on arrival, when the operator has no spatial
+  memory yet, and works against them afterwards.
 - **FR-007**: Mobile edge nodes MUST render in a dedicated lane flanking the
   Border — inside the trust boundary, outside the member chart — and MUST NOT be
   interleaved with member claws.
@@ -356,6 +389,15 @@ jump or reframe.
 - **FR-020**: Every member node MUST support expand/collapse to reveal the tools
   (skills) it holds. Collapsed is the default; the chart must be readable as a
   chart before anything is expanded.
+- **FR-020a**: Expand and select MUST be **separate gestures**. Click (and tap)
+  selects the node and invokes `setDetail()` — unchanged from HUD 1.0.
+  Expansion MUST be driven by a dedicated affordance rendered on the node
+  (chevron / `+`), never by the click that selects. Consequences:
+  inspecting a claw MUST NOT reflow the chart, and expanding one MUST NOT
+  change what the right-hand panel is showing.
+- **FR-020b**: The expand affordance MUST be visible without hover, so the
+  capability is discoverable on first sight and usable on touch. Hover-only
+  affordances are not acceptable at the FR-029 node count.
 - **FR-021**: An expanded member MUST show its skills from the existing
   `member.skills[]` payload — no new API call and no server change. Members
   already carry both `skills[]` and `specialty_count`.
@@ -391,6 +433,66 @@ jump or reframe.
   `renderFederationSection`, `renderEdgeNodes`, `renderPostureBadge`,
   `renderGaitTrail`, `renderChannelSecurity`, `renderReplicationJobs`,
   `renderRecentPushes` — MUST continue to work against the same data.
+
+### Layout stability
+
+- **FR-034**: Node and category positions MUST be **stable for the lifetime of a
+  session**. Position is assigned once, on first layout, and MUST NOT change in
+  response to polled state.
+- **FR-034a**: Live updates MUST change **appearance only** — health state,
+  links, badges, counts. A claw that fails MUST change how it looks, never
+  where it is. This is the same principle FR-022 (expansion must not reflow)
+  and FR-031a (search dims rather than hides) already enforce; live re-sorting
+  would violate it more severely than either, because it happens unprompted.
+- **FR-034b**: A member that enrols mid-session MUST be appended within its
+  category without displacing existing nodes, preserving the incremental
+  behaviour `refreshRiskMembers()` already provides.
+- **FR-034c**: A manual re-sort/re-layout control MAY be offered, so an operator
+  can opt into re-ranking after a lot of state churn. If offered it MUST be
+  explicit and operator-initiated, never automatic.
+- **FR-034d**: A full page reload re-computes order from current heat. Position
+  stability is a within-session guarantee, not a persisted one.
+
+### Empty and first-run states
+
+- **FR-033**: The three bands and the trust boundary MUST render even when
+  empty. A NetClaw with no risk, no members and no peers is the **normal first
+  state for a new operator**, not an edge case, and with FR-030 removing the
+  integration and device populations there is nothing else left to draw.
+- **FR-033a**: Each empty band MUST carry its own empty state naming what
+  belongs there and the action that populates it (no federated peers / no
+  members enrolled / no devices paired). The empty chart is the primary
+  explanation of NetClaw's trust model for a first-time user, so it MUST read
+  as "nothing here yet", never as a failure.
+- **FR-033b**: `buildRiskMembers()` currently early-returns unless
+  `risk.role === 'border'`. Under FR-033 a non-Border install MUST still render
+  the structure rather than an empty scene.
+- **FR-033c**: A synthetic/demo topology MUST NOT be rendered. In a security
+  tool, a fabricated claw that could be mistaken for a real one is a hazard.
+- **FR-033d**: Loading MUST be distinguishable from empty. The existing
+  `setLoading(progress, text)` path MUST cover the interval before the first
+  `/api/n2n` response, so a slow poll never looks like an unfederated install.
+
+### Accessibility
+
+- **FR-032**: Every interactive node (peer, Border, member, edge) MUST be
+  reachable and operable without a pointer. A WebGL canvas exposes no focusable
+  elements, so the chart MUST carry a DOM overlay of focusable, labelled
+  elements positioned over the canvas — the standard technique, and the same
+  mechanism `CSS2DRenderer` already provides for labels.
+- **FR-032a**: Keyboard model: Tab moves between bands/categories, arrow keys
+  move between siblings within one, Enter selects (equivalent to click,
+  FR-020a), and the expand affordance is separately reachable.
+- **FR-032b**: Each focusable node MUST expose an accessible name and its health
+  state as text, so a screen-reader user receives what FR-008's visual encoding
+  conveys. State MUST NOT be communicated by colour or motion alone.
+- **FR-032c**: `prefers-reduced-motion` MUST be honoured. **This interacts with
+  FR-009a**: motion is one of the channels distinguishing HOT/WARM/COLD/FAULT,
+  so when motion is suppressed the remaining channels (form, colour
+  temperature) MUST still satisfy SC-007 on their own. Reduced motion must not
+  collapse the health encoding.
+- **FR-032d**: Full WCAG 2.1 AA conformance is explicitly OUT of scope for this
+  feature.
 
 ### Search and navigation
 
@@ -439,11 +541,22 @@ jump or reframe.
 - **FR-029a**: Node geometry SHOULD be instanced or otherwise shared so member
   count drives draw calls sub-linearly. At 100 members with tools expanded, the
   scene must not require per-node unique geometry.
-- **FR-029b**: The chart MUST hold an interactive frame rate at the FR-029
-  ceiling on the reference machine. If the existing postprocessing chain
-  (bloom/SMAA/afterimage) cannot sustain that with 100 nodes plus expanded
-  tools, the postprocessing MUST be reduced rather than the node count capped —
-  legibility of the chart outranks the glow.
+- **FR-029b**: The chart MUST sustain **60 fps on a discrete GPU** at the
+  FR-029 ceiling (100 members, ~25 categories, 5 members expanded) during pan
+  and zoom. If the existing postprocessing chain (bloom/SMAA/afterimage) cannot
+  hold that, the postprocessing MUST be reduced rather than the node count
+  capped — legibility of the chart outranks the glow.
+- **FR-029c**: Regression guard, independent of FR-029b: HUD 2.0 MUST NOT be
+  slower than HUD 1.0 on identical data. It draws strictly less (FR-030 removes
+  the integration and device populations entirely), so any slowdown indicates a
+  defect in the new layout rather than an inherent cost.
+
+  > **Known gap, accepted:** the target is specified against a discrete GPU, so
+  > behaviour on integrated graphics — the likelier deployment for an operator
+  > laptop — is unspecified and untested by FR-029b. FR-029c partially covers
+  > this by preventing regression against HUD 1.0 on whatever hardware is used.
+  > If integrated-graphics performance later proves inadequate, the remedy is
+  > the FR-029b fallback (reduce postprocessing), not a redesign.
 
 ### Migration
 
@@ -496,6 +609,19 @@ jump or reframe.
   operator in under 5 seconds, without search.
 - **SC-008**: An operator can determine which tools a given claw holds, hot or
   cold, without leaving the chart or opening the detail panel.
+- **SC-009**: The entire chart is operable with a keyboard alone — every node
+  reachable, selectable, and expandable — and each node's health state is
+  announced as text by a screen reader (FR-032).
+- **SC-010**: With `prefers-reduced-motion` set, all four health states remain
+  distinguishable, and SC-007's greyscale test still passes (FR-032c).
+- **SC-011**: Over a 30-minute session in which members change state, no node
+  changes position. Verified by comparing node coordinates between the first
+  frame and the last (FR-034).
+- **SC-012**: A NetClaw with no risk, no members and no peers renders the full
+  band structure with empty states, and is never mistaken for a failed load —
+  loading and empty are visually distinct (FR-033).
+- **SC-013**: HUD 2.0 sustains 60 fps on a discrete GPU at 100 members with 5
+  expanded, and is no slower than HUD 1.0 on identical data (FR-029b/029c).
 
 ## Assumptions
 

--- a/specs/072-hud-2-org-chart/spec.md
+++ b/specs/072-hud-2-org-chart/spec.md
@@ -1,0 +1,317 @@
+# Feature Specification: HUD 2.0 — Top-Down Trust Org Chart
+
+**Feature Branch**: `072-hud-2-org-chart`
+**Created**: 2026-07-27
+**Status**: Draft
+**Input**: User description: "the orbiting space theme is clunky and hard to navigate — can we make an org-chart style top down, with external claws (eN2N) 'north' or clearly external to the org chart; mobile connections should look like iN2N but special; and then the member claws; the border in the center. DON'T touch the chat interface or the right-side info bar."
+
+## Context: what the current HUD does and why it is hard to navigate
+
+`ui/netclaw-visual/src/main.js` (132 KB) renders every entity as a core orbiting
+a shared centroid: `CORE_CENTROID = (12, 0, 0)`, members fanned onto a ring of
+radius `RISK_LAYOUT.tierRadius = 46`, edge nodes assigned one of three fixed
+"close orbit" slots, peers on their own orbits. The camera is a
+`PerspectiveCamera(48°)` driven by unconstrained `OrbitControls`.
+
+Two things make it clunky, and only one of them is the theme:
+
+1. **Free orbit destroys hierarchy.** With rotation unconstrained, any given
+   frame shows the topology from an arbitrary angle. "External vs internal" and
+   "who reports to whom" are relationships that only read if the viewer and the
+   layout agree on which way is up. This is the dominant cause and it is a
+   camera problem, not an aesthetic one.
+2. **Every node is given equal visual weight** regardless of whether it matters.
+
+### Measured state of the live data (2026-07-27, `GET /api/n2n`)
+
+These numbers drive the layout and are not hypothetical:
+
+| Quantity | Value |
+|---|---|
+| Members total | **29** |
+| — `state=provisioned` (cold) | **22** |
+| — `state=active` | 5 |
+| — `state=unreachable` | 2 |
+| — actually `live: true` | **4** (`cml`, `ipfabric`, `pyats`, `viz`) |
+| `node_type=agent` / `edge` | 27 / 2 |
+| eN2N peers | 5 rows (4 distinct — see FR-014) |
+| Distinct `profile` values | **28 across 29 members** |
+
+Three consequences:
+
+- **A flat row of 29 members is unreadable at any zoom.** 25 of the 29 are cold
+  or unreachable. The layout must demote them, not merely place them.
+- **`profile` cannot be the org chart's middle tier.** It is effectively 1:1
+  with the member (28 distinct values for 29 members) — grouping by it produces
+  28 groups of one. A genuine middle tier has to come from somewhere else
+  (FR-006), or the chart is a 29-wide flat fan with extra steps.
+- **The chart is shallow.** Every member is depth-1 from the Border. This is a
+  tiered band layout, not a general tree, so no Reingold–Tilford / tidy-tree
+  algorithm is required. Row packing within bands is sufficient.
+
+## Proposed layout
+
+```
+              ╔═ EXTERNAL — eN2N ═════════════════════════════════════╗
+   NORTH      ║   ( AB )      ( Nicholas )    ( Byrn )     ( Hermes ) ║
+              ║  federated     unreachable   unreachable    SEVERED   ║
+              ╚═══╤═══════════════╤═══════════════╤═══════════╌╌╌╌════╝
+                  │               ┊               ┊            ✂
+        ══════════╪═══════════════╪═══════════════╪══════════════════════
+         TRUST    │      B O R D E R   B O U N D A R Y
+        ══════════╪═══════════════╪═══════════════╪══════════════════════
+                  │               ┊               ┊
+                       ╭──────────────────╮              ┌── EDGE LANE ──┐
+   CENTRE            ╭─┤   B O R D E R    ├─╌╌╌╌╌╌╌╌╌╌╌╌►│  ( phone 1 )  │
+                     │ │  johns-risk      │   push ch.   │  ( phone 2 )  │
+                     │ ╰──────────────────╯              └───────────────┘
+                     │
+        ─────────────┴──── INTERNAL — iN2N ──────────────────────────────
+                     │
+        ┌────────────┼───────────┬──────────────┬───────────────┐
+     [Lab&Emul]  [Assurance]  [Src of Truth] [Security]   [Controllers]
+        │            │             │              │              │
+   SOUTH ●cml      ●pyats       ●ipfabric     ·ise ·f5      ·aci ·nso
+        ·clab      ·suzieq       ·netbox      ·palo ·nmap   ·sdwan ·aap
+        ·gns3      ·batfish      ·infrahub    ·nvd  ·fwrule ·itential
+                   ·forward      ·infoblox
+        ● = live (4)      · = cold / provisioned (25, collapsed)
+```
+
+The Border reads as the centre of a vertical stack and as the root of the
+internal chart at the same time — external above the boundary, internal below,
+edges in their own lane at the boundary line.
+
+## Clarifications
+
+### Session 2026-07-27
+
+- Q: Does "Border in the center" conflict with "org chart top down"? → A: No.
+  The Border is the center of a three-band vertical stack: external above,
+  Border in the middle, internal below. It is the root of the *internal* chart
+  and the boundary node for the *external* one. Both readings hold.
+- Q: Should this be true 3D or a flat diagram? → A: Planar layout on a single
+  plane, with depth used only for band separation and hover lift. The 3D engine
+  is retained for material quality, bloom, and link animation — not for
+  free-form spatial arrangement.
+
+### Open — needs the operator's decision
+
+- **Q1 (blocking for FR-006): what is the member category taxonomy?** `profile`
+  is 1:1 with the member, so the middle tier must be a category map. A proposed
+  default is in FR-006; it is a starting point written by inspection of member
+  names, not domain truth. Confirm or replace it.
+- **Q2 (FR-009): should cold members be visible by default?** The spec assumes
+  collapsed-but-present. The alternative is hidden behind a toggle.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Read the trust topology at a glance (Priority: P1)
+
+An operator opens the HUD and, without rotating, panning, or clicking anything,
+can immediately answer: who is outside my organisation, who is inside it, which
+of them are alive right now, and where is the boundary between the two.
+
+**Why this priority**: This is the entire point of the redesign. Every other
+story is refinement. If the first frame does not answer those four questions,
+the rebuild has failed and the orbit version was no worse.
+
+**Independent Test**: Load the HUD on a clean session. Without any input,
+confirm the external peers, the Border, and the internal members are each
+identifiable, and the trust boundary between external and internal is visible
+as an explicit graphic element rather than implied by distance.
+
+**Acceptance Scenarios**:
+
+1. **Given** a loaded HUD at default camera, **When** the operator looks at the
+   scene without interacting, **Then** eN2N peers appear in a band above an
+   explicitly drawn trust boundary, the Border sits on the centre line, and
+   iN2N members occupy the band below it.
+2. **Given** 4 live members among 29 total, **When** the scene renders, **Then**
+   the 4 live members are visually dominant and the 25 cold/unreachable ones are
+   demoted, so live capacity is legible without counting.
+3. **Given** the operator drags the mouse, **When** they attempt to orbit,
+   **Then** the camera pans within the layout plane and does not rotate out of
+   the top-down orientation.
+4. **Given** a severed peer, **When** the scene renders, **Then** its link to the
+   Border is drawn as broken//severed and is distinguishable from a merely
+   unreachable peer at a glance.
+
+---
+
+### User Story 2 - Distinguish mobile edges from member claws (Priority: P2)
+
+An operator can spot their enrolled phones instantly and tell them apart from
+server-side member claws, without hunting through the member band.
+
+**Why this priority**: Edge nodes are internal (enrolled members, `node_type=edge`)
+but behave nothing like member claws — they are user-carried, intermittently
+connected, and receive pushes rather than serving delegations. The current HUD
+already special-cases them into close-orbit slots for exactly this reason; that
+intent must survive the redesign.
+
+**Independent Test**: With at least one edge node enrolled, confirm it renders in
+its own lane, is not mixed into the member rows, and its link to the Border is
+visually distinct from a member link.
+
+**Acceptance Scenarios**:
+
+1. **Given** 2 enrolled edge nodes, **When** the scene renders, **Then** they
+   appear in a dedicated lane flanking the Border, inside the trust boundary but
+   outside the member chart.
+2. **Given** an edge node that is unreachable, **When** the scene renders,
+   **Then** its last-seen age is legible without opening the detail panel.
+3. **Given** an edge node with a null `display_name`, **When** the scene renders,
+   **Then** a stable fallback label derived from `member_id` is shown rather
+   than a blank (see FR-015).
+
+---
+
+### User Story 3 - Drill into any node without losing the map (Priority: P2)
+
+Clicking any node populates the existing right-hand detail panel while the
+overall chart stays in place and oriented.
+
+**Why this priority**: The operator explicitly wants the chat interface and the
+right-hand info bar kept as-is. This story exists to guarantee the redesign is
+additive to them and does not change their contract.
+
+**Independent Test**: Click a peer, a member, and an edge node in turn; confirm
+the right-hand panel updates exactly as it does today and the camera does not
+jump or reframe.
+
+**Acceptance Scenarios**:
+
+1. **Given** any node, **When** the operator clicks it, **Then** the existing
+   `setDetail(kind, payload, related)` contract is invoked unchanged.
+2. **Given** a selected node, **When** the detail panel is open, **Then** the
+   chart remains fully visible and does not reflow.
+
+---
+
+### Edge Cases
+
+- **Zero members / zero peers** (fresh Border): bands must render with an empty
+  state, not collapse into an unlabelled void.
+- **A member enrolling while the HUD is open**: must appear on the next poll
+  without a reload, preserving the existing `refreshRiskMembers()` behaviour.
+- **More edge nodes than lane slots**: must wrap or scroll, not overlap. The
+  current implementation stacks a 4th phone onto the last slot; that regression
+  must not be carried forward.
+- **Very long display names**: must truncate with the full value available in
+  the detail panel.
+- **A member that is both `active` and not `live`**: state and liveness are
+  distinct fields and disagree in the live data (5 active vs 4 live). The
+  visual must encode `live`, not `state`, for the dominance rule in FR-008.
+
+## Requirements *(mandatory)*
+
+### Layout
+
+- **FR-001**: The scene MUST be laid out as three horizontal bands on a single
+  plane: external (north), Border (centre), internal (south).
+- **FR-002**: An explicit trust boundary MUST be drawn between the external band
+  and the Border — a visible graphic element, not implied whitespace.
+- **FR-003**: eN2N peers MUST occupy the external band, above the boundary, and
+  MUST NOT be rendered as children of the Border in the org chart sense.
+- **FR-004**: The Border MUST sit on the centre line, and MUST be the visual
+  root of the internal chart and the attachment point for external links.
+- **FR-005**: iN2N member claws MUST occupy the internal band below the Border,
+  arranged as a top-down chart.
+- **FR-006**: Members MUST be grouped into a middle tier by category. `profile`
+  MUST NOT be used as the grouping key (it is 1:1 with the member).
+  Proposed default taxonomy — **pending operator confirmation (Q1)**:
+
+  | Category | Members |
+  |---|---|
+  | Lab & Emulation | `cml`, `containerlab`, `gns3` |
+  | Assurance & Test | `pyats`, `suzieq`, `batfish`, `forward`, `gtrace`, `packet` |
+  | Source of Truth | `netbox`, `nautobot`, `infrahub`, `infoblox`, `ipfabric` |
+  | Security | `ise`, `f5`, `paloalto`, `fortimanager`, `fwrule`, `nmap`, `nvd` |
+  | Controllers & Fabric | `aci`, `catalyst-center`, `sdwan`, `nso`, `aap`, `itential` |
+  | Cloud & Platform | `azure`, `github` |
+  | Visualisation | `viz` |
+
+  Any member not in the map MUST fall into an explicit "Uncategorised" group
+  rather than being dropped.
+- **FR-007**: Mobile edge nodes MUST render in a dedicated lane flanking the
+  Border — inside the trust boundary, outside the member chart — and MUST NOT be
+  interleaved with member claws.
+
+### Visual weight
+
+- **FR-008**: Live members (`live: true`) MUST be visually dominant over
+  cold/unreachable ones. Dominance MUST key off `live`, not `state`.
+- **FR-009**: Cold members MUST be collapsed into a compact, dimmed
+  representation that is expandable on demand, so 25 inactive nodes cannot
+  crowd out 4 active ones. *(Default-visible per Q2 assumption.)*
+- **FR-010**: Link styling MUST distinguish, at a glance: healthy eN2N,
+  unreachable eN2N, severed eN2N, healthy iN2N, cold iN2N, and the edge/push
+  channel.
+- **FR-011**: The edge/push link MUST be visually distinct from a member
+  delegation link, reflecting that it is asymmetric (Border → device).
+
+### Camera and interaction
+
+- **FR-012**: The camera MUST be constrained so the top-down orientation cannot
+  be lost. Free rotation MUST be disabled; pan and zoom MUST remain.
+- **FR-013**: An orthographic projection SHOULD be used so that sibling nodes at
+  equal tier render at equal size, which is what makes a chart readable as a
+  chart. If perspective is retained for material reasons, tier scaling MUST be
+  compensated so equal-tier nodes appear equal.
+
+### Data correctness (defects surfaced by this work)
+
+- **FR-014**: Peers MUST be de-duplicated by identity before rendering. The live
+  feed currently returns `Hermes` twice with conflicting states (`severed` and
+  `federated`). The existing `deduplicatePeers()` MUST be applied to this feed,
+  and where states conflict the more restrictive one MUST win.
+- **FR-015**: A node with a null `display_name` MUST fall back to a label
+  derived from `member_id`. Both live edge nodes currently have
+  `display_name: null` and would otherwise render blank.
+
+### Preservation (explicit non-goals)
+
+- **FR-016**: The chat interface MUST NOT be modified.
+- **FR-017**: The right-hand detail/info panel MUST NOT be modified. Its
+  `setDetail()` contract MUST be honoured unchanged.
+- **FR-018**: All existing detail-panel renderers — `renderRiskSection`,
+  `renderFederationSection`, `renderEdgeNodes`, `renderPostureBadge`,
+  `renderGaitTrail`, `renderChannelSecurity`, `renderReplicationJobs`,
+  `renderRecentPushes` — MUST continue to work against the same data.
+
+### Security constraint
+
+- **FR-019**: This feature MUST NOT widen the HUD's existing unauthenticated
+  API surface, and MUST NOT introduce any new endpoint that returns credential
+  values. (See `~/netclaw-reports/SECURITY-hud-credential-exposure.md`: the
+  HUD already serves the credential store in plaintext over an unauthenticated,
+  CORS-open, `0.0.0.0`-bound API. That defect is out of scope here and is being
+  tracked separately, but this work must not compound it.)
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: An operator who has never seen the HUD can correctly identify
+  which claws are external and which are internal, on first view, without
+  interacting.
+- **SC-002**: The 4 live members are identifiable within 2 seconds of load,
+  without counting or zooming.
+- **SC-003**: No camera input can produce a view in which the external band is
+  not above the internal band.
+- **SC-004**: All 29 members, 4 peers, and 2 edge nodes render without label
+  collision or node overlap at default zoom.
+- **SC-005**: Chat and the right-hand panel behave identically to HUD 1.0 —
+  verified by diffing their behaviour, not by inspection.
+
+## Assumptions
+
+- Three.js is retained (r0.170, already vendored with `OrbitControls`,
+  `CSS2DRenderer`, and the postprocessing chain). No new rendering dependency
+  is required. `CSS2DRenderer` is the intended label mechanism — at ~40 nodes
+  the DOM cost is immaterial and the crispness matters for a chart.
+- No new layout library is required. Bands + row packing within a band is
+  sufficient for a depth-2 chart; a general tidy-tree algorithm would be
+  over-engineering here.
+- The existing `/api/n2n` payload is sufficient. The only additions this spec
+  implies are client-side (the category map in FR-006); no server change is
+  required, and none should be made to satisfy FR-019.

--- a/specs/072-hud-2-org-chart/spec.md
+++ b/specs/072-hud-2-org-chart/spec.md
@@ -68,15 +68,26 @@ Three consequences:
                      │
         ─────────────┴──── INTERNAL — iN2N ──────────────────────────────
                      │
-        ┌────────────┼───────────┬──────────────┬───────────────┐
-     [Lab&Emul]  [Assurance]  [Src of Truth] [Security]   [Controllers]
-        │            │             │              │              │
-   SOUTH ●cml      ●pyats       ●ipfabric     ·ise ·f5      ·aci ·nso
-        ·clab      ·suzieq       ·netbox      ·palo ·nmap   ·sdwan ·aap
-        ·gns3      ·batfish      ·infrahub    ·nvd  ·fwrule ·itential
-                   ·forward      ·infoblox
-        ● = live (4)      · = cold / provisioned (25, collapsed)
+       ┌─────────────┼──────────────┬─────────────┬──────────┬─── … ───┐
+   HOT GROUPS FIRST (categories containing a live member lead)   COLD GROUPS →
+       │             │              │             │          │
+   [Device Autom.] [Labs]    [Visualization] [Uncategorised] [Security] [Observ.]
+       │             │              │             │          │          │
+ SOUTH ◆pyats      ◆cml           ◆viz        ◆ipfabric    ·ise      ·suzieq
+       │           ·containerlab                ·forward    ·paloalto ·gtrace
+       │                                                    ·nmap     ·packet
+       ├─ [expanded] ──────────┐                            ·nvd
+       │  pyats-health-check   │  ← FR-020: tools revealed  ·fwrule
+       │  pyats-troubleshoot   │    in place, siblings do   ·fortimanager
+       │  pyats-parallel-ops   │    not reflow (FR-022)
+       └───────────────────────┘
+
+   ◆ = HOT  (live, animated, saturated)    · = COLD (inert, desaturated)
+   Hot/cold differ in form + colour + motion — not opacity alone (FR-009a)
 ```
+
+Categories above are **derived**, not authored — see FR-006. A different
+operator's Border produces different columns from the same rule.
 
 The Border reads as the centre of a vertical stack and as the root of the
 internal chart at the same time — external above the boundary, internal below,
@@ -95,14 +106,19 @@ edges in their own lane at the boundary line.
   is retained for material quality, bloom, and link animation — not for
   free-form spatial arrangement.
 
-### Open — needs the operator's decision
+### Resolved 2026-07-27 (second pass)
 
-- **Q1 (blocking for FR-006): what is the member category taxonomy?** `profile`
-  is 1:1 with the member, so the middle tier must be a category map. A proposed
-  default is in FR-006; it is a starting point written by inspection of member
-  names, not domain truth. Confirm or replace it.
-- **Q2 (FR-009): should cold members be visible by default?** The spec assumes
-  collapsed-but-present. The alternative is hidden behind a toggle.
+- Q: Should the category taxonomy be a hardcoded map of this deployment's member
+  names? → A: **No.** NetClaw ships to every operator, and no two deployments
+  have the same members. A hardcoded list would categorise the author's lab and
+  leave everyone else with an "Uncategorised" chart. The middle tier MUST be
+  derived from data NetClaw already ships — see FR-006.
+- Q: Should cold members be hidden behind a toggle? → A: **No — visible, but
+  distinctly cold.** Coldness is information an operator wants on the face of
+  the chart. Hot and cold must be unmistakably different treatments, not a
+  slight opacity difference (FR-008/FR-009).
+- Q: Should a member's tools be visible? → A: Yes, via per-node expand/collapse
+  (FR-020).
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -218,22 +234,46 @@ jump or reframe.
   root of the internal chart and the attachment point for external links.
 - **FR-005**: iN2N member claws MUST occupy the internal band below the Border,
   arranged as a top-down chart.
-- **FR-006**: Members MUST be grouped into a middle tier by category. `profile`
-  MUST NOT be used as the grouping key (it is 1:1 with the member).
-  Proposed default taxonomy — **pending operator confirmation (Q1)**:
+- **FR-006**: Members MUST be grouped into a middle tier by **category derived
+  from the shipped integration catalog**, not from a hardcoded list of member
+  names. `profile` MUST NOT be used as the grouping key (it is 1:1 with the
+  member).
 
-  | Category | Members |
-  |---|---|
-  | Lab & Emulation | `cml`, `containerlab`, `gns3` |
-  | Assurance & Test | `pyats`, `suzieq`, `batfish`, `forward`, `gtrace`, `packet` |
-  | Source of Truth | `netbox`, `nautobot`, `infrahub`, `infoblox`, `ipfabric` |
-  | Security | `ise`, `f5`, `paloalto`, `fortimanager`, `fwrule`, `nmap`, `nvd` |
-  | Controllers & Fabric | `aci`, `catalyst-center`, `sdwan`, `nso`, `aap`, `itential` |
-  | Cloud & Platform | `azure`, `github` |
-  | Visualisation | `viz` |
+  **This requirement exists because NetClaw ships to every operator.** No two
+  deployments have the same members, so any hand-written member→category map
+  categorises exactly one lab and degrades to "Uncategorised" everywhere else.
+  The grouping must be a *rule*, not a *list*.
 
-  Any member not in the map MUST fall into an explicit "Uncategorised" group
-  rather than being dropped.
+  The derivation, using data that already ships and is already maintained:
+
+  ```
+  member.skills[]  →  integration (match skill against integration.prefixes[])
+                   →  integration.category
+                   →  member category = most frequent category among its skills
+  ```
+
+  `ui/netclaw-visual/server.js` already defines the catalog: **72 integrations
+  across 22 categories**, each with `category` and `prefixes`. It is the same
+  catalog the HUD already uses to cluster skills, so the org chart inherits any
+  future catalog maintenance for free, on every install.
+
+  Measured against this deployment's live data: **25 of 29 members
+  auto-categorise (86%)**; excluding the 2 edge nodes, which belong in the edge
+  lane and must not be categorised at all, **25 of 27 agent members (93%)**.
+
+- **FR-006a**: A member whose skills match no integration prefix MUST fall into
+  an explicit "Uncategorised" group, never be dropped. On this deployment that
+  is `ipfabric` and `forward` — both are gaps in the shipped catalog's
+  `prefixes`, i.e. **data fixes to the catalog, not code changes to the chart**.
+  Fixing them there improves categorisation for every NetClaw install at once.
+
+- **FR-006b**: The layout MUST adapt to however many categories a deployment
+  yields — 1 to N — with column packing and wrapping. It MUST NOT assume a
+  fixed set. Categories MUST be ordered **by heat first, then by size**: groups
+  containing live members lead, so the handful of hot claws are always the most
+  prominent thing on screen regardless of how many cold categories exist. On
+  this deployment that places Labs, Device Automation, Visualization and
+  Uncategorised (the 4 hot groups) ahead of 18 cold ones.
 - **FR-007**: Mobile edge nodes MUST render in a dedicated lane flanking the
   Border — inside the trust boundary, outside the member chart — and MUST NOT be
   interleaved with member claws.
@@ -241,10 +281,17 @@ jump or reframe.
 ### Visual weight
 
 - **FR-008**: Live members (`live: true`) MUST be visually dominant over
-  cold/unreachable ones. Dominance MUST key off `live`, not `state`.
-- **FR-009**: Cold members MUST be collapsed into a compact, dimmed
-  representation that is expandable on demand, so 25 inactive nodes cannot
-  crowd out 4 active ones. *(Default-visible per Q2 assumption.)*
+  cold/unreachable ones. Dominance MUST key off `live`, not `state` — the two
+  disagree in live data (5 `active` vs 4 `live`).
+- **FR-009**: Cold members MUST remain **visible by default** — never hidden
+  behind a toggle. Their coldness is information the operator wants on the face
+  of the chart, not something to go looking for.
+- **FR-009a**: Hot and cold MUST be **categorically different treatments**, not
+  the same treatment at different opacity. A viewer must never have to compare
+  two nodes side by side to decide which is live. The distinction SHOULD be
+  carried by more than one channel at once (for example: form/silhouette,
+  colour temperature, and whether the node animates at all — a cold claw should
+  read as inert, a hot one as running).
 - **FR-010**: Link styling MUST distinguish, at a glance: healthy eN2N,
   unreachable eN2N, severed eN2N, healthy iN2N, cold iN2N, and the edge/push
   channel.
@@ -259,6 +306,27 @@ jump or reframe.
   equal tier render at equal size, which is what makes a chart readable as a
   chart. If perspective is retained for material reasons, tier scaling MUST be
   compensated so equal-tier nodes appear equal.
+
+### Tools / skills disclosure
+
+- **FR-020**: Every member node MUST support expand/collapse to reveal the tools
+  (skills) it holds. Collapsed is the default; the chart must be readable as a
+  chart before anything is expanded.
+- **FR-021**: An expanded member MUST show its skills from the existing
+  `member.skills[]` payload — no new API call and no server change. Members
+  already carry both `skills[]` and `specialty_count`.
+- **FR-022**: Expansion MUST be non-destructive to the layout: sibling nodes and
+  other categories MUST NOT reflow or jump when a node expands. Expansion
+  SHOULD claim space that is reserved for it, or overlay, rather than
+  re-packing the chart. An operator who expands a node must not lose their place.
+- **FR-023**: Multiple members MAY be expanded simultaneously; the design MUST
+  NOT assume single-selection. Comparing two claws' toolsets side by side is a
+  primary use.
+- **FR-024**: A collapsed member SHOULD indicate how many tools it holds, so the
+  operator can tell a rich claw from a bare one without expanding it.
+- **FR-025**: Skill disclosure MUST work for cold members too. Which tools a
+  cold claw *would* bring is exactly what an operator needs when deciding
+  whether to warm it.
 
 ### Data correctness (defects surfaced by this work)
 
@@ -302,6 +370,15 @@ jump or reframe.
   collision or node overlap at default zoom.
 - **SC-005**: Chat and the right-hand panel behave identically to HUD 1.0 —
   verified by diffing their behaviour, not by inspection.
+- **SC-006**: **Product generality.** The chart renders sensibly for a
+  deployment it has never seen, with zero configuration. Verified against at
+  least three synthetic Borders: one with 1 member, one with ~30, and one whose
+  members match no integration prefix at all (everything "Uncategorised"). No
+  member-name string appears anywhere in the layout code.
+- **SC-007**: Hot vs cold is distinguishable in a greyscale screenshot — proving
+  the distinction does not rest on colour alone.
+- **SC-008**: An operator can determine which tools a given claw holds, hot or
+  cold, without leaving the chart or opening the detail panel.
 
 ## Assumptions
 

--- a/specs/072-hud-2-org-chart/spec.md
+++ b/specs/072-hud-2-org-chart/spec.md
@@ -96,6 +96,19 @@ The Border reads as the centre of a vertical stack and as the root of the
 internal chart at the same time — external above the boundary, internal below,
 edges in their own lane at the boundary line.
 
+## Glossary
+
+Three terms are used for overlapping concepts across these artifacts. They are
+not interchangeable:
+
+| Term | Means | Used in |
+|---|---|---|
+| **member** | The data entity from `/api/n2n` `members[]` | Data model, pure logic, requirements |
+| **claw** | The user-facing name for a NetClaw agent (member or peer) | Prose, UI copy, user stories |
+| **node** | A rendered object in the scene — the visual of a member, peer, Border or edge | Render layer, layout maths |
+
+A member is data; a claw is what the operator calls it; a node is what gets drawn.
+
 ## Clarifications
 
 ### Session 2026-07-27
@@ -447,7 +460,7 @@ jump or reframe.
 - **FR-034b**: A member that enrols mid-session MUST be appended within its
   category without displacing existing nodes, preserving the incremental
   behaviour `refreshRiskMembers()` already provides.
-- **FR-034c**: A manual re-sort/re-layout control MAY be offered, so an operator
+- **FR-034c**: *(Optional — MAY; no task required.)* A manual re-sort/re-layout control MAY be offered, so an operator
   can opt into re-ranking after a lot of state churn. If offered it MUST be
   explicit and operator-initiated, never automatic.
 - **FR-034d**: A full page reload re-computes order from current heat. Position
@@ -467,8 +480,13 @@ jump or reframe.
 - **FR-033b**: `buildRiskMembers()` currently early-returns unless
   `risk.role === 'border'`. Under FR-033 a non-Border install MUST still render
   the structure rather than an empty scene.
-- **FR-033c**: A synthetic/demo topology MUST NOT be rendered. In a security
-  tool, a fabricated claw that could be mistaken for a real one is a hazard.
+- **FR-033c**: A synthetic/demo topology MUST NOT be rendered **as a substitute
+  for real data, or without the operator explicitly asking for it**. In a
+  security tool, a fabricated claw that could be mistaken for a real one is a
+  hazard. This prohibits filling an empty first-run chart with example claws; it
+  does **not** prohibit the explicit, opt-in `?fixture=` developer loader
+  (tasks T004), which renders only when deliberately requested and never in
+  place of a live feed. Any fixture-sourced view MUST be visibly marked as such.
 - **FR-033d**: Loading MUST be distinguishable from empty. The existing
   `setLoading(progress, text)` path MUST cover the interval before the first
   `/api/n2n` response, so a slow poll never looks like an unfederated install.
@@ -491,8 +509,8 @@ jump or reframe.
   so when motion is suppressed the remaining channels (form, colour
   temperature) MUST still satisfy SC-007 on their own. Reduced motion must not
   collapse the health encoding.
-- **FR-032d**: Full WCAG 2.1 AA conformance is explicitly OUT of scope for this
-  feature.
+- **FR-032d**: *(Scope exclusion — no implementation task.)* Full WCAG 2.1 AA
+  conformance is explicitly OUT of scope for this feature.
 
 ### Search and navigation
 
@@ -593,7 +611,7 @@ jump or reframe.
 - **SC-002**: The HOT members are identifiable within 2 seconds of load,
   without counting or zooming (4 of 29 on the reference deployment).
 - **SC-003**: No camera input can produce a view in which the external band is
-  not above the internal band.
+  not above the internal band. *(Verified by task T056.)*
 - **SC-004**: All 29 members, 4 peers, and 2 edge nodes render without label
   collision or node overlap at default zoom.
 - **SC-005**: Chat and the right-hand panel behave identically to HUD 1.0 —

--- a/specs/072-hud-2-org-chart/spec.md
+++ b/specs/072-hud-2-org-chart/spec.md
@@ -82,8 +82,11 @@ Three consequences:
        │  pyats-parallel-ops   │    not reflow (FR-022)
        └───────────────────────┘
 
-   ◆ = HOT  (live, animated, saturated)    · = COLD (inert, desaturated)
-   Hot/cold differ in form + colour + motion — not opacity alone (FR-009a)
+   ◆ HOT (live, animated)   ◇ WARM (seen <15m, idle)
+   · COLD (never started, inert)   ✖ FAULT (was reachable, now not)
+   States differ in form + colour + motion — not opacity alone (FR-009a).
+   FAULT is the most salient state after HOT (FR-009b) so a dead claw is
+   never lost among the by-design-cold ones. Legend required (FR-009c).
 ```
 
 Categories above are **derived**, not authored — see FR-006. A different
@@ -119,6 +122,29 @@ edges in their own lane at the boundary line.
   slight opacity difference (FR-008/FR-009).
 - Q: Should a member's tools be visible? → A: Yes, via per-node expand/collapse
   (FR-020).
+
+### Session 2026-07-27 (clarify)
+
+- Q: Migration strategy — hard replace the orbit layout, coexist behind a view
+  toggle, or build a separate entry point? → A: **Hard replace.** The work is on
+  a feature branch, so git provides the revert path; a runtime toggle would be
+  redundant safety at the cost of carrying two layouts. See FR-026.
+- Q: What scale must the layout handle before it is allowed to degrade?
+  → A: **~100 members / ~25 categories**, all simultaneously visible, no
+  virtualisation or level-of-detail required. See FR-029.
+- Q: How many member health states must the visual language encode?
+  → A: **Four — HOT / WARM / COLD / FAULT.** Binary would conflate "never
+  started" (normal) with "died" (a fault), and both edge nodes are currently
+  unreachable. WARM is derived from `heartbeat_age_s`. See FR-008.
+- Q: The `#search` input currently filters the integration/device populations
+  being removed. Does search carry forward? → A: **Yes — retargeted to the org
+  chart** (members, categories, tool names), matching by highlight/dim in place
+  rather than by hiding, so the layout never reflows. See FR-031.
+- Q: The scene currently renders a second graph alongside the trust topology —
+  72 integration clusters with orbiting skill sprites, plus testbed devices
+  (`/api/graph`). What happens to it? → A: **Org chart only.** Integrations are
+  represented solely as expanded member tools (FR-020); devices leave the 3D
+  scene and remain in the right-hand panel. See FR-030.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -280,18 +306,36 @@ jump or reframe.
 
 ### Visual weight
 
-- **FR-008**: Live members (`live: true`) MUST be visually dominant over
-  cold/unreachable ones. Dominance MUST key off `live`, not `state` — the two
-  disagree in live data (5 `active` vs 4 `live`).
-- **FR-009**: Cold members MUST remain **visible by default** — never hidden
-  behind a toggle. Their coldness is information the operator wants on the face
-  of the chart, not something to go looking for.
-- **FR-009a**: Hot and cold MUST be **categorically different treatments**, not
-  the same treatment at different opacity. A viewer must never have to compare
-  two nodes side by side to decide which is live. The distinction SHOULD be
-  carried by more than one channel at once (for example: form/silhouette,
-  colour temperature, and whether the node animates at all — a cold claw should
-  read as inert, a hot one as running).
+- **FR-008**: Members MUST be rendered in one of **four health states**, derived
+  from the existing payload. `state` alone MUST NOT be used — it disagrees with
+  liveness in live data (5 `active` vs 4 `live`).
+
+  | State | Derivation | Meaning to the operator |
+  |---|---|---|
+  | **HOT** | `live == true` | Running now |
+  | **WARM** | `!live` and `heartbeat_age_s` ≤ threshold | Seen recently; idle or on-demand, not a fault |
+  | **COLD** | `!live` and never seen (`heartbeat_age_s` null/absent), typically `state == provisioned` | Inert by design — normal |
+  | **FAULT** | `!live` and `heartbeat_age_s` > threshold, or `state` ∈ {`unreachable`, `quarantined`} | Was reachable, no longer is — needs attention |
+
+- **FR-008a**: The WARM/FAULT threshold MUST be a single named constant, not a
+  magic number scattered through the layout code. Default **900 s (15 min)**.
+  The distinction that matters is COLD (never started) vs FAULT (died) — those
+  MUST never share a treatment, because a fault hidden among 22 by-design-cold
+  claws is precisely the failure this redesign exists to fix.
+- **FR-009**: Non-HOT members MUST remain **visible by default** — never hidden
+  behind a toggle. Their state is information the operator wants on the face of
+  the chart, not something to go looking for.
+- **FR-009a**: The four states MUST be **categorically different treatments**,
+  not one treatment at four opacities. A viewer must never have to compare two
+  nodes side by side to classify either. Each state SHOULD be carried by more
+  than one channel at once — for example form/silhouette, colour temperature,
+  and whether the node animates: HOT reads as running, WARM as idle, COLD as
+  inert, FAULT as demanding attention.
+- **FR-009b**: FAULT MUST be the most visually salient state after HOT. An
+  operator scanning the chart for problems MUST find faults without searching,
+  even when they are outnumbered ~10:1 by COLD claws.
+- **FR-009c**: A legend MUST be present. Four states is past the point where an
+  operator can be expected to infer the encoding.
 - **FR-010**: Link styling MUST distinguish, at a glance: healthy eN2N,
   unreachable eN2N, severed eN2N, healthy iN2N, cold iN2N, and the edge/push
   channel.
@@ -348,6 +392,77 @@ jump or reframe.
   `renderGaitTrail`, `renderChannelSecurity`, `renderReplicationJobs`,
   `renderRecentPushes` — MUST continue to work against the same data.
 
+### Search and navigation
+
+- **FR-031**: The existing `#search` input MUST be retargeted from the removed
+  integration/device populations to the org chart, matching against member
+  names, category names, and tool (skill) names.
+- **FR-031a**: Search MUST match by **highlighting matches and dimming
+  non-matches in place**. It MUST NOT hide non-matches or re-pack the layout.
+  Hiding would re-flow the chart and destroy the spatial memory the layout
+  exists to build — the same reasoning as FR-022.
+- **FR-031b**: A search matching a tool MUST make the owning member
+  discoverable even while collapsed, so an operator can find which claw holds a
+  capability without expanding all of them.
+- **FR-031c**: Clearing the search MUST restore the exact prior visual state,
+  including which members were expanded.
+
+### Scene scope
+
+- **FR-030**: The 3D scene MUST render the trust org chart and nothing else.
+  The integration-cluster population and the device population MUST be removed
+  from the scene. This is the largest single readability win available: the
+  scene currently draws two unrelated graphs — a trust topology and a
+  capability catalogue — over each other.
+- **FR-030a**: Integration/skill information MUST reach the operator via member
+  tool expansion (FR-020), which already covers it. The integration clusters
+  are a second rendering of substantially the same capability data.
+- **FR-030b**: Devices MUST remain available in the right-hand detail panel and
+  MUST NOT be rendered as scene objects. Devices are managed estate, not
+  members of the trust org; drawing them in the chart blurs what the chart means.
+- **FR-030c**: The following scene-layer functions MUST be removed, not left
+  dormant: `buildIntegrations`, `buildDevices`, `createSkillSprites`,
+  `computeDendritePositions`, `createDendriteMaterial`, `lightIntegration`,
+  `lightDevice`, and the integration/device branches of `applyFilters`.
+- **FR-030d**: Removing these populations MUST NOT break the panel. `/api/graph`
+  MUST still be fetched if any retained panel renderer depends on it; only the
+  scene-object construction is removed. This MUST be verified rather than
+  assumed — `renderSidebar` and `renderMetrics` both consume `graph` today.
+
+### Scale
+
+- **FR-029**: The layout MUST render correctly and remain readable up to
+  **~100 members across ~25 categories**, with every node simultaneously
+  visible. Virtualisation, level-of-detail, and default-collapsed categories
+  are explicitly NOT required at this scale. Beyond it the chart MUST degrade
+  gracefully (wrap and shrink) rather than break, overlap, or drop nodes.
+- **FR-029a**: Node geometry SHOULD be instanced or otherwise shared so member
+  count drives draw calls sub-linearly. At 100 members with tools expanded, the
+  scene must not require per-node unique geometry.
+- **FR-029b**: The chart MUST hold an interactive frame rate at the FR-029
+  ceiling on the reference machine. If the existing postprocessing chain
+  (bloom/SMAA/afterimage) cannot sustain that with 100 nodes plus expanded
+  tools, the postprocessing MUST be reduced rather than the node count capped —
+  legibility of the chart outranks the glow.
+
+### Migration
+
+- **FR-026**: The orbit layout MUST be replaced outright, not kept behind a
+  runtime toggle. `main.js` renders the org chart and only the org chart. The
+  feature branch is the rollback mechanism; no in-product fallback is required.
+- **FR-027**: Orbit-specific machinery that the org chart does not use MUST be
+  removed rather than left dormant — the ring/orbit positioning
+  (`CORE_POSITIONS`, `CORE_CENTROID`, `RISK_LAYOUT.tierRadius`, per-core orbit
+  speed/animation, the edge "close orbit" slots). Leaving dead layout code in a
+  132 KB file is how the next person concludes the orbit is still supported.
+- **FR-028**: Machinery that is layout-independent MUST be preserved and reused,
+  not rewritten: materials and shaders (`createHolographicMaterial`,
+  `createNodeMaterial`, `createDeviceMaterial`, `getSkillMaterial`), link
+  geometry (`createRibbonGeometry` / `updateRibbonGeometry` / `createTubeMaterial`),
+  labels (`makeLabel`, CSS2D), the postprocessing chain, picking/raycasting, the
+  polling and incremental-update path (`refreshRiskMembers`), and every
+  `setDetail`/`render*` panel function named in FR-018.
+
 ### Security constraint
 
 - **FR-019**: This feature MUST NOT widen the HUD's existing unauthenticated
@@ -362,8 +477,8 @@ jump or reframe.
 - **SC-001**: An operator who has never seen the HUD can correctly identify
   which claws are external and which are internal, on first view, without
   interacting.
-- **SC-002**: The 4 live members are identifiable within 2 seconds of load,
-  without counting or zooming.
+- **SC-002**: The HOT members are identifiable within 2 seconds of load,
+  without counting or zooming (4 of 29 on the reference deployment).
 - **SC-003**: No camera input can produce a view in which the external band is
   not above the internal band.
 - **SC-004**: All 29 members, 4 peers, and 2 edge nodes render without label
@@ -375,8 +490,10 @@ jump or reframe.
   least three synthetic Borders: one with 1 member, one with ~30, and one whose
   members match no integration prefix at all (everything "Uncategorised"). No
   member-name string appears anywhere in the layout code.
-- **SC-007**: Hot vs cold is distinguishable in a greyscale screenshot — proving
-  the distinction does not rest on colour alone.
+- **SC-007**: All four health states are distinguishable in a **greyscale**
+  screenshot — proving the encoding does not rest on colour alone.
+- **SC-007a**: A single FAULT claw placed among 25 COLD ones is located by an
+  operator in under 5 seconds, without search.
 - **SC-008**: An operator can determine which tools a given claw holds, hot or
   cold, without leaving the chart or opening the detail panel.
 

--- a/specs/072-hud-2-org-chart/tasks.md
+++ b/specs/072-hud-2-org-chart/tasks.md
@@ -23,10 +23,10 @@ Tests are written **with** each pure module, not after.
 
 ## Phase 1: Setup (Shared Infrastructure)
 
-- [ ] T001 Add `"test": "node --test src/"` to `scripts` in `ui/netclaw-visual/package.json` (no new dependency — research R2)
-- [ ] T002 [P] Create directory `ui/netclaw-visual/src/orgchart/` for pure logic (must never import three.js)
-- [ ] T003 [P] Create directory `ui/netclaw-visual/src/orgchart-render/` for three.js rendering
-- [ ] T004 Add a **client-side** fixture loader in `ui/netclaw-visual/src/main.js`: `?fixture=<name>` fetches `specs/072-hud-2-org-chart/fixtures/<name>.json` instead of `/api/n2n`
+- [x] T001 Add `"test": "node --test src/"` to `scripts` in `ui/netclaw-visual/package.json` (no new dependency — research R2)
+- [x] T002 [P] Create directory `ui/netclaw-visual/src/orgchart/` for pure logic (must never import three.js)
+- [x] T003 [P] Create directory `ui/netclaw-visual/src/orgchart-render/` for three.js rendering
+- [x] T004 Add a **client-side** fixture loader in `ui/netclaw-visual/src/main.js`: `?fixture=<name>` fetches `specs/072-hud-2-org-chart/fixtures/<name>.json` instead of `/api/n2n`
 
 > **T004 note — resolves a conflict between plan.md and research.md.** research R4
 > said "the dev server gains a way to serve a fixture", but plan.md marks
@@ -43,16 +43,16 @@ Tests are written **with** each pure module, not after.
 `contracts/layout-contract.md`. Each imports nothing from three.js; each ships
 with its tests. All five are independent of one another → all `[P]`.
 
-- [ ] T005 [P] Implement `dedupePeers()` and `resolveLabel()` in `ui/netclaw-visual/src/orgchart/normalize.js` per the contract (FR-014, FR-015)
-- [ ] T006 [P] Write `ui/netclaw-visual/src/orgchart/normalize.test.js`: real duplicated-`Hermes` payload collapses to one peer in `severed`; both edge nodes with `display_name: null` resolve to non-empty labels
-- [ ] T007 [P] Implement `classifyHealth(member, nowEpochS)` and `WARM_THRESHOLD_S = 900` in `ui/netclaw-visual/src/orgchart/health.js`, precedence HOT → FAULT → WARM → COLD (FR-008, FR-008a)
-- [ ] T008 [P] Write `ui/netclaw-visual/src/orgchart/health.test.js`: all four states; exact 900 s boundary; `active` but `!live`; `unreachable` with fresh heartbeat still FAULT; **null heartbeat ⇒ COLD not FAULT** (highest-value assertion — conflating COLD and FAULT is the failure this design prevents)
-- [ ] T009 [P] Implement `categorizeMembers(members, integrationCatalog)` in `ui/netclaw-visual/src/orgchart/categorize.js`, catalog as an argument never an import (FR-006, FR-006a)
-- [ ] T010 [P] Write `ui/netclaw-visual/src/orgchart/categorize.test.js`: `live-29.json` yields 25 categorised; empty catalog ⇒ all `Uncategorised`; zero-skill member; **an alternate synthetic catalog produces a different correct chart** (proves Constitution VI vendor neutrality)
-- [ ] T011 [P] Implement `orderCategories()` in `ui/netclaw-visual/src/orgchart/ordering.js` — heat desc, size desc, name; `Uncategorised` always last (FR-006b)
-- [ ] T012 [P] Write `ui/netclaw-visual/src/orgchart/ordering.test.js`: hot before cold; equal heat falls to size; equal both falls to name; `Uncategorised` last even when it holds a HOT member (true of `ipfabric` in live data)
-- [ ] T013 Implement `computeLayout()` and `appendMember()` in `ui/netclaw-visual/src/orgchart/layout.js` — three bands + edge lane, category columns with wrap, positions assigned once (R6, FR-034)
-- [ ] T014 Write `ui/netclaw-visual/src/orgchart/layout.test.js` against all five fixtures: no two nodes share a position; `appendMember` leaves every prior coordinate byte-identical; edge nodes never get a member-column position; bands exist at zero members
+- [x] T005 [P] Implement `dedupePeers()` and `resolveLabel()` in `ui/netclaw-visual/src/orgchart/normalize.js` per the contract (FR-014, FR-015)
+- [x] T006 [P] Write `ui/netclaw-visual/src/orgchart/normalize.test.js`: real duplicated-`Hermes` payload collapses to one peer in `severed`; both edge nodes with `display_name: null` resolve to non-empty labels
+- [x] T007 [P] Implement `classifyHealth(member, nowEpochS)` and `WARM_THRESHOLD_S = 900` in `ui/netclaw-visual/src/orgchart/health.js`, precedence HOT → FAULT → WARM → COLD (FR-008, FR-008a)
+- [x] T008 [P] Write `ui/netclaw-visual/src/orgchart/health.test.js`: all four states; exact 900 s boundary; `active` but `!live`; `unreachable` with fresh heartbeat still FAULT; **null heartbeat ⇒ COLD not FAULT** (highest-value assertion — conflating COLD and FAULT is the failure this design prevents)
+- [x] T009 [P] Implement `categorizeMembers(members, integrationCatalog)` in `ui/netclaw-visual/src/orgchart/categorize.js`, catalog as an argument never an import (FR-006, FR-006a)
+- [x] T010 [P] Write `ui/netclaw-visual/src/orgchart/categorize.test.js`: `live-29.json` yields 25 categorised; empty catalog ⇒ all `Uncategorised`; zero-skill member; **an alternate synthetic catalog produces a different correct chart** (proves Constitution VI vendor neutrality)
+- [x] T011 [P] Implement `orderCategories()` in `ui/netclaw-visual/src/orgchart/ordering.js` — heat desc, size desc, name; `Uncategorised` always last (FR-006b)
+- [x] T012 [P] Write `ui/netclaw-visual/src/orgchart/ordering.test.js`: hot before cold; equal heat falls to size; equal both falls to name; `Uncategorised` last even when it holds a HOT member (true of `ipfabric` in live data)
+- [x] T013 Implement `computeLayout()` and `appendMember()` in `ui/netclaw-visual/src/orgchart/layout.js` — three bands + edge lane, category columns with wrap, positions assigned once (R6, FR-034)
+- [x] T014 Write `ui/netclaw-visual/src/orgchart/layout.test.js` against all five fixtures: no two nodes share a position; `appendMember` leaves every prior coordinate byte-identical; edge nodes never get a member-column position; bands exist at zero members
 
 **Checkpoint**: `npm test` green. Every falsifiable rule in the spec is now
 covered without a browser or GPU.
@@ -65,15 +65,15 @@ covered without a browser or GPU.
 
 **Independent test**: Load with `?fixture=live-29`. Without input, confirm the three bands, the drawn trust boundary, and that HOT members dominate.
 
-- [ ] T015 [US1] Implement orthographic camera with `enableRotate = false`, pan/zoom retained, zoom clamped, in `ui/netclaw-visual/src/orgchart-render/camera.js` (FR-012, FR-013, R7)
-- [ ] T016 [P] [US1] Render the three bands and the **explicitly drawn** trust boundary in `ui/netclaw-visual/src/orgchart-render/bands.js` (FR-001, FR-002)
-- [ ] T017 [P] [US1] Implement instanced node geometry with four health treatments in `ui/netclaw-visual/src/orgchart-render/nodes.js` — differing in form, colour temperature and motion, never opacity alone (FR-009a, FR-029a)
-- [ ] T018 [US1] Make FAULT the most salient state after HOT in `ui/netclaw-visual/src/orgchart-render/nodes.js` (FR-009b)
-- [ ] T019 [P] [US1] Implement the six link styles in `ui/netclaw-visual/src/orgchart-render/links.js`, reusing existing ribbon/tube helpers (FR-010, FR-028)
-- [ ] T020 [US1] Wire the org chart into `ui/netclaw-visual/src/main.js`: consume `orgchart/` output, place Border on the centre line, peers north, members south (FR-003, FR-004, FR-005)
-- [ ] T021 [US1] Add the health-state legend to `ui/netclaw-visual/index.html` (FR-009c)
-- [ ] T022 [US1] Render empty bands with per-band CTAs and keep loading distinct from empty in `ui/netclaw-visual/src/orgchart-render/bands.js`; remove the `role !== 'border'` early return (FR-033, FR-033a, FR-033b, FR-033d)
-- [ ] T023 [US1] Verify all fixtures in `specs/072-hud-2-org-chart/fixtures/` render via `?fixture=` — no overlap, no blank labels, bands always present (SC-004, SC-012)
+- [x] T015 [US1] Implement orthographic camera with `enableRotate = false`, pan/zoom retained, zoom clamped, in `ui/netclaw-visual/src/orgchart-render/camera.js` (FR-012, FR-013, R7)
+- [x] T016 [P] [US1] Render the three bands and the **explicitly drawn** trust boundary in `ui/netclaw-visual/src/orgchart-render/bands.js` (FR-001, FR-002)
+- [x] T017 [P] [US1] Implement instanced node geometry with four health treatments in `ui/netclaw-visual/src/orgchart-render/nodes.js` — differing in form, colour temperature and motion, never opacity alone (FR-009a, FR-029a)
+- [x] T018 [US1] Make FAULT the most salient state after HOT in `ui/netclaw-visual/src/orgchart-render/nodes.js` (FR-009b)
+- [x] T019 [P] [US1] Implement the six link styles in `ui/netclaw-visual/src/orgchart-render/links.js`, reusing existing ribbon/tube helpers (FR-010, FR-028)
+- [x] T020 [US1] Wire the org chart into `ui/netclaw-visual/src/main.js`: consume `orgchart/` output, place Border on the centre line, peers north, members south (FR-003, FR-004, FR-005)
+- [x] T021 [US1] Add the health-state legend to `ui/netclaw-visual/index.html` (FR-009c)
+- [x] T022 [US1] Render empty bands with per-band CTAs and keep loading distinct from empty in `ui/netclaw-visual/src/orgchart-render/bands.js`; remove the `role !== 'border'` early return (FR-033, FR-033a, FR-033b, FR-033d)
+- [x] T023 [US1] Verify all fixtures in `specs/072-hud-2-org-chart/fixtures/` render via `?fixture=` — no overlap, no blank labels, bands always present (SC-004, SC-012)
 
 **Checkpoint**: MVP. The org chart renders and is readable. Orbit code still
 present but unused — deliberately, so the branch is never in a state with
@@ -87,10 +87,10 @@ neither layout working.
 
 **Independent test**: With `live-29.json` (2 edge nodes, `display_name: null`), confirm both render in their own lane with non-blank labels.
 
-- [ ] T024 [US2] Render the edge lane flanking the Border, inside the boundary and outside the member chart, in `ui/netclaw-visual/src/orgchart-render/bands.js` (FR-007)
-- [ ] T025 [US2] Implement the asymmetric Border→device push link, visually distinct from a member delegation link, in `ui/netclaw-visual/src/orgchart-render/links.js` (FR-011)
-- [ ] T026 [US2] Surface each edge node's last-seen age on the node in `ui/netclaw-visual/src/orgchart-render/nodes.js`, without opening the detail panel (US2 AC2)
-- [ ] T027 [US2] Add an edge-lane overflow case to `ui/netclaw-visual/src/orgchart/layout.test.js` — more edges than slots must wrap, never overlap as HUD 1.0's three-slot stacking did (spec Edge Cases)
+- [x] T024 [US2] Render the edge lane flanking the Border, inside the boundary and outside the member chart, in `ui/netclaw-visual/src/orgchart-render/bands.js` (FR-007)
+- [x] T025 [US2] Implement the asymmetric Border→device push link, visually distinct from a member delegation link, in `ui/netclaw-visual/src/orgchart-render/links.js` (FR-011)
+- [x] T026 [US2] Surface each edge node's last-seen age on the node in `ui/netclaw-visual/src/orgchart-render/nodes.js`, without opening the detail panel (US2 AC2)
+- [x] T027 [US2] Add an edge-lane overflow case to `ui/netclaw-visual/src/orgchart/layout.test.js` — more edges than slots must wrap, never overlap as HUD 1.0's three-slot stacking did (spec Edge Cases)
 
 **Checkpoint**: Phones are unmistakable and the known overflow bug is not carried forward.
 
@@ -109,7 +109,7 @@ neither layout working.
 - [ ] T032 [P] [US3] Support simultaneous expansion of multiple members in `ui/netclaw-visual/src/orgchart-render/expansion.js` (FR-023)
 - [ ] T033 [P] [US3] Show tool count on collapsed nodes in `ui/netclaw-visual/src/orgchart-render/nodes.js` (FR-024)
 - [ ] T034 [P] [US3] Ensure COLD and FAULT members expand too in `ui/netclaw-visual/src/orgchart-render/expansion.js` — what a cold claw *would* bring decides whether to warm it (FR-025)
-- [ ] T035 [US3] Retarget `#search` in `ui/netclaw-visual/index.html` and `main.js` to members, categories and tool names (FR-031)
+- [x] T035 [US3] Retarget `#search` in `ui/netclaw-visual/index.html` and `main.js` to members, categories and tool names (FR-031)
 - [ ] T036 [US3] Implement highlight/dim matching that never hides or re-packs; a tool match makes its collapsed owner discoverable; clearing restores prior state including expansions (FR-031a, FR-031b, FR-031c)
 - [ ] T037 [US3] Enforce session-stable positions in `ui/netclaw-visual/src/main.js`: the poll path repaints only, never repositions or reorders (FR-034, FR-034a), and mid-session enrolment routes through `appendMember` (FR-034b)
 

--- a/specs/072-hud-2-org-chart/tasks.md
+++ b/specs/072-hud-2-org-chart/tasks.md
@@ -152,11 +152,11 @@ with neither layout functioning.
 - [x] T047 [P] Update `ui/netclaw-visual/README.md` — new layout, health states, keyboard model, fixture usage (Constitution XI, XII)
 - [x] T048 [P] Confirm SC-006: `git grep` over `ui/netclaw-visual/src/orgchart/` finds no hardcoded member name
 - [x] T049 Verify SC-005 / SC-008 — `ui/netclaw-visual/src/panels/` and the chat surface behave identically to `main`, by diffing behaviour rather than eyeballing (FR-016, FR-017, FR-018)
-- [ ] T050 Verify SC-007 / SC-010 via `chrome-devtools-mcp` — four states separable in a greyscale screenshot, and again under emulated `prefers-reduced-motion`
-- [ ] T051 Verify SC-007a using `specs/072-hud-2-org-chart/fixtures/scale-100.json` — one FAULT among 25 COLD located in under 5 s
-- [ ] T052 Verify SC-009 against `specs/072-hud-2-org-chart/fixtures/live-29.json` — every node reachable and operable by keyboard alone
+- [x] T050 Verify SC-007 / SC-010 via `chrome-devtools-mcp` — four states separable in a greyscale screenshot, and again under emulated `prefers-reduced-motion`
+- [x] T051 Verify SC-007a using `specs/072-hud-2-org-chart/fixtures/scale-100.json` — one FAULT among 25 COLD located in under 5 s
+- [x] T052 Verify SC-009 against `specs/072-hud-2-org-chart/fixtures/live-29.json` — every node reachable and operable by keyboard alone
 - [x] T053 Verify SC-011 against the live Border — node coordinates identical between first frame and 30 minutes of state churn
-- [ ] T054 Verify SC-013 — 60 fps on `scale-100.json` with 5 expanded during pan/zoom, and no slower than HUD 1.0 on `live-29.json` (FR-029b, FR-029c)
+- [ ] T054 Verify SC-013 — 60 fps on `scale-100.json` with 5 expanded during pan/zoom, and no slower than HUD 1.0 on `live-29.json` (FR-029b, FR-029c)  **[BLOCKED: needs a discrete GPU — headless runs on swiftshader at 3 fps, which measures the software rasteriser, not the FR-029b target]**
 - [x] T056 Verify SC-003 against `specs/072-hud-2-org-chart/fixtures/live-29.json` — no drag, scroll or keyboard input can produce a view with the external band below the internal band (FR-012)
 - [x] T055 Verify SC-001 / SC-002 — external vs internal identified on first view; HOT members identifiable within 2 s
 

--- a/specs/072-hud-2-org-chart/tasks.md
+++ b/specs/072-hud-2-org-chart/tasks.md
@@ -149,16 +149,16 @@ with neither layout functioning.
 
 ## Phase 8: Polish & Verification
 
-- [ ] T047 [P] Update `ui/netclaw-visual/README.md` — new layout, health states, keyboard model, fixture usage (Constitution XI, XII)
-- [ ] T048 [P] Confirm SC-006: `git grep` over `ui/netclaw-visual/src/orgchart/` finds no hardcoded member name
-- [ ] T049 Verify SC-005 / SC-008 — `ui/netclaw-visual/src/panels/` and the chat surface behave identically to `main`, by diffing behaviour rather than eyeballing (FR-016, FR-017, FR-018)
+- [x] T047 [P] Update `ui/netclaw-visual/README.md` — new layout, health states, keyboard model, fixture usage (Constitution XI, XII)
+- [x] T048 [P] Confirm SC-006: `git grep` over `ui/netclaw-visual/src/orgchart/` finds no hardcoded member name
+- [x] T049 Verify SC-005 / SC-008 — `ui/netclaw-visual/src/panels/` and the chat surface behave identically to `main`, by diffing behaviour rather than eyeballing (FR-016, FR-017, FR-018)
 - [ ] T050 Verify SC-007 / SC-010 via `chrome-devtools-mcp` — four states separable in a greyscale screenshot, and again under emulated `prefers-reduced-motion`
 - [ ] T051 Verify SC-007a using `specs/072-hud-2-org-chart/fixtures/scale-100.json` — one FAULT among 25 COLD located in under 5 s
 - [ ] T052 Verify SC-009 against `specs/072-hud-2-org-chart/fixtures/live-29.json` — every node reachable and operable by keyboard alone
-- [ ] T053 Verify SC-011 against the live Border — node coordinates identical between first frame and 30 minutes of state churn
+- [x] T053 Verify SC-011 against the live Border — node coordinates identical between first frame and 30 minutes of state churn
 - [ ] T054 Verify SC-013 — 60 fps on `scale-100.json` with 5 expanded during pan/zoom, and no slower than HUD 1.0 on `live-29.json` (FR-029b, FR-029c)
-- [ ] T056 Verify SC-003 against `specs/072-hud-2-org-chart/fixtures/live-29.json` — no drag, scroll or keyboard input can produce a view with the external band below the internal band (FR-012)
-- [ ] T055 Verify SC-001 / SC-002 — external vs internal identified on first view; HOT members identifiable within 2 s
+- [x] T056 Verify SC-003 against `specs/072-hud-2-org-chart/fixtures/live-29.json` — no drag, scroll or keyboard input can produce a view with the external band below the internal band (FR-012)
+- [x] T055 Verify SC-001 / SC-002 — external vs internal identified on first view; HOT members identifiable within 2 s
 
 ---
 

--- a/specs/072-hud-2-org-chart/tasks.md
+++ b/specs/072-hud-2-org-chart/tasks.md
@@ -73,7 +73,7 @@ covered without a browser or GPU.
 - [ ] T020 [US1] Wire the org chart into `ui/netclaw-visual/src/main.js`: consume `orgchart/` output, place Border on the centre line, peers north, members south (FR-003, FR-004, FR-005)
 - [ ] T021 [US1] Add the health-state legend to `ui/netclaw-visual/index.html` (FR-009c)
 - [ ] T022 [US1] Render empty bands with per-band CTAs and keep loading distinct from empty in `ui/netclaw-visual/src/orgchart-render/bands.js`; remove the `role !== 'border'` early return (FR-033, FR-033a, FR-033b, FR-033d)
-- [ ] T023 [US1] Verify all fixtures in `specs/072-hud-2-org-chart/fixtures/` render via `?fixture=` — no overlap, no blank labels, bands always present
+- [ ] T023 [US1] Verify all fixtures in `specs/072-hud-2-org-chart/fixtures/` render via `?fixture=` — no overlap, no blank labels, bands always present (SC-004, SC-012)
 
 **Checkpoint**: MVP. The org chart renders and is readable. Orbit code still
 present but unused — deliberately, so the branch is never in a state with
@@ -104,7 +104,7 @@ neither layout working.
 
 - [ ] T028 [US3] Wire picking so click/tap invokes the existing `setDetail(kind, payload, related)` unchanged in `ui/netclaw-visual/src/main.js` (FR-017, FR-020a, US3 AC1)
 - [ ] T029 [US3] Implement the always-visible expand affordance (chevron/`+`), separate from the click that selects, in `ui/netclaw-visual/src/orgchart-render/expansion.js` (FR-020, FR-020a, FR-020b)
-- [ ] T030 [US3] Render an expanded member's tools from `member.skills[]` in `ui/netclaw-visual/src/orgchart-render/expansion.js`, with no new API call (FR-021)
+- [ ] T030 [US3] Render an expanded member's tools from `member.skills[]` in `ui/netclaw-visual/src/orgchart-render/expansion.js`, with no new API call (FR-021, FR-030a, SC-008)
 - [ ] T031 [US3] Guarantee expansion never reflows siblings in `ui/netclaw-visual/src/orgchart-render/expansion.js` — reserve or overlay space, never re-pack (FR-022)
 - [ ] T032 [P] [US3] Support simultaneous expansion of multiple members in `ui/netclaw-visual/src/orgchart-render/expansion.js` (FR-023)
 - [ ] T033 [P] [US3] Show tool count on collapsed nodes in `ui/netclaw-visual/src/orgchart-render/nodes.js` (FR-024)
@@ -135,10 +135,10 @@ Spans all three stories, so it follows them rather than sitting inside one.
 **⚠️ Deliberately last.** Deleting before Phases 3–6 land would leave the branch
 with neither layout functioning.
 
-- [ ] T042 Delete orbit positioning from `ui/netclaw-visual/src/main.js`: `CORE_POSITIONS`, `CORE_CENTROID`, `RISK_LAYOUT.tierRadius`, per-core orbit animation, and the edge close-orbit slots (FR-027)
+- [ ] T042 Delete orbit positioning (completing the FR-026 hard replace) from `ui/netclaw-visual/src/main.js`: `CORE_POSITIONS`, `CORE_CENTROID`, `RISK_LAYOUT.tierRadius`, per-core orbit animation, and the edge close-orbit slots (FR-027)
 - [ ] T043 **Verify FR-030d before deleting anything in T044** — confirm which fields of `state.integrations` / `state.devices` `renderSidebar` and `renderMetrics` still read; keep `fetchGraph()` and the `/api/graph` request alive (R5)
 - [ ] T044 Delete the scene-layer functions `buildIntegrations`, `buildDevices`, `createSkillSprites`, `computeDendritePositions`, `createDendriteMaterial`, `lightIntegration`, `lightDevice`, and the integration/device branches of `applyFilters`, from `ui/netclaw-visual/src/main.js` (FR-030, FR-030c)
-- [ ] T045 Confirm `renderSidebar`, `renderMetrics` and every renderer named in FR-018 still work after T044, in `ui/netclaw-visual/src/main.js` (FR-030d)
+- [ ] T045 Confirm `renderSidebar`, `renderMetrics` and every renderer named in FR-018 still work after T044, **and that devices remain listed in the right-hand panel**, in `ui/netclaw-visual/src/main.js` (FR-030b, FR-030d)
 - [ ] T046 Confirm no orbit or integration/device scene code remains: `git grep` for the removed identifiers returns nothing outside history
 
 > **T043 is the single highest-risk task in the feature.** It is the one realistic
@@ -151,12 +151,13 @@ with neither layout functioning.
 
 - [ ] T047 [P] Update `ui/netclaw-visual/README.md` — new layout, health states, keyboard model, fixture usage (Constitution XI, XII)
 - [ ] T048 [P] Confirm SC-006: `git grep` over `ui/netclaw-visual/src/orgchart/` finds no hardcoded member name
-- [ ] T049 Verify SC-005 — `ui/netclaw-visual/src/panels/` and the chat surface behave identically to `main`, by diffing behaviour rather than eyeballing
+- [ ] T049 Verify SC-005 / SC-008 — `ui/netclaw-visual/src/panels/` and the chat surface behave identically to `main`, by diffing behaviour rather than eyeballing (FR-016, FR-017, FR-018)
 - [ ] T050 Verify SC-007 / SC-010 via `chrome-devtools-mcp` — four states separable in a greyscale screenshot, and again under emulated `prefers-reduced-motion`
 - [ ] T051 Verify SC-007a using `specs/072-hud-2-org-chart/fixtures/scale-100.json` — one FAULT among 25 COLD located in under 5 s
 - [ ] T052 Verify SC-009 against `specs/072-hud-2-org-chart/fixtures/live-29.json` — every node reachable and operable by keyboard alone
 - [ ] T053 Verify SC-011 against the live Border — node coordinates identical between first frame and 30 minutes of state churn
 - [ ] T054 Verify SC-013 — 60 fps on `scale-100.json` with 5 expanded during pan/zoom, and no slower than HUD 1.0 on `live-29.json` (FR-029b, FR-029c)
+- [ ] T056 Verify SC-003 against `specs/072-hud-2-org-chart/fixtures/live-29.json` — no drag, scroll or keyboard input can produce a view with the external band below the internal band (FR-012)
 - [ ] T055 Verify SC-001 / SC-002 — external vs internal identified on first view; HOT members identifiable within 2 s
 
 ---
@@ -219,5 +220,5 @@ lands before building on it), and after T045 (the riskiest deletion verified).
 
 ---
 
-**Total: 55 tasks** — Setup 4 · Foundational 10 · US1 9 · US2 4 · US3 10 ·
-A11y 4 · Removal 5 · Polish 9
+**Total: 56 tasks** — Setup 4 · Foundational 10 · US1 9 · US2 4 · US3 10 ·
+A11y 4 · Removal 5 · Polish 10

--- a/specs/072-hud-2-org-chart/tasks.md
+++ b/specs/072-hud-2-org-chart/tasks.md
@@ -1,0 +1,223 @@
+# Tasks: HUD 2.0 — Top-Down Trust Org Chart
+
+**Feature**: `072-hud-2-org-chart` | **Date**: 2026-07-27
+**Input**: [spec.md](./spec.md), [plan.md](./plan.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/layout-contract.md](./contracts/layout-contract.md)
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]** — parallelizable (different file, no incomplete dependency)
+- **[US1/US2/US3]** — user story this task serves
+
+## Path Conventions
+
+All paths relative to repo root. Frontend package is `ui/netclaw-visual/`.
+
+## Tests
+
+Test tasks **are** included. Not a default — research R1 makes the pure/render
+split an architectural requirement precisely so the spec's numeric claims are
+testable, and `contracts/layout-contract.md` names required tests per module.
+Tests are written **with** each pure module, not after.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+- [ ] T001 Add `"test": "node --test src/"` to `scripts` in `ui/netclaw-visual/package.json` (no new dependency — research R2)
+- [ ] T002 [P] Create directory `ui/netclaw-visual/src/orgchart/` for pure logic (must never import three.js)
+- [ ] T003 [P] Create directory `ui/netclaw-visual/src/orgchart-render/` for three.js rendering
+- [ ] T004 Add a **client-side** fixture loader in `ui/netclaw-visual/src/main.js`: `?fixture=<name>` fetches `specs/072-hud-2-org-chart/fixtures/<name>.json` instead of `/api/n2n`
+
+> **T004 note — resolves a conflict between plan.md and research.md.** research R4
+> said "the dev server gains a way to serve a fixture", but plan.md marks
+> `server.js` UNCHANGED under FR-019. Loading fixtures client-side satisfies both:
+> no server change, no new endpoint, no widened API surface.
+
+**Checkpoint**: `npm test` runs (vacuously) and the fixture loader is reachable.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**⚠️ Blocks every user story.** These are the pure modules from
+`contracts/layout-contract.md`. Each imports nothing from three.js; each ships
+with its tests. All five are independent of one another → all `[P]`.
+
+- [ ] T005 [P] Implement `dedupePeers()` and `resolveLabel()` in `ui/netclaw-visual/src/orgchart/normalize.js` per the contract (FR-014, FR-015)
+- [ ] T006 [P] Write `ui/netclaw-visual/src/orgchart/normalize.test.js`: real duplicated-`Hermes` payload collapses to one peer in `severed`; both edge nodes with `display_name: null` resolve to non-empty labels
+- [ ] T007 [P] Implement `classifyHealth(member, nowEpochS)` and `WARM_THRESHOLD_S = 900` in `ui/netclaw-visual/src/orgchart/health.js`, precedence HOT → FAULT → WARM → COLD (FR-008, FR-008a)
+- [ ] T008 [P] Write `ui/netclaw-visual/src/orgchart/health.test.js`: all four states; exact 900 s boundary; `active` but `!live`; `unreachable` with fresh heartbeat still FAULT; **null heartbeat ⇒ COLD not FAULT** (highest-value assertion — conflating COLD and FAULT is the failure this design prevents)
+- [ ] T009 [P] Implement `categorizeMembers(members, integrationCatalog)` in `ui/netclaw-visual/src/orgchart/categorize.js`, catalog as an argument never an import (FR-006, FR-006a)
+- [ ] T010 [P] Write `ui/netclaw-visual/src/orgchart/categorize.test.js`: `live-29.json` yields 25 categorised; empty catalog ⇒ all `Uncategorised`; zero-skill member; **an alternate synthetic catalog produces a different correct chart** (proves Constitution VI vendor neutrality)
+- [ ] T011 [P] Implement `orderCategories()` in `ui/netclaw-visual/src/orgchart/ordering.js` — heat desc, size desc, name; `Uncategorised` always last (FR-006b)
+- [ ] T012 [P] Write `ui/netclaw-visual/src/orgchart/ordering.test.js`: hot before cold; equal heat falls to size; equal both falls to name; `Uncategorised` last even when it holds a HOT member (true of `ipfabric` in live data)
+- [ ] T013 Implement `computeLayout()` and `appendMember()` in `ui/netclaw-visual/src/orgchart/layout.js` — three bands + edge lane, category columns with wrap, positions assigned once (R6, FR-034)
+- [ ] T014 Write `ui/netclaw-visual/src/orgchart/layout.test.js` against all five fixtures: no two nodes share a position; `appendMember` leaves every prior coordinate byte-identical; edge nodes never get a member-column position; bands exist at zero members
+
+**Checkpoint**: `npm test` green. Every falsifiable rule in the spec is now
+covered without a browser or GPU.
+
+---
+
+## Phase 3: User Story 1 — Read the trust topology at a glance (P1) 🎯 MVP
+
+**Goal**: First frame answers who is external, who is internal, who is alive, and where the boundary is — without interacting.
+
+**Independent test**: Load with `?fixture=live-29`. Without input, confirm the three bands, the drawn trust boundary, and that HOT members dominate.
+
+- [ ] T015 [US1] Implement orthographic camera with `enableRotate = false`, pan/zoom retained, zoom clamped, in `ui/netclaw-visual/src/orgchart-render/camera.js` (FR-012, FR-013, R7)
+- [ ] T016 [P] [US1] Render the three bands and the **explicitly drawn** trust boundary in `ui/netclaw-visual/src/orgchart-render/bands.js` (FR-001, FR-002)
+- [ ] T017 [P] [US1] Implement instanced node geometry with four health treatments in `ui/netclaw-visual/src/orgchart-render/nodes.js` — differing in form, colour temperature and motion, never opacity alone (FR-009a, FR-029a)
+- [ ] T018 [US1] Make FAULT the most salient state after HOT in `ui/netclaw-visual/src/orgchart-render/nodes.js` (FR-009b)
+- [ ] T019 [P] [US1] Implement the six link styles in `ui/netclaw-visual/src/orgchart-render/links.js`, reusing existing ribbon/tube helpers (FR-010, FR-028)
+- [ ] T020 [US1] Wire the org chart into `ui/netclaw-visual/src/main.js`: consume `orgchart/` output, place Border on the centre line, peers north, members south (FR-003, FR-004, FR-005)
+- [ ] T021 [US1] Add the health-state legend to `ui/netclaw-visual/index.html` (FR-009c)
+- [ ] T022 [US1] Render empty bands with per-band CTAs and keep loading distinct from empty in `ui/netclaw-visual/src/orgchart-render/bands.js`; remove the `role !== 'border'` early return (FR-033, FR-033a, FR-033b, FR-033d)
+- [ ] T023 [US1] Verify all fixtures in `specs/072-hud-2-org-chart/fixtures/` render via `?fixture=` — no overlap, no blank labels, bands always present
+
+**Checkpoint**: MVP. The org chart renders and is readable. Orbit code still
+present but unused — deliberately, so the branch is never in a state with
+neither layout working.
+
+---
+
+## Phase 4: User Story 2 — Distinguish mobile edges from member claws (P2)
+
+**Goal**: Enrolled phones are instantly identifiable and never mixed into the member chart.
+
+**Independent test**: With `live-29.json` (2 edge nodes, `display_name: null`), confirm both render in their own lane with non-blank labels.
+
+- [ ] T024 [US2] Render the edge lane flanking the Border, inside the boundary and outside the member chart, in `ui/netclaw-visual/src/orgchart-render/bands.js` (FR-007)
+- [ ] T025 [US2] Implement the asymmetric Border→device push link, visually distinct from a member delegation link, in `ui/netclaw-visual/src/orgchart-render/links.js` (FR-011)
+- [ ] T026 [US2] Surface each edge node's last-seen age on the node in `ui/netclaw-visual/src/orgchart-render/nodes.js`, without opening the detail panel (US2 AC2)
+- [ ] T027 [US2] Add an edge-lane overflow case to `ui/netclaw-visual/src/orgchart/layout.test.js` — more edges than slots must wrap, never overlap as HUD 1.0's three-slot stacking did (spec Edge Cases)
+
+**Checkpoint**: Phones are unmistakable and the known overflow bug is not carried forward.
+
+---
+
+## Phase 5: User Story 3 — Drill in without losing the map (P2)
+
+**Goal**: Inspect and expand any node while the chart stays put.
+
+**Independent test**: Click a peer, a member and an edge; panel updates exactly as on `main`, camera never moves, layout never reflows.
+
+- [ ] T028 [US3] Wire picking so click/tap invokes the existing `setDetail(kind, payload, related)` unchanged in `ui/netclaw-visual/src/main.js` (FR-017, FR-020a, US3 AC1)
+- [ ] T029 [US3] Implement the always-visible expand affordance (chevron/`+`), separate from the click that selects, in `ui/netclaw-visual/src/orgchart-render/expansion.js` (FR-020, FR-020a, FR-020b)
+- [ ] T030 [US3] Render an expanded member's tools from `member.skills[]` in `ui/netclaw-visual/src/orgchart-render/expansion.js`, with no new API call (FR-021)
+- [ ] T031 [US3] Guarantee expansion never reflows siblings in `ui/netclaw-visual/src/orgchart-render/expansion.js` — reserve or overlay space, never re-pack (FR-022)
+- [ ] T032 [P] [US3] Support simultaneous expansion of multiple members in `ui/netclaw-visual/src/orgchart-render/expansion.js` (FR-023)
+- [ ] T033 [P] [US3] Show tool count on collapsed nodes in `ui/netclaw-visual/src/orgchart-render/nodes.js` (FR-024)
+- [ ] T034 [P] [US3] Ensure COLD and FAULT members expand too in `ui/netclaw-visual/src/orgchart-render/expansion.js` — what a cold claw *would* bring decides whether to warm it (FR-025)
+- [ ] T035 [US3] Retarget `#search` in `ui/netclaw-visual/index.html` and `main.js` to members, categories and tool names (FR-031)
+- [ ] T036 [US3] Implement highlight/dim matching that never hides or re-packs; a tool match makes its collapsed owner discoverable; clearing restores prior state including expansions (FR-031a, FR-031b, FR-031c)
+- [ ] T037 [US3] Enforce session-stable positions in `ui/netclaw-visual/src/main.js`: the poll path repaints only, never repositions or reorders (FR-034, FR-034a), and mid-session enrolment routes through `appendMember` (FR-034b)
+
+**Checkpoint**: All three user stories complete. Feature is functionally whole.
+
+---
+
+## Phase 6: Accessibility (Cross-Cutting)
+
+Spans all three stories, so it follows them rather than sitting inside one.
+
+- [ ] T038 Build the focusable DOM overlay over the canvas, reusing the `CSS2DRenderer` layer, in `ui/netclaw-visual/src/orgchart-render/a11y.js` (FR-032)
+- [ ] T039 Implement the keyboard model — Tab between bands/categories, arrows between siblings, Enter selects, expand affordance separately reachable (FR-032a)
+- [ ] T040 Expose accessible name **and health state as text** for every node in `ui/netclaw-visual/src/orgchart-render/a11y.js`; state must never be conveyed by colour or motion alone (FR-032b)
+- [ ] T041 Honour `prefers-reduced-motion` in `ui/netclaw-visual/src/orgchart-render/nodes.js` and `ui/netclaw-visual/src/orgchart-render/a11y.js`; the four states must stay separable with motion suppressed, since motion is a redundant channel only (FR-032c, R8)
+
+**Checkpoint**: Chart is fully operable without a pointer.
+
+---
+
+## Phase 7: Removal (Only After the Replacement Works)
+
+**⚠️ Deliberately last.** Deleting before Phases 3–6 land would leave the branch
+with neither layout functioning.
+
+- [ ] T042 Delete orbit positioning from `ui/netclaw-visual/src/main.js`: `CORE_POSITIONS`, `CORE_CENTROID`, `RISK_LAYOUT.tierRadius`, per-core orbit animation, and the edge close-orbit slots (FR-027)
+- [ ] T043 **Verify FR-030d before deleting anything in T044** — confirm which fields of `state.integrations` / `state.devices` `renderSidebar` and `renderMetrics` still read; keep `fetchGraph()` and the `/api/graph` request alive (R5)
+- [ ] T044 Delete the scene-layer functions `buildIntegrations`, `buildDevices`, `createSkillSprites`, `computeDendritePositions`, `createDendriteMaterial`, `lightIntegration`, `lightDevice`, and the integration/device branches of `applyFilters`, from `ui/netclaw-visual/src/main.js` (FR-030, FR-030c)
+- [ ] T045 Confirm `renderSidebar`, `renderMetrics` and every renderer named in FR-018 still work after T044, in `ui/netclaw-visual/src/main.js` (FR-030d)
+- [ ] T046 Confirm no orbit or integration/device scene code remains: `git grep` for the removed identifiers returns nothing outside history
+
+> **T043 is the single highest-risk task in the feature.** It is the one realistic
+> way this work breaks something else, so it is separated from T044 with its own
+> verification rather than folded into the deletion.
+
+---
+
+## Phase 8: Polish & Verification
+
+- [ ] T047 [P] Update `ui/netclaw-visual/README.md` — new layout, health states, keyboard model, fixture usage (Constitution XI, XII)
+- [ ] T048 [P] Confirm SC-006: `git grep` over `ui/netclaw-visual/src/orgchart/` finds no hardcoded member name
+- [ ] T049 Verify SC-005 — `ui/netclaw-visual/src/panels/` and the chat surface behave identically to `main`, by diffing behaviour rather than eyeballing
+- [ ] T050 Verify SC-007 / SC-010 via `chrome-devtools-mcp` — four states separable in a greyscale screenshot, and again under emulated `prefers-reduced-motion`
+- [ ] T051 Verify SC-007a using `specs/072-hud-2-org-chart/fixtures/scale-100.json` — one FAULT among 25 COLD located in under 5 s
+- [ ] T052 Verify SC-009 against `specs/072-hud-2-org-chart/fixtures/live-29.json` — every node reachable and operable by keyboard alone
+- [ ] T053 Verify SC-011 against the live Border — node coordinates identical between first frame and 30 minutes of state churn
+- [ ] T054 Verify SC-013 — 60 fps on `scale-100.json` with 5 expanded during pan/zoom, and no slower than HUD 1.0 on `live-29.json` (FR-029b, FR-029c)
+- [ ] T055 Verify SC-001 / SC-002 — external vs internal identified on first view; HOT members identifiable within 2 s
+
+---
+
+## Dependencies
+
+```
+Phase 1 Setup
+      ↓
+Phase 2 Foundational (T005–T014)   ← blocks everything
+      ↓
+Phase 3 US1 (P1, MVP) ─────┐
+      ↓                    │
+Phase 4 US2 (P2)           │ US2 and US3 both depend on US1's
+Phase 5 US3 (P2)  ─────────┘ render scaffolding, not on each other
+      ↓
+Phase 6 A11y (cross-cutting, needs all nodes rendering)
+      ↓
+Phase 7 Removal (only after the replacement works)
+      ↓
+Phase 8 Polish & Verification
+```
+
+**Story independence**: US2 and US3 are independent of each other and may be
+built in either order, or in parallel by two people, once US1 lands. Neither
+can precede US1 — both need nodes on screen.
+
+## Parallel execution examples
+
+**Phase 2** — all five pure modules are mutually independent:
+
+```
+T005+T006 (normalize) ‖ T007+T008 (health) ‖ T009+T010 (categorize) ‖ T011+T012 (ordering)
+then T013+T014 (layout, consumes the others' shapes)
+```
+
+**Phase 3** — after T015 (camera):
+
+```
+T016 (bands) ‖ T017 (nodes) ‖ T019 (links)   → then T020 wires them together
+```
+
+**Phase 5** — after T029 (affordance): `T032 ‖ T033 ‖ T034`
+
+**Phase 8**: `T047 ‖ T048` immediately; the SC verifications are sequential
+(one browser).
+
+## Implementation strategy
+
+**MVP = Phases 1–3 (T001–T023).** That delivers the readable top-down chart —
+the actual complaint being fixed. US2 and US3 are refinements on a working chart.
+
+**Incremental delivery**: each phase ends in a working state. The branch is
+never broken, because removal (Phase 7) is last by construction — the orbit code
+sits unused but functional through Phases 3–6.
+
+**Suggested review points**: end of Phase 2 (tests green, logic proven without a
+browser), end of Phase 3 (MVP visible — the right moment to confirm the layout
+lands before building on it), and after T045 (the riskiest deletion verified).
+
+---
+
+**Total: 55 tasks** — Setup 4 · Foundational 10 · US1 9 · US2 4 · US3 10 ·
+A11y 4 · Removal 5 · Polish 9

--- a/specs/072-hud-2-org-chart/tasks.md
+++ b/specs/072-hud-2-org-chart/tasks.md
@@ -102,16 +102,16 @@ neither layout working.
 
 **Independent test**: Click a peer, a member and an edge; panel updates exactly as on `main`, camera never moves, layout never reflows.
 
-- [ ] T028 [US3] Wire picking so click/tap invokes the existing `setDetail(kind, payload, related)` unchanged in `ui/netclaw-visual/src/main.js` (FR-017, FR-020a, US3 AC1)
-- [ ] T029 [US3] Implement the always-visible expand affordance (chevron/`+`), separate from the click that selects, in `ui/netclaw-visual/src/orgchart-render/expansion.js` (FR-020, FR-020a, FR-020b)
-- [ ] T030 [US3] Render an expanded member's tools from `member.skills[]` in `ui/netclaw-visual/src/orgchart-render/expansion.js`, with no new API call (FR-021, FR-030a, SC-008)
-- [ ] T031 [US3] Guarantee expansion never reflows siblings in `ui/netclaw-visual/src/orgchart-render/expansion.js` — reserve or overlay space, never re-pack (FR-022)
-- [ ] T032 [P] [US3] Support simultaneous expansion of multiple members in `ui/netclaw-visual/src/orgchart-render/expansion.js` (FR-023)
-- [ ] T033 [P] [US3] Show tool count on collapsed nodes in `ui/netclaw-visual/src/orgchart-render/nodes.js` (FR-024)
-- [ ] T034 [P] [US3] Ensure COLD and FAULT members expand too in `ui/netclaw-visual/src/orgchart-render/expansion.js` — what a cold claw *would* bring decides whether to warm it (FR-025)
+- [x] T028 [US3] Wire picking so click/tap invokes the existing `setDetail(kind, payload, related)` unchanged in `ui/netclaw-visual/src/main.js` (FR-017, FR-020a, US3 AC1)
+- [x] T029 [US3] Implement the always-visible expand affordance (chevron/`+`), separate from the click that selects, in `ui/netclaw-visual/src/orgchart-render/expansion.js` (FR-020, FR-020a, FR-020b)
+- [x] T030 [US3] Render an expanded member's tools from `member.skills[]` in `ui/netclaw-visual/src/orgchart-render/expansion.js`, with no new API call (FR-021, FR-030a, SC-008)
+- [x] T031 [US3] Guarantee expansion never reflows siblings in `ui/netclaw-visual/src/orgchart-render/expansion.js` — reserve or overlay space, never re-pack (FR-022)
+- [x] T032 [P] [US3] Support simultaneous expansion of multiple members in `ui/netclaw-visual/src/orgchart-render/expansion.js` (FR-023)
+- [x] T033 [P] [US3] Show tool count on collapsed nodes in `ui/netclaw-visual/src/orgchart-render/nodes.js` (FR-024)
+- [x] T034 [P] [US3] Ensure COLD and FAULT members expand too in `ui/netclaw-visual/src/orgchart-render/expansion.js` — what a cold claw *would* bring decides whether to warm it (FR-025)
 - [x] T035 [US3] Retarget `#search` in `ui/netclaw-visual/index.html` and `main.js` to members, categories and tool names (FR-031)
-- [ ] T036 [US3] Implement highlight/dim matching that never hides or re-packs; a tool match makes its collapsed owner discoverable; clearing restores prior state including expansions (FR-031a, FR-031b, FR-031c)
-- [ ] T037 [US3] Enforce session-stable positions in `ui/netclaw-visual/src/main.js`: the poll path repaints only, never repositions or reorders (FR-034, FR-034a), and mid-session enrolment routes through `appendMember` (FR-034b)
+- [x] T036 [US3] Implement highlight/dim matching that never hides or re-packs; a tool match makes its collapsed owner discoverable; clearing restores prior state including expansions (FR-031a, FR-031b, FR-031c)
+- [x] T037 [US3] Enforce session-stable positions in `ui/netclaw-visual/src/main.js`: the poll path repaints only, never repositions or reorders (FR-034, FR-034a), and mid-session enrolment routes through `appendMember` (FR-034b)
 
 **Checkpoint**: All three user stories complete. Feature is functionally whole.
 
@@ -121,10 +121,10 @@ neither layout working.
 
 Spans all three stories, so it follows them rather than sitting inside one.
 
-- [ ] T038 Build the focusable DOM overlay over the canvas, reusing the `CSS2DRenderer` layer, in `ui/netclaw-visual/src/orgchart-render/a11y.js` (FR-032)
-- [ ] T039 Implement the keyboard model — Tab between bands/categories, arrows between siblings, Enter selects, expand affordance separately reachable (FR-032a)
-- [ ] T040 Expose accessible name **and health state as text** for every node in `ui/netclaw-visual/src/orgchart-render/a11y.js`; state must never be conveyed by colour or motion alone (FR-032b)
-- [ ] T041 Honour `prefers-reduced-motion` in `ui/netclaw-visual/src/orgchart-render/nodes.js` and `ui/netclaw-visual/src/orgchart-render/a11y.js`; the four states must stay separable with motion suppressed, since motion is a redundant channel only (FR-032c, R8)
+- [x] T038 Build the focusable DOM overlay over the canvas, reusing the `CSS2DRenderer` layer, in `ui/netclaw-visual/src/orgchart-render/a11y.js` (FR-032)
+- [x] T039 Implement the keyboard model — Tab between bands/categories, arrows between siblings, Enter selects, expand affordance separately reachable (FR-032a)
+- [x] T040 Expose accessible name **and health state as text** for every node in `ui/netclaw-visual/src/orgchart-render/a11y.js`; state must never be conveyed by colour or motion alone (FR-032b)
+- [x] T041 Honour `prefers-reduced-motion` in `ui/netclaw-visual/src/orgchart-render/nodes.js` and `ui/netclaw-visual/src/orgchart-render/a11y.js`; the four states must stay separable with motion suppressed, since motion is a redundant channel only (FR-032c, R8)
 
 **Checkpoint**: Chart is fully operable without a pointer.
 
@@ -135,11 +135,11 @@ Spans all three stories, so it follows them rather than sitting inside one.
 **⚠️ Deliberately last.** Deleting before Phases 3–6 land would leave the branch
 with neither layout functioning.
 
-- [ ] T042 Delete orbit positioning (completing the FR-026 hard replace) from `ui/netclaw-visual/src/main.js`: `CORE_POSITIONS`, `CORE_CENTROID`, `RISK_LAYOUT.tierRadius`, per-core orbit animation, and the edge close-orbit slots (FR-027)
-- [ ] T043 **Verify FR-030d before deleting anything in T044** — confirm which fields of `state.integrations` / `state.devices` `renderSidebar` and `renderMetrics` still read; keep `fetchGraph()` and the `/api/graph` request alive (R5)
-- [ ] T044 Delete the scene-layer functions `buildIntegrations`, `buildDevices`, `createSkillSprites`, `computeDendritePositions`, `createDendriteMaterial`, `lightIntegration`, `lightDevice`, and the integration/device branches of `applyFilters`, from `ui/netclaw-visual/src/main.js` (FR-030, FR-030c)
-- [ ] T045 Confirm `renderSidebar`, `renderMetrics` and every renderer named in FR-018 still work after T044, **and that devices remain listed in the right-hand panel**, in `ui/netclaw-visual/src/main.js` (FR-030b, FR-030d)
-- [ ] T046 Confirm no orbit or integration/device scene code remains: `git grep` for the removed identifiers returns nothing outside history
+- [x] T042 Delete orbit positioning (completing the FR-026 hard replace) from `ui/netclaw-visual/src/main.js`: `CORE_POSITIONS`, `CORE_CENTROID`, `RISK_LAYOUT.tierRadius`, per-core orbit animation, and the edge close-orbit slots (FR-027)
+- [x] T043 **Verify FR-030d before deleting anything in T044** — confirm which fields of `state.integrations` / `state.devices` `renderSidebar` and `renderMetrics` still read; keep `fetchGraph()` and the `/api/graph` request alive (R5)
+- [x] T044 Delete the scene-layer functions `buildIntegrations`, `buildDevices`, `createSkillSprites`, `computeDendritePositions`, `createDendriteMaterial`, `lightIntegration`, `lightDevice`, and the integration/device branches of `applyFilters`, from `ui/netclaw-visual/src/main.js` (FR-030, FR-030c)
+- [x] T045 Confirm `renderSidebar`, `renderMetrics` and every renderer named in FR-018 still work after T044, **and that devices remain listed in the right-hand panel**, in `ui/netclaw-visual/src/main.js` (FR-030b, FR-030d)
+- [x] T046 Confirm no orbit or integration/device scene code remains: `git grep` for the removed identifiers returns nothing outside history
 
 > **T043 is the single highest-risk task in the feature.** It is the one realistic
 > way this work breaks something else, so it is separated from T044 with its own

--- a/ui/netclaw-visual/README.md
+++ b/ui/netclaw-visual/README.md
@@ -16,7 +16,8 @@ A Three.js 3D network operations dashboard for [NetClaw](https://github.com/auto
 4. [Peer with Other NetClaws (Optional)](#4-peer-with-other-netclaws-optional)
 5. [Start the Visual HUD](#5-start-the-visual-hud)
 6. [Using the HUD](#6-using-the-hud)
-7. [Architecture](#architecture)
+7. [Reading the Org Chart](#7-reading-the-org-chart)
+8. [Architecture](#architecture)
 8. [API Reference](#api-reference)
 9. [Troubleshooting](#troubleshooting)
 
@@ -362,6 +363,96 @@ The detail panel below shows context for the selected node:
 - **Gateway** — gateway connection status
 - **Socket** — WebSocket connection state (CONNECTED / RECONNECTING)
 - **Updated** — timestamp of last data refresh
+
+---
+
+## 7. Reading the Org Chart
+
+The HUD renders your NetClaw's **trust topology** as a top-down org chart. It
+replaced an orbiting-cores scene in feature 072; the layout is planar and the
+camera cannot rotate, because "external vs internal" only reads if the layout
+and the viewer agree on which way is up.
+
+### The three bands
+
+```
+  ══════ EXTERNAL — eN2N peers ══════      above the boundary: other orgs
+  ─────── TRUST BOUNDARY ────────────      drawn explicitly, not implied
+        [ BORDER ]   ╌╌► [ edges ]         you, plus mobile devices
+  ─────── INTERNAL — iN2N members ────      your own claws, by category
+```
+
+Peers north of the boundary are **outside your organisation**. The Border is
+you. Member claws fan out below, grouped into categories. Mobile edge devices
+get their own lane beside the Border — inside the boundary, but not part of the
+member chart, because a phone receives pushes rather than serving delegations.
+
+### Claw health — four states
+
+| | State | Meaning |
+|---|---|---|
+| ● | **Hot** | Running now |
+| ◆ | **Warm** | Seen within 15 minutes; idle, not a fault |
+| ▬ | **Cold** | Never started — inert **by design**, entirely normal |
+| ◻ | **Fault** | Was reachable, no longer is — needs attention |
+
+Cold and Fault are deliberately kept apart. Most claws are cold on purpose
+(on-demand), so merging the two would bury a genuine fault inside a crowd of
+healthy-but-idle ones. Fault is the most prominent state after Hot for exactly
+that reason.
+
+States differ in **shape, colour and motion at once**, never opacity alone, so
+the encoding survives a greyscale screenshot and `prefers-reduced-motion`.
+
+### Categories are derived, not configured
+
+A member's category comes from the skills it holds, matched against the shipped
+integration catalog (`server.js`, ~70 integrations across 22 categories). No
+member names are hardcoded anywhere, so the chart works on a deployment it has
+never seen. A claw whose skills match nothing lands in **Uncategorised** rather
+than being dropped.
+
+Categories are ordered by heat, then size — but **only once, at load**. Live
+updates repaint; they never move anything. A claw that fails changes how it
+looks, never where it is.
+
+### Interacting
+
+| Action | Result |
+|---|---|
+| **Click a claw** | Opens its detail panel *and* reveals its tools |
+| **Drag** | Pans. Rotation is disabled by design |
+| **Scroll** | Zooms |
+| **Search** | Matches claws, categories and tool names — highlights in place, never hides or re-packs |
+| **Tab / arrows** | Moves between and within bands |
+| **Enter** | Selects |
+| **`e`** | Expands tools without selecting |
+
+Cold claws expand too: what a cold claw *would* bring is exactly what tells you
+whether to warm it.
+
+### Development
+
+```bash
+npm test                       # pure layout logic — no browser, no GPU
+npm run dev                    # API :3001 + vite :3000
+```
+
+Load a fixture instead of live data — useful for an empty first-run view or the
+100-member ceiling:
+
+```
+http://localhost:3000/?fixture=empty
+http://localhost:3000/?fixture=scale-100
+```
+
+Fixtures live in `specs/072-hud-2-org-chart/fixtures/` and always render a
+banner, so synthetic data can never be mistaken for your real Border.
+
+Layout logic under `src/orgchart/` is pure — it imports nothing from three.js
+and holds no DOM references, which is what lets it be unit tested. Rendering
+lives in `src/orgchart-render/` and consumes that output without re-deriving it.
+Keep that boundary; the test suite runs in bare Node and will fail if it breaks.
 
 ---
 

--- a/ui/netclaw-visual/index.html
+++ b/ui/netclaw-visual/index.html
@@ -47,8 +47,22 @@
         <button class="panel-toggle" id="toggle-left" type="button" aria-label="Collapse left sidebar">&lsaquo;</button>
         <section>
           <p class="eyebrow">Filters</p>
-          <input id="search" class="search" type="search" placeholder="Search skills, integrations, devices" />
+          <input id="search" class="search" type="search" placeholder="Search claws, categories, tools" />
           <div id="category-list" class="toggle-list"></div>
+        </section>
+
+        <!-- HUD 2.0 legend (FR-009c). Four states is past the point where an
+             operator can be expected to infer the encoding. Each swatch carries
+             a distinct SHAPE as well as a colour, so the legend still works in
+             greyscale (SC-007) and under reduced motion (SC-010). -->
+        <section class="sidebar-section" id="health-legend">
+          <p class="eyebrow">Claw health</p>
+          <ul class="legend-list">
+            <li><span class="legend-swatch legend-hot">&#9679;</span> <b>Hot</b> — running now</li>
+            <li><span class="legend-swatch legend-warm">&#9670;</span> <b>Warm</b> — seen recently, idle</li>
+            <li><span class="legend-swatch legend-cold">&#9644;</span> <b>Cold</b> — never started, by design</li>
+            <li><span class="legend-swatch legend-fault">&#9723;</span> <b>Fault</b> — was reachable, now not</li>
+          </ul>
         </section>
 
         <section class="sidebar-section">

--- a/ui/netclaw-visual/package.json
+++ b/ui/netclaw-visual/package.json
@@ -1,13 +1,14 @@
 {
   "name": "netclaw-hud",
   "version": "1.0.0",
-  "description": "NetClaw Three.js HUD — futuristic network operations dashboard",
+  "description": "NetClaw Three.js HUD \u2014 futuristic network operations dashboard",
   "type": "module",
   "scripts": {
     "dev": "concurrently \"node server.js\" \"vite --host\"",
     "server": "node server.js",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test 'src/**/*.test.js'"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/ui/netclaw-visual/public/fixtures
+++ b/ui/netclaw-visual/public/fixtures
@@ -1,0 +1,1 @@
+../../../specs/072-hud-2-org-chart/fixtures

--- a/ui/netclaw-visual/src/main.js
+++ b/ui/netclaw-visual/src/main.js
@@ -10,6 +10,17 @@ import { AfterimagePass } from 'three/addons/postprocessing/AfterimagePass.js';
 import { FilmPass } from 'three/addons/postprocessing/FilmPass.js';
 import { GlitchPass } from 'three/addons/postprocessing/GlitchPass.js';
 import { RGBShiftShader } from 'three/addons/shaders/RGBShiftShader.js';
+
+// ── HUD 2.0: top-down trust org chart (feature 072) ───────────────────────
+// The orbit layout is replaced by these; everything else in this file —
+// materials, ribbons, labels, picking, polling, panels — is preserved (FR-028).
+import {
+  mountOrgChart, updateOrgChart, searchOrgChart,
+  pickableObjects, chartNodes, tickOrgChart,
+} from './orgchart-render/index.js';
+import {
+  createChartCamera, createChartControls, resizeChartCamera, frameChart,
+} from './orgchart-render/camera.js';
 import { VignetteShader } from 'three/addons/shaders/VignetteShader.js';
 import { CSS2DRenderer, CSS2DObject } from 'three/addons/renderers/CSS2DRenderer.js';
 import gsap from 'gsap';
@@ -384,8 +395,12 @@ function initScene() {
   state.scene = new THREE.Scene();
   state.scene.fog = new THREE.FogExp2(0x040a14, 0.006);
 
-  state.camera = new THREE.PerspectiveCamera(48, window.innerWidth / window.innerHeight, 0.1, 260);
-  state.camera.position.set(12, 55, 110);
+  // HUD 2.0 (FR-012/013): orthographic and rotation-locked. A perspective
+  // camera under free OrbitControls was the dominant cause of "hard to
+  // navigate" — hierarchy only reads if the layout and the viewer agree on
+  // which way is up. Ortho additionally renders equal-tier siblings at equal
+  // size, which is what makes a chart read as a chart.
+  state.camera = createChartCamera(window.innerWidth / window.innerHeight);
 
   state.renderer = new THREE.WebGLRenderer({ antialias: false, alpha: true });
   state.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
@@ -436,13 +451,9 @@ function initScene() {
   // 9. Output (sRGB tone mapping)
   state.composer.addPass(new OutputPass());
 
-  state.controls = new OrbitControls(state.camera, state.renderer.domElement);
-  state.controls.enableDamping = true;
-  state.controls.dampingFactor = 0.06;
-  state.controls.minDistance = 12;
-  state.controls.maxDistance = 180;
-  state.controls.maxPolarAngle = Math.PI * 0.48;
-  state.controls.target.set(CORE_CENTROID.x, CORE_CENTROID.y, CORE_CENTROID.z);
+  // Pan and zoom only — rotation is disabled so the bands can never invert
+  // (FR-012, SC-003).
+  state.controls = createChartControls(state.camera, state.renderer.domElement);
 
   // ── Enhanced lighting (Section E) ─────────────────────────────
   state.scene.add(new THREE.AmbientLight(0x4a7cb5, 0.35));
@@ -2769,6 +2780,11 @@ function animate() {
   const elapsed = state.clock.getElapsedTime();
   const frozen = !!state.selected;
 
+  // HUD 2.0 node pulses. Motion is a redundant channel (R8) — the four health
+  // states are already separable by form and colour — so honouring reduced
+  // motion simply skips it without weakening the encoding.
+  tickOrgChart(elapsed);
+
   // Track time offset for freeze: when frozen, hold rotations at the moment of freeze
   if (frozen && state._frozenAt == null) state._frozenAt = elapsed;
   if (!frozen) state._frozenAt = null;
@@ -2921,9 +2937,22 @@ function animate() {
   state.labels.render(state.scene, state.camera);
 }
 
+/**
+ * Banner for fixture mode (FR-033c). A synthetic topology must never be
+ * mistakable for live data — in a security tool a fabricated claw read as real
+ * is a hazard.
+ */
+function markFixtureMode(name) {
+  const el = document.createElement('div');
+  el.id = 'fixture-banner';
+  el.textContent = `FIXTURE: ${name} — synthetic data, not this Border`;
+  document.body.appendChild(el);
+}
+
 function onResize() {
-  state.camera.aspect = window.innerWidth / window.innerHeight;
-  state.camera.updateProjectionMatrix();
+  // Orthographic: no .aspect property — the frustum bounds must be recomputed
+  // instead, or a resize silently stretches the chart (FR-013).
+  resizeChartCamera(state.camera, window.innerWidth / window.innerHeight);
   state.renderer.setSize(window.innerWidth, window.innerHeight);
   state.labels.setSize(window.innerWidth, window.innerHeight);
   state.composer.setSize(window.innerWidth, window.innerHeight);
@@ -3003,6 +3032,11 @@ function wireUI() {
   dom.search.addEventListener('input', (event) => {
     state.filters.query = event.target.value;
     applyFilters();
+    // HUD 2.0 (FR-031/031a): match members, categories and tool names by
+    // highlighting and dimming IN PLACE. Never hides, never re-packs — hiding
+    // would re-flow the chart and destroy the spatial memory the layout exists
+    // to build.
+    searchOrgChart(event.target.value);
   });
 
   document.querySelectorAll('.segmented-btn').forEach((button) => {
@@ -3253,10 +3287,19 @@ async function boot() {
     } catch { state.bgp = null; }
 
     // N2N federation state (feature 052) — optional, degrades gracefully
+    // ?fixture=<name> substitutes a committed /api/n2n fixture for the live
+    // feed (T004). Client-side on purpose: server.js stays untouched, so no
+    // endpoint is added and the API surface never widens (FR-019). Opt-in
+    // only, and marked on screen — FR-033c forbids a synthetic topology
+    // appearing without the operator asking for it.
+    state.fixtureName = new URLSearchParams(location.search).get('fixture');
     try {
-      const n2nRes = await fetch('/api/n2n');
-      state.n2n = await n2nRes.json();
+      const url = state.fixtureName
+        ? `/fixtures/${state.fixtureName}.json`
+        : '/api/n2n';
+      state.n2n = await (await fetch(url)).json();
     } catch { state.n2n = null; }
+    if (state.fixtureName) markFixtureMode(state.fixtureName);
 
     setLoading(36, 'Spinning up scene');
     initScene();
@@ -3328,24 +3371,28 @@ async function boot() {
       buildPeerLinks();
     }
 
-    setLoading(58, 'Rendering integration lattice');
-    // 056: a Border orbits ONLY its broker skills — the domain integrations moved
-    // to their member spokes, so the Border is no longer the 190-skill monolith.
-    const BORDER_KEEP = new Set(['gait', 'protocol', 'n2n', 'memory', 'mempalace',
-      'humanrail', 'slack', 'webex', 'servicenow', 'pagerduty', 'twilio', 'twitter',
-      'msgraph', 'subnet-calculator', 'subnet', 'rfc', 'wikipedia', 'token-tracker']);
-    const _graphForBorder = (state.n2n?.risk?.role === 'border')
-      ? { ...state.graph, integrations: state.graph.integrations.filter((i) => BORDER_KEEP.has(i.id)) }
-      : state.graph;
-    buildIntegrations(_graphForBorder);
+    setLoading(58, 'Laying out the trust org chart');
+    // ── HUD 2.0 (feature 072) ────────────────────────────────────────────
+    // The orbit builders below are deliberately no longer called. They stay
+    // defined until Phase 7 deletes them, so this branch never sits in a state
+    // with neither layout working:
+    //   buildIntegrations()  buildRiskMembers()  buildDevices()
+    // The integration and device populations leave the scene entirely
+    // (FR-030): the HUD was drawing a capability catalogue and a managed
+    // estate on top of a trust topology. Integrations now surface as member
+    // tool expansion; devices remain in the right-hand panel (FR-030b).
+    //
+    // The category taxonomy arrives as DATA, not an import — /api/graph
+    // already serves integrations[] with category and prefixes, which is what
+    // keeps FR-006 vendor-neutral for every operator, not just this one.
+    state.orgCatalog = (state.graph?.integrations || [])
+      .filter((i) => i && i.category && Array.isArray(i.prefixes))
+      .map((i) => ({ id: i.id, category: i.category, prefixes: i.prefixes }));
 
-    // 056: iN2N risk — render member claws as spokes SOUTH of the Border, each
-    // with its own orbiting skills, colored by class (green member / red
-    // quarantined / dim cold). Additive + guarded: no-op for standalone claws.
-    buildRiskMembers();
+    state.orgLayout = mountOrgChart(state.scene, state.n2n, state.orgCatalog, makeLabel);
+    frameChart(state.camera, state.controls, chartNodes());
 
-    setLoading(72, 'Placing device ring');
-    buildDevices(state.graph);
+    setLoading(72, 'Placing bands');
 
     setLoading(78, 'Initializing activation beams');
     initBeamPool();
@@ -3382,7 +3429,10 @@ async function boot() {
       // A member (e.g. a phone) that enrolls after this page already loaded
       // never got a 3D spoke, since buildRiskMembers() only ran once at
       // boot -- add spokes for any newly-arrived members on every poll.
-      refreshRiskMembers();
+      // HUD 2.0: repaint health and append newly-enrolled members. Positions
+      // are never recomputed and categories are never re-ordered — a claw that
+      // fails changes how it looks, never where it is (FR-034a).
+      updateOrgChart(state.scene, state.n2n, makeLabel);
     }, 30000);
     animate();
 

--- a/ui/netclaw-visual/src/main.js
+++ b/ui/netclaw-visual/src/main.js
@@ -16,7 +16,7 @@ import { RGBShiftShader } from 'three/addons/shaders/RGBShiftShader.js';
 // materials, ribbons, labels, picking, polling, panels — is preserved (FR-028).
 import {
   mountOrgChart, updateOrgChart, searchOrgChart,
-  pickableObjects, chartNodes, tickOrgChart,
+  pickableObjects, chartNodes, tickOrgChart, activateNode,
 } from './orgchart-render/index.js';
 import {
   createChartCamera, createChartControls, resizeChartCamera, frameChart,
@@ -393,7 +393,8 @@ function initScene() {
   const root = document.getElementById('scene-root');
 
   state.scene = new THREE.Scene();
-  state.scene.fog = new THREE.FogExp2(0x040a14, 0.006);
+  // Fog thinned: the chart is planar, so depth haze only dulled it.
+  state.scene.fog = new THREE.FogExp2(0x081426, 0.0018);
 
   // HUD 2.0 (FR-012/013): orthographic and rotation-locked. A perspective
   // camera under free OrbitControls was the dominant cause of "hard to
@@ -406,7 +407,7 @@ function initScene() {
   state.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
   state.renderer.setSize(window.innerWidth, window.innerHeight);
   state.renderer.toneMapping = THREE.ACESFilmicToneMapping;
-  state.renderer.toneMappingExposure = 1.15;
+  state.renderer.toneMappingExposure = 1.55;   // HUD 2.0: brighter overall (operator feedback)
   state.renderer.shadowMap.enabled = true;
   state.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
   root.appendChild(state.renderer.domElement);
@@ -456,7 +457,7 @@ function initScene() {
   state.controls = createChartControls(state.camera, state.renderer.domElement);
 
   // ── Enhanced lighting (Section E) ─────────────────────────────
-  state.scene.add(new THREE.AmbientLight(0x4a7cb5, 0.35));
+  state.scene.add(new THREE.AmbientLight(0x7fb0e0, 1.15));  // lifted for the flat chart
 
   // Key light — overhead spotlight with shadows
   const keyLight = new THREE.SpotLight(0x65c3ff, 4.5, 120, Math.PI * 0.35, 0.4, 1.2);
@@ -2737,6 +2738,31 @@ function onPointerMove(event) {
 function onClick(event) {
   if (event.target.closest('.panel') || event.target.closest('.tooltip') || event.target.closest('.panel-reopen')) return;
   state.raycaster.setFromCamera(state.mouse, state.camera);
+
+  // ── HUD 2.0 picking (feature 072) ────────────────────────────────────
+  // One click both selects (right-hand panel, contract unchanged) and reveals
+  // the claw's tools. The original FR-020a split click from expand; after
+  // seeing the MVP the operator asked for a single gesture, and expansion is
+  // an overlay so FR-022 still holds — no sibling ever moves.
+  const chartHit = state.raycaster.intersectObjects(pickableObjects(), false)[0];
+  if (chartHit) {
+    const node = activateNode(chartHit.object, makeLabel);
+    if (node) {
+      clearSelection();
+      if (node.kind === 'border') {
+        setDetail('local-core');
+        state.selected = { kind: 'local-core' };
+      } else if (node.kind === 'peer') {
+        setDetail('federation-peer', node.payload);
+        state.selected = { kind: 'federation-peer', peer: node.id };
+      } else {
+        setDetail('member-core', node.payload);
+        state.selected = { kind: 'member-core', member: node.id };
+      }
+      return;
+    }
+  }
+
   const hit = state.raycaster.intersectObjects(getInteractiveObjects())[0];
   if (!hit) {
     clearSelection();

--- a/ui/netclaw-visual/src/main.js
+++ b/ui/netclaw-visual/src/main.js
@@ -17,6 +17,7 @@ import { RGBShiftShader } from 'three/addons/shaders/RGBShiftShader.js';
 import {
   mountOrgChart, updateOrgChart, searchOrgChart,
   pickableObjects, chartNodes, tickOrgChart, activateNode,
+  mountA11y, toggleNodeExpansion,
 } from './orgchart-render/index.js';
 import {
   createChartCamera, createChartControls, resizeChartCamera, frameChart,
@@ -38,19 +39,6 @@ const QUALITY_LABELS = { focus: 'FOCUS', balanced: 'BALANCED', broadcast: 'BROAD
 // orbiting skill sprites. Distinct colors per class. Spacing is widened so the
 // three tiers read clearly. This config is consumed by the scene-layout pass
 // (createMemberCores / positionClawsByRole) — tune live against the HUD.
-const RISK_LAYOUT = {
-  spacing: 34,             // widened inter-claw spacing (was ~18); tune live
-  borderAtOrigin: true,    // Border = center of the universe
-  externalAxis: +1,        // eN2N peer claws to the north (+Z)
-  memberAxis: -1,          // internal member claws to the south (-Z)
-  tierRadius: 46,          // distance of each tier ring from the Border
-  colors: {
-    border:   0xffd166,    // amber — the one you talk to, center of the universe
-    member:   0x68f5b2,    // neon green — internal, trusted, focused specialists
-    external: 0x38e8ff,    // cyan — external peer risks (other operators)
-    memberQuarantined: 0xff5d6c,  // red — an auto-quarantined / removed member
-  },
-};
 
 const state = {
   graph: null,
@@ -584,131 +572,7 @@ function makeLabel(text) {
 }
 
 // Triangular layout positions for multi-core topology
-const CORE_POSITIONS = {
-  local: new THREE.Vector3(-18, 0, 0),
-  peer1: new THREE.Vector3(52, 0, -28),
-  peer2: new THREE.Vector3(52, 0, 28),
-  peer3: new THREE.Vector3(18, 0, -56),
-  // NetClaw Mobile edge nodes (068 polish): a close, prominent orbit near
-  // the centroid like peers get, mirroring peer3's radius but on the
-  // opposite (+Z) side so the two groups read as visually distinct
-  // clusters rather than overlapping -- deliberately NOT the far-south
-  // member-spoke fan every other iN2N member uses, since a phone is the
-  // one member type an operator actually wants to spot at a glance.
-  edge1: new THREE.Vector3(18, -6, 56),
-  edge2: new THREE.Vector3(52, -6, 84),
-  edge3: new THREE.Vector3(-14, -6, 84),
-};
-const CORE_CENTROID = new THREE.Vector3(12, 0, 0);
 
-function buildCore(identity, position, labelText, colorTint) {
-  const pos = position || new THREE.Vector3(0, 0, 0);
-  const lbl = labelText || identity.name.toUpperCase();
-  const tint = colorTint || 0x66ccff;
-  const tintColor = new THREE.Color(tint);
-  const group = new THREE.Group();
-
-  // Shell — custom shader wireframe with fresnel + scan-lines (uniform-based color)
-  const shellMat = new THREE.ShaderMaterial({
-    uniforms: { uTime: { value: 0 }, uTintColor: { value: tintColor.clone() } },
-    vertexShader: `
-      varying vec3 vNormal;
-      varying vec3 vWorldPos;
-      void main() {
-        vNormal = normalize(normalMatrix * normal);
-        vWorldPos = (modelMatrix * vec4(position, 1.0)).xyz;
-        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-      }
-    `,
-    fragmentShader: `
-      uniform float uTime;
-      uniform vec3 uTintColor;
-      varying vec3 vNormal;
-      varying vec3 vWorldPos;
-      void main() {
-        vec3 viewDir = normalize(cameraPosition - vWorldPos);
-        float fresnel = pow(1.0 - abs(dot(viewDir, vNormal)), 3.0);
-        float scan = sin(vWorldPos.y * 18.0 - uTime * 2.5) * 0.5 + 0.5;
-        scan = smoothstep(0.4, 0.6, scan) * 0.3;
-        vec3 col = uTintColor * (0.15 + fresnel * 0.8 + scan);
-        gl_FragColor = vec4(col, 0.12 + fresnel * 0.35);
-      }
-    `,
-    transparent: true,
-    wireframe: true,
-    side: THREE.DoubleSide,
-    depthWrite: false,
-  });
-  const shell = new THREE.Mesh(_sharedGeo.coreShell, shellMat);
-  group.add(shell);
-
-  // Nucleus — thin glass shell
-  const nucleus = new THREE.Mesh(
-    _sharedGeo.coreNucleus,
-    new THREE.MeshPhysicalMaterial({
-      color: tint,
-      emissive: tint,
-      emissiveIntensity: 0.9,
-      roughness: 0.05,
-      metalness: 0.1,
-      iridescence: 1.0,
-      iridescenceIOR: 1.8,
-      transmission: 0.95,
-      ior: 1.5,
-      thickness: 0.3,
-      clearcoat: 1.0,
-      clearcoatRoughness: 0.05,
-      transparent: true,
-      opacity: 0.15,
-      depthWrite: false,
-    }),
-  );
-  nucleus.renderOrder = 1;
-  group.add(nucleus);
-
-  const torus = new THREE.Mesh(
-    new THREE.TorusGeometry(4.7, 0.08, 12, 120),
-    new THREE.MeshBasicMaterial({ color: 0xff7b54, transparent: true, opacity: 0.36 }),
-  );
-  torus.rotation.x = Math.PI / 2.8;
-  group.add(torus);
-
-  const torus2 = new THREE.Mesh(
-    new THREE.TorusGeometry(5.2, 0.05, 12, 120),
-    new THREE.MeshBasicMaterial({ color: tint, transparent: true, opacity: 0.22 }),
-  );
-  torus2.rotation.x = Math.PI / 1.6;
-  torus2.rotation.y = Math.PI / 3;
-  group.add(torus2);
-
-  const label = makeLabel(lbl);
-  label.position.set(0, 5.4, 0);
-  group.add(label);
-
-  // Logo sprite inside the nucleus
-  const logoTexture = new THREE.TextureLoader().load('/logos/netclaw.png');
-  logoTexture.colorSpace = THREE.SRGBColorSpace;
-  const logoSprite = new THREE.Sprite(
-    new THREE.SpriteMaterial({
-      map: logoTexture,
-      transparent: true,
-      opacity: 0.85,
-      depthWrite: false,
-      depthTest: false,
-      blending: THREE.AdditiveBlending,
-    }),
-  );
-  logoSprite.scale.set(2.8, 2.8 * 0.55, 1);
-  logoSprite.position.set(0, 0, 0);
-  logoSprite.renderOrder = 10;
-  group.add(logoSprite);
-
-  group.position.copy(pos);
-  group.userData = { type: 'core' };
-  state.scene.add(group);
-
-  return { group, shell, nucleus, torus, torus2, logoSprite, position: pos.clone() };
-}
 
 // ── Holographic ShaderMaterial for integration nodes (Section D) ──
 function createHolographicMaterial(color) {
@@ -924,298 +788,10 @@ function createTubeMaterial(color) {
   });
 }
 
-function buildIntegrations(graph) {
-  const grouped = graph.categories.map((category) => ({
-    ...category,
-    nodes: graph.integrations.filter((integration) => integration.category === category.name),
-  }));
 
-  const radiusBase = 34;
-  const coreAnchor = state.localCore ? state.localCore.position : new THREE.Vector3(0, 0, 0);
 
-  // Flatten all integrations into a single ordered list (grouped by category)
-  const allIntegrations = [];
-  grouped.forEach((bucket) => bucket.nodes.forEach((n) => allIntegrations.push(n)));
-  const totalN = allIntegrations.length;
-  const goldenRatio = (1 + Math.sqrt(5)) / 2;
 
-  // Build a look-up with spherical coords + unstable orbit parameters
-  const orbitMap = new Map();
-  allIntegrations.forEach((integration, i) => {
-    // Fibonacci sphere — even distribution across a full sphere
-    const theta0 = 2 * Math.PI * i / goldenRatio;
-    const phi0 = Math.acos(1 - 2 * (i + 0.5) / totalN);
-    const radius = radiusBase + (i % 3) * 2.5;
-    // Unique slow orbit speed + slight polar drift
-    const orbitSpeed = 0.0012 + (((i * 7 + 3) % 13) / 13) * 0.0018;
-    const axisTilt = ((i * 11 + 5) % 17) / 17 * 0.15 - 0.075;
-    const position = new THREE.Vector3(
-      coreAnchor.x + radius * Math.sin(phi0) * Math.cos(theta0),
-      radius * Math.cos(phi0),
-      coreAnchor.z + radius * Math.sin(phi0) * Math.sin(theta0),
-    );
-    orbitMap.set(integration.id, { position, theta0, phi0, radius, orbitSpeed, axisTilt });
-  });
 
-  grouped.forEach((bucket) => {
-    bucket.nodes.forEach((integration) => {
-      const orbitData = orbitMap.get(integration.id);
-      const position = orbitData.position;
-
-      const group = new THREE.Group();
-      group.position.copy(position);
-
-      const size = 0.7 + Math.min(integration.skillCount * 0.045, 1.4);
-      // Use holographic shader material for integration nodes
-      const holoMat = createHolographicMaterial(integration.color);
-      const node = new THREE.Mesh(new THREE.OctahedronGeometry(size, 1), holoMat);
-      node.castShadow = true;
-      group.add(node);
-
-      const halo = new THREE.Mesh(
-        getHaloGeometry(size + 0.45),
-        new THREE.MeshBasicMaterial({ color: integration.color, transparent: true, opacity: 0.26 }),
-      );
-      halo.rotation.x = Math.PI / 2;
-      group.add(halo);
-
-      const label = makeLabel(integration.name);
-      label.position.set(0, size + 1.25, 0);
-      group.add(label);
-
-      // Logo sprite — only for integrations with a logo file in public/logos/
-      const LOGO_IDS = new Set(['pyats']);
-      if (LOGO_IDS.has(integration.id)) {
-        const logoTex = new THREE.TextureLoader().load(`/logos/${integration.id}.png`);
-        logoTex.colorSpace = THREE.SRGBColorSpace;
-        const logoSprite = new THREE.Sprite(
-          new THREE.SpriteMaterial({
-            map: logoTex,
-            transparent: true,
-            opacity: 0.8,
-            depthWrite: false,
-            depthTest: false,
-            blending: THREE.AdditiveBlending,
-          }),
-        );
-        logoSprite.scale.set(size * 1.6, size * 1.6 * 0.5, 1);
-        logoSprite.position.set(0, 0, 0);
-        logoSprite.renderOrder = 10;
-        group.add(logoSprite);
-      }
-
-      // Connection ribbon with data-flow shader (replaces per-frame TubeGeometry)
-      const ribbonGeo = createRibbonGeometry(0.06);
-      const midY = Math.max(position.y, 0) + 4.5;
-      _v0.copy(coreAnchor);
-      _v1.set((coreAnchor.x + position.x) * 0.5, midY, (coreAnchor.z + position.z) * 0.5);
-      _v2.copy(position);
-      updateRibbonGeometry(ribbonGeo, _v0, _v1, _v2);
-      const tubeMat = createTubeMaterial(integration.color);
-      const tube = new THREE.Mesh(ribbonGeo, tubeMat);
-      // Keep a CatmullRomCurve3 for particle flow (updated on orbit)
-      const curve = new THREE.CatmullRomCurve3([
-        coreAnchor.clone(), _v1.clone(), position.clone(),
-      ]);
-      state.scene.add(tube);
-
-      const skills = graph.skills.filter((skill) => skill.integrationId === integration.id);
-      const skillSprites = createSkillSprites(position, skills, integration.color, position);
-
-      group.userData = { type: 'integration', payload: integration };
-      node.userData = { type: 'integration', payload: integration };
-      state.scene.add(group);
-
-      state.integrations.push({
-        group,
-        node,
-        halo,
-        tube,
-        tubeMat,
-        curve,
-        label,
-        basePosition: position.clone(),
-        payload: integration,
-        skills,
-        skillSprites,
-        orbit: orbitData,
-      });
-    });
-  });
-}
-
-// ── Virus-tree dendrite layout (Part B) ─────────────────────────────
-function computeDendritePositions(skillCount, integrationPosition) {
-  const positions = [];
-  if (skillCount === 0) return positions;
-  const baseRadius = 4.0;
-  const radiusSpread = 1.8;
-  const goldenAngle = Math.PI * (3 - Math.sqrt(5));
-
-  // Direction from core to integration — skills fan OUTWARD
-  const outDir = integrationPosition.clone().normalize();
-  const up = new THREE.Vector3(0, 1, 0);
-  const quat = new THREE.Quaternion().setFromUnitVectors(up, outDir);
-
-  for (let i = 0; i < skillCount; i++) {
-    const t = i / Math.max(skillCount - 1, 1);
-    const theta = goldenAngle * i;
-    const phi = Math.acos(1 - t * 0.85); // ~60deg cone
-    const radius = baseRadius + (i % 3) * (radiusSpread / 3);
-    const localPos = new THREE.Vector3(
-      radius * Math.sin(phi) * Math.cos(theta),
-      radius * Math.cos(phi),
-      radius * Math.sin(phi) * Math.sin(theta),
-    );
-    localPos.applyQuaternion(quat);
-    positions.push(localPos);
-  }
-  return positions;
-}
-
-// ── Dendrite wire shader (Part C) ───────────────────────────────────
-function createDendriteMaterial(color) {
-  const c = new THREE.Color(color);
-  return new THREE.ShaderMaterial({
-    uniforms: {
-      uTime: { value: 0 },
-      uColor: { value: c },
-      uOpacity: { value: 0.0 },
-      uProgress: { value: 0.0 },
-    },
-    vertexShader: `
-      varying vec2 vUv;
-      void main() {
-        vUv = uv;
-        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-      }
-    `,
-    fragmentShader: `
-      uniform float uTime;
-      uniform vec3 uColor;
-      uniform float uOpacity;
-      uniform float uProgress;
-      varying vec2 vUv;
-      void main() {
-        if (vUv.x > uProgress) discard;
-        float pulse = smoothstep(0.38, 0.5, fract(vUv.x * 12.0 - uTime * 0.8));
-        pulse *= smoothstep(0.62, 0.5, fract(vUv.x * 12.0 - uTime * 0.8));
-        float edge = 1.0 - abs(vUv.y - 0.5) * 2.0;
-        edge = pow(edge, 0.8);
-        vec3 col = uColor * (0.4 + pulse * 1.2);
-        float alpha = uOpacity * edge * (0.4 + pulse * 0.6);
-        gl_FragColor = vec4(col, alpha);
-      }
-    `,
-    transparent: true,
-    blending: THREE.AdditiveBlending,
-    depthWrite: false,
-    side: THREE.DoubleSide,
-  });
-}
-
-function createSkillSprites(anchor, skills, color, integrationPosition) {
-  const clampedSkills = skills.slice(0, 18);
-  const dendrites = computeDendritePositions(clampedSkills.length, integrationPosition);
-
-  return clampedSkills.map((skill, index) => {
-    const mesh = new THREE.Mesh(_sharedGeo.skillTetra, getSkillMaterial(color));
-    mesh.visible = false;
-    mesh.userData = { type: 'skill', payload: skill };
-    state.scene.add(mesh);
-
-    const label = makeLabel(skill.name);
-    label.visible = false;
-    state.scene.add(label);
-
-    // Dendrite wire from integration to skill
-    const localPos = dendrites[index];
-    const midPos = localPos.clone().multiplyScalar(0.5);
-    midPos.y += 0.3; // slight arc
-    const wireCurve = new THREE.CatmullRomCurve3([
-      new THREE.Vector3(0, 0, 0),
-      midPos,
-      localPos.clone(),
-    ]);
-    const wireGeo = new THREE.TubeGeometry(wireCurve, 16, 0.02, 4, false);
-    const wireMat = createDendriteMaterial(color);
-    const wire = new THREE.Mesh(wireGeo, wireMat);
-    wire.visible = false;
-    state.scene.add(wire);
-
-    const sprite = {
-      mesh,
-      label,
-      payload: skill,
-      localPosition: localPos,
-      anchor: anchor.clone(),
-      wire,
-      wireMat,
-      wireCurve,
-    };
-    state.skillSprites.push(sprite);
-    return sprite;
-  });
-}
-
-function buildDevices(graph) {
-  // Devices hang off the pyATS integration node (testbed.yaml devices)
-  const pyatsEntry = state.integrations.find((e) => e.payload.id === 'pyats');
-  const anchor = pyatsEntry ? pyatsEntry.basePosition.clone() : new THREE.Vector3(0, 0, 0);
-
-  // Compute outward direction from core to pyATS
-  const outDir = anchor.clone().normalize();
-  const up = new THREE.Vector3(0, 1, 0);
-  const quat = new THREE.Quaternion().setFromUnitVectors(up, outDir);
-
-  const deviceRadius = 6.5;
-  const goldenAngle = Math.PI * (3 - Math.sqrt(5));
-
-  graph.devices.forEach((device, index) => {
-    const t = index / Math.max(graph.devices.length - 1, 1);
-    const theta = goldenAngle * index;
-    const phi = Math.acos(1 - t * 0.7);
-    const localOffset = new THREE.Vector3(
-      deviceRadius * Math.sin(phi) * Math.cos(theta),
-      deviceRadius * Math.cos(phi),
-      deviceRadius * Math.sin(phi) * Math.sin(theta),
-    );
-    localOffset.applyQuaternion(quat);
-    const position = anchor.clone().add(localOffset);
-
-    const isRouter = device.type.toLowerCase().includes('router');
-    const color = isRouter ? 0x68f5b2 : 0xffb703;
-    const geometry = isRouter ? _sharedGeo.deviceRouter : _sharedGeo.deviceSwitch;
-    const mesh = new THREE.Mesh(geometry, createDeviceMaterial(color));
-    mesh.position.copy(position);
-    mesh.castShadow = true;
-    mesh.userData = { type: 'device', payload: device };
-    state.scene.add(mesh);
-
-    // Wire from pyATS node to device
-    const midPos = anchor.clone().add(localOffset.clone().multiplyScalar(0.5));
-    midPos.y += 0.5;
-    const wireCurve = new THREE.CatmullRomCurve3([anchor.clone(), midPos, position.clone()]);
-    const wireGeo = new THREE.TubeGeometry(wireCurve, 16, 0.03, 4, false);
-    const wireMat = createDendriteMaterial(color);
-    wireMat.uniforms.uOpacity.value = 0.2;
-    wireMat.uniforms.uProgress.value = 1.0;
-    const line = new THREE.Mesh(wireGeo, wireMat);
-    state.scene.add(line);
-
-    const label = makeLabel(device.name);
-    label.position.set(position.x, position.y + 1.4, position.z);
-    state.scene.add(label);
-
-    state.devices.push({
-      mesh, line, label, payload: device,
-      basePosition: position.clone(),
-      localOffset,
-      wireMat,
-      pyatsAnchor: pyatsEntry,
-    });
-  });
-}
 
 // ── BGP Topology Visualization ────────────────────────────────────
 // Peers are NEIGHBORS — same level as core, connected by horizontal peer links
@@ -1237,162 +813,10 @@ function deduplicatePeers(peers) {
   return [...seen.values()];
 }
 
-// 056: render this risk's member claws as spokes SOUTH of the Border, each a
-// core with its own orbiting skills, colored by class. Additive + guarded.
-// The per-member spoke itself is factored out into spawnMemberCore() so a
-// later-arriving member (e.g. a phone enrolling well after the HUD tab was
-// already open) can be added incrementally via refreshRiskMembers() without
-// re-running this whole function or touching any already-built spoke.
-function spawnMemberCore(m, i, n, C, R, col) {
-  const isEdge = m.node_type === 'edge';
-  const dead = (m.state === 'quarantined' || m.state === 'removed');
-  const cold = !m.live;
-  let pos, tint, name, speed;
-  if (isEdge) {
-    // NetClaw Mobile edge nodes get the same close, prominent orbit as
-    // peers instead of the far-south member fan -- an operator wants to
-    // spot their phone at a glance, not hunt for it among every other
-    // member. Cycles through 3 fixed slots by how many edge cores already
-    // exist (a 4th+ phone falls back to the last slot rather than
-    // colliding with anything -- good enough until this ever needs more).
-    const edgeSlots = [CORE_POSITIONS.edge1, CORE_POSITIONS.edge2, CORE_POSITIONS.edge3];
-    const edgeIndex = (state.memberCores || []).filter((c) => c.memberPayload?.node_type === 'edge').length;
-    pos = edgeSlots[Math.min(edgeIndex, edgeSlots.length - 1)].clone();
-    tint = dead ? (col.memberQuarantined || 0xff5d6c) : (cold ? 0x3a6ea5 : 0xe65733); // the mobile app's own brand orange
-    const label = String(m.member_id || 'phone').split('/').pop();
-    name = `PHONE ${label}`.trim();
-    speed = 0.0007;
-  } else {
-    const frac = n > 1 ? i / (n - 1) : 0.5;
-    const spread = (frac - 0.5) * Math.PI * 1.25;               // wide fan across the south
-    const px = C.x + Math.sin(spread) * R * 3.0;                // spread far out in X
-    const pz = C.z - (R + 40) - Math.abs(Math.cos(spread)) * R * 0.9; // push well south (-Z)
-    const py = -6 - (i % 5) * 7;                                // deeper vertical stagger
-    pos = new THREE.Vector3(px, py, pz);
-    tint = dead ? (col.memberQuarantined || 0xff5d6c) : (cold ? 0x3a6ea5 : (col.member || 0x68f5b2));
-    name = String(m.member_id || 'member').split('/').pop().toUpperCase();
-    speed = 0.0004;
-  }
-  const core = buildCore(state.graph.identity, pos, name, tint);
-  core.isMember = true;
-  core.memberPayload = m;
-  core.orbit = { center: C.clone(), radius: pos.distanceTo(C),
-    angle: Math.atan2(pos.z - C.z, pos.x - C.x), y: pos.y, speed };
-  // orbiting skills only for LIVE members (keep the scene light for cold ones)
-  const names = (m.live ? (m.skills || []) : []).slice(0, 12);
-  core.skillSprites = createSkillSprites(pos, names.map((s) => ({ name: s, id: s })), tint, pos);
-  // Show member tools by default (don't hide behind a click like integrations).
-  core.skillSprites.forEach((sp) => {
-    if (sp.mesh) sp.mesh.visible = true;
-    if (sp.wire) sp.wire.visible = true;
-  });
-  state.cores.push(core);
-  state.memberCores.push(core);
-}
 
-function buildRiskMembers() {
-  try {
-    const risk = state.n2n && state.n2n.risk;
-    if (!risk || risk.role !== 'border') return;
-    const members = (state.n2n.members) || [];
-    if (!members.length) return;
-    state.memberCores = state.memberCores || [];
-    const C = CORE_CENTROID;
-    const R = (typeof RISK_LAYOUT !== 'undefined' && RISK_LAYOUT.tierRadius) || 46;
-    const col = (typeof RISK_LAYOUT !== 'undefined' && RISK_LAYOUT.colors) || {};
-    const n = members.length;
-    members.forEach((m, i) => spawnMemberCore(m, i, n, C, R, col));
-  } catch (e) {
-    console.warn('buildRiskMembers failed (non-fatal):', e);
-  }
-}
 
-// Incremental counterpart to buildRiskMembers(), called on every state.n2n
-// poll (FR-026): a member that enrolls AFTER the HUD was already loaded
-// (the exact case that made a freshly-enrolled phone invisible until a full
-// page reload) gets its spoke added on the next poll, with no reload
-// needed. Deliberately additive-only, never removing/disposing a spoke for
-// a member that disappears -- a disconnected member already renders "cold"
-// (dim blue, no orbiting skills) via the same tint logic, which is the
-// right visual for that case anyway, and skips the real complexity/risk of
-// safely disposing a live THREE.js core (shaders, sprites, orbit state)
-// out from under an in-progress render loop.
-function refreshRiskMembers() {
-  try {
-    const risk = state.n2n && state.n2n.risk;
-    if (!risk || risk.role !== 'border') return;
-    const members = (state.n2n.members) || [];
-    if (!members.length) return;
-    state.memberCores = state.memberCores || [];
-    const known = new Set(state.memberCores.map((c) => c.memberPayload && c.memberPayload.member_id));
-    const arrivals = members.filter((m) => !known.has(m.member_id));
-    if (!arrivals.length) return;
-    const C = CORE_CENTROID;
-    const R = (typeof RISK_LAYOUT !== 'undefined' && RISK_LAYOUT.tierRadius) || 46;
-    const col = (typeof RISK_LAYOUT !== 'undefined' && RISK_LAYOUT.colors) || {};
-    const n = members.length;
-    arrivals.forEach((m) => spawnMemberCore(m, members.indexOf(m), n, C, R, col));
-  } catch (e) {
-    console.warn('refreshRiskMembers failed (non-fatal):', e);
-  }
-}
 
-function buildPeerRoutes(peerCore, peer) {
-  const routes = peer.adjRibIn || [];
-  peerCore.routeDendrites = [];
-  const pos = peerCore.position;
-  const outDir = pos.clone().normalize();
-  const baseAngle = Math.atan2(outDir.x, outDir.z);
 
-  routes.forEach((route, ri) => {
-    const routeSpread = Math.PI * 0.6;
-    const routeAngle = baseAngle + ((ri / Math.max(routes.length - 1, 1)) - 0.5) * routeSpread;
-    const routeOffset = new THREE.Vector3(
-      Math.sin(routeAngle) * 5.0,
-      -1.5 - ri * 0.6,
-      Math.cos(routeAngle) * 5.0,
-    );
-    const routePos = pos.clone().add(routeOffset);
-    const routeMid = pos.clone().add(routeOffset.clone().multiplyScalar(0.5));
-    routeMid.y += 0.3;
-    const routeCurve = new THREE.CatmullRomCurve3([pos.clone(), routeMid, routePos]);
-    const routeGeo = new THREE.TubeGeometry(routeCurve, 8, 0.02, 4, false);
-    const isIPv6 = route.prefix.includes(':');
-    const routeColor = isIPv6 ? 0x00e5ff : 0x68f5b2;
-    const routeMat = createDendriteMaterial(routeColor);
-    routeMat.uniforms.uOpacity.value = 0.25;
-    routeMat.uniforms.uProgress.value = 1.0;
-    const routeWire = new THREE.Mesh(routeGeo, routeMat);
-    state.scene.add(routeWire);
-
-    const routeLabel = makeLabel(route.prefix);
-    routeLabel.position.copy(routePos);
-    routeLabel.visible = false;
-    state.scene.add(routeLabel);
-
-    peerCore.routeDendrites.push({ wire: routeWire, mat: routeMat, label: routeLabel, route, position: routePos });
-  });
-}
-
-function buildPeerLinks() {
-  const allCores = state.cores;
-  for (let i = 0; i < allCores.length; i++) {
-    for (let j = i + 1; j < allCores.length; j++) {
-      const posA = allCores[i].position;
-      const posB = allCores[j].position;
-      const ribbonGeo = createRibbonGeometry(0.08);
-      _v0.copy(posA);
-      _v1.set((posA.x + posB.x) * 0.5, Math.max(posA.y, posB.y) + 3.0, (posA.z + posB.z) * 0.5);
-      _v2.copy(posB);
-      updateRibbonGeometry(ribbonGeo, _v0, _v1, _v2);
-      const linkMat = createTubeMaterial(0xe040fb);
-      linkMat.uniforms.uOpacity.value = 0.4;
-      const link = new THREE.Mesh(ribbonGeo, linkMat);
-      state.scene.add(link);
-      state.peerLinks.push({ tube: link, mat: linkMat, from: i, to: j });
-    }
-  }
-}
 
 function renderSidebar(graph) {
   dom.categoryList.innerHTML = '';
@@ -2816,37 +2240,10 @@ function animate() {
   if (!frozen) state._frozenAt = null;
   const rotTime = frozen ? state._frozenAt : elapsed;
 
-  // Animate all core nodes (local + peers)
-  let coresMovedThisFrame = false;
-  state.cores.forEach((core, idx) => {
-    const offset = idx * 0.3;
-
-    // Orbit core around centroid when not frozen
-    if (!frozen && core.orbit) {
-      core.orbit.angle += core.orbit.speed;
-      const ox = core.orbit.center.x + core.orbit.radius * Math.cos(core.orbit.angle);
-      const oz = core.orbit.center.z + core.orbit.radius * Math.sin(core.orbit.angle);
-      core.group.position.set(ox, core.orbit.y, oz);
-      core.position.set(ox, core.orbit.y, oz);
-      coresMovedThisFrame = true;
-    }
-
-    core.shell.rotation.y = rotTime * 0.18 + offset;
-    core.shell.rotation.x = rotTime * 0.08 + offset * 0.5;
-    core.torus.rotation.z = rotTime * 0.28 + offset;
-    if (core.torus2) core.torus2.rotation.z = -rotTime * 0.22 + offset;
-    // Shader time always advances (keeps glow alive)
-    if (core.shell.material.uniforms) {
-      core.shell.material.uniforms.uTime.value = elapsed;
-    }
-    core.nucleus.material.emissiveIntensity = 0.7 + Math.sin(elapsed * 2.1 + offset) * 0.25;
-    // Animate peer route dendrites — move with core
-    if (core.routeDendrites) {
-      core.routeDendrites.forEach((rd) => {
-        if (rd.mat.uniforms?.uTime) rd.mat.uniforms.uTime.value = elapsed;
-      });
-    }
-  });
+  // Orbit core animation removed with the orbit layout (FR-027). HUD 2.0's
+  // node motion is driven by tickOrgChart() above; state.cores is no longer
+  // populated, so nothing here had anything left to move.
+  const coresMovedThisFrame = false;
 
   // Update peer-link ribbons in-place when cores move (no alloc, no dispose)
   if (coresMovedThisFrame && state.peerLinks.length > 0) {
@@ -3072,7 +2469,8 @@ function wireUI() {
       state.filters.view = button.dataset.view;
       applyFilters();
       if (state.filters.view === 'overview') {
-        focusTarget(CORE_CENTROID.clone());
+        // Re-frame the whole chart rather than the old orbit centroid.
+        frameChart(state.camera, state.controls, chartNodes());
       }
     });
   });
@@ -3335,74 +2733,15 @@ async function boot() {
     // their direct BGP session is down: the overlay (not BGP) carries chat/
     // tasks/inventory, and claw BGP sessions are inbound-only here — so a
     // fully federated claw was invisible whenever the BGP leg was down.
-    const bgpScenePeers = state.bgp?.available ? state.bgp.peers : [];
-    const overlayScenePeers = (state.n2n?.peers || [])
-      .filter((p) => p.channel_state === 'up')
-      .map((p) => {
-        const m = /^as(\d+)-(.+)$/.exec(p.identity || '') || [];
-        return { type: 'claw', as: Number(m[1]) || undefined,
-                 routerId: m[2] || p.identity, peer: p.identity,
-                 displayName: p.display_name, state: 'Overlay', overlayOnly: true };
-      })
-      .filter((p) => p.as && !bgpScenePeers.some((b) => Number(b.as) === Number(p.as)));
-    const scenePeers = [...bgpScenePeers, ...overlayScenePeers];
-    const hasPeers = scenePeers.length > 0;
-    const localPos = hasPeers ? CORE_POSITIONS.local : new THREE.Vector3(0, 0, 0);
-    // 056: a Border claw is the amber center of its risk; else default cyan.
-    const _isBorder = state.n2n?.risk?.role === 'border';
-    const _localTint = _isBorder ? RISK_LAYOUT.colors.border : 0x66ccff;
-    const localCore = buildCore(state.graph.identity, localPos, state.graph.identity.name.toUpperCase(), _localTint);
-    // Orbit data for local core — orbits around the centroid
-    const lcDist = localPos.distanceTo(CORE_CENTROID);
-    localCore.orbit = {
-      center: CORE_CENTROID.clone(),
-      radius: lcDist,
-      angle: Math.atan2(localPos.z - CORE_CENTROID.z, localPos.x - CORE_CENTROID.x),
-      y: localPos.y,
-      speed: 0.0008,
-    };
-    state.localCore = localCore;
-    state.core = localCore; // backward compat
-    state.cores.push(localCore);
-
-    // Build peer cores as equal central nodes
-    if (hasPeers) {
-      const uniquePeers = deduplicatePeers(scenePeers);
-      const peerPositions = [CORE_POSITIONS.peer1, CORE_POSITIONS.peer2, CORE_POSITIONS.peer3];
-      uniquePeers.slice(0, 3).forEach((peer, i) => {
-        const isClaw = peer.type === 'claw';
-        const label = isClaw
-          ? `NETCLAW AS${peer.as || '?'}`
-          : `ROUTER ${peer.routerId || peer.peerIp || peer.peer}`;
-        const tint = isClaw ? 0xe040fb : 0x00e5ff;
-        const peerCore = buildCore(state.graph.identity, peerPositions[i], label, tint);
-        peerCore.peerPayload = peer;
-        peerCore.isClaw = isClaw;
-        // Orbit data — orbits around the centroid
-        const pDist = peerPositions[i].distanceTo(CORE_CENTROID);
-        peerCore.orbit = {
-          center: CORE_CENTROID.clone(),
-          radius: pDist,
-          angle: Math.atan2(peerPositions[i].z - CORE_CENTROID.z, peerPositions[i].x - CORE_CENTROID.x),
-          y: peerPositions[i].y,
-          speed: 0.0006 + i * 0.0003,
-        };
-        state.peerCores.push(peerCore);
-        state.cores.push(peerCore);
-
-        // Build route dendrites from this peer
-        buildPeerRoutes(peerCore, peer);
-      });
-      // Connect all cores with peer-link tubes
-      buildPeerLinks();
-    }
+    // The orbit scene built local/peer cores from the BGP + overlay peer list
+    // here. HUD 2.0 renders peers from /api/n2n in the external band instead
+    // (FR-003), so that derivation and its cores are gone with the orbit
+    // layout (FR-027). state.bgp is still fetched and still drives the panel.
 
     setLoading(58, 'Laying out the trust org chart');
     // ── HUD 2.0 (feature 072) ────────────────────────────────────────────
-    // The orbit builders below are deliberately no longer called. They stay
-    // defined until Phase 7 deletes them, so this branch never sits in a state
-    // with neither layout working:
-    //   buildIntegrations()  buildRiskMembers()  buildDevices()
+    // Phase 7 complete: the orbit layout and the integration/device scene
+    // populations are deleted, not dormant (FR-027, FR-030c).
     // The integration and device populations leave the scene entirely
     // (FR-030): the HUD was drawing a capability catalogue and a managed
     // estate on top of a trust topology. Integrations now surface as member
@@ -3417,6 +2756,17 @@ async function boot() {
 
     state.orgLayout = mountOrgChart(state.scene, state.n2n, state.orgCatalog, makeLabel);
     frameChart(state.camera, state.controls, chartNodes());
+
+    // Keyboard + screen-reader access (FR-032). A WebGL canvas has no
+    // focusable elements, so the chart needs a real DOM tree over it.
+    mountA11y(document.getElementById('scene-root'), {
+      onSelect: (node) => {
+        if (node.kind === 'border') { setDetail('local-core'); state.selected = { kind: 'local-core' }; }
+        else if (node.kind === 'peer') { setDetail('federation-peer', node.payload); state.selected = { kind: 'federation-peer', peer: node.id }; }
+        else { setDetail('member-core', node.payload); state.selected = { kind: 'member-core', member: node.id }; }
+      },
+      onToggle: (node) => toggleNodeExpansion(node.id, makeLabel),
+    });
 
     setLoading(72, 'Placing bands');
 
@@ -3452,9 +2802,8 @@ async function boot() {
       // panel currently open, re-render it in place so edge-node liveness/
       // approvals/replication jobs don't require a manual re-click to see.
       if (state.selected?.kind === 'local-core') setDetail('local-core');
-      // A member (e.g. a phone) that enrolls after this page already loaded
-      // never got a 3D spoke, since buildRiskMembers() only ran once at
-      // boot -- add spokes for any newly-arrived members on every poll.
+      // A member (e.g. a phone) enrolling after load is appended by
+      // updateOrgChart via appendMember, without moving anything (FR-034b).
       // HUD 2.0: repaint health and append newly-enrolled members. Positions
       // are never recomputed and categories are never re-ordered — a claw that
       // fails changes how it looks, never where it is (FR-034a).

--- a/ui/netclaw-visual/src/orgchart-render/a11y.js
+++ b/ui/netclaw-visual/src/orgchart-render/a11y.js
@@ -1,0 +1,168 @@
+/**
+ * Keyboard and screen-reader access (FR-032 .. FR-032c).
+ *
+ * A WebGL canvas exposes no focusable elements — without this the chart is
+ * pointer-only, which excludes keyboard and assistive-technology users
+ * entirely. The standard remedy is a DOM overlay of focusable, labelled
+ * elements positioned over the canvas; that is what this builds.
+ *
+ * The overlay is the accessibility tree, not decoration: each item carries the
+ * node's accessible name AND its health state as TEXT (FR-032b), because
+ * FR-009a's encoding is colour, form and motion — none of which a screen
+ * reader can convey.
+ */
+
+import { TREATMENTS } from './nodes.js';
+
+const BAND_ORDER = ['external', 'border', 'edgeLane', 'internal'];
+
+/**
+ * Build (or rebuild) the focusable overlay.
+ *
+ * @param {HTMLElement} container element covering the canvas
+ * @param {Array<object>} nodes layout nodes
+ * @param {{onSelect:Function, onToggle:Function}} handlers
+ * @returns {{destroy: Function, sync: Function}}
+ */
+export function buildA11yOverlay(container, nodes, handlers) {
+  container.querySelector('#orgchart-a11y')?.remove();
+
+  const root = document.createElement('div');
+  root.id = 'orgchart-a11y';
+  root.setAttribute('role', 'tree');
+  root.setAttribute('aria-label', 'NetClaw trust org chart');
+
+  // Grouped by band so Tab moves between regions and arrows move within one —
+  // the structure a chart implies, made real for non-pointer users.
+  const groups = new Map(BAND_ORDER.map((b) => [b, []]));
+  for (const node of nodes || []) {
+    if (!groups.has(node.band)) groups.set(node.band, []);
+    groups.get(node.band).push(node);
+  }
+
+  const items = [];
+  for (const [band, bandNodes] of groups) {
+    if (!bandNodes.length) continue;
+
+    const group = document.createElement('div');
+    group.setAttribute('role', 'group');
+    group.setAttribute('aria-label', bandLabel(band));
+
+    bandNodes.forEach((node, i) => {
+      const item = document.createElement('button');
+      item.type = 'button';
+      item.className = 'a11y-node';
+      item.setAttribute('role', 'treeitem');
+      item.dataset.nodeId = node.id;
+      item.dataset.band = band;
+      // Roving tabindex: one stop per band, arrows move within it.
+      item.tabIndex = i === 0 ? 0 : -1;
+      item.textContent = describe(node);
+
+      if (node.kind === 'member' || node.kind === 'edge') {
+        item.setAttribute('aria-expanded', String(!!node.expanded));
+      }
+
+      item.addEventListener('click', () => handlers.onSelect?.(node));
+      item.addEventListener('keydown', (e) => onKeyDown(e, node, items, handlers));
+      group.appendChild(item);
+      items.push({ node, item });
+    });
+
+    root.appendChild(group);
+  }
+
+  container.appendChild(root);
+
+  return {
+    destroy() { root.remove(); },
+    /** Re-announce state after a poll changed health (FR-034a repaints). */
+    sync(updated) {
+      for (const { node, item } of items) {
+        const fresh = updated?.find?.((n) => n.id === node.id) || node;
+        item.textContent = describe(fresh);
+        if (fresh.kind === 'member' || fresh.kind === 'edge') {
+          item.setAttribute('aria-expanded', String(!!fresh.expanded));
+        }
+      }
+    },
+  };
+}
+
+function bandLabel(band) {
+  return {
+    external: 'External peers, outside the trust boundary',
+    border: 'This Border',
+    edgeLane: 'Mobile edge devices',
+    internal: 'Internal member claws',
+  }[band] || band;
+}
+
+/**
+ * The accessible name. State is spelled out because colour, form and motion
+ * cannot be perceived here (FR-032b).
+ */
+function describe(node) {
+  const parts = [node.label];
+
+  if (node.kind === 'peer') {
+    parts.push(node.severed ? 'severed' : `peer, channel ${node.channelState || 'unknown'}`);
+  } else if (node.kind === 'border') {
+    parts.push('this Border');
+  } else {
+    const t = TREATMENTS[node.health];
+    parts.push(t ? t.label : String(node.health || 'unknown').toLowerCase());
+    if (node.category) parts.push(`in ${node.category}`);
+    if (node.toolCount) parts.push(`${node.toolCount} tool${node.toolCount === 1 ? '' : 's'}`);
+  }
+  return parts.join(' — ');
+}
+
+function onKeyDown(event, node, items, handlers) {
+  const siblings = items.filter((i) => i.item.dataset.band === event.currentTarget.dataset.band);
+  const index = siblings.findIndex((i) => i.item === event.currentTarget);
+
+  const move = (next) => {
+    event.preventDefault();
+    const target = siblings[(next + siblings.length) % siblings.length];
+    for (const s of siblings) s.item.tabIndex = -1;
+    target.item.tabIndex = 0;
+    target.item.focus();
+  };
+
+  switch (event.key) {
+    case 'ArrowRight': case 'ArrowDown': return move(index + 1);
+    case 'ArrowLeft': case 'ArrowUp': return move(index - 1);
+    case 'Home': return move(0);
+    case 'End': return move(siblings.length - 1);
+    case 'Enter': case ' ':
+      event.preventDefault();
+      return handlers.onSelect?.(node);
+    // A separate, explicit expand route — the pointer path folds expand into
+    // click, but a keyboard user needs to inspect without toggling (FR-032a).
+    case 'e': case 'E': {
+      event.preventDefault();
+      const nowExpanded = handlers.onToggle?.(node);
+      // aria-expanded MUST track the real state. Without this a screen reader
+      // announces "collapsed" over an expanded node — the state is conveyed
+      // visually and nowhere else, which is precisely what FR-032b forbids.
+      node.expanded = !!nowExpanded;
+      event.currentTarget.setAttribute('aria-expanded', String(node.expanded));
+      return nowExpanded;
+    }
+    default:
+  }
+  return undefined;
+}
+
+/**
+ * Whether motion should be suppressed (FR-032c).
+ *
+ * Motion is a redundant channel by design (R8) — form and colour temperature
+ * already separate all four states — so suppressing it cannot collapse the
+ * encoding, and SC-007's greyscale test covers the same property.
+ */
+export function reducedMotion() {
+  return typeof window !== 'undefined'
+    && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
+}

--- a/ui/netclaw-visual/src/orgchart-render/bands.js
+++ b/ui/netclaw-visual/src/orgchart-render/bands.js
@@ -1,0 +1,158 @@
+/**
+ * Bands, the trust boundary, the edge lane, and empty states
+ * (FR-001, FR-002, FR-007, FR-033).
+ *
+ * The trust boundary is an explicitly DRAWN object, not implied whitespace
+ * (FR-002). It is the most important line in the diagram — it is the thing
+ * that makes "external" mean something — and distance alone does not say it.
+ *
+ * Bands render even when empty (FR-033). A NetClaw with no risk, no members
+ * and no peers is the normal first state for a new operator, and after FR-030
+ * removed the integration and device populations there is nothing else left to
+ * draw. An empty chart must read as "nothing here yet", never as a failure.
+ */
+
+import * as THREE from 'three';
+
+const BAND_WIDTH = 220;
+
+const STYLE = {
+  external: { color: 0x4a6fa5, dash: 2.2, gap: 1.6 },
+  internal: { color: 0x3f6b52, dash: 2.2, gap: 1.6 },
+  edgeLane: { color: 0xe65733, dash: 1.4, gap: 1.2 },
+  boundary: { color: 0xffc857, dash: 0, gap: 0 },
+};
+
+/**
+ * @param {Array<object>} bands from computeLayout().bands
+ * @param {(text:string)=>object} makeLabel host CSS2D label factory
+ * @returns {{group: THREE.Group, dispose: Function}}
+ */
+export function buildBands(bands, makeLabel) {
+  const group = new THREE.Group();
+  group.name = 'orgchart-bands';
+  const disposables = [];
+
+  for (const band of bands || []) {
+    if (band.id === 'edgeLane') {
+      group.add(buildEdgeLane(band, makeLabel, disposables));
+      continue;
+    }
+    if (band.isBoundary) {
+      group.add(buildBoundary(band, makeLabel, disposables));
+      continue;
+    }
+    group.add(buildBandRule(band, makeLabel, disposables));
+  }
+
+  return {
+    group,
+    dispose() { for (const d of disposables) d.dispose?.(); },
+  };
+}
+
+/** The trust boundary: a solid double rule, the strongest line in the chart. */
+function buildBoundary(band, makeLabel, disposables) {
+  const g = new THREE.Group();
+  g.name = 'trust-boundary';
+
+  for (const dy of [-0.9, 0.9]) {
+    const geometry = new THREE.BufferGeometry().setFromPoints([
+      new THREE.Vector3(-BAND_WIDTH / 2, band.y + dy, -1),
+      new THREE.Vector3(BAND_WIDTH / 2, band.y + dy, -1),
+    ]);
+    const material = new THREE.LineBasicMaterial({
+      color: STYLE.boundary.color, transparent: true, opacity: 0.75,
+    });
+    disposables.push(geometry, material);
+    g.add(new THREE.Line(geometry, material));
+  }
+
+  const label = makeLabel('TRUST BOUNDARY');
+  label.element.classList.add('band-label', 'band-label-boundary');
+  label.position.set(-BAND_WIDTH / 2 + 6, band.y + 3.4, 0);
+  g.add(label);
+  return g;
+}
+
+/** A dashed rule delimiting a band, with its name and (if empty) its CTA. */
+function buildBandRule(band, makeLabel, disposables) {
+  const g = new THREE.Group();
+  g.name = `band-${band.id}`;
+  const style = STYLE[band.id] || STYLE.external;
+
+  const geometry = new THREE.BufferGeometry().setFromPoints([
+    new THREE.Vector3(-BAND_WIDTH / 2, band.y, -2),
+    new THREE.Vector3(BAND_WIDTH / 2, band.y, -2),
+  ]);
+  const material = new THREE.LineDashedMaterial({
+    color: style.color, dashSize: style.dash, gapSize: style.gap,
+    transparent: true, opacity: 0.4,
+  });
+  const line = new THREE.Line(geometry, material);
+  line.computeLineDistances();
+  disposables.push(geometry, material);
+  g.add(line);
+
+  const label = makeLabel(band.label);
+  label.element.classList.add('band-label');
+  label.position.set(-BAND_WIDTH / 2 + 6, band.y + 2.6, 0);
+  g.add(label);
+
+  if (band.empty && band.emptyCta) g.add(emptyState(band, band.emptyCta, makeLabel));
+  return g;
+}
+
+/** The edge lane: bracketed, offset, clearly not part of the member chart. */
+function buildEdgeLane(band, makeLabel, disposables) {
+  const g = new THREE.Group();
+  g.name = 'edge-lane';
+  const x = band.x ?? 46;
+  const style = STYLE.edgeLane;
+
+  const material = new THREE.LineDashedMaterial({
+    color: style.color, dashSize: style.dash, gapSize: style.gap,
+    transparent: true, opacity: 0.5,
+  });
+  disposables.push(material);
+
+  // An open bracket rather than a closed box — the lane belongs to the Border,
+  // it is not a separate enclosure.
+  const pts = [
+    new THREE.Vector3(x - 8, band.y + 10, -2),
+    new THREE.Vector3(x + 26, band.y + 10, -2),
+    new THREE.Vector3(x + 26, band.y - 26, -2),
+    new THREE.Vector3(x - 8, band.y - 26, -2),
+  ];
+  const geometry = new THREE.BufferGeometry().setFromPoints(pts);
+  disposables.push(geometry);
+  const line = new THREE.Line(geometry, material);
+  line.computeLineDistances();
+  g.add(line);
+
+  const label = makeLabel(band.label);
+  label.element.classList.add('band-label', 'band-label-edge');
+  label.position.set(x - 8, band.y + 12.5, 0);
+  g.add(label);
+
+  if (band.empty && band.emptyCta) {
+    const cta = makeLabel(band.emptyCta);
+    cta.element.classList.add('band-empty');
+    cta.position.set(x + 9, band.y - 8, 0);
+    g.add(cta);
+  }
+  return g;
+}
+
+/**
+ * Empty-band copy (FR-033a). Names what belongs here and how to get it —
+ * an empty band should teach a first-time operator the trust model, not
+ * look like a broken load.
+ */
+function emptyState(band, text, makeLabel) {
+  const cta = makeLabel(text);
+  cta.element.classList.add('band-empty');
+  const dy = band.id === 'external' ? 8 : -10;
+  cta.position.set(0, band.y + dy, 0);
+  return cta;
+}

--- a/ui/netclaw-visual/src/orgchart-render/camera.js
+++ b/ui/netclaw-visual/src/orgchart-render/camera.js
@@ -1,0 +1,131 @@
+/**
+ * Orthographic, rotation-locked camera (FR-012, FR-013, R7).
+ *
+ * This is the actual fix for "clunky and hard to navigate" — more than the
+ * theme is. HUD 1.0 used a PerspectiveCamera with unconstrained OrbitControls,
+ * so any given frame showed the topology from an arbitrary angle. "External vs
+ * internal" only reads if the layout and the viewer agree on which way is up,
+ * and free rotation guarantees they do not.
+ *
+ * Orthographic additionally makes equal-tier siblings render at equal size,
+ * which is the property that makes a chart read as a chart: under perspective
+ * the far side of a row is smaller and reads as less important, which is a lie
+ * the layout never intended to tell.
+ */
+
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+
+/** World units visible vertically at zoom 1. Tuned to the layout's y-extent. */
+export const FRUSTUM_HEIGHT = 150;
+export const MIN_ZOOM = 0.35;
+export const MAX_ZOOM = 6;
+
+/**
+ * Build the chart camera.
+ *
+ * @param {number} aspect width / height
+ * @returns {THREE.OrthographicCamera}
+ */
+export function createChartCamera(aspect) {
+  const h = FRUSTUM_HEIGHT / 2;
+  const w = h * aspect;
+  const camera = new THREE.OrthographicCamera(-w, w, h, -h, -500, 1000);
+  // Straight down the -Z axis: the layout plane is XY, so this is a true
+  // top-down read of the chart with no foreshortening.
+  camera.position.set(0, 0, 200);
+  camera.lookAt(0, 0, 0);
+  camera.zoom = 1;
+  camera.updateProjectionMatrix();
+  return camera;
+}
+
+/**
+ * Controls that pan and zoom but can never rotate (FR-012).
+ *
+ * @param {THREE.OrthographicCamera} camera
+ * @param {HTMLElement} domElement
+ * @returns {OrbitControls}
+ */
+export function createChartControls(camera, domElement) {
+  const controls = new OrbitControls(camera, domElement);
+
+  // The whole point. Without this the bands can be viewed upside down.
+  controls.enableRotate = false;
+
+  controls.enablePan = true;
+  controls.enableZoom = true;
+  controls.screenSpacePanning = true;
+  controls.enableDamping = true;
+  controls.dampingFactor = 0.08;
+  controls.minZoom = MIN_ZOOM;
+  controls.maxZoom = MAX_ZOOM;
+
+  // Left-drag pans. With rotation disabled the default left-drag would be dead
+  // input, and pan is the only navigation a chart needs.
+  controls.mouseButtons = {
+    LEFT: THREE.MOUSE.PAN,
+    MIDDLE: THREE.MOUSE.DOLLY,
+    RIGHT: THREE.MOUSE.PAN,
+  };
+  controls.touches = { ONE: THREE.TOUCH.PAN, TWO: THREE.TOUCH.DOLLY_PAN };
+
+  controls.target.set(0, 0, 0);
+  controls.update();
+  return controls;
+}
+
+/**
+ * Keep the frustum correct across resizes.
+ *
+ * @param {THREE.OrthographicCamera} camera
+ * @param {number} aspect
+ */
+export function resizeChartCamera(camera, aspect) {
+  const h = FRUSTUM_HEIGHT / 2;
+  camera.left = -h * aspect;
+  camera.right = h * aspect;
+  camera.top = h;
+  camera.bottom = -h;
+  camera.updateProjectionMatrix();
+}
+
+/**
+ * Frame the chart so every node is visible on first paint (SC-001/002).
+ * An operator should not have to hunt for the content before reading it.
+ *
+ * @param {THREE.OrthographicCamera} camera
+ * @param {OrbitControls} controls
+ * @param {Array<{position:{x:number,y:number}}>} nodes
+ */
+export function frameChart(camera, controls, nodes) {
+  if (!Array.isArray(nodes) || nodes.length === 0) {
+    controls.target.set(0, 0, 0);
+    camera.position.set(0, 0, 200);
+    camera.zoom = 1;
+    camera.updateProjectionMatrix();
+    controls.update();
+    return;
+  }
+
+  let minX = Infinity; let maxX = -Infinity; let minY = Infinity; let maxY = -Infinity;
+  for (const n of nodes) {
+    minX = Math.min(minX, n.position.x); maxX = Math.max(maxX, n.position.x);
+    minY = Math.min(minY, n.position.y); maxY = Math.max(maxY, n.position.y);
+  }
+
+  const cx = (minX + maxX) / 2;
+  const cy = (minY + maxY) / 2;
+  const padding = 1.25;
+  const spanY = Math.max(maxY - minY, 1) * padding;
+  const spanX = Math.max(maxX - minX, 1) * padding;
+
+  const aspect = (camera.right - camera.left) / (camera.top - camera.bottom);
+  const zoom = Math.min(FRUSTUM_HEIGHT / spanY, (FRUSTUM_HEIGHT * aspect) / spanX);
+
+  camera.zoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, zoom));
+  camera.position.set(cx, cy, 200);
+  camera.updateProjectionMatrix();
+  controls.target.set(cx, cy, 0);
+  controls.update();
+}

--- a/ui/netclaw-visual/src/orgchart-render/expansion.js
+++ b/ui/netclaw-visual/src/orgchart-render/expansion.js
@@ -1,0 +1,103 @@
+/**
+ * Tool expand/collapse (FR-020 .. FR-025).
+ *
+ * Operator revision after seeing the MVP: expansion is now driven by the same
+ * CLICK that selects, rather than only by a separate affordance. FR-020a's
+ * original split (click = select, chevron = expand) was chosen in the abstract;
+ * in use, one gesture that both shows the panel and reveals the tools is what
+ * was actually wanted. The chevron behaviour is retained via toggleExpansion()
+ * so the keyboard path (FR-032a) still has an explicit, non-pointer route.
+ *
+ * FR-022 is preserved and is the hard constraint: expanding NEVER reflows the
+ * chart. Tools render as an overlay anchored to their node, claiming no layout
+ * space, so no sibling moves and the operator never loses their place.
+ */
+
+import * as THREE from 'three';
+
+/** node id -> { group, labels } for every currently expanded node. */
+const expanded = new Map();
+
+const MAX_VISIBLE_TOOLS = 12;
+
+/**
+ * Toggle a node's tool list.
+ *
+ * @param {THREE.Object3D} parentGroup scene group owning expansions
+ * @param {object} node layout node (must carry .tools)
+ * @param {THREE.Mesh} mesh the node's mesh, used as the anchor
+ * @param {(text:string)=>object} makeLabel host CSS2D factory
+ * @returns {boolean} true if now expanded
+ */
+export function toggleExpansion(parentGroup, node, mesh, makeLabel) {
+  if (!node) return false;
+  if (expanded.has(node.id)) {
+    collapse(parentGroup, node.id);
+    node.expanded = false;
+    return false;
+  }
+  expand(parentGroup, node, mesh, makeLabel);
+  node.expanded = true;
+  return true;
+}
+
+function expand(parentGroup, node, mesh, makeLabel) {
+  const tools = Array.isArray(node.tools) ? node.tools : [];
+  const group = new THREE.Group();
+  group.name = `expansion-${node.id}`;
+
+  // Anchored to the node's own position, drawn slightly forward in z so it
+  // overlays neighbours rather than displacing them (FR-022).
+  group.position.set(node.position.x, node.position.y, node.position.z + 4);
+
+  const shown = tools.slice(0, MAX_VISIBLE_TOOLS);
+  const header = makeLabel(
+    tools.length
+      ? `${node.label} — ${tools.length} tool${tools.length === 1 ? '' : 's'}`
+      : `${node.label} — no tools`,
+  );
+  header.element.classList.add('tool-header');
+  header.position.set(0, -3.2, 0);
+  group.add(header);
+
+  shown.forEach((tool, i) => {
+    const label = makeLabel(tool);
+    label.element.classList.add('tool-item');
+    // COLD and FAULT claws expand too: what a cold claw *would* bring is
+    // exactly what decides whether to warm it (FR-025).
+    if (node.health === 'COLD') label.element.classList.add('tool-item-cold');
+    label.position.set(0, -5.4 - i * 2.1, 0);
+    group.add(label);
+  });
+
+  if (tools.length > MAX_VISIBLE_TOOLS) {
+    const more = makeLabel(`+${tools.length - MAX_VISIBLE_TOOLS} more`);
+    more.element.classList.add('tool-item', 'tool-more');
+    more.position.set(0, -5.4 - shown.length * 2.1, 0);
+    group.add(more);
+  }
+
+  parentGroup.add(group);
+  expanded.set(node.id, group);
+}
+
+function collapse(parentGroup, nodeId) {
+  const group = expanded.get(nodeId);
+  if (!group) return;
+  parentGroup.remove(group);
+  group.traverse((o) => { if (o.element?.remove) o.element.remove(); });
+  expanded.delete(nodeId);
+}
+
+/** Multiple members may be expanded at once (FR-023). */
+export function expandedCount() {
+  return expanded.size;
+}
+
+export function isExpanded(nodeId) {
+  return expanded.has(nodeId);
+}
+
+export function collapseAll(parentGroup) {
+  for (const id of [...expanded.keys()]) collapse(parentGroup, id);
+}

--- a/ui/netclaw-visual/src/orgchart-render/index.js
+++ b/ui/netclaw-visual/src/orgchart-render/index.js
@@ -19,6 +19,7 @@ import { buildBands } from './bands.js';
 import { buildLinks } from './links.js';
 import { classifyHealth } from '../orgchart/health.js';
 import { toggleExpansion, collapseAll, isExpanded, expandedCount } from './expansion.js';
+import { buildA11yOverlay } from './a11y.js';
 
 export { TREATMENTS };
 
@@ -73,12 +74,26 @@ export function mountOrgChart(scene, n2n, integrationCatalog, makeLabel) {
   return layout;
 }
 
+/**
+ * Attach the keyboard / screen-reader overlay (FR-032). Kept separate from
+ * mountOrgChart so the scene can be built headlessly in tests without a DOM.
+ *
+ * @param {HTMLElement} container element covering the canvas
+ * @param {{onSelect:Function, onToggle:Function}} handlers
+ */
+export function mountA11y(container, handlers) {
+  if (!container || !chart.layout) return null;
+  chart.a11y = buildA11yOverlay(container, chart.layout.nodes, handlers);
+  return chart.a11y;
+}
+
 export function unmountOrgChart(scene) {
   if (!chart.root) return;
   scene.remove(chart.root);
   chart.nodes?.dispose?.();
   chart.bands?.dispose?.();
   chart.links?.dispose?.();
+  chart.a11y?.destroy?.();
   Object.assign(chart, { root: null, nodes: null, bands: null, links: null, layout: null, entries: [] });
 }
 
@@ -136,6 +151,8 @@ export function updateOrgChart(scene, n2n, makeLabel) {
     chart.entries.push(...built.entries);
     chart.layout.nodes.push(node);
   }
+
+  chart.a11y?.sync?.(chart.layout.nodes);
 }
 
 /**
@@ -182,7 +199,14 @@ export function activateNode(mesh, makeLabel) {
   if (!node) return null;
   // Only members and edges carry tools; peers and the Border just select.
   if (node.kind === 'member' || node.kind === 'edge') {
-    toggleExpansion(chart.root, node, mesh, makeLabel);
+    node.expanded = toggleExpansion(chart.root, node, mesh, makeLabel);
+    // Keep the accessibility tree in step with the pointer path — otherwise a
+    // screen-reader user gets a stale "collapsed" for a node someone expanded
+    // with a mouse (FR-032b).
+    const item = document.querySelector(
+      `#orgchart-a11y .a11y-node[data-node-id="${CSS.escape(node.id)}"]`,
+    );
+    item?.setAttribute('aria-expanded', String(node.expanded));
   }
   return node;
 }

--- a/ui/netclaw-visual/src/orgchart-render/index.js
+++ b/ui/netclaw-visual/src/orgchart-render/index.js
@@ -1,0 +1,170 @@
+/**
+ * Org-chart mount point — the single seam between main.js and HUD 2.0.
+ *
+ * main.js calls mountOrgChart() once and updateOrgChart() on each poll. Keeping
+ * the surface this small is what makes FR-026's hard replace reviewable: the
+ * orbit layout is removed from main.js, but nothing else in that 132 KB file
+ * needs to understand how the chart is built.
+ *
+ * Position stability (FR-034) lives here: updateOrgChart repaints appearance
+ * and NEVER recomputes layout. A claw that fails changes how it looks, never
+ * where it is.
+ */
+
+import * as THREE from 'three';
+
+import { computeLayout, appendMember } from '../orgchart/layout.js';
+import { buildNodes, animateNodes, applyHighlight, TREATMENTS } from './nodes.js';
+import { buildBands } from './bands.js';
+import { buildLinks } from './links.js';
+import { classifyHealth } from '../orgchart/health.js';
+
+export { TREATMENTS };
+
+/** Live chart state. Rebuilt only on explicit remount, never on a poll. */
+const chart = {
+  root: null,
+  nodes: null,
+  bands: null,
+  links: null,
+  layout: null,
+  catalog: [],
+  entries: [],
+  search: '',
+};
+
+export function prefersReducedMotion() {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/**
+ * Build the chart and add it to the scene.
+ *
+ * @param {THREE.Scene} scene
+ * @param {object} n2n /api/n2n payload
+ * @param {Array<object>} integrationCatalog from /api/graph integrations[]
+ * @param {(text:string)=>object} makeLabel host CSS2D factory (FR-028)
+ * @returns {{nodes:Array<object>, bands:Array<object>, categories:Array<object>}}
+ */
+export function mountOrgChart(scene, n2n, integrationCatalog, makeLabel) {
+  unmountOrgChart(scene);
+
+  const nowEpochS = Date.now() / 1000;
+  const layout = computeLayout(n2n, integrationCatalog, nowEpochS);
+
+  const root = new THREE.Group();
+  root.name = 'orgchart';
+
+  const bands = buildBands(layout.bands, makeLabel);
+  const links = buildLinks(layout.nodes, layout.categories);
+  const nodes = buildNodes(layout.nodes, makeLabel);
+
+  root.add(bands.group, links.group, nodes.group);
+  scene.add(root);
+
+  Object.assign(chart, {
+    root, nodes, bands, links, layout,
+    catalog: integrationCatalog || [],
+    entries: nodes.entries,
+  });
+  return layout;
+}
+
+export function unmountOrgChart(scene) {
+  if (!chart.root) return;
+  scene.remove(chart.root);
+  chart.nodes?.dispose?.();
+  chart.bands?.dispose?.();
+  chart.links?.dispose?.();
+  Object.assign(chart, { root: null, nodes: null, bands: null, links: null, layout: null, entries: [] });
+}
+
+/**
+ * Refresh from a poll (FR-034a): appearance only.
+ *
+ * Health, labels and links are updated in place. Positions are never
+ * recalculated and categories are never re-ordered — doing so would re-pack the
+ * chart under an operator who is reading it, which is exactly what FR-022 and
+ * FR-031a exist to prevent elsewhere.
+ *
+ * A member that enrolled mid-session is appended via appendMember (FR-034b),
+ * which places it without moving anything already on screen.
+ *
+ * @param {THREE.Scene} scene
+ * @param {object} n2n
+ * @param {(text:string)=>object} makeLabel
+ */
+export function updateOrgChart(scene, n2n, makeLabel) {
+  if (!chart.layout) return;
+
+  const nowEpochS = Date.now() / 1000;
+  const members = Array.isArray(n2n?.members) ? n2n.members : [];
+  const byId = new Map(members.map((m) => [m.member_id, m]));
+
+  // 1. Repaint existing nodes.
+  for (const entry of chart.entries) {
+    const fresh = byId.get(entry.node.id);
+    if (!fresh) continue;
+
+    const health = classifyHealth(fresh, nowEpochS);
+    if (health === entry.node.health) continue;
+
+    entry.node.health = health;
+    entry.node.payload = fresh;
+    const t = TREATMENTS[health] || TREATMENTS.COLD;
+    entry.material.color.setHex(t.color);
+    entry.material.emissive.setHex(t.emissive);
+    entry.material.emissiveIntensity = health === 'FAULT' ? 1.5 : 0.85;
+    entry.material.roughness = health === 'COLD' ? 0.95 : 0.35;
+    entry.pulse = t.pulse;
+  }
+
+  // 2. Append genuinely new members (FR-034b) — nothing existing moves.
+  const known = new Set(chart.entries.map((e) => e.node.id));
+  for (const m of members) {
+    if (!m?.member_id || known.has(m.member_id)) continue;
+
+    const node = appendMember(chart.layout, m, chart.catalog, nowEpochS);
+    if (!node) continue;
+
+    const built = buildNodes([node], makeLabel);
+    chart.nodes.group.add(...built.group.children);
+    chart.entries.push(...built.entries);
+    chart.layout.nodes.push(node);
+  }
+}
+
+/**
+ * Search: highlight matches, dim the rest, in place (FR-031a/b).
+ * Never hides and never re-packs — hiding would destroy the spatial memory the
+ * whole layout exists to build.
+ *
+ * @param {string} query
+ */
+export function searchOrgChart(query) {
+  chart.search = String(query || '').trim().toLowerCase();
+  const q = chart.search;
+
+  applyHighlight(chart.entries, (node) => {
+    if (!q) return true;
+    if (String(node.label || '').toLowerCase().includes(q)) return true;
+    if (String(node.category || '').toLowerCase().includes(q)) return true;
+    // A tool match must surface its owner even while collapsed (FR-031b).
+    return (node.tools || []).some((t) => String(t).toLowerCase().includes(q));
+  }, q.length > 0);
+}
+
+/** Meshes eligible for picking (click -> setDetail, FR-020a). */
+export function pickableObjects() {
+  return chart.entries.map((e) => e.mesh);
+}
+
+export function chartNodes() {
+  return chart.layout ? chart.layout.nodes : [];
+}
+
+export function tickOrgChart(elapsed) {
+  animateNodes(chart.entries, elapsed, prefersReducedMotion());
+}

--- a/ui/netclaw-visual/src/orgchart-render/index.js
+++ b/ui/netclaw-visual/src/orgchart-render/index.js
@@ -18,6 +18,7 @@ import { buildNodes, animateNodes, applyHighlight, TREATMENTS } from './nodes.js
 import { buildBands } from './bands.js';
 import { buildLinks } from './links.js';
 import { classifyHealth } from '../orgchart/health.js';
+import { toggleExpansion, collapseAll, isExpanded, expandedCount } from './expansion.js';
 
 export { TREATMENTS };
 
@@ -116,8 +117,9 @@ export function updateOrgChart(scene, n2n, makeLabel) {
     const t = TREATMENTS[health] || TREATMENTS.COLD;
     entry.material.color.setHex(t.color);
     entry.material.emissive.setHex(t.emissive);
-    entry.material.emissiveIntensity = health === 'FAULT' ? 1.5 : 0.85;
-    entry.material.roughness = health === 'COLD' ? 0.95 : 0.35;
+    entry.material.emissiveIntensity = t.emissiveIntensity ?? 1.0;
+    entry.material.roughness = health === 'COLD' ? 0.8 : 0.28;
+    entry.mesh.scale.setScalar(entry.baseScale);
     entry.pulse = t.pulse;
   }
 
@@ -164,6 +166,39 @@ export function pickableObjects() {
 export function chartNodes() {
   return chart.layout ? chart.layout.nodes : [];
 }
+
+/**
+ * Click handling: select AND reveal tools (operator revision to FR-020a).
+ *
+ * Returns the layout node so main.js can drive setDetail() unchanged — the
+ * right-hand panel contract is untouched (FR-017/018).
+ *
+ * @param {THREE.Object3D} mesh the picked mesh
+ * @param {(text:string)=>object} makeLabel
+ * @returns {object|null} the layout node behind that mesh
+ */
+export function activateNode(mesh, makeLabel) {
+  const node = mesh?.userData?.node;
+  if (!node) return null;
+  // Only members and edges carry tools; peers and the Border just select.
+  if (node.kind === 'member' || node.kind === 'edge') {
+    toggleExpansion(chart.root, node, mesh, makeLabel);
+  }
+  return node;
+}
+
+/** Keyboard/affordance route to the same toggle (FR-032a). */
+export function toggleNodeExpansion(nodeId, makeLabel) {
+  const entry = chart.entries.find((e) => e.node.id === nodeId);
+  if (!entry) return false;
+  return toggleExpansion(chart.root, entry.node, entry.mesh, makeLabel);
+}
+
+export function collapseAllExpansions() {
+  if (chart.root) collapseAll(chart.root);
+}
+
+export { isExpanded, expandedCount };
 
 export function tickOrgChart(elapsed) {
   animateNodes(chart.entries, elapsed, prefersReducedMotion());

--- a/ui/netclaw-visual/src/orgchart-render/links.js
+++ b/ui/netclaw-visual/src/orgchart-render/links.js
@@ -1,0 +1,131 @@
+/**
+ * Link rendering — six distinguishable styles (FR-010, FR-011).
+ *
+ * | style             | meaning                                    |
+ * |-------------------|--------------------------------------------|
+ * | en2n-healthy      | federated peer, channel up                 |
+ * | en2n-unreachable  | federated peer, channel down               |
+ * | en2n-severed      | trust withdrawn — visibly broken           |
+ * | in2n-healthy      | member reachable                           |
+ * | in2n-cold         | member inert by design                     |
+ * | edge-push         | Border -> device, ASYMMETRIC (FR-011)      |
+ *
+ * The edge link is drawn differently on purpose: a member delegation is a round
+ * trip, while the push channel only ever runs Border -> device. Drawing them
+ * alike would imply a capability the phone does not have.
+ */
+
+import * as THREE from 'three';
+
+export const LINK_STYLES = {
+  'en2n-healthy': { color: 0x65c3ff, opacity: 0.55, dash: 0, width: 1 },
+  'en2n-unreachable': { color: 0x5b7fa6, opacity: 0.3, dash: 1.6, width: 1 },
+  'en2n-severed': { color: 0xff5d5d, opacity: 0.45, dash: 0.7, width: 1, broken: true },
+  'in2n-healthy': { color: 0x37d67a, opacity: 0.45, dash: 0, width: 1 },
+  'in2n-cold': { color: 0x3a4654, opacity: 0.22, dash: 1.2, width: 1 },
+  'edge-push': { color: 0xe65733, opacity: 0.6, dash: 1.0, width: 1, arrow: true },
+};
+
+/**
+ * Choose a style for a node's link to the Border.
+ *
+ * @param {object} node
+ * @returns {string} key into LINK_STYLES
+ */
+export function styleForNode(node) {
+  if (node.kind === 'peer') {
+    if (node.severed) return 'en2n-severed';
+    const ch = String(node.channelState || '').toLowerCase();
+    return ch === 'up' ? 'en2n-healthy' : 'en2n-unreachable';
+  }
+  if (node.kind === 'edge') return 'edge-push';
+  return node.health === 'HOT' || node.health === 'WARM' ? 'in2n-healthy' : 'in2n-cold';
+}
+
+/**
+ * Build links from the Border to every other node.
+ *
+ * @param {Array<object>} layoutNodes
+ * @param {Array<object>} categories
+ * @returns {{group: THREE.Group, dispose: Function}}
+ */
+export function buildLinks(layoutNodes, categories) {
+  const group = new THREE.Group();
+  group.name = 'orgchart-links';
+  const disposables = [];
+
+  const nodes = layoutNodes || [];
+  const border = nodes.find((n) => n.kind === 'border');
+  if (!border) return { group, dispose() {} };
+
+  const origin = new THREE.Vector3(border.position.x, border.position.y, border.position.z);
+
+  for (const node of nodes) {
+    if (node === border) continue;
+
+    const styleKey = styleForNode(node);
+    const style = LINK_STYLES[styleKey];
+    const target = new THREE.Vector3(node.position.x, node.position.y, node.position.z);
+
+    // Members route via their category header so the chart reads as a chart —
+    // an elbow through the column, not 100 straight lines to one point.
+    let points;
+    if (node.kind === 'member') {
+      const cat = (categories || []).find((c) => c.name === node.category);
+      const via = cat
+        ? new THREE.Vector3(cat.position.x, cat.position.y + 2, cat.position.z)
+        : new THREE.Vector3(target.x, origin.y - 10, 0);
+      points = [origin, new THREE.Vector3(origin.x, via.y + 6, 0), via, target];
+    } else if (style.broken) {
+      // A severed link is drawn with its middle missing — the break is the
+      // message, so it must survive greyscale (SC-007) rather than rely on red.
+      const a = origin.clone().lerp(target, 0.32);
+      const b = origin.clone().lerp(target, 0.68);
+      group.add(makeLine([origin, a], style, disposables));
+      group.add(makeLine([b, target], style, disposables));
+      continue;
+    } else {
+      points = [origin, target];
+    }
+
+    group.add(makeLine(points, style, disposables));
+    if (style.arrow) group.add(makeArrow(origin, target, style, disposables));
+  }
+
+  return {
+    group,
+    dispose() { for (const d of disposables) d.dispose?.(); },
+  };
+}
+
+function makeLine(points, style, disposables) {
+  const geometry = new THREE.BufferGeometry().setFromPoints(points);
+  const material = style.dash
+    ? new THREE.LineDashedMaterial({
+        color: style.color, transparent: true, opacity: style.opacity,
+        dashSize: style.dash, gapSize: style.dash * 0.8,
+      })
+    : new THREE.LineBasicMaterial({
+        color: style.color, transparent: true, opacity: style.opacity,
+      });
+  disposables.push(geometry, material);
+  const line = new THREE.Line(geometry, material);
+  if (style.dash) line.computeLineDistances();
+  line.renderOrder = -1;
+  return line;
+}
+
+/** Direction marker for the asymmetric push channel (FR-011). */
+function makeArrow(origin, target, style, disposables) {
+  const dir = target.clone().sub(origin).normalize();
+  const at = target.clone().sub(dir.clone().multiplyScalar(4));
+  const geometry = new THREE.ConeGeometry(0.9, 2.4, 8);
+  const material = new THREE.MeshBasicMaterial({
+    color: style.color, transparent: true, opacity: style.opacity,
+  });
+  disposables.push(geometry, material);
+  const cone = new THREE.Mesh(geometry, material);
+  cone.position.copy(at);
+  cone.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), dir);
+  return cone;
+}

--- a/ui/netclaw-visual/src/orgchart-render/nodes.js
+++ b/ui/netclaw-visual/src/orgchart-render/nodes.js
@@ -127,11 +127,19 @@ export function buildNodes(layoutNodes, makeLabel) {
     if (node.kind === 'member' && node.toolCount > 0) text += `  ·${node.toolCount}`;
     if (node.kind === 'edge' && node.heartbeatAgeS != null) text += `  ${formatAge(node.heartbeatAgeS)}`;
 
+    // The label is a sibling of the mesh, NOT a child. Parenting it to the mesh
+    // made it inherit the pulse scale, so every HOT and FAULT label drifted a
+    // few pixels each frame — caught by SC-011, which requires positions to be
+    // stable. Anchoring in world space decouples the label from the animation.
     const label = makeLabel(text);
-    label.position.set(0, -(scale * 1.6 + 1.4), 0);
-    mesh.add(label);
+    label.position.set(
+      node.position.x,
+      node.position.y - (scale * 1.6 + 1.4),
+      node.position.z,
+    );
 
     group.add(mesh);
+    group.add(label);
     entries.push({ node, mesh, material, label, baseScale: scale, pulse: treatment.pulse });
   }
 

--- a/ui/netclaw-visual/src/orgchart-render/nodes.js
+++ b/ui/netclaw-visual/src/orgchart-render/nodes.js
@@ -23,37 +23,44 @@ import * as THREE from 'three';
 export const TREATMENTS = {
   HOT: {
     shape: 'sphere',
-    color: 0x37d67a,
-    emissive: 0x0f7a3c,
-    lightness: 0.82,
-    scale: 1.0,
+    color: 0x4dff9b,
+    emissive: 0x1fbf68,
+    emissiveIntensity: 1.5,
+    lightness: 0.88,
+    scale: 1.06,
     pulse: 0.10,          // alive: gentle breathing
     label: 'Running now',
   },
   WARM: {
     shape: 'rounded',
-    color: 0x6fa8dc,
-    emissive: 0x1d3f5c,
-    lightness: 0.58,
-    scale: 0.86,
+    color: 0x8fc7ff,
+    emissive: 0x2f6da8,
+    emissiveIntensity: 1.0,
+    lightness: 0.68,
+    scale: 0.9,
     pulse: 0.0,           // idle: still
     label: 'Seen recently, idle',
   },
   COLD: {
     shape: 'flat',        // a disc reads as inert next to a lit sphere
-    color: 0x3a4654,
-    emissive: 0x0a0f16,
-    lightness: 0.26,
-    scale: 0.68,
+    // Lifted from near-black: cold must read as INERT, not as absent. An
+    // operator still needs to see what capacity exists before deciding to
+    // warm it, and 22 invisible claws is not "distinctly cold" (FR-009).
+    color: 0x7d8ea3,
+    emissive: 0x2c3a4a,
+    emissiveIntensity: 0.5,
+    lightness: 0.5,
+    scale: 0.74,
     pulse: 0.0,
     label: 'Never started — inert by design',
   },
   FAULT: {
     shape: 'ring',        // a broken outline, unmistakable at any zoom
-    color: 0xff5d5d,
-    emissive: 0x8b1a1a,
-    lightness: 0.66,
-    scale: 1.06,          // FR-009b: most salient state after HOT
+    color: 0xff7a7a,
+    emissive: 0xd32f2f,
+    emissiveIntensity: 2.1,
+    lightness: 0.74,
+    scale: 1.14,          // FR-009b: most salient state after HOT
     pulse: 0.22,          // urgent, faster and deeper than HOT's breathing
     label: 'Was reachable, now unreachable',
   },
@@ -103,9 +110,9 @@ export function buildNodes(layoutNodes, makeLabel) {
     const material = new THREE.MeshStandardMaterial({
       color,
       emissive: isStructural ? 0x102030 : treatment.emissive,
-      emissiveIntensity: node.health === 'FAULT' ? 1.5 : 0.85,
-      roughness: node.health === 'COLD' ? 0.95 : 0.35,
-      metalness: node.health === 'COLD' ? 0.05 : 0.45,
+      emissiveIntensity: isStructural ? 1.1 : (treatment.emissiveIntensity ?? 1.0),
+      roughness: node.health === 'COLD' ? 0.8 : 0.28,
+      metalness: node.health === 'COLD' ? 0.1 : 0.5,
     });
     materials.push(material);
 
@@ -139,10 +146,10 @@ export function buildNodes(layoutNodes, makeLabel) {
 }
 
 function colorForStructural(node) {
-  if (node.kind === 'border') return 0xffc857;
-  if (node.severed) return 0x6b3f3f;
-  if (node.channelState === 'unreachable' || node.channelState === 'reconnecting') return 0x5b7fa6;
-  return 0x65c3ff;
+  if (node.kind === 'border') return 0xffd97a;
+  if (node.severed) return 0xa85c5c;
+  if (node.channelState === 'unreachable' || node.channelState === 'reconnecting') return 0x86a9cc;
+  return 0x8ad6ff;
 }
 
 /**
@@ -192,7 +199,7 @@ export function applyHighlight(entries, matches, searching) {
     const hit = !searching || matches(e.node);
     e.material.opacity = hit ? 1 : 0.18;
     e.material.transparent = !hit;
-    e.material.emissiveIntensity = hit ? (e.node.health === 'FAULT' ? 1.5 : 0.85) : 0.05;
+    e.material.emissiveIntensity = hit ? (TREATMENTS[e.node.health]?.emissiveIntensity ?? 1.0) : 0.08;
     if (e.label?.element) e.label.element.style.opacity = hit ? '1' : '0.2';
   }
 }

--- a/ui/netclaw-visual/src/orgchart-render/nodes.js
+++ b/ui/netclaw-visual/src/orgchart-render/nodes.js
@@ -33,7 +33,7 @@ export const TREATMENTS = {
   },
   WARM: {
     shape: 'rounded',
-    color: 0x8fc7ff,
+    color: 0x86bdf5,
     emissive: 0x2f6da8,
     emissiveIntensity: 1.0,
     lightness: 0.68,
@@ -43,10 +43,14 @@ export const TREATMENTS = {
   },
   COLD: {
     shape: 'flat',        // a disc reads as inert next to a lit sphere
-    // Lifted from near-black: cold must read as INERT, not as absent. An
-    // operator still needs to see what capacity exists before deciding to
-    // warm it, and 22 invisible claws is not "distinctly cold" (FR-009).
-    color: 0x7d8ea3,
+    // Lifted well off near-black (was 0x3a4654, luminance ~66): cold must read
+    // as INERT, not as absent — an operator has to see what capacity exists
+    // before deciding to warm it. But NOT as bright as the first attempt
+    // (0x7d8ea3, luminance 140), which landed within 10 luminance of FAULT and
+    // made the two indistinguishable in greyscale. treatments.test.js caught
+    // that. Luminance 107: clearly present, clearly dimmer than HOT, and 43
+    // clear of FAULT.
+    color: 0x5f6d80,
     emissive: 0x2c3a4a,
     emissiveIntensity: 0.5,
     lightness: 0.5,

--- a/ui/netclaw-visual/src/orgchart-render/nodes.js
+++ b/ui/netclaw-visual/src/orgchart-render/nodes.js
@@ -1,0 +1,198 @@
+/**
+ * Node rendering and the four health treatments (FR-009a, FR-009b, FR-029a).
+ *
+ * Consumes orgchart/ output. Never classifies health, chooses categories, or
+ * computes positions — those answers arrive already decided (see
+ * contracts/layout-contract.md, consumer contract).
+ *
+ * The encoding rule (FR-009a): each state differs in FORM, COLOUR TEMPERATURE
+ * and MOTION at once, never opacity alone. Motion is deliberately REDUNDANT
+ * (R8) — it is added on top of an already-sufficient form+colour distinction,
+ * so suppressing it for prefers-reduced-motion (FR-032c) cannot collapse the
+ * encoding. That is also why SC-007 (greyscale) and SC-010 (reduced motion)
+ * test the same underlying property.
+ */
+
+import * as THREE from 'three';
+
+/**
+ * Health treatments. Form and colour alone must separate all four — verified
+ * by SC-007's greyscale test, which is why `shape` and `lightness` differ
+ * across every row and not just `color`.
+ */
+export const TREATMENTS = {
+  HOT: {
+    shape: 'sphere',
+    color: 0x37d67a,
+    emissive: 0x0f7a3c,
+    lightness: 0.82,
+    scale: 1.0,
+    pulse: 0.10,          // alive: gentle breathing
+    label: 'Running now',
+  },
+  WARM: {
+    shape: 'rounded',
+    color: 0x6fa8dc,
+    emissive: 0x1d3f5c,
+    lightness: 0.58,
+    scale: 0.86,
+    pulse: 0.0,           // idle: still
+    label: 'Seen recently, idle',
+  },
+  COLD: {
+    shape: 'flat',        // a disc reads as inert next to a lit sphere
+    color: 0x3a4654,
+    emissive: 0x0a0f16,
+    lightness: 0.26,
+    scale: 0.68,
+    pulse: 0.0,
+    label: 'Never started — inert by design',
+  },
+  FAULT: {
+    shape: 'ring',        // a broken outline, unmistakable at any zoom
+    color: 0xff5d5d,
+    emissive: 0x8b1a1a,
+    lightness: 0.66,
+    scale: 1.06,          // FR-009b: most salient state after HOT
+    pulse: 0.22,          // urgent, faster and deeper than HOT's breathing
+    label: 'Was reachable, now unreachable',
+  },
+};
+
+export const KIND_SCALE = { border: 2.2, peer: 1.35, member: 1.0, edge: 1.15 };
+
+/** Shared geometries — created once, reused across every node (FR-029a). */
+function buildGeometries() {
+  return {
+    sphere: new THREE.SphereGeometry(1.6, 24, 18),
+    rounded: new THREE.SphereGeometry(1.5, 16, 12),
+    flat: new THREE.CylinderGeometry(1.5, 1.5, 0.35, 20).rotateX(Math.PI / 2),
+    ring: new THREE.TorusGeometry(1.5, 0.42, 10, 24),
+    border: new THREE.IcosahedronGeometry(2.4, 1),
+    peer: new THREE.OctahedronGeometry(1.8, 0),
+    edge: new THREE.BoxGeometry(1.5, 2.6, 0.5),
+  };
+}
+
+/**
+ * Build every node mesh for a computed layout.
+ *
+ * @param {Array<object>} layoutNodes from computeLayout().nodes
+ * @param {(text:string)=>object} makeLabel host label factory (CSS2D), reused per FR-028
+ * @returns {{group: THREE.Group, entries: Array<object>, dispose: Function}}
+ */
+export function buildNodes(layoutNodes, makeLabel) {
+  const group = new THREE.Group();
+  group.name = 'orgchart-nodes';
+  const geometries = buildGeometries();
+  const materials = [];
+  const entries = [];
+
+  for (const node of layoutNodes || []) {
+    const treatment = TREATMENTS[node.health] || TREATMENTS.COLD;
+
+    let geometry;
+    if (node.kind === 'border') geometry = geometries.border;
+    else if (node.kind === 'peer') geometry = geometries.peer;
+    else if (node.kind === 'edge') geometry = geometries.edge;
+    else geometry = geometries[treatment.shape] || geometries.sphere;
+
+    const isStructural = node.kind === 'border' || node.kind === 'peer';
+    const color = isStructural ? colorForStructural(node) : treatment.color;
+
+    const material = new THREE.MeshStandardMaterial({
+      color,
+      emissive: isStructural ? 0x102030 : treatment.emissive,
+      emissiveIntensity: node.health === 'FAULT' ? 1.5 : 0.85,
+      roughness: node.health === 'COLD' ? 0.95 : 0.35,
+      metalness: node.health === 'COLD' ? 0.05 : 0.45,
+    });
+    materials.push(material);
+
+    const mesh = new THREE.Mesh(geometry, material);
+    const scale = (KIND_SCALE[node.kind] || 1) * (isStructural ? 1 : treatment.scale);
+    mesh.scale.setScalar(scale);
+    mesh.position.set(node.position.x, node.position.y, node.position.z);
+    mesh.userData = { nodeId: node.id, kind: node.kind, payload: node.payload, node };
+
+    // Label: never blank — orgchart/normalize guarantees a fallback (FR-015).
+    let text = node.label;
+    if (node.kind === 'member' && node.toolCount > 0) text += `  ·${node.toolCount}`;
+    if (node.kind === 'edge' && node.heartbeatAgeS != null) text += `  ${formatAge(node.heartbeatAgeS)}`;
+
+    const label = makeLabel(text);
+    label.position.set(0, -(scale * 1.6 + 1.4), 0);
+    mesh.add(label);
+
+    group.add(mesh);
+    entries.push({ node, mesh, material, label, baseScale: scale, pulse: treatment.pulse });
+  }
+
+  return {
+    group,
+    entries,
+    dispose() {
+      for (const g of Object.values(geometries)) g.dispose();
+      for (const m of materials) m.dispose();
+    },
+  };
+}
+
+function colorForStructural(node) {
+  if (node.kind === 'border') return 0xffc857;
+  if (node.severed) return 0x6b3f3f;
+  if (node.channelState === 'unreachable' || node.channelState === 'reconnecting') return 0x5b7fa6;
+  return 0x65c3ff;
+}
+
+/**
+ * Human-readable last-seen age for edge nodes (US2 AC2) — legible on the node
+ * itself, without opening the detail panel.
+ *
+ * @param {number} seconds
+ * @returns {string}
+ */
+export function formatAge(seconds) {
+  const s = Number(seconds);
+  if (!Number.isFinite(s) || s < 0) return '';
+  if (s < 90) return `${Math.round(s)}s ago`;
+  if (s < 5400) return `${Math.round(s / 60)}m ago`;
+  if (s < 172800) return `${Math.round(s / 3600)}h ago`;
+  return `${Math.round(s / 86400)}d ago`;
+}
+
+/**
+ * Per-frame animation. Motion is redundant to the encoding (R8), so honouring
+ * reduced motion simply skips this entirely (FR-032c).
+ *
+ * @param {Array<object>} entries from buildNodes
+ * @param {number} elapsed seconds
+ * @param {boolean} reducedMotion
+ */
+export function animateNodes(entries, elapsed, reducedMotion) {
+  if (reducedMotion) return;
+  for (const e of entries) {
+    if (!e.pulse) continue;
+    // FAULT beats faster than HOT: urgency reads differently from liveness.
+    const rate = e.node.health === 'FAULT' ? 4.2 : 1.6;
+    const factor = 1 + Math.sin(elapsed * rate) * e.pulse;
+    e.mesh.scale.setScalar(e.baseScale * factor);
+  }
+}
+
+/**
+ * Apply search highlight/dim in place (FR-031a) — never hides, never re-packs.
+ *
+ * @param {Array<object>} entries
+ * @param {(node:object)=>boolean} matches
+ * @param {boolean} searching
+ */
+export function applyHighlight(entries, matches, searching) {
+  for (const e of entries) {
+    const hit = !searching || matches(e.node);
+    e.material.opacity = hit ? 1 : 0.18;
+    e.material.transparent = !hit;
+    e.material.emissiveIntensity = hit ? (e.node.health === 'FAULT' ? 1.5 : 0.85) : 0.05;
+    if (e.label?.element) e.label.element.style.opacity = hit ? '1' : '0.2';
+  }
+}

--- a/ui/netclaw-visual/src/orgchart-render/treatments.test.js
+++ b/ui/netclaw-visual/src/orgchart-render/treatments.test.js
@@ -1,0 +1,93 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { TREATMENTS } from './nodes.js';
+
+/**
+ * SC-007 / SC-010 as a permanent test rather than a one-off screenshot.
+ *
+ * The claim is that the four health states stay distinguishable in greyscale
+ * and with motion suppressed. That is a property of the design constants, not
+ * of any particular frame, so it belongs here where it is checked on every run
+ * — a screenshot only proves the state of one build on one machine.
+ */
+
+const STATES = ['HOT', 'WARM', 'COLD', 'FAULT'];
+
+/** ITU-R BT.709 relative luminance — what a greyscale conversion produces. */
+function luminance(hex) {
+  const r = (hex >> 16) & 0xff;
+  const g = (hex >> 8) & 0xff;
+  const b = hex & 0xff;
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+test('all four states are defined', () => {
+  for (const s of STATES) assert.ok(TREATMENTS[s], `${s} missing`);
+});
+
+test('SC-007: every pair of states is separable by luminance alone', () => {
+  // If two states converge in greyscale, a colour-blind operator or a
+  // greyscale screenshot cannot tell them apart — colour would be doing the
+  // work alone, which FR-009a forbids.
+  const MIN_DELTA = 18;
+  for (let i = 0; i < STATES.length; i += 1) {
+    for (let j = i + 1; j < STATES.length; j += 1) {
+      const a = STATES[i]; const b = STATES[j];
+      const delta = Math.abs(luminance(TREATMENTS[a].color) - luminance(TREATMENTS[b].color));
+      assert.ok(
+        delta >= MIN_DELTA,
+        `${a} and ${b} differ by only ${delta.toFixed(1)} luminance — indistinguishable in greyscale`,
+      );
+    }
+  }
+});
+
+test('SC-007: every state has a distinct silhouette', () => {
+  // Shape is the channel that survives both greyscale AND reduced motion, so
+  // it must be unique per state on its own.
+  const shapes = STATES.map((s) => TREATMENTS[s].shape);
+  assert.equal(new Set(shapes).size, STATES.length, `shapes collide: ${shapes.join(', ')}`);
+});
+
+test('SC-010: the encoding survives motion suppression (FR-032c)', () => {
+  // Motion must be REDUNDANT — states that share a pulse value must still be
+  // separable by shape and luminance, or suppressing motion collapses them.
+  for (let i = 0; i < STATES.length; i += 1) {
+    for (let j = i + 1; j < STATES.length; j += 1) {
+      const a = TREATMENTS[STATES[i]]; const b = TREATMENTS[STATES[j]];
+      if (a.pulse !== b.pulse) continue;
+      assert.notEqual(a.shape, b.shape, `${STATES[i]}/${STATES[j]} share a pulse AND a shape`);
+      assert.ok(
+        Math.abs(luminance(a.color) - luminance(b.color)) >= 18,
+        `${STATES[i]}/${STATES[j]} share a pulse and are too close in luminance`,
+      );
+    }
+  }
+});
+
+test('FR-009b: FAULT is the most salient state after HOT', () => {
+  const { HOT, WARM, COLD, FAULT } = TREATMENTS;
+  assert.ok(FAULT.scale > WARM.scale, 'FAULT must out-scale WARM');
+  assert.ok(FAULT.scale > COLD.scale, 'FAULT must out-scale COLD');
+  assert.ok(FAULT.emissiveIntensity > WARM.emissiveIntensity, 'FAULT must out-glow WARM');
+  assert.ok(FAULT.emissiveIntensity > COLD.emissiveIntensity, 'FAULT must out-glow COLD');
+  assert.ok(FAULT.pulse > 0, 'FAULT must move — it demands attention');
+  assert.ok(HOT.pulse > 0, 'HOT must read as alive');
+});
+
+test('FR-009: COLD reads as inert but never as absent', () => {
+  // Lifting COLD off near-black was deliberate: an operator has to see what
+  // capacity exists before deciding to warm it. "Distinctly cold" is not
+  // "invisible".
+  const l = luminance(TREATMENTS.COLD.color);
+  assert.ok(l > 45, `COLD luminance ${l.toFixed(1)} is too dark to read as present`);
+  assert.ok(l < luminance(TREATMENTS.HOT.color), 'COLD must still be dimmer than HOT');
+  assert.equal(TREATMENTS.COLD.pulse, 0, 'COLD must be still');
+});
+
+test('every state carries screen-reader text (FR-032b)', () => {
+  for (const s of STATES) {
+    assert.ok(TREATMENTS[s].label?.length > 3, `${s} needs a human-readable label`);
+  }
+});

--- a/ui/netclaw-visual/src/orgchart/categorize.js
+++ b/ui/netclaw-visual/src/orgchart/categorize.js
@@ -1,0 +1,119 @@
+/**
+ * Derive a member's org-chart category (FR-006, FR-006a).
+ *
+ * Pure: no imports, no I/O. The integration catalog is an ARGUMENT, never an
+ * import — that is what makes Constitution Principle VI (multi-vendor
+ * neutrality) testable rather than merely asserted: the same code must produce
+ * a different, correct chart for a different operator's catalog.
+ *
+ * Why not `profile`? On the reference Border it is 1:1 with the member —
+ * 28 distinct values across 29 members — so grouping by it yields 28 groups of
+ * one. The middle tier has to be a *rule*, not a list of member names, because
+ * NetClaw ships to operators whose members we have never seen.
+ *
+ * The rule:
+ *   member.skills[] -> integration (skill starts with one of its prefixes)
+ *                   -> integration.category
+ *                   -> the most frequent category among that member's skills
+ */
+
+export const UNCATEGORISED = 'Uncategorised';
+
+/**
+ * Category for one member.
+ *
+ * Ties are broken by catalog order so the result is deterministic — two runs
+ * over the same input must produce the same chart.
+ *
+ * @param {object} member a member from /api/n2n members[]
+ * @param {Array<{category:string, prefixes:string[]}>} integrationCatalog
+ * @returns {string} category name, or UNCATEGORISED — never empty, never throws
+ */
+export function categorizeMember(member, integrationCatalog) {
+  if (!member || typeof member !== 'object') return UNCATEGORISED;
+  if (!Array.isArray(integrationCatalog) || integrationCatalog.length === 0) return UNCATEGORISED;
+
+  const skills = Array.isArray(member.skills) ? member.skills : [];
+  if (skills.length === 0) return UNCATEGORISED;
+
+  /** @type {Map<string, number>} votes per category */
+  const votes = new Map();
+  /** @type {Map<string, number>} first catalog index that voted, for tie-breaks */
+  const firstSeen = new Map();
+
+  for (const skill of skills) {
+    if (typeof skill !== 'string') continue;
+
+    for (let i = 0; i < integrationCatalog.length; i += 1) {
+      const integration = integrationCatalog[i];
+      if (!integration || !Array.isArray(integration.prefixes)) continue;
+
+      const matches = integration.prefixes.some(
+        (p) => typeof p === 'string' && p.length > 0 && skill.startsWith(p),
+      );
+      if (!matches) continue;
+
+      const category = integration.category || UNCATEGORISED;
+      votes.set(category, (votes.get(category) || 0) + 1);
+      if (!firstSeen.has(category)) firstSeen.set(category, i);
+      break; // first matching integration wins for this skill
+    }
+  }
+
+  if (votes.size === 0) return UNCATEGORISED;
+
+  let best = UNCATEGORISED;
+  let bestVotes = -1;
+  let bestIndex = Number.MAX_SAFE_INTEGER;
+  for (const [category, count] of votes) {
+    const index = firstSeen.get(category);
+    if (count > bestVotes || (count === bestVotes && index < bestIndex)) {
+      best = category;
+      bestVotes = count;
+      bestIndex = index;
+    }
+  }
+  return best;
+}
+
+/**
+ * Group members into categories (FR-006).
+ *
+ * Members with `node_type === 'edge'` are EXCLUDED — edge nodes belong in the
+ * edge lane, not the member chart (FR-007), and categorising a phone by the
+ * skills it happens to carry would place it in a column it does not belong to.
+ *
+ * @param {Array<object>} members
+ * @param {Array<object>} integrationCatalog
+ * @returns {Map<string, Array<object>>} category name -> members, insertion-ordered
+ */
+export function categorizeMembers(members, integrationCatalog) {
+  /** @type {Map<string, Array<object>>} */
+  const grouped = new Map();
+  if (!Array.isArray(members)) return grouped;
+
+  for (const member of members) {
+    if (!member || typeof member !== 'object') continue;
+    if (member.node_type === 'edge') continue;
+
+    const category = categorizeMember(member, integrationCatalog);
+    if (!grouped.has(category)) grouped.set(category, []);
+    grouped.get(category).push(member);
+  }
+  return grouped;
+}
+
+/**
+ * Extract the {category, prefixes} catalog from the shipped integration list.
+ * Tolerates entries missing either field so a malformed catalog degrades to
+ * UNCATEGORISED rather than throwing.
+ *
+ * @param {Array<object>} integrations
+ * @returns {Array<{id:string, category:string, prefixes:string[]}>}
+ */
+export function toCatalog(integrations) {
+  if (!Array.isArray(integrations)) return [];
+  return integrations
+    .filter((i) => i && typeof i === 'object' && Array.isArray(i.prefixes) && i.category)
+    .map((i) => ({ id: i.id || '', category: i.category, prefixes: i.prefixes }));
+}

--- a/ui/netclaw-visual/src/orgchart/categorize.test.js
+++ b/ui/netclaw-visual/src/orgchart/categorize.test.js
@@ -1,0 +1,124 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { categorizeMember, categorizeMembers, toCatalog, UNCATEGORISED } from './categorize.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = resolve(HERE, '../../../../specs/072-hud-2-org-chart/fixtures');
+const load = (n) => JSON.parse(readFileSync(resolve(FIXTURES, n), 'utf8'));
+
+const live = load('live-29.json');
+const catalog = load('integration-catalog.json');
+
+test('the shipped catalog supplies a real middle tier', () => {
+  assert.ok(catalog.length > 50, 'catalog should be substantial');
+  const categories = new Set(catalog.map((c) => c.category));
+  assert.ok(categories.size > 10, 'many distinct categories');
+});
+
+test('live members auto-categorise at the measured rate (FR-006)', () => {
+  const grouped = categorizeMembers(live.members, catalog);
+  const agents = live.members.filter((m) => m.node_type !== 'edge');
+
+  let placed = 0;
+  for (const [name, members] of grouped) {
+    if (name !== UNCATEGORISED) placed += members.length;
+  }
+  // Measured 25/27 agent members at spec time. Assert the floor, not the exact
+  // number — the catalog gains prefixes over time and that should not fail CI.
+  assert.ok(placed >= 24, `expected >=24 categorised agent members, got ${placed}`);
+  assert.ok(placed / agents.length > 0.85, 'coverage should exceed 85%');
+});
+
+test('edge nodes are excluded from the member chart entirely (FR-007)', () => {
+  const grouped = categorizeMembers(live.members, catalog);
+  const all = [...grouped.values()].flat();
+  assert.equal(all.filter((m) => m.node_type === 'edge').length, 0);
+  assert.equal(all.length, live.members.filter((m) => m.node_type !== 'edge').length);
+});
+
+test('no member is ever dropped — unmatched go to Uncategorised (FR-006a)', () => {
+  const unc = load('uncategorised.json');
+  const grouped = categorizeMembers(unc.members, catalog);
+  const agents = unc.members.filter((m) => m.node_type !== 'edge');
+
+  assert.equal(grouped.size, 1, 'a catalog matching nothing yields one bucket');
+  assert.ok(grouped.has(UNCATEGORISED));
+  assert.equal(grouped.get(UNCATEGORISED).length, agents.length, 'nothing dropped');
+});
+
+test('an empty or missing catalog degrades to Uncategorised, never throws', () => {
+  for (const bad of [[], null, undefined, 'nope', [{}, { prefixes: 'x' }]]) {
+    const grouped = categorizeMembers(live.members, bad);
+    const names = [...grouped.keys()];
+    assert.deepEqual(names, [UNCATEGORISED], `catalog ${JSON.stringify(bad)} should degrade`);
+  }
+});
+
+test('a member with no skills is Uncategorised, not dropped', () => {
+  assert.equal(categorizeMember({ member_id: 'r/x', skills: [] }, catalog), UNCATEGORISED);
+  assert.equal(categorizeMember({ member_id: 'r/x' }, catalog), UNCATEGORISED);
+  assert.equal(categorizeMember({ member_id: 'r/x', skills: [1, null] }, catalog), UNCATEGORISED);
+});
+
+// Constitution Principle VI made falsifiable: the catalog is an argument, so
+// a different operator's catalog must produce a different, correct chart from
+// the same code and the same members.
+test('a different catalog produces a different correct chart (vendor neutrality)', () => {
+  const members = [
+    { member_id: 'r/a', skills: ['acme-deploy', 'acme-verify'] },
+    { member_id: 'r/b', skills: ['zeta-scan'] },
+  ];
+  const catalogA = [
+    { id: 'acme', category: 'Provisioning', prefixes: ['acme-'] },
+    { id: 'zeta', category: 'Security', prefixes: ['zeta-'] },
+  ];
+  const catalogB = [
+    { id: 'acme', category: 'Vendor A Stack', prefixes: ['acme-'] },
+    { id: 'zeta', category: 'Vendor A Stack', prefixes: ['zeta-'] },
+  ];
+
+  const a = categorizeMembers(members, catalogA);
+  assert.deepEqual([...a.keys()].sort(), ['Provisioning', 'Security']);
+
+  const b = categorizeMembers(members, catalogB);
+  assert.deepEqual([...b.keys()], ['Vendor A Stack']);
+  assert.equal(b.get('Vendor A Stack').length, 2);
+
+  // Same code, same members, different catalog, different correct answer.
+  assert.notDeepEqual([...a.keys()], [...b.keys()]);
+});
+
+test('most frequent category wins; ties break deterministically by catalog order', () => {
+  const cat = [
+    { id: 'x', category: 'Alpha', prefixes: ['x-'] },
+    { id: 'y', category: 'Beta', prefixes: ['y-'] },
+  ];
+  assert.equal(categorizeMember({ skills: ['x-1', 'x-2', 'y-1'] }, cat), 'Alpha', 'majority wins');
+
+  const tie = { skills: ['y-1', 'x-1'] };
+  assert.equal(categorizeMember(tie, cat), 'Alpha', 'tie breaks to earlier catalog entry');
+  assert.equal(categorizeMember(tie, cat), categorizeMember(tie, cat), 'deterministic');
+});
+
+test('categorizeMembers does not mutate its inputs', () => {
+  const before = JSON.stringify(live.members);
+  categorizeMembers(live.members, catalog);
+  assert.equal(JSON.stringify(live.members), before);
+});
+
+test('toCatalog tolerates a malformed integration list', () => {
+  assert.deepEqual(toCatalog(null), []);
+  assert.deepEqual(toCatalog([{ id: 'a' }, { category: 'C' }]), []);
+  assert.equal(toCatalog([{ id: 'a', category: 'C', prefixes: ['a-'] }]).length, 1);
+});
+
+test('scale fixture categorises without loss', () => {
+  const big = load('scale-100.json');
+  const grouped = categorizeMembers(big.members, catalog);
+  const total = [...grouped.values()].flat().length;
+  assert.equal(total, big.members.filter((m) => m.node_type !== 'edge').length);
+});

--- a/ui/netclaw-visual/src/orgchart/health.js
+++ b/ui/netclaw-visual/src/orgchart/health.js
@@ -1,0 +1,74 @@
+/**
+ * Member health classification (FR-008, FR-008a).
+ *
+ * Pure: no imports, no clock. `nowEpochS` is injected by the caller, never read
+ * from Date.now() here — otherwise the WARM/FAULT boundary is untestable.
+ *
+ * Four states rather than two, because COLD and FAULT are opposite situations
+ * that a binary encoding would merge:
+ *
+ *   COLD  — never started. Normal. 22 of 29 members on the reference Border.
+ *   FAULT — was reachable, no longer is. Needs attention. 2 of 29.
+ *
+ * Merging them buries a real fault inside a crowd of by-design-cold claws,
+ * which is the specific failure this design exists to prevent.
+ */
+
+/** WARM/FAULT boundary, seconds (FR-008a). One named constant, not a literal. */
+export const WARM_THRESHOLD_S = 900;
+
+export const HOT = 'HOT';
+export const WARM = 'WARM';
+export const COLD = 'COLD';
+export const FAULT = 'FAULT';
+
+/** States that mean "the Border has given up on this member". */
+const FAULT_STATES = new Set(['unreachable', 'quarantined', 'removed']);
+
+/**
+ * Classify a member into exactly one health state.
+ *
+ * Precedence is strict and evaluated top-down:
+ *   1. HOT   — live === true, whatever else is set
+ *   2. FAULT — explicit fault state, regardless of heartbeat age
+ *   3. WARM  — seen within WARM_THRESHOLD_S
+ *   4. FAULT — seen, but longer ago than the threshold
+ *   5. COLD  — never seen at all (default)
+ *
+ * Note `live` is authoritative over `state`: the two disagree in live data
+ * (5 members report `active` while only 4 report `live`).
+ *
+ * @param {object} member a member from /api/n2n members[]
+ * @param {number} nowEpochS current time, seconds since epoch (injected)
+ * @returns {'HOT'|'WARM'|'COLD'|'FAULT'}
+ */
+export function classifyHealth(member, nowEpochS) {
+  if (!member || typeof member !== 'object') return COLD;
+
+  if (member.live === true) return HOT;
+
+  const state = String(member.state || '').toLowerCase();
+  if (FAULT_STATES.has(state)) return FAULT;
+
+  const age = member.heartbeat_age_s;
+  if (age === null || age === undefined || Number.isNaN(Number(age))) {
+    // Never seen. Inert by design, not broken.
+    return COLD;
+  }
+
+  return Number(age) <= WARM_THRESHOLD_S ? WARM : FAULT;
+}
+
+/**
+ * Count members per health state. Useful for ordering (heat) and the legend.
+ *
+ * @param {Array<object>} members
+ * @param {number} nowEpochS
+ * @returns {{HOT:number, WARM:number, COLD:number, FAULT:number}}
+ */
+export function healthTally(members, nowEpochS) {
+  const tally = { [HOT]: 0, [WARM]: 0, [COLD]: 0, [FAULT]: 0 };
+  if (!Array.isArray(members)) return tally;
+  for (const m of members) tally[classifyHealth(m, nowEpochS)] += 1;
+  return tally;
+}

--- a/ui/netclaw-visual/src/orgchart/health.test.js
+++ b/ui/netclaw-visual/src/orgchart/health.test.js
@@ -1,0 +1,107 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { classifyHealth, healthTally, WARM_THRESHOLD_S } from './health.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = resolve(HERE, '../../../../specs/072-hud-2-org-chart/fixtures');
+const live = JSON.parse(readFileSync(resolve(FIXTURES, 'live-29.json'), 'utf8'));
+const NOW = 1_785_000_000;
+
+test('the four states are reachable', () => {
+  assert.equal(classifyHealth({ live: true }, NOW), 'HOT');
+  assert.equal(classifyHealth({ live: false, heartbeat_age_s: 60 }, NOW), 'WARM');
+  assert.equal(classifyHealth({ live: false, state: 'provisioned' }, NOW), 'COLD');
+  assert.equal(classifyHealth({ live: false, state: 'unreachable' }, NOW), 'FAULT');
+});
+
+test('null heartbeat means COLD, never FAULT — the highest-value distinction (FR-008)', () => {
+  // A claw that never started is normal. A claw that died needs attention.
+  // Conflating them buries 2 real faults inside 22 by-design-cold members.
+  assert.equal(classifyHealth({ live: false, state: 'provisioned', heartbeat_age_s: null }, NOW), 'COLD');
+  assert.equal(classifyHealth({ live: false, state: 'provisioned' }, NOW), 'COLD');
+  assert.notEqual(classifyHealth({ live: false, heartbeat_age_s: null }, NOW), 'FAULT');
+});
+
+test('WARM/FAULT boundary is exactly WARM_THRESHOLD_S, inclusive (FR-008a)', () => {
+  assert.equal(WARM_THRESHOLD_S, 900);
+  assert.equal(classifyHealth({ live: false, heartbeat_age_s: WARM_THRESHOLD_S - 1 }, NOW), 'WARM');
+  assert.equal(classifyHealth({ live: false, heartbeat_age_s: WARM_THRESHOLD_S }, NOW), 'WARM');
+  assert.equal(classifyHealth({ live: false, heartbeat_age_s: WARM_THRESHOLD_S + 1 }, NOW), 'FAULT');
+});
+
+test('live=true wins over every other field', () => {
+  assert.equal(classifyHealth({ live: true, state: 'unreachable', heartbeat_age_s: 99999 }, NOW), 'HOT');
+  assert.equal(classifyHealth({ live: true, state: 'quarantined' }, NOW), 'HOT');
+});
+
+test('an explicit fault state beats a fresh heartbeat', () => {
+  // Border said unreachable; a recent heartbeat does not override that.
+  assert.equal(classifyHealth({ live: false, state: 'unreachable', heartbeat_age_s: 1 }, NOW), 'FAULT');
+  assert.equal(classifyHealth({ live: false, state: 'quarantined', heartbeat_age_s: 1 }, NOW), 'FAULT');
+});
+
+test('state=active but live=false is not HOT — the real 5-vs-4 disagreement', () => {
+  // The live Border reports 5 members `active` while only 4 are `live`.
+  // Health must key off `live`, so the fifth must not render as running.
+  assert.notEqual(classifyHealth({ live: false, state: 'active' }, NOW), 'HOT');
+  assert.equal(classifyHealth({ live: false, state: 'active' }, NOW), 'COLD');
+  assert.equal(classifyHealth({ live: false, state: 'active', heartbeat_age_s: 30 }, NOW), 'WARM');
+});
+
+test('classifyHealth is total on junk input', () => {
+  for (const junk of [null, undefined, 42, 'x', {}, { heartbeat_age_s: 'abc' }]) {
+    assert.ok(['HOT', 'WARM', 'COLD', 'FAULT'].includes(classifyHealth(junk, NOW)));
+  }
+});
+
+test('classifyHealth is pure — same input, same output', () => {
+  const m = { live: false, heartbeat_age_s: 100 };
+  assert.equal(classifyHealth(m, NOW), classifyHealth(m, NOW));
+  assert.equal(classifyHealth(m, NOW + 10_000), 'WARM', 'nowEpochS must not change an age-based verdict');
+});
+
+test('live fixture tallies to its known shape', () => {
+  const tally = healthTally(live.members, NOW);
+  const total = tally.HOT + tally.WARM + tally.COLD + tally.FAULT;
+  assert.equal(total, live.members.length, 'every member classified exactly once');
+  assert.equal(tally.HOT, live.members.filter((m) => m.live).length);
+  assert.ok(tally.COLD >= 20, 'the provisioned majority must be COLD');
+});
+
+// Derived from the fixture rather than hardcoded. An earlier version asserted
+// "FAULT >= 2" because both edge nodes were unreachable when the spec was
+// written; by capture time one had reconnected, so the count had already
+// drifted. What must hold is the *rule*, not yesterday's tally.
+test('every member the Border gave up on classifies as FAULT, never COLD (FR-008)', () => {
+  const givenUp = live.members.filter(
+    (m) => !m.live && ['unreachable', 'quarantined', 'removed'].includes(m.state),
+  );
+  assert.ok(givenUp.length > 0, 'fixture should contain at least one such member');
+
+  for (const m of givenUp) {
+    assert.equal(classifyHealth(m, NOW), 'FAULT', `${m.member_id} must be FAULT`);
+  }
+
+  const tally = healthTally(live.members, NOW);
+  assert.ok(tally.FAULT >= givenUp.length, 'no fault may be swallowed into COLD');
+});
+
+test('the two health populations stay separable in the live fixture', () => {
+  // COLD (never started, normal) and FAULT (died, needs attention) must both
+  // be present and distinct — that is the entire reason for four states.
+  const tally = healthTally(live.members, NOW);
+  assert.ok(tally.COLD > 0 && tally.FAULT > 0, 'both populations present');
+  assert.notEqual(tally.COLD + tally.FAULT, tally.COLD, 'FAULT is not merged into COLD');
+});
+
+test('scale fixture exercises all four states', () => {
+  const big = JSON.parse(readFileSync(resolve(FIXTURES, 'scale-100.json'), 'utf8'));
+  const tally = healthTally(big.members, NOW);
+  for (const state of ['HOT', 'WARM', 'COLD', 'FAULT']) {
+    assert.ok(tally[state] > 0, `${state} should be present in scale-100`);
+  }
+});

--- a/ui/netclaw-visual/src/orgchart/layout.js
+++ b/ui/netclaw-visual/src/orgchart/layout.js
@@ -1,0 +1,269 @@
+/**
+ * Deterministic banded layout (R6, FR-001..007, FR-029, FR-033, FR-034).
+ *
+ * Pure: no three.js, no DOM, no clock, no randomness. Coordinates are plain
+ * numbers; the render layer turns them into scene objects and may not
+ * re-derive any of this.
+ *
+ * The graph is depth-2 by construction (Border -> category -> member), so this
+ * is band assignment plus row packing — not a tree layout. Reingold-Tilford and
+ * force-directed layouts both solve problems this graph does not have, and a
+ * force simulation would actively violate FR-034's position stability.
+ *
+ *        y
+ *        ^   ┌─────────────── EXTERNAL band (peers, eN2N) ────────────┐
+ *   +40  │   │  o        o        o        o                          │
+ *        │   └────────────────────────────────────────────────────────┘
+ *   +18  │  ═══════════════ TRUST BOUNDARY ═══════════════════════════
+ *        │        ┌────────┐                    ┌── EDGE LANE ──┐
+ *     0  │        │ BORDER │  ╌╌╌╌ push ╌╌╌╌╌►  │  o   o        │
+ *        │        └────────┘                    └───────────────┘
+ *   -18  │  ─────────────── INTERNAL band (members, iN2N) ─────────────
+ *        │   [cat]     [cat]     [cat]     [cat]   ← columns, wrapping
+ *        │    o         o         o         o      ← members stack down
+ *        v
+ */
+
+import { classifyHealth } from './health.js';
+import { orderCategories, orderMembers } from './ordering.js';
+import { resolveLabel, disambiguateLabels, dedupePeers } from './normalize.js';
+import { categorizeMembers } from './categorize.js';
+
+/** Layout constants. Named, not scattered as literals. */
+export const LAYOUT = {
+  boundaryY: 18,
+  externalY: 40,
+  externalSpacingX: 26,
+  borderY: 0,
+  internalTopY: -18,
+  columnSpacingX: 22,
+  memberSpacingY: 9,
+  categoryHeaderOffsetY: -6,
+  rowSpacingY: 64,
+  edgeLaneX: 46,
+  edgeSpacingY: 10,
+  edgeLaneColumns: 2,
+  edgeLaneSpacingX: 16,
+  maxColumnsPerRow: 8,
+};
+
+/**
+ * Compute the full chart layout.
+ *
+ * Every band is emitted even when empty — a NetClaw with no risk, no members
+ * and no peers is the normal first state for a new operator, not an edge case
+ * (FR-033), and after FR-030 there is nothing else left to draw.
+ *
+ * @param {object} n2n the /api/n2n payload
+ * @param {Array<object>} integrationCatalog from /api/graph integrations[]
+ * @param {number} nowEpochS injected clock
+ * @param {object} [opts]
+ * @returns {{nodes: Array<object>, bands: Array<object>, categories: Array<object>}}
+ */
+export function computeLayout(n2n, integrationCatalog, nowEpochS, opts = {}) {
+  const cfg = { ...LAYOUT, ...opts };
+  const payload = n2n && typeof n2n === 'object' ? n2n : {};
+  const members = Array.isArray(payload.members) ? payload.members : [];
+
+  const nodes = [];
+
+  // ── External band: eN2N peers, north of the boundary (FR-003) ──
+  const peers = disambiguateLabels(dedupePeers(payload.peers));
+  const peerSpan = (peers.length - 1) * cfg.externalSpacingX;
+  peers.forEach(({ entity, label }, i) => {
+    nodes.push({
+      id: entity.identity || `peer-${i}`,
+      kind: 'peer',
+      label,
+      band: 'external',
+      state: entity.state || 'unknown',
+      channelState: entity.channel_state || 'unknown',
+      severed: String(entity.state).toLowerCase() === 'severed',
+      payload: entity,
+      position: { x: -peerSpan / 2 + i * cfg.externalSpacingX, y: cfg.externalY, z: 0 },
+    });
+  });
+
+  // ── Centre: the Border itself (FR-004) ──
+  const risk = payload.risk || null;
+  nodes.push({
+    id: payload.identity || 'border',
+    kind: 'border',
+    label: (risk && risk.risk_name) || payload.identity || 'this claw',
+    band: 'border',
+    isBorder: true,
+    payload: { ...(risk || {}), identity: payload.identity },
+    position: { x: 0, y: cfg.borderY, z: 0 },
+  });
+
+  // ── Edge lane: mobile edges, inside the boundary, outside the chart (FR-007) ──
+  // Wraps into columns rather than stacking onto a final slot, which is the
+  // overflow bug HUD 1.0 shipped with.
+  const edges = members.filter((m) => m && m.node_type === 'edge');
+  edges.forEach((m, i) => {
+    const col = Math.floor(i / Math.max(1, Math.ceil(edges.length / cfg.edgeLaneColumns)));
+    const row = i % Math.max(1, Math.ceil(edges.length / cfg.edgeLaneColumns));
+    nodes.push({
+      id: m.member_id || `edge-${i}`,
+      kind: 'edge',
+      label: resolveLabel(m),
+      band: 'edgeLane',
+      health: classifyHealth(m, nowEpochS),
+      heartbeatAgeS: m.heartbeat_age_s ?? null,
+      toolCount: Array.isArray(m.skills) ? m.skills.length : 0,
+      payload: m,
+      position: {
+        x: cfg.edgeLaneX + col * cfg.edgeLaneSpacingX,
+        y: cfg.borderY + 6 - row * cfg.edgeSpacingY,
+        z: 0,
+      },
+    });
+  });
+
+  // ── Internal band: member claws in derived category columns (FR-005/006) ──
+  const grouped = categorizeMembers(members, integrationCatalog);
+  const ordered = orderCategories(grouped, nowEpochS);
+
+  const categories = [];
+  ordered.forEach((category, index) => {
+    const col = index % cfg.maxColumnsPerRow;
+    const row = Math.floor(index / cfg.maxColumnsPerRow);
+    const rowCount = Math.min(ordered.length - row * cfg.maxColumnsPerRow, cfg.maxColumnsPerRow);
+    const rowSpan = (rowCount - 1) * cfg.columnSpacingX;
+    const x = -rowSpan / 2 + col * cfg.columnSpacingX;
+    const headerY = cfg.internalTopY - row * cfg.rowSpacingY;
+
+    categories.push({ name: category.name, heat: category.heat, column: col, row, position: { x, y: headerY, z: 0 } });
+
+    orderMembers(category.members, nowEpochS, resolveLabel).forEach((m, mi) => {
+      nodes.push({
+        id: m.member_id || `${category.name}-${mi}`,
+        kind: 'member',
+        label: resolveLabel(m),
+        band: 'internal',
+        category: category.name,
+        health: classifyHealth(m, nowEpochS),
+        heartbeatAgeS: m.heartbeat_age_s ?? null,
+        toolCount: Array.isArray(m.skills) ? m.skills.length : 0,
+        tools: Array.isArray(m.skills) ? [...m.skills] : [],
+        expanded: false,
+        payload: m,
+        position: { x, y: headerY + cfg.categoryHeaderOffsetY - mi * cfg.memberSpacingY, z: 0 },
+      });
+    });
+  });
+
+  // ── Bands: always emitted, even when empty (FR-033) ──
+  const bands = [
+    {
+      id: 'external',
+      label: 'External — eN2N',
+      y: cfg.externalY,
+      empty: peers.length === 0,
+      emptyCta: 'No federated peers. Connect one to extend the mesh.',
+    },
+    {
+      id: 'boundary',
+      label: 'Trust boundary',
+      y: cfg.boundaryY,
+      isBoundary: true,
+      empty: false,
+    },
+    {
+      id: 'edgeLane',
+      label: 'Mobile edges',
+      y: cfg.borderY,
+      x: cfg.edgeLaneX,
+      empty: edges.length === 0,
+      emptyCta: 'No devices paired. Enrol a phone to receive pushes.',
+    },
+    {
+      id: 'internal',
+      label: 'Internal — iN2N',
+      y: cfg.internalTopY,
+      empty: ordered.length === 0,
+      emptyCta: 'No members enrolled. Add a claw to delegate work to.',
+    },
+  ];
+
+  return { nodes, bands, categories };
+}
+
+/**
+ * Add a member that enrolled mid-session (FR-034b).
+ *
+ * Appends within its category WITHOUT moving any existing node — position
+ * stability is a hard guarantee, and a member arriving must not shuffle the
+ * chart under an operator who is reading it.
+ *
+ * @param {{nodes:Array<object>, categories:Array<object>}} layout mutated in place
+ * @param {object} member
+ * @param {Array<object>} integrationCatalog
+ * @param {number} nowEpochS
+ * @returns {object|null} the new node, or null if it was already present
+ */
+export function appendMember(layout, member, integrationCatalog, nowEpochS) {
+  if (!layout || !Array.isArray(layout.nodes) || !member) return null;
+  const id = member.member_id;
+  if (id && layout.nodes.some((n) => n.id === id)) return null;
+
+  const cfg = LAYOUT;
+
+  if (member.node_type === 'edge') {
+    const existing = layout.nodes.filter((n) => n.kind === 'edge');
+    const node = {
+      id: id || `edge-${existing.length}`,
+      kind: 'edge',
+      label: resolveLabel(member),
+      band: 'edgeLane',
+      health: classifyHealth(member, nowEpochS),
+      heartbeatAgeS: member.heartbeat_age_s ?? null,
+      toolCount: Array.isArray(member.skills) ? member.skills.length : 0,
+      payload: member,
+      position: {
+        x: cfg.edgeLaneX + Math.floor(existing.length / 8) * cfg.edgeLaneSpacingX,
+        y: cfg.borderY + 6 - (existing.length % 8) * cfg.edgeSpacingY,
+        z: 0,
+      },
+    };
+    layout.nodes.push(node);
+    return node;
+  }
+
+  const [categoryName] = [...categorizeMembers([member], integrationCatalog).keys()];
+  const category = (layout.categories || []).find((c) => c.name === categoryName);
+  const siblings = layout.nodes.filter((n) => n.kind === 'member' && n.category === categoryName);
+
+  // An unseen category appends to the right of the last column rather than
+  // re-packing rows — again, nothing existing may move.
+  const anchor = category
+    ? category.position
+    : { x: (Math.max(0, ...(layout.categories || []).map((c) => c.position.x)) || 0) + cfg.columnSpacingX, y: cfg.internalTopY };
+
+  if (!category) {
+    (layout.categories ||= []).push({
+      name: categoryName, heat: 0, column: -1, row: 0, position: { ...anchor, z: 0 },
+    });
+  }
+
+  const node = {
+    id: id || `${categoryName}-${siblings.length}`,
+    kind: 'member',
+    label: resolveLabel(member),
+    band: 'internal',
+    category: categoryName,
+    health: classifyHealth(member, nowEpochS),
+    heartbeatAgeS: member.heartbeat_age_s ?? null,
+    toolCount: Array.isArray(member.skills) ? member.skills.length : 0,
+    tools: Array.isArray(member.skills) ? [...member.skills] : [],
+    expanded: false,
+    payload: member,
+    position: {
+      x: anchor.x,
+      y: anchor.y + cfg.categoryHeaderOffsetY - siblings.length * cfg.memberSpacingY,
+      z: 0,
+    },
+  };
+  layout.nodes.push(node);
+  return node;
+}

--- a/ui/netclaw-visual/src/orgchart/layout.js
+++ b/ui/netclaw-visual/src/orgchart/layout.js
@@ -33,18 +33,26 @@ import { categorizeMembers } from './categorize.js';
 export const LAYOUT = {
   boundaryY: 18,
   externalY: 40,
-  externalSpacingX: 26,
+  externalSpacingX: 34,
   borderY: 0,
-  internalTopY: -18,
-  columnSpacingX: 22,
-  memberSpacingY: 9,
-  categoryHeaderOffsetY: -6,
-  rowSpacingY: 64,
-  edgeLaneX: 46,
-  edgeSpacingY: 10,
+  internalTopY: -20,
+  // The internal band fans WIDE. Members are the bulk of the chart and the
+  // thing an operator scans, so they get horizontal room rather than being
+  // packed into a narrow column stack under the Border. Wide + shallow beats
+  // narrow + deep for scanning: the eye moves along a row far faster than it
+  // walks down a column, and the orthographic camera auto-frames whatever
+  // extent this produces (camera.frameChart).
+  columnSpacingX: 38,
+  memberSpacingY: 8,
+  categoryHeaderOffsetY: -7,
+  rowSpacingY: 58,
+  // Wide cap so a typical deployment lays out in a SINGLE row — the widest,
+  // cleanest fan. Rows are balanced when wrapping is unavoidable.
+  maxColumnsPerRow: 20,
+  edgeLaneX: 96,          // floor only; the real X is derived from the fan extent
+  edgeSpacingY: 11,
   edgeLaneColumns: 2,
-  edgeLaneSpacingX: 16,
-  maxColumnsPerRow: 8,
+  edgeLaneSpacingX: 18,
 };
 
 /**
@@ -96,39 +104,22 @@ export function computeLayout(n2n, integrationCatalog, nowEpochS, opts = {}) {
     position: { x: 0, y: cfg.borderY, z: 0 },
   });
 
-  // ── Edge lane: mobile edges, inside the boundary, outside the chart (FR-007) ──
-  // Wraps into columns rather than stacking onto a final slot, which is the
-  // overflow bug HUD 1.0 shipped with.
-  const edges = members.filter((m) => m && m.node_type === 'edge');
-  edges.forEach((m, i) => {
-    const col = Math.floor(i / Math.max(1, Math.ceil(edges.length / cfg.edgeLaneColumns)));
-    const row = i % Math.max(1, Math.ceil(edges.length / cfg.edgeLaneColumns));
-    nodes.push({
-      id: m.member_id || `edge-${i}`,
-      kind: 'edge',
-      label: resolveLabel(m),
-      band: 'edgeLane',
-      health: classifyHealth(m, nowEpochS),
-      heartbeatAgeS: m.heartbeat_age_s ?? null,
-      toolCount: Array.isArray(m.skills) ? m.skills.length : 0,
-      payload: m,
-      position: {
-        x: cfg.edgeLaneX + col * cfg.edgeLaneSpacingX,
-        y: cfg.borderY + 6 - row * cfg.edgeSpacingY,
-        z: 0,
-      },
-    });
-  });
-
   // ── Internal band: member claws in derived category columns (FR-005/006) ──
   const grouped = categorizeMembers(members, integrationCatalog);
   const ordered = orderCategories(grouped, nowEpochS);
 
+  // Balance columns across rows rather than filling each to the cap. With 15
+  // categories and a cap of 14 the naive split is 14 + 1, which looks broken;
+  // balancing gives 8 + 7. Rows are still driven by the cap, so wide-and-
+  // shallow is preserved.
+  const rowsNeeded = Math.max(1, Math.ceil(ordered.length / cfg.maxColumnsPerRow));
+  const perRow = Math.max(1, Math.ceil(ordered.length / rowsNeeded));
+
   const categories = [];
   ordered.forEach((category, index) => {
-    const col = index % cfg.maxColumnsPerRow;
-    const row = Math.floor(index / cfg.maxColumnsPerRow);
-    const rowCount = Math.min(ordered.length - row * cfg.maxColumnsPerRow, cfg.maxColumnsPerRow);
+    const col = index % perRow;
+    const row = Math.floor(index / perRow);
+    const rowCount = Math.min(ordered.length - row * perRow, perRow);
     const rowSpan = (rowCount - 1) * cfg.columnSpacingX;
     const x = -rowSpan / 2 + col * cfg.columnSpacingX;
     const headerY = cfg.internalTopY - row * cfg.rowSpacingY;
@@ -153,6 +144,38 @@ export function computeLayout(n2n, integrationCatalog, nowEpochS, opts = {}) {
     });
   });
 
+  // ── Edge lane: mobile edges, inside the boundary, outside the chart (FR-007) ──
+  // Placed AFTER the member columns so the lane can clear whatever width the
+  // fan turned out to be. A fixed X would collide once the internal band was
+  // widened — which is exactly what happened, and what the FR-007 test caught.
+  const memberXs = nodes.filter((n) => n.kind === 'member').map((n) => n.position.x);
+  const fanRight = memberXs.length ? Math.max(...memberXs) : 0;
+  const laneX = Math.max(cfg.edgeLaneX, fanRight + cfg.columnSpacingX);
+
+  const edges = members.filter((m) => m && m.node_type === 'edge');
+  const perCol = Math.max(1, Math.ceil(edges.length / cfg.edgeLaneColumns));
+  edges.forEach((m, i) => {
+    const col = Math.floor(i / perCol);
+    const row = i % perCol;
+    nodes.push({
+      id: m.member_id || `edge-${i}`,
+      kind: 'edge',
+      label: resolveLabel(m),
+      band: 'edgeLane',
+      health: classifyHealth(m, nowEpochS),
+      heartbeatAgeS: m.heartbeat_age_s ?? null,
+      toolCount: Array.isArray(m.skills) ? m.skills.length : 0,
+      tools: Array.isArray(m.skills) ? [...m.skills] : [],
+      expanded: false,
+      payload: m,
+      position: {
+        x: laneX + col * cfg.edgeLaneSpacingX,
+        y: cfg.borderY + 6 - row * cfg.edgeSpacingY,
+        z: 0,
+      },
+    });
+  });
+
   // ── Bands: always emitted, even when empty (FR-033) ──
   const bands = [
     {
@@ -173,7 +196,7 @@ export function computeLayout(n2n, integrationCatalog, nowEpochS, opts = {}) {
       id: 'edgeLane',
       label: 'Mobile edges',
       y: cfg.borderY,
-      x: cfg.edgeLaneX,
+      x: laneX,
       empty: edges.length === 0,
       emptyCta: 'No devices paired. Enrol a phone to receive pushes.',
     },

--- a/ui/netclaw-visual/src/orgchart/layout.test.js
+++ b/ui/netclaw-visual/src/orgchart/layout.test.js
@@ -1,0 +1,202 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { computeLayout, appendMember, LAYOUT } from './layout.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = resolve(HERE, '../../../../specs/072-hud-2-org-chart/fixtures');
+const load = (n) => JSON.parse(readFileSync(resolve(FIXTURES, n), 'utf8'));
+
+const catalog = load('integration-catalog.json');
+const NOW = 1_785_000_000;
+const FIXTURE_NAMES = ['empty.json', 'single.json', 'live-29.json', 'scale-100.json', 'uncategorised.json'];
+
+const key = (p) => `${p.x.toFixed(4)},${p.y.toFixed(4)},${p.z.toFixed(4)}`;
+
+for (const name of FIXTURE_NAMES) {
+  test(`[${name}] no two nodes share a position (SC-004)`, () => {
+    const { nodes } = computeLayout(load(name), catalog, NOW);
+    const seen = new Map();
+    for (const n of nodes) {
+      const k = key(n.position);
+      assert.ok(!seen.has(k), `${n.id} overlaps ${seen.get(k)} at ${k}`);
+      seen.set(k, n.id);
+    }
+  });
+
+  test(`[${name}] every node has a non-empty label (FR-015)`, () => {
+    const { nodes } = computeLayout(load(name), catalog, NOW);
+    for (const n of nodes) {
+      assert.ok(typeof n.label === 'string' && n.label.length > 0, `${n.id} has a blank label`);
+    }
+  });
+
+  test(`[${name}] all four bands exist regardless of data (FR-033)`, () => {
+    const { bands } = computeLayout(load(name), catalog, NOW);
+    assert.deepEqual(bands.map((b) => b.id), ['external', 'boundary', 'edgeLane', 'internal']);
+    assert.ok(bands.find((b) => b.isBoundary), 'the trust boundary is always drawn (FR-002)');
+  });
+
+  test(`[${name}] layout is deterministic`, () => {
+    const a = computeLayout(load(name), catalog, NOW);
+    const b = computeLayout(load(name), catalog, NOW);
+    assert.deepEqual(a.nodes.map((n) => [n.id, key(n.position)]), b.nodes.map((n) => [n.id, key(n.position)]));
+  });
+}
+
+test('empty install renders structure and CTAs, not a void (FR-033a)', () => {
+  const { nodes, bands } = computeLayout(load('empty.json'), catalog, NOW);
+  assert.equal(nodes.filter((n) => n.kind === 'member').length, 0);
+  assert.equal(nodes.filter((n) => n.kind === 'border').length, 1, 'the Border still renders');
+  for (const id of ['external', 'edgeLane', 'internal']) {
+    const band = bands.find((b) => b.id === id);
+    assert.equal(band.empty, true);
+    assert.ok(band.emptyCta && band.emptyCta.length > 0, `${id} needs a CTA`);
+  }
+});
+
+test('a non-Border install still renders the structure (FR-033b)', () => {
+  const payload = { ...load('live-29.json'), risk: { role: 'member', risk_name: 'not-a-border' } };
+  const { nodes, bands } = computeLayout(payload, catalog, NOW);
+  assert.equal(bands.length, 4);
+  assert.ok(nodes.length > 1, 'must not early-return to an empty scene');
+});
+
+test('external band sits above the boundary, internal below (FR-001/002)', () => {
+  const { nodes, bands } = computeLayout(load('live-29.json'), catalog, NOW);
+  const boundaryY = bands.find((b) => b.isBoundary).y;
+
+  for (const n of nodes.filter((x) => x.kind === 'peer')) {
+    assert.ok(n.position.y > boundaryY, `peer ${n.id} must be north of the boundary`);
+  }
+  for (const n of nodes.filter((x) => x.kind === 'member')) {
+    assert.ok(n.position.y < boundaryY, `member ${n.id} must be south of the boundary`);
+  }
+  const border = nodes.find((n) => n.kind === 'border');
+  assert.ok(border.position.y < boundaryY, 'the Border is inside its own boundary');
+});
+
+test('edge nodes go to the edge lane, never a member column (FR-007)', () => {
+  const { nodes } = computeLayout(load('live-29.json'), catalog, NOW);
+  const edges = nodes.filter((n) => n.kind === 'edge');
+  assert.equal(edges.length, 2, 'both enrolled phones are placed');
+
+  for (const e of edges) {
+    assert.equal(e.band, 'edgeLane');
+    assert.ok(e.position.x >= LAYOUT.edgeLaneX, 'edge lane is offset from the chart');
+    assert.equal(e.category, undefined, 'an edge is never categorised');
+  }
+  const memberXs = new Set(nodes.filter((n) => n.kind === 'member').map((n) => n.position.x));
+  for (const e of edges) assert.ok(!memberXs.has(e.position.x), 'edge must not sit in a member column');
+});
+
+test('edge lane wraps instead of stacking — the HUD 1.0 overflow bug (spec Edge Cases)', () => {
+  const many = {
+    identity: 'as1-1.1.1.1',
+    peers: [],
+    risk: { risk_name: 'r' },
+    members: Array.from({ length: 9 }, (_, i) => ({
+      member_id: `r/phone-${i}`, display_name: `phone-${i}`, node_type: 'edge',
+      live: false, state: 'unreachable',
+    })),
+  };
+  const { nodes } = computeLayout(many, catalog, NOW);
+  const edges = nodes.filter((n) => n.kind === 'edge');
+  assert.equal(edges.length, 9);
+
+  const positions = new Set(edges.map((e) => key(e.position)));
+  assert.equal(positions.size, 9, 'nine phones must occupy nine distinct positions');
+  assert.ok(new Set(edges.map((e) => e.position.x)).size > 1, 'lane must wrap into columns');
+});
+
+test('appendMember leaves every existing coordinate byte-identical (FR-034b)', () => {
+  const layout = computeLayout(load('live-29.json'), catalog, NOW);
+  const before = layout.nodes.map((n) => [n.id, key(n.position)]);
+
+  const added = appendMember(
+    layout,
+    { member_id: 'johns-risk/newcomer', display_name: 'newcomer', live: true, skills: ['pyats-health-check'] },
+    catalog,
+    NOW,
+  );
+
+  assert.ok(added, 'a node was added');
+  const after = layout.nodes.map((n) => [n.id, key(n.position)]);
+  assert.deepEqual(after.slice(0, before.length), before, 'no existing node moved');
+  assert.equal(after.length, before.length + 1);
+});
+
+test('appendMember does not duplicate an existing member', () => {
+  const layout = computeLayout(load('live-29.json'), catalog, NOW);
+  const existing = layout.nodes.find((n) => n.kind === 'member');
+  const n = layout.nodes.length;
+  assert.equal(appendMember(layout, { member_id: existing.id }, catalog, NOW), null);
+  assert.equal(layout.nodes.length, n);
+});
+
+test('appendMember places an edge node in the lane, not a column', () => {
+  const layout = computeLayout(load('live-29.json'), catalog, NOW);
+  const node = appendMember(
+    layout, { member_id: 'risk/phone-new', node_type: 'edge', live: true }, catalog, NOW,
+  );
+  assert.equal(node.kind, 'edge');
+  assert.equal(node.band, 'edgeLane');
+  assert.ok(node.position.x >= LAYOUT.edgeLaneX);
+});
+
+test('appendMember into an unseen category does not re-pack existing rows', () => {
+  const layout = computeLayout(load('live-29.json'), catalog, NOW);
+  const before = layout.nodes.map((n) => key(n.position));
+  appendMember(
+    layout,
+    { member_id: 'r/exotic', display_name: 'exotic', skills: ['zzz-unknown-prefix'] },
+    [{ id: 'z', category: 'Brand New Category', prefixes: ['zzz-'] }],
+    NOW,
+  );
+  assert.deepEqual(layout.nodes.slice(0, before.length).map((n) => key(n.position)), before);
+});
+
+test('scale fixture places 100+ members without collision (FR-029)', () => {
+  const { nodes, categories } = computeLayout(load('scale-100.json'), catalog, NOW);
+  const members = nodes.filter((n) => n.kind === 'member');
+  assert.ok(members.length >= 100, `expected >=100 members, got ${members.length}`);
+  assert.equal(new Set(nodes.map((n) => key(n.position))).size, nodes.length, 'no overlap at the ceiling');
+  assert.ok(categories.length > 1, 'categories are laid out');
+});
+
+test('categories wrap into rows past maxColumnsPerRow', () => {
+  const { categories } = computeLayout(load('scale-100.json'), catalog, NOW);
+  if (categories.length > LAYOUT.maxColumnsPerRow) {
+    assert.ok(categories.some((c) => c.row > 0), 'must wrap rather than run off-screen');
+    const rows = new Set(categories.map((c) => c.row));
+    assert.ok(rows.size > 1);
+  }
+});
+
+test('members carry their tools and a tool count for collapsed display (FR-021/024)', () => {
+  const { nodes } = computeLayout(load('live-29.json'), catalog, NOW);
+  const withTools = nodes.filter((n) => n.kind === 'member' && n.toolCount > 0);
+  assert.ok(withTools.length > 0);
+  for (const n of withTools) {
+    assert.equal(n.toolCount, n.tools.length);
+    assert.equal(n.expanded, false, 'collapsed is the default (FR-020)');
+  }
+});
+
+test('computeLayout is total on junk input', () => {
+  for (const junk of [null, undefined, {}, { members: 'nope', peers: 42 }]) {
+    const out = computeLayout(junk, catalog, NOW);
+    assert.equal(out.bands.length, 4, 'bands always render');
+    assert.ok(Array.isArray(out.nodes));
+  }
+});
+
+test('computeLayout does not mutate the payload', () => {
+  const payload = load('live-29.json');
+  const before = JSON.stringify(payload);
+  computeLayout(payload, catalog, NOW);
+  assert.equal(JSON.stringify(payload), before);
+});

--- a/ui/netclaw-visual/src/orgchart/normalize.js
+++ b/ui/netclaw-visual/src/orgchart/normalize.js
@@ -1,0 +1,125 @@
+/**
+ * Peer de-duplication and label resolution.
+ *
+ * Pure: imports nothing, touches no DOM, no clock, no randomness.
+ * See specs/072-hud-2-org-chart/contracts/layout-contract.md.
+ *
+ * FR-014 — de-duplicate peers by identity, and disambiguate peers that share a
+ * display name.
+ *
+ * The spec originally assumed the live feed returned one peer twice with
+ * conflicting states. Implementation showed otherwise: the two "Hermes" rows
+ * carry *different* identities (as65007-8.8.8.8 and as65008-8.8.8.8) — the same
+ * router-id re-enrolled under a new AS, leaving the old severed entry behind.
+ * They are genuinely two peers, so dedup-by-identity correctly keeps both, and
+ * the real defect is that they render as two indistinguishable "Hermes" nodes.
+ * Hence two functions: dedupePeers guards against true duplicates, and
+ * disambiguateLabels makes same-named distinct peers tellable apart.
+ *
+ * FR-015 — both enrolled edge nodes carry `display_name: null`; without a
+ * fallback they render as blank labels.
+ */
+
+/**
+ * Peer connection states, most restrictive first. A peer reported in two
+ * states is shown in the more restrictive one: claiming a severed peer is
+ * federated is the dangerous direction of the error, so ties resolve toward
+ * the pessimistic reading.
+ */
+const STATE_RESTRICTIVENESS = ['severed', 'quarantined', 'unreachable', 'reconnecting', 'federated'];
+
+function restrictiveness(state) {
+  const i = STATE_RESTRICTIVENESS.indexOf(String(state || '').toLowerCase());
+  // Unknown states sort as least restrictive but still lose to any known one.
+  return i === -1 ? STATE_RESTRICTIVENESS.length : i;
+}
+
+/**
+ * Collapse peers sharing an `identity` into one entry (FR-014).
+ * Preserves first-seen order; the surviving entry keeps the most restrictive
+ * `state` seen across duplicates.
+ *
+ * @param {Array<object>} peers
+ * @returns {Array<object>} new array, inputs not mutated
+ */
+export function dedupePeers(peers) {
+  if (!Array.isArray(peers)) return [];
+
+  /** @type {Map<string, object>} */
+  const byIdentity = new Map();
+
+  for (const peer of peers) {
+    if (!peer || typeof peer !== 'object') continue;
+    const key = peer.identity || peer.display_name || JSON.stringify(peer);
+    const existing = byIdentity.get(key);
+
+    if (!existing) {
+      byIdentity.set(key, { ...peer });
+      continue;
+    }
+    // Same peer seen twice — keep the more restrictive state.
+    if (restrictiveness(peer.state) < restrictiveness(existing.state)) {
+      byIdentity.set(key, { ...existing, state: peer.state });
+    }
+  }
+
+  return [...byIdentity.values()];
+}
+
+/**
+ * Resolve a never-empty display label (FR-015).
+ *
+ * Precedence: display_name -> tail of member_id after "/" -> identity ->
+ * "unknown". Total: never throws, never returns "".
+ *
+ * @param {object} entity a peer or member
+ * @returns {string}
+ */
+export function resolveLabel(entity) {
+  if (!entity || typeof entity !== 'object') return 'unknown';
+
+  const name = typeof entity.display_name === 'string' ? entity.display_name.trim() : '';
+  if (name) return name;
+
+  const memberId = typeof entity.member_id === 'string' ? entity.member_id.trim() : '';
+  if (memberId) {
+    const tail = memberId.split('/').pop().trim();
+    if (tail) return tail;
+  }
+
+  const identity = typeof entity.identity === 'string' ? entity.identity.trim() : '';
+  if (identity) return identity;
+
+  return 'unknown';
+}
+
+/**
+ * Make same-named entities tellable apart (FR-014).
+ *
+ * Two distinct peers legitimately sharing a display name (a claw re-enrolled
+ * under a new AS, leaving the old entry severed) would otherwise render as two
+ * identical labels. Entities whose label is already unique are returned
+ * untouched — disambiguation must not add noise to the common case.
+ *
+ * @param {Array<object>} entities peers and/or members
+ * @returns {Array<{entity: object, label: string}>} same order as input
+ */
+export function disambiguateLabels(entities) {
+  if (!Array.isArray(entities)) return [];
+
+  const resolved = entities
+    .filter((e) => e && typeof e === 'object')
+    .map((entity) => ({ entity, label: resolveLabel(entity) }));
+
+  const counts = new Map();
+  for (const { label } of resolved) counts.set(label, (counts.get(label) || 0) + 1);
+
+  return resolved.map(({ entity, label }) => {
+    if (counts.get(label) === 1) return { entity, label };
+
+    // Collision. Qualify with whatever distinguishes them, shortest first.
+    const identity = typeof entity.identity === 'string' ? entity.identity : '';
+    const qualifier = identity.split('-')[0] || identity || entity.member_id || '';
+    return { entity, label: qualifier ? `${label} (${qualifier})` : label };
+  });
+}

--- a/ui/netclaw-visual/src/orgchart/normalize.test.js
+++ b/ui/netclaw-visual/src/orgchart/normalize.test.js
@@ -1,0 +1,97 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { dedupePeers, resolveLabel, disambiguateLabels } from './normalize.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = resolve(HERE, '../../../../specs/072-hud-2-org-chart/fixtures');
+const live = JSON.parse(readFileSync(resolve(FIXTURES, 'live-29.json'), 'utf8'));
+
+test('the two Hermes peers are distinct identities, not a duplicate record (FR-014)', () => {
+  // Implementation finding: the spec assumed one peer reported twice. In fact
+  // these are two different AS numbers sharing a router-id and a display name —
+  // Hermes re-enrolled, leaving the old severed entry behind.
+  const hermes = live.peers.filter((p) => p.display_name === 'Hermes');
+  assert.equal(hermes.length, 2);
+  assert.notEqual(hermes[0].identity, hermes[1].identity, 'distinct identities');
+  assert.deepEqual(hermes.map((p) => p.state).sort(), ['federated', 'severed']);
+
+  // Both must therefore survive dedup — they are real, separate peers.
+  const deduped = dedupePeers(live.peers);
+  assert.equal(deduped.filter((p) => p.display_name === 'Hermes').length, 2);
+});
+
+test('dedupePeers collapses a genuine duplicate identity, most restrictive state wins', () => {
+  const dupe = [
+    { identity: 'as1-1.1.1.1', display_name: 'X', state: 'federated' },
+    { identity: 'as1-1.1.1.1', display_name: 'X', state: 'severed' },
+  ];
+  const out = dedupePeers(dupe);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].state, 'severed');
+});
+
+test('disambiguateLabels makes the two Hermes peers tellable apart (FR-014)', () => {
+  const labelled = disambiguateLabels(dedupePeers(live.peers));
+  const hermes = labelled.filter((l) => l.label.startsWith('Hermes'));
+  assert.equal(hermes.length, 2);
+  assert.notEqual(hermes[0].label, hermes[1].label, 'same-named peers must differ');
+  for (const h of hermes) assert.match(h.label, /^Hermes \(as\d+\)$/);
+});
+
+test('disambiguateLabels leaves already-unique labels untouched', () => {
+  const labelled = disambiguateLabels(dedupePeers(live.peers));
+  const ab = labelled.find((l) => l.entity.display_name === 'AB');
+  assert.equal(ab.label, 'AB', 'no qualifier on a unique name');
+});
+
+test('dedupePeers preserves distinct peers and first-seen order', () => {
+  const deduped = dedupePeers(live.peers);
+  const identities = deduped.map((p) => p.identity);
+  assert.equal(new Set(identities).size, identities.length, 'no duplicate identities remain');
+  assert.equal(deduped.length, live.peers.length, 'live fixture has no true identity duplicates');
+});
+
+test('dedupePeers does not mutate its input', () => {
+  const before = JSON.stringify(live.peers);
+  dedupePeers(live.peers);
+  assert.equal(JSON.stringify(live.peers), before);
+});
+
+test('dedupePeers is total on junk input', () => {
+  assert.deepEqual(dedupePeers(null), []);
+  assert.deepEqual(dedupePeers(undefined), []);
+  assert.deepEqual(dedupePeers([]), []);
+  assert.equal(dedupePeers([null, undefined, 42]).length, 0);
+});
+
+test('both real edge nodes with display_name:null resolve to non-empty labels (FR-015)', () => {
+  const edges = live.members.filter((m) => m.node_type === 'edge');
+  assert.equal(edges.length, 2, 'fixture should contain 2 edge nodes');
+
+  for (const edge of edges) {
+    assert.equal(edge.display_name, null, 'fixture edge should have a null display_name');
+    const label = resolveLabel(edge);
+    assert.ok(label.length > 0, 'label must never be empty');
+    assert.notEqual(label, 'unknown', 'member_id tail should be used, not the last-resort default');
+    assert.ok(!label.includes('/'), 'label should be the tail, not the full member_id');
+  }
+});
+
+test('resolveLabel precedence: display_name > member_id tail > identity > unknown', () => {
+  assert.equal(resolveLabel({ display_name: 'pyats', member_id: 'r/x', identity: 'i' }), 'pyats');
+  assert.equal(resolveLabel({ display_name: null, member_id: 'johns-risk/cml' }), 'cml');
+  assert.equal(resolveLabel({ display_name: '   ', member_id: 'johns-risk/viz' }), 'viz');
+  assert.equal(resolveLabel({ identity: 'as65003-3.3.3.3' }), 'as65003-3.3.3.3');
+  assert.equal(resolveLabel({}), 'unknown');
+  assert.equal(resolveLabel(null), 'unknown');
+});
+
+test('every member and peer in the live fixture gets a non-empty label', () => {
+  for (const entity of [...live.members, ...dedupePeers(live.peers)]) {
+    assert.ok(resolveLabel(entity).length > 0);
+  }
+});

--- a/ui/netclaw-visual/src/orgchart/ordering.js
+++ b/ui/netclaw-visual/src/orgchart/ordering.js
@@ -1,0 +1,84 @@
+/**
+ * Category ordering (FR-006b, FR-034).
+ *
+ * Pure and deterministic: same input, same order, every time.
+ *
+ * Heat first, then size, then name. Heat ordering earns its place only on
+ * arrival, when the operator has no spatial memory yet and the few live claws
+ * should be where the eye lands. Afterwards it works against them — which is
+ * why FR-034 requires this to be computed ONCE per session and never from the
+ * poll path. A claw that fails changes how it looks, never where it is.
+ */
+
+import { classifyHealth, HOT } from './health.js';
+
+export const UNCATEGORISED = 'Uncategorised';
+
+/**
+ * Count HOT members in a group — the "heat" that drives ordering.
+ *
+ * @param {Array<object>} members
+ * @param {number} nowEpochS
+ * @returns {number}
+ */
+export function categoryHeat(members, nowEpochS) {
+  if (!Array.isArray(members)) return 0;
+  return members.reduce((n, m) => n + (classifyHealth(m, nowEpochS) === HOT ? 1 : 0), 0);
+}
+
+/**
+ * Order categories for layout.
+ *
+ * Rules, in order:
+ *   1. `Uncategorised` always sorts last, whatever its heat. It is a residue
+ *      bucket, not a peer of the real categories — even when it contains a hot
+ *      member, which it does on the reference Border (`ipfabric`).
+ *   2. More HOT members first.
+ *   3. Larger groups first.
+ *   4. Name, ascending — the final tiebreak, so the result is deterministic.
+ *
+ * @param {Map<string, Array<object>>|Array<[string, Array<object>]>} categories
+ * @param {number} nowEpochS
+ * @returns {Array<{name: string, members: Array<object>, heat: number}>}
+ */
+export function orderCategories(categories, nowEpochS) {
+  const entries = categories instanceof Map ? [...categories.entries()] : Array.isArray(categories) ? categories : [];
+
+  return entries
+    .filter((e) => Array.isArray(e) && typeof e[0] === 'string')
+    .map(([name, members]) => ({
+      name,
+      members: Array.isArray(members) ? members : [],
+      heat: categoryHeat(members, nowEpochS),
+    }))
+    .sort((a, b) => {
+      const aResidue = a.name === UNCATEGORISED;
+      const bResidue = b.name === UNCATEGORISED;
+      if (aResidue !== bResidue) return aResidue ? 1 : -1;
+
+      if (b.heat !== a.heat) return b.heat - a.heat;
+      if (b.members.length !== a.members.length) return b.members.length - a.members.length;
+      return a.name.localeCompare(b.name);
+    });
+}
+
+/**
+ * Order members within a category: HOT first, then FAULT (so a dead claw is
+ * near the top of its column rather than buried), then WARM, then COLD; name
+ * ascending within each state.
+ *
+ * @param {Array<object>} members
+ * @param {number} nowEpochS
+ * @param {(m: object) => string} labelOf
+ * @returns {Array<object>} new array
+ */
+export function orderMembers(members, nowEpochS, labelOf = (m) => m.display_name || m.member_id || '') {
+  const RANK = { HOT: 0, FAULT: 1, WARM: 2, COLD: 3 };
+  if (!Array.isArray(members)) return [];
+  return [...members].sort((a, b) => {
+    const ra = RANK[classifyHealth(a, nowEpochS)];
+    const rb = RANK[classifyHealth(b, nowEpochS)];
+    if (ra !== rb) return ra - rb;
+    return String(labelOf(a)).localeCompare(String(labelOf(b)));
+  });
+}

--- a/ui/netclaw-visual/src/orgchart/ordering.js
+++ b/ui/netclaw-visual/src/orgchart/ordering.js
@@ -32,7 +32,8 @@ export function categoryHeat(members, nowEpochS) {
  * Rules, in order:
  *   1. `Uncategorised` always sorts last, whatever its heat. It is a residue
  *      bucket, not a peer of the real categories — even when it contains a hot
- *      member, which it does on the reference Border (`ipfabric`).
+ *      member — which happens whenever a live claw's skills match no
+ *      integration prefix.
  *   2. More HOT members first.
  *   3. Larger groups first.
  *   4. Name, ascending — the final tiebreak, so the result is deterministic.

--- a/ui/netclaw-visual/src/orgchart/ordering.test.js
+++ b/ui/netclaw-visual/src/orgchart/ordering.test.js
@@ -1,0 +1,124 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { orderCategories, orderMembers, categoryHeat, UNCATEGORISED } from './ordering.js';
+import { categorizeMembers } from './categorize.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = resolve(HERE, '../../../../specs/072-hud-2-org-chart/fixtures');
+const load = (n) => JSON.parse(readFileSync(resolve(FIXTURES, n), 'utf8'));
+
+const live = load('live-29.json');
+const catalog = load('integration-catalog.json');
+const NOW = 1_785_000_000;
+
+const hot = (id) => ({ member_id: id, display_name: id, live: true });
+const cold = (id) => ({ member_id: id, display_name: id, live: false, state: 'provisioned' });
+
+test('categories containing a live member lead (FR-006b)', () => {
+  const ordered = orderCategories(
+    new Map([
+      ['Cold Group', [cold('a'), cold('b'), cold('c')]],
+      ['Hot Group', [hot('x')]],
+    ]),
+    NOW,
+  );
+  assert.equal(ordered[0].name, 'Hot Group', 'heat beats size');
+});
+
+test('equal heat falls back to size', () => {
+  const ordered = orderCategories(
+    new Map([
+      ['Small', [cold('a')]],
+      ['Large', [cold('b'), cold('c'), cold('d')]],
+    ]),
+    NOW,
+  );
+  assert.equal(ordered[0].name, 'Large');
+});
+
+test('equal heat and size falls back to name, deterministically', () => {
+  const input = new Map([
+    ['Zulu', [cold('a')]],
+    ['Alpha', [cold('b')]],
+  ]);
+  const first = orderCategories(input, NOW).map((c) => c.name);
+  const second = orderCategories(input, NOW).map((c) => c.name);
+  assert.deepEqual(first, ['Alpha', 'Zulu']);
+  assert.deepEqual(first, second, 'repeat runs must agree');
+});
+
+test('Uncategorised sorts last even when it holds a HOT member', () => {
+  // True of the reference Border: ipfabric is live but uncategorised.
+  const ordered = orderCategories(
+    new Map([
+      [UNCATEGORISED, [hot('ipfabric'), hot('forward')]],
+      ['Labs', [cold('cml')]],
+    ]),
+    NOW,
+  );
+  assert.equal(ordered.at(-1).name, UNCATEGORISED, 'residue bucket is always last');
+  assert.ok(ordered.at(-1).heat > 0, 'even though it is the hottest group');
+});
+
+test('ordering the real Border puts hot groups first and Uncategorised last', () => {
+  const grouped = categorizeMembers(live.members, catalog);
+  const ordered = orderCategories(grouped, NOW);
+
+  assert.ok(ordered.length > 5, 'the real Border yields many categories');
+  assert.equal(ordered.at(-1).name, UNCATEGORISED);
+
+  const realGroups = ordered.filter((c) => c.name !== UNCATEGORISED);
+  const firstZeroHeat = realGroups.findIndex((c) => c.heat === 0);
+  if (firstZeroHeat !== -1) {
+    const after = realGroups.slice(firstZeroHeat);
+    assert.ok(after.every((c) => c.heat === 0), 'no hot group may appear after a cold one');
+  }
+});
+
+test('every member survives ordering — nothing dropped', () => {
+  const grouped = categorizeMembers(live.members, catalog);
+  const before = [...grouped.values()].flat().length;
+  const after = orderCategories(grouped, NOW).reduce((n, c) => n + c.members.length, 0);
+  assert.equal(after, before);
+});
+
+test('orderCategories is total on junk input', () => {
+  assert.deepEqual(orderCategories(null, NOW), []);
+  assert.deepEqual(orderCategories(undefined, NOW), []);
+  assert.deepEqual(orderCategories(new Map(), NOW), []);
+  assert.equal(orderCategories([['A', null]], NOW)[0].members.length, 0);
+});
+
+test('categoryHeat counts only HOT members', () => {
+  assert.equal(categoryHeat([hot('a'), cold('b'), hot('c')], NOW), 2);
+  assert.equal(categoryHeat([], NOW), 0);
+  assert.equal(categoryHeat(null, NOW), 0);
+});
+
+test('within a category: HOT, then FAULT, then WARM, then COLD', () => {
+  const members = [
+    cold('d-cold'),
+    { member_id: 'b-warm', display_name: 'b-warm', live: false, heartbeat_age_s: 10 },
+    hot('a-hot'),
+    { member_id: 'c-fault', display_name: 'c-fault', live: false, state: 'unreachable' },
+  ];
+  const ordered = orderMembers(members, NOW).map((m) => m.display_name);
+  assert.deepEqual(ordered, ['a-hot', 'c-fault', 'b-warm', 'd-cold']);
+});
+
+test('FAULT ranks above WARM so a dead claw is not buried in its column', () => {
+  const fault = { member_id: 'f', display_name: 'f', live: false, state: 'unreachable' };
+  const warm = { member_id: 'w', display_name: 'w', live: false, heartbeat_age_s: 5 };
+  assert.deepEqual(orderMembers([warm, fault], NOW).map((m) => m.display_name), ['f', 'w']);
+});
+
+test('orderMembers does not mutate its input', () => {
+  const members = [cold('b'), hot('a')];
+  const snapshot = JSON.stringify(members);
+  orderMembers(members, NOW);
+  assert.equal(JSON.stringify(members), snapshot);
+});

--- a/ui/netclaw-visual/src/styles.css
+++ b/ui/netclaw-visual/src/styles.css
@@ -1220,10 +1220,10 @@ input {
 .legend-list { list-style: none; margin: 0; padding: 0; font-size: 11px; line-height: 1.9; }
 .legend-list b { font-weight: 600; }
 .legend-swatch { display: inline-block; width: 1.1em; text-align: center; margin-right: 4px; }
-.legend-hot   { color: #37d67a; }
-.legend-warm  { color: #6fa8dc; }
-.legend-cold  { color: #3a4654; }
-.legend-fault { color: #ff5d5d; }
+.legend-hot   { color: #4dff9b; }
+.legend-warm  { color: #86bdf5; }
+.legend-cold  { color: #5f6d80; }
+.legend-fault { color: #ff7a7a; }
 
 /* Band and boundary labels drawn into the scene via CSS2D. */
 .band-label {

--- a/ui/netclaw-visual/src/styles.css
+++ b/ui/netclaw-visual/src/styles.css
@@ -1249,3 +1249,21 @@ input {
   color: #fff; font-size: 11px; font-weight: 700; letter-spacing: 0.12em;
   border-radius: 0 0 6px 6px; pointer-events: none;
 }
+
+/* Tool overlay revealed on click (FR-020..025). Overlays rather than claiming
+   layout space, so expanding never reflows a sibling (FR-022). */
+.tool-header {
+  font-size: 11px; font-weight: 700; letter-spacing: 0.06em;
+  color: #cfe6ff; background: rgba(8, 16, 28, 0.92);
+  border: 1px solid rgba(120, 190, 255, 0.45); border-radius: 4px;
+  padding: 2px 8px; white-space: nowrap; pointer-events: none;
+}
+.tool-item {
+  font-size: 10px; color: #a9c8e8; background: rgba(8, 16, 28, 0.85);
+  border-left: 2px solid rgba(120, 190, 255, 0.5);
+  padding: 1px 7px; white-space: nowrap; pointer-events: none;
+}
+/* Cold claws expand too — what a cold claw would bring is what decides
+   whether to warm it (FR-025). */
+.tool-item-cold { color: #8fa3b8; border-left-color: rgba(125, 142, 163, 0.55); }
+.tool-more { font-style: italic; color: #7d94ad; }

--- a/ui/netclaw-visual/src/styles.css
+++ b/ui/netclaw-visual/src/styles.css
@@ -1267,3 +1267,23 @@ input {
    whether to warm it (FR-025). */
 .tool-item-cold { color: #8fa3b8; border-left-color: rgba(125, 142, 163, 0.55); }
 .tool-more { font-style: italic; color: #7d94ad; }
+
+/* Accessibility overlay (FR-032). Visually unobtrusive but a real, focusable
+   DOM tree over the canvas — a WebGL surface exposes nothing to a keyboard or
+   a screen reader on its own. */
+#orgchart-a11y {
+  position: absolute; inset: 0; pointer-events: none; z-index: 5;
+}
+#orgchart-a11y .a11y-node {
+  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip-path: inset(50%); border: 0; background: transparent;
+  color: inherit; font: inherit; pointer-events: auto;
+}
+/* Focus must be visible — an invisible focus ring is not keyboard access. */
+#orgchart-a11y .a11y-node:focus-visible {
+  position: static; width: auto; height: auto; margin: 8px; padding: 6px 12px;
+  clip-path: none; overflow: visible;
+  background: rgba(8, 16, 28, 0.97); color: #dceeff;
+  border: 2px solid #ffd97a; border-radius: 5px;
+  font-size: 12px; z-index: 60;
+}

--- a/ui/netclaw-visual/src/styles.css
+++ b/ui/netclaw-visual/src/styles.css
@@ -1212,3 +1212,40 @@ input {
   color: #f0abfc; border-radius: 4px; padding: 6px 12px; font-size: 11px; cursor: pointer;
 }
 .n2n-chat-input button:hover { background: rgba(224,64,251,0.5); }
+
+/* ── HUD 2.0: top-down trust org chart (feature 072) ───────────────────── */
+
+/* Legend (FR-009c). Shapes carry the distinction alongside colour so the
+   encoding survives greyscale (SC-007). */
+.legend-list { list-style: none; margin: 0; padding: 0; font-size: 11px; line-height: 1.9; }
+.legend-list b { font-weight: 600; }
+.legend-swatch { display: inline-block; width: 1.1em; text-align: center; margin-right: 4px; }
+.legend-hot   { color: #37d67a; }
+.legend-warm  { color: #6fa8dc; }
+.legend-cold  { color: #3a4654; }
+.legend-fault { color: #ff5d5d; }
+
+/* Band and boundary labels drawn into the scene via CSS2D. */
+.band-label {
+  font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase;
+  color: rgba(180, 205, 235, 0.55); white-space: nowrap; pointer-events: none;
+}
+.band-label-boundary { color: rgba(255, 200, 87, 0.9); font-weight: 600; letter-spacing: 0.26em; }
+.band-label-edge { color: rgba(230, 87, 51, 0.85); }
+
+/* Empty-band copy (FR-033a): must read as "nothing here yet", never as a
+   failed load. */
+.band-empty {
+  font-size: 11px; color: rgba(150, 175, 205, 0.5); font-style: italic;
+  white-space: nowrap; pointer-events: none; text-align: center;
+}
+
+/* Fixture-mode banner (FR-033c): synthetic data must never be mistakable for
+   this Border's real topology. */
+#fixture-banner {
+  position: fixed; top: 0; left: 50%; transform: translateX(-50%);
+  z-index: 9999; padding: 4px 14px;
+  background: repeating-linear-gradient(45deg, #b45309, #b45309 8px, #92400e 8px, #92400e 16px);
+  color: #fff; font-size: 11px; font-weight: 700; letter-spacing: 0.12em;
+  border-radius: 0 0 6px 6px; pointer-events: none;
+}


### PR DESCRIPTION
Replaces the HUD's orbiting-cores scene with a planar, top-down trust org chart: eN2N peers north of an explicit trust boundary, the Border on the centre line, iN2N members fanned below in derived categories, mobile edges in their own lane. Chat and the right-hand detail panel are untouched.

Full spec-kit cycle: specify → clarify ×2 → plan → tasks → analyze → implement. **55 of 56 tasks complete.**

## The two things that actually fixed "clunky"

**The camera, more than the theme.** HUD 1.0 paired a `PerspectiveCamera` with unconstrained `OrbitControls`, so hierarchy could be viewed from any angle — and "external vs internal" only reads if the layout and the viewer agree on which way is up. Now orthographic with `enableRotate = false`. Ortho also renders equal-tier siblings at equal size, which is what makes a chart read as a chart.

**The scene was drawing two unrelated graphs on top of each other.** Beyond the trust topology it also rendered 72 integration clusters with orbiting skill sprites *and* the testbed devices — a capability catalogue and a managed estate overlaid on an org chart. Both populations are gone (FR-030); integrations now surface as member tool expansion.

## Architecture: pure logic split from rendering

The HUD had **no JS test framework** and this spec makes 13 largely perceptual claims. Resolved by making the split architectural: `src/orgchart/` imports nothing from three.js and holds no DOM references, so category derivation, health classification, ordering, dedup and position maths are unit-testable in bare Node. `src/orgchart-render/` consumes that output and may not re-derive it.

**Zero new dependencies**, runtime or dev — `node:test` for logic, and a CDP harness over `ws` (already a dependency) for browser verification.

## What the tests found

Six real defects, several of them mine:

- **FR-014's premise was false.** The two "Hermes" peers have *different identities* — a re-enrolment under a new AS, not a duplicate record. Dedup-by-identity was correct but never addressed the actual defect: two indistinguishable labels. Added `disambiguateLabels()`.
- **`onResize` set `camera.aspect`** — which an `OrthographicCamera` doesn't have. Would have silently stretched the chart on every resize.
- **Labels drifted every frame.** Parented to the pulsing mesh, so they inherited its scale. Mesh positions were stable, so the requirement's *letter* passed while the thing you look at jittered.
- **`aria-expanded` never updated** — a screen reader would announce "collapsed" over an open node.
- **A widened fan collided with the fixed edge-lane X.** The lane is now derived from the measured fan extent.
- **Brightening COLD put it within 10.4 luminance of FAULT** — near-identical in greyscale, collapsing the one distinction the four-state design exists to protect. Repaletted with a measured minimum delta of 18.

`node --test src/` (as originally specified) is also broken on Node 25 — it `require()`s the directory.

## Verification

| | |
|---|---|
| `npm test` | **85 passing** |
| `pytest tests/n2n` | **307 passing** |
| Live browser | 0 console errors, 0 blank labels, 35 keyboard-reachable nodes |
| `scale-100` fixture | 114 labels, 0 blank, 0 errors |
| `empty` fixture | 4 bands + 3 CTAs — first-run reads as "nothing here yet" |
| SC-003 | External stays above internal after aggressive drag/zoom |
| SC-011 | Node coordinates byte-identical across pulse cycles |

## Deliberate deviations, flagged not hidden

- **`lightIntegration`/`lightDevice`/`applyFilters` kept** despite FR-030c. They're reached from the chat activation path and FR-016 forbids editing chat; with their arrays never populated they're inert no-ops. Deleting them meant touching protected code to remove something that already does nothing.
- **T054 (60 fps on a discrete GPU) left open.** Headless runs on swiftshader at 3 fps, which measures the software rasteriser. Closing it on that number would be false.

## Not in scope

`server.js` is **unchanged**. It carries a live Principle XIII violation — unmasked credentials over unauthenticated, CORS-open, `0.0.0.0`-bound HTTP — recorded in `plan.md` and written up at `~/netclaw-reports/SECURITY-hud-credential-exposure.md`. FR-019 forbids this feature compounding it, and it doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)