### PR TITLE
fix(mobile): clear-destroys-in-flight and mic hang/no-record

### DIFF
--- a/mobile/netclaw-mobile/BUG_clear_destroys_inflight.md
+++ b/mobile/netclaw-mobile/BUG_clear_destroys_inflight.md
@@ -1,0 +1,185 @@
+# Bug Report — "Clear messages" destroys in-flight requests
+
+**Reported by:** Justin, 2026-07-27 18:44 EDT
+**Triaged & fixed by:** NetClaw Border (`as65001-4.4.4.4`)
+**Severity:** High — silent, unrecoverable data loss
+**Status:** FIXED · `flutter analyze` clean · `flutter test` 132/132 · APK rebuilt
+
+---
+
+## Report
+
+> "when you clear messages it actually clears all messages including the pending
+> actual working messages that are processing currently"
+
+Confirmed exactly as described.
+
+---
+
+## Root cause
+
+`ConversationStore.clear()` deleted every turn unconditionally, regardless of
+state. The old implementation:
+
+```dart
+Future<void> clear() async {
+  await load();
+  for (final turn in _turns) { /* delete photo */ }
+  _turns.clear();
+  final file = _file();
+  if (await file.exists()) await file.delete();
+}
+```
+
+`_turns.clear()` takes `pending` and `working` rows along with finished ones.
+
+### Why the loss is silent and permanent
+
+The Border keeps working on a cleared request. When the answer arrives,
+`updateState` looks for its row:
+
+```dart
+for (final t in _turns) {
+  if (t.taskId == taskId) { ... }
+}
+```
+
+No row matches, the loop finds nothing, and **the answer is dropped with no
+error**. `reconcileStaleTurns` is equally helpless — it iterates local turns to
+decide what to re-query, so a deleted turn is invisible to it. The work is done,
+billed, and audited on the Border, and the operator never sees it. There is no
+recovery path from the phone: the Border never re-pushes spontaneously.
+
+### It was a deliberate decision, documented in the source
+
+This was not an oversight. The old doc comment:
+
+> *"In-progress turns go too. That's deliberate: the Border keeps working and
+> reconciliation no longer has a local row to reconcile against, so a cleared
+> in-flight answer simply never appears. Callers should warn when anything is
+> still running."*
+
+And the confirmation dialog **described the data loss rather than preventing
+it**:
+
+> *"A request is still in progress. The Border will finish it, but the answer
+> will no longer appear here."*
+
+Someone saw this exact failure, wrote it down, and shipped a warning instead of
+a fix. Justin is right that a warning is the wrong answer: **clearing history
+should not cancel the future.** An operator tidying a transcript is not asking
+to throw away a running request, and no amount of dialog copy makes that
+mapping intuitive.
+
+Worth stating plainly: deleting the local row **never cancelled anything**. The
+Border kept working either way. So the old behaviour bought nothing — it only
+discarded the operator's ability to see the result.
+
+---
+
+## Fix
+
+`clear()` now preserves non-terminal turns by default:
+
+```dart
+Future<void> clear({bool includeInProgress = false}) async {
+  await load();
+  final kept = includeInProgress
+      ? const <ConversationTurn>[]
+      : _turns.where((t) => !_isTerminal(t.state)).toList();
+  ...
+}
+```
+
+Reuses the existing `_isTerminal` helper (`completed` / `failed` / `cancelled`),
+so "in progress" means the same thing here as it does in `updateState`'s
+terminal-state guard and in `hasInProgressTurns` — one definition, three call
+sites.
+
+Three details that matter:
+
+1. **Photos of surviving turns are retained.** A preserved turn still renders,
+   so deleting its `photo_*.jpg` would leave a broken `[Photo unavailable]` tile
+   attached to a live request. Only finished turns' photos are removed, so the
+   original disk-growth problem this method exists to solve is still solved.
+2. **The file is rewritten, not deleted, when anything survives.** Preserving a
+   turn in memory alone would lose it on the next cold start — and reconciliation
+   after a restart is precisely when it matters most.
+3. **`includeInProgress: true`** retains the old all-or-nothing behaviour for a
+   caller that has explicitly confirmed that intent. Nothing in the app uses it
+   yet; it exists so the capability isn't lost.
+
+### UI
+
+`main.dart` dialog copy, now truthful:
+
+- Title/body: *"Deletes **finished** requests from this phone."*
+- When something is running: *"Requests still in progress will be kept so their
+  answers can still arrive."*
+
+### Not changed — deliberately
+
+`MessageFeedStore.clear()` (the Feed tab's "Clear all messages") still deletes
+everything, correctly. Feed entries are **already-delivered pushes** with no
+pending state and nothing in flight to protect. Only the Chat conversation store
+had this defect.
+
+---
+
+## The tests were asserting the bug
+
+Both failing tests had been **encoding the defect as the expected contract**,
+which is why 126 green tests said nothing about it:
+
+`test/clear_and_revocation_test.dart`
+```dart
+await store.addPending('t1', 'first');
+await store.addPending('t2', 'second');   // both PENDING
+await store.clear();
+expect(store.turns, isEmpty);             // asserted the data loss
+```
+
+`test/conversation_store_test.dart` — same shape: two pending turns, asserting
+both vanish.
+
+Neither ever marked a turn terminal, so neither exercised what clearing history
+is actually for. This is the same class of gap as the mic bug: **a green suite
+that tests the wrong contract is worse than no test**, because it actively
+defends the defect against change.
+
+Rewritten to mark turns terminal first, plus six new cases:
+
+| Test | Asserts |
+|---|---|
+| removes finished turns and the backing file | normal clear still works |
+| **an in-progress turn SURVIVES a clear** | the regression |
+| a `working` turn survives too, not just `pending` | both non-terminal states |
+| a surviving turn is still there after a restart | the rewrite actually persists |
+| `includeInProgress: true` clears everything | opt-in escape hatch |
+| a finished turn cleared alongside a survivor stays gone on restart | no accidental resurrection |
+| keeps an in-flight turn's photo on disk | photo retention, both directions |
+
+---
+
+## Verification
+
+```
+flutter analyze     → No issues found!
+flutter test        → 132/132 passed   (126 before; 2 rewritten, +6 new)
+flutter build apk   → ✓ Built app-debug.apk  (exit 0)
+```
+
+**Not verified on-device.** The fix is store-level logic with direct unit
+coverage, but the end-to-end path worth confirming by hand is: submit a request,
+clear chat while it is still working, then let the answer arrive and check it
+appears.
+
+---
+
+## Related
+
+Same session, same codebase:
+- `BUG_mic_recording.md` — mic hang/no-record, six root causes, fixed.
+- `MIC_HOTFIX_ANDROID_COMPAT.md` — Android 15/16 verified, 17 unverifiable.
+- Still outstanding: **the repo has no git remote.** None of these fixes exist
+  anywhere but this disk.

--- a/mobile/netclaw-mobile/BUG_mic_recording.md
+++ b/mobile/netclaw-mobile/BUG_mic_recording.md
@@ -1,0 +1,402 @@
+# Bug Report — Microphone recording intermittently fails or hangs
+
+**Reported by:** Justin, 2026-07-27 18:02 EDT
+**Device:** Android **15**, recognition engine = **Google** (Google app / Speech Services)
+**Plugin:** `speech_to_text` **7.4.0**
+**Triaged by:** NetClaw Border (`as65001-4.4.4.4`) — code read, not inferred
+**Severity:** High — core input path, and the UI blocks retry while stuck
+**Component:** `lib/ncfed/voice_transcription.dart` → `_defaultListenOnce()`
+
+---
+
+## Reported symptoms
+
+1. Sometimes the mic **does not record** at all.
+2. Sometimes it **stays hanging**.
+
+Both are reproducible consequences of the current implementation. They are two
+faces of the same defect cluster, and they *cause each other* (see §3).
+
+---
+
+## Permissions are NOT the cause — ruled out
+
+Checked first because the code's own comments blame this. All declarations are
+correct and present:
+
+| Declaration | File | Status |
+|---|---|---|
+| `RECORD_AUDIO` | `AndroidManifest.xml` | ✅ explicit |
+| `<queries><intent android:name="android.speech.RecognitionService">` | `AndroidManifest.xml` | ✅ present (Android 11+ package visibility) |
+| `NSMicrophoneUsageDescription` | `ios/Runner/Info.plist` | ✅ |
+| `NSSpeechRecognitionUsageDescription` | `ios/Runner/Info.plist` | ✅ |
+
+So this is **not** the previously-reported "microphone option isn't working"
+issue. That one was a missing manifest query and is genuinely fixed. This is a
+different, subtler defect in the session state machine.
+
+---
+
+## Root causes
+
+### BUG 1 — No `pauseFor`: the engine listens for the full 30 s after you stop talking
+**This is the "hanging" the user sees.** Highest impact, simplest fix.
+
+**CONFIRMED against the installed plugin source** (`~/.pub-cache/.../speech_to_text-7.4.0`).
+Two findings raise this from "likely" to "certain", and they are specific to this
+reporter's exact device/plugin combination:
+
+**(a) 7.4.0's headline change is literally this feature.** `CHANGELOG.md`, top entry:
+
+```
+## 7.4.0-beta
+### New
+* Android now respects the pauseFor value
+```
+
+The app is pinned to the *first* version where `pauseFor` works on Android at
+all — and does not set it. Before 7.4.0 the omission was harmless because
+Android ignored it regardless; on 7.4.0 it is the whole bug. Silence-based
+early stop is available and switched off.
+
+**(b) With `pauseFor` null, `_stopOnPauseOrListen()` can only stop on `listenFor`.**
+From `lib/speech_to_text.dart` (~line 585):
+
+```dart
+if (null != listenFor && _elapsedListenMillis >= listenFor.inMilliseconds) {
+  _stop();
+} else if (null != pauseFor &&
+    _elapsedSinceSpeechEvent >= pauseFor.inMilliseconds) {
+  _stop();
+}
+```
+
+The silence branch is guarded by `null != pauseFor`. Unset, it is dead code:
+the session is guaranteed to run the **full 30 s** irrespective of when the
+speaker stops. This is deterministic, not engine-dependent — so the *hang* is
+**not** intermittent at all. It happens on every utterance shorter than 30 s.
+What varies is only whether the user waits it out or force-closes.
+
+**Android 15 + Google engine relevance:** Android 12+ routes Google recognition
+through on-device models that hold the recogniser open awaiting more speech
+rather than finalising eagerly. Combined with (b), a 3-word request occupies the
+mic for 30 s.
+
+```dart
+listenOptions: stt.SpeechListenOptions(
+  partialResults: false,
+  cancelOnError: true,
+  listenFor: listenTimeout,   // 30 s
+  // pauseFor: MISSING
+),
+```
+
+`listenFor` is the **maximum session length**; `pauseFor` is the
+**silence-timeout that ends the session early**. With `pauseFor` unset, many
+Android engines hold the session open for the entire `listenFor` window
+regardless of the speaker falling silent. Say three words and the mic icon stays
+red for up to 30 seconds.
+
+Compounding it: `onPressed: _listening ? null : _recordVoice` **disables the mic
+button** for the whole duration, so the operator cannot cancel or retry. There is
+no cancel affordance at all. That is precisely what "stays hanging" feels like.
+
+**Fix:** add `pauseFor`. **Revised 2026-07-27 18:37 EDT after Justin's review** —
+the initial 3 s was too aggressive; see §"Pause tuning" below. Now a two-stage
+10 s → 5 s window.
+
+⚠️ **Fix BUG 1 and BUG 6 together — they are coupled in the plugin.**
+`pauseFor` is driven by `_lastSpeechEventAt`, which is updated *only* inside
+`_notifyResults()` (line ~682). With `partialResults: false`, `_notifyResults`
+returns early for non-final results:
+
+```dart
+if (!_partialResults && !speechResult.finalResult) {
+  return;
+}
+```
+
+— but note the timestamp assignment sits *above* that guard, so it does still
+fire. The plugin's own convenience path nonetheless treats the two as
+inseparable (line ~479):
+
+```dart
+partialResults: partialResults || null != pauseFor,
+```
+
+i.e. **the plugin force-enables partial results whenever `pauseFor` is set.**
+Setting `pauseFor` while leaving `partialResults: false` in an explicit
+`SpeechListenOptions` bypasses that coercion and is an untested combination.
+Set **both**: `pauseFor: 3s` *and* `partialResults: true`, filtering non-final
+results in `onResult` (which the app already does via
+`if (!result.finalResult) return;`). The Border still only ever receives final
+text — the existing contract is preserved.
+
+### BUG 2 — The error path never completes the completer → guaranteed 32 s stall
+`initialize(onError: (e) => lastError = e)` records the error and **nothing
+else**. `finish()` is never called from `onError`.
+
+With `cancelOnError: true`, an engine error cancels the session — so
+`onResult` will never fire either. The `Completer` is then orphaned and the code
+waits out the **full `listenTimeout + 2 s` = 32 seconds** before the `onTimeout`
+handler salvages it.
+
+The source comment acknowledges the scenario ("an error raised after `listen()`
+returned … land here instead of hanging") but treats a 32-second stall as
+acceptable. It is not: every mid-session error costs 32 s of frozen, un-cancellable UI.
+
+**Fix:** complete immediately on error.
+```dart
+final available = await speech.initialize(onError: (e) {
+  lastError = e;
+  finish(VoiceResult.failed(VoiceFailure.engineError,
+      'Speech recognition failed: ${e.errorMsg}'));
+});
+```
+Requires hoisting `completer`/`finish` above `initialize`.
+
+### BUG 3 — No `onStatus` listener: a clean-but-empty session also waits 32 s
+`speech_to_text` exposes `onStatus` with `listening` / `notListening` / `done`.
+It is not wired up. When the engine ends a session cleanly having heard nothing,
+there is no final result and no error — so again the only exit is the 32-second
+timeout.
+
+**Fix:** pass `onStatus` to `initialize` and `finish(noSpeechDetected)` on
+`done`/`notListening` if the completer is still pending.
+
+### BUG 4 — Fresh `SpeechToText()` per call against a platform singleton → the "doesn't record" case
+```dart
+static Future<VoiceResult> _defaultListenOnce() async {
+  final speech = stt.SpeechToText();     // new Dart object every tap
+  final available = await speech.initialize(...);
+```
+
+A new Dart wrapper is constructed on every invocation, but the underlying
+`SpeechRecognizer` (Android) / `SFSpeechRecognizer` (iOS) is a **single
+platform-side resource**. Calling `initialize()` again while a prior session is
+still tearing down commonly yields `available == true` from the Dart side while
+`listen()` silently attaches to a busy recogniser — **no audio captured, no
+error raised**. That is the "sometimes does not record" report exactly.
+
+**Fix:** hold one `SpeechToText` instance for the app lifetime, `initialize()`
+once, and reuse it. `VoiceTranscription` is already an injectable class — make
+the instance a field.
+
+### BUG 5 — `speech.stop()` is not protected, and there is no `cancel()`
+```dart
+final result = await completer.future.timeout(...);
+await speech.stop();     // only reached on the normal path
+return result;
+```
+Any throw between `listen()` and here (or a widget dispose / app backgrounding
+mid-listen) skips `stop()` entirely and **leaks a live recognition session**.
+
+**This is the mechanism that links the two symptoms.** A leaked session from
+attempt *N* is exactly what poisons attempt *N+1* via BUG 4. One hang begets one
+silent non-recording — a cascading failure, which matches "intermittent" far
+better than any single independent fault.
+
+**Fix:** wrap in `try/finally` with `await speech.cancel()` in the `finally`;
+add a `dispose()` on `VoiceTranscription` called from `ChatScreen.dispose()`.
+
+### BUG 6 — `partialResults: false` removes the only progress signal
+With partials disabled, `onResult` fires **once**, at the very end. Two costs:
+- Some Android engines are known not to emit a final result for very short
+  utterances when partials are off → straight to the 32 s timeout.
+- The operator gets no live feedback that anything is being heard, so a working
+  slow recording is indistinguishable from a broken one.
+
+**Fix:** set `partialResults: true`, ignore non-final results for the *request*
+(preserving the existing contract that the Border only ever sees final text),
+but use their arrival as proof of life — and optionally show interim text.
+
+---
+
+## Why it is intermittent
+
+**Revised after confirming BUG 1 in plugin source.** The two reported symptoms
+have *different* determinacy, which matters for triage:
+
+**The hang is deterministic, not intermittent.** With `pauseFor` unset on
+plugin 7.4.0, the silence-stop branch is unreachable and every session runs the
+full 30 s. It only *looks* intermittent because a long utterance masks it — if
+you happen to speak for most of the window, the wait is short. Short requests
+hang every single time.
+
+**The non-recording is genuinely intermittent**, and is caused by the hang:
+
+1. Session runs 30 s (BUG 1) → user gives up, backgrounds the app or switches tab.
+2. Dispose mid-listen skips `speech.stop()` — it sits outside any `try/finally`
+   (BUG 5) → **live recognition session leaked**.
+3. Next tap constructs a *new* `SpeechToText()` against the same platform
+   singleton (BUG 4). `initialize()` returns true; `listen()` attaches to a busy
+   recogniser → **no audio, no error**.
+4. On Android 15 the Google engine surfaces this as `ERROR_RECOGNIZER_BUSY`
+   or simply never emits a result — and since `onError` never completes the
+   completer (BUG 2), that path stalls 32 s too.
+
+So: **BUG 1 fires constantly, and each occurrence has a chance of leaking a
+session that breaks the next attempt.** That is the cascade, and it explains why
+the two symptoms alternate.
+
+**Practical implication:** fixing BUG 1 alone should sharply reduce the
+non-recording reports too, because it removes the abandonment that causes the
+leak. Fix 1 + 3 + 5 together and the cascade is closed.
+
+---
+
+## Test-coverage gap (why CI is green)
+
+`test/voice_transcription_test.dart` injects `listenOnce`:
+
+```dart
+final voice = VoiceTranscription(
+  listenOnce: () async => const VoiceResult.success('check every core router...'),
+);
+```
+
+The injection seam is good design and the test is legitimate — it asserts a voice
+request produces the same wire shape as a typed one. **But it stubs out
+`_defaultListenOnce` entirely, and that is where all six bugs live.** The
+recording state machine has *zero* test coverage. That is why 24 passing tests
+tell us nothing here.
+
+**Recommend:** a fake `SpeechToText` seam (inject the plugin, not just the
+result) with cases for: error-during-listen, session-ends-with-no-result,
+short-utterance, and back-to-back invocations.
+
+---
+
+## Suggested fix order
+
+| # | Fix | Effort | Impact |
+|---|---|---|---|
+| 1 | Add `pauseFor: 3s` | 5 min | Removes the common hang outright |
+| 2 | `finish()` from `onError` | 20 min | Kills the 32 s error stall |
+| 3 | `try/finally` + `cancel()` | 30 min | Stops session leaks → stops the cascade |
+| 4 | Single reused `SpeechToText` | 45 min | Fixes "doesn't record" |
+| 5 | Wire `onStatus` | 30 min | Kills the silent-session stall |
+| 6 | `partialResults: true` | 30 min | Progress signal + short-utterance reliability |
+| 7 | Cancel button while listening | 30 min | Operator can always escape |
+| 8 | Tests around the plugin seam | 2 h | Prevents regression |
+
+**≈ 5 hours.** Items 1–3 alone should remove most of what Justin is seeing and
+could ship as a hotfix.
+
+---
+
+## Pause tuning — revised after reviewer objection
+
+Justin raised that 3 s risks cutting off a slow speaker, or someone who pauses
+mid-sentence before continuing. Correct, and it is the *worse* of the two
+failure directions: a truncated request ("check BGP on…") is actively
+misleading, whereas an extra second of waiting is merely mild. Investigated
+against the plugin's own documentation and API.
+
+### Finding 1 — 3 s sat exactly on a platform floor
+
+`listen()`'s doc comment for `pauseFor`:
+
+> *"On some systems, notably Android, there is a system imposed pause of from
+> **one to three seconds** that cannot be overridden. The plugin ensures that
+> the pause is no longer than the pauseFor value but it may be shorter."*
+
+Two consequences:
+- A 3 s request left **zero headroom** above a floor the platform may enforce
+  anyway.
+- `pauseFor` is a **ceiling, not a floor** — "may be shorter" means asking for
+  3 s could yield an *even shorter* effective pause on some devices. Exactly the
+  cut-off Justin predicted.
+
+### Finding 2 — the plugin has a purpose-built API for this
+
+`changePauseFor()`, documented as:
+
+> *"Call this while [listen] is active to change the pauseFor duration… It is
+> useful for allowing **a long first pause then dynamically shortening it once
+> the user starts speaking**."*
+
+That is precisely the problem. Two different silences deserve two different
+tolerances:
+
+| Silence | Meaning | Window |
+|---|---|---|
+| Before any speech | operator collecting their thoughts | **10 s** (`initialPauseFor`) |
+| After speech began | mid-sentence pause, or finished | **5 s** (`pauseFor`) |
+
+Implemented: session starts at `initialPauseFor`, and on the **first** partial
+result calls `changePauseFor(pauseFor)` (guarded on `speech.isListening`, since
+`changePauseFor` throws `ListenNotStartedException` otherwise).
+
+So the operator may take up to 10 s to begin without being cut off, yet a
+*finished* request still ends ~5 s after they stop — rather than every request
+paying the full opening window. This is only possible because
+`partialResults: true` (BUG 6) is now set: the transition is driven by the first
+partial.
+
+### Finding 3 — `listenMode` was wrong for dictated sentences
+
+`SpeechListenOptions` defaults to `listenMode: ListenMode.confirmation`, which
+the plugin describes as *"the most common use case, words or short phrases to
+confirm a command"*, versus `ListenMode.dictation` for *"longer spoken content,
+sentences or paragraphs"*.
+
+A NetClaw request is a sentence ("check every core router for BGP problems"),
+not a command word. `confirmation` biases the engine toward finalising early —
+the opposite of what a slow speaker needs. Changed to `dictation`.
+
+**Caveat, stated plainly:** the plugin marks `listenMode` as *"currently only
+supported on iOS"*, so this will **not** change Android behaviour today. It is
+still correct to declare, costs nothing, and benefits the iOS port (spec 071).
+The Android improvement comes entirely from Findings 1 and 2.
+
+### Why 5 s rather than 8 or 10
+
+Bounded on both sides. Above ~10 s a completed request feels broken again —
+re-creating the original complaint in milder form. 5 s clears the 1–3 s platform
+floor with real margin, accommodates the hesitation typical of dictating device
+names, interface IDs and IP addresses, and still ends a finished request
+promptly. Tests assert `pauseFor > 3 s` (floor cleared) and `≤ 10 s` (still
+bounded), so neither direction can silently regress.
+
+**Tunable:** both values are named `static const` on `VoiceTranscription`. If 5 s
+still clips slow speakers in field use, raise it — the guard tests define the
+safe band rather than pinning an exact number.
+
+---
+
+## Related observation
+
+Two speech defects are now on record for this build:
+- This one (recording reliability).
+- 2026-07-27 11:28 EDT — transcription emitted a duplicated phoneme
+  ("speak speak" for "speech"). Accuracy, not session state; likely unrelated.
+
+---
+
+## Verification note
+
+Read from the working tree at `/home/johncapobianco/netclaw/mobile/netclaw-mobile`
+on 2026-07-27: full `lib/ncfed/voice_transcription.dart`,
+`lib/screens/chat_screen.dart` (mic handler + button wiring),
+`android/app/src/main/AndroidManifest.xml`, `ios/Runner/Info.plist`,
+`test/voice_transcription_test.dart`.
+
+Also read: `~/.pub-cache/hosted/pub.dev/speech_to_text-7.4.0/lib/speech_to_text.dart`
+(lines ~470–600, ~670–695) and its `CHANGELOG.md` — confirming the `pauseFor`
+null-guard in `_stopOnPauseOrListen()`, the
+`partialResults: partialResults || null != pauseFor` coercion, the
+`_lastSpeechEventAt` update site, and that "Android now respects the pauseFor
+value" is 7.4.0's headline change.
+
+**Device confirmed by reporter:** Android 15, Google recognition engine.
+
+**Still not verified:** no device logcat was captured during a reproduction.
+Expected signatures if one is taken while the mic misbehaves:
+`ERROR_RECOGNIZER_BUSY` (confirms BUG 4/5 leak) or `ERROR_NO_MATCH` /
+`ERROR_SPEECH_TIMEOUT` (confirms BUG 1/3/6 path). Also unverified: whether
+Google's *on-device* vs *network* recognition is selected on this handset — the
+app never sets `onDevice`, leaving it to engine default.
+
+BUG 1 no longer requires device confirmation: it is provable from plugin source
+and version alone.

--- a/mobile/netclaw-mobile/DARK_MODE_SPEC.md
+++ b/mobile/netclaw-mobile/DARK_MODE_SPEC.md
@@ -1,0 +1,391 @@
+# Spec — Dark Mode for NetClaw Mobile
+
+**Status:** Draft for review
+**Author:** NetClaw Border (`as65001-4.4.4.4`)
+**Date:** 2026-07-27
+**Target:** `netclaw_mobile` v1.0.0+1 — Flutter, Dart SDK ^3.12.2, Material 3
+**Codebase surveyed:** 28 Dart files / 3,533 LOC in `lib/`, 24 unit tests + 1 integration test
+
+---
+
+## 1. Why this is cheap
+
+The app is unusually well positioned for this. Total colour/theme references
+across the entire `lib/` tree: **20**. Of those, **6 already resolve through
+`Theme.of(context)`** and need no change at all.
+
+That leaves **14 hardcoded colour references in 7 files** — the complete scope
+of the visual work. There is no design-token layer to build, no stylesheet
+refactor, no third-party theming dependency to add. Material 3 is already on
+(`useMaterial3` is default-true in Flutter 3.x when `ColorScheme` is supplied).
+
+Current theme, `lib/main.dart:43`:
+
+```dart
+theme: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFFE65733))),
+```
+
+One seed colour — the claw-mark orange — and no `darkTheme`, no `themeMode`.
+Because `ColorScheme.fromSeed` generates a full tonal palette from that seed,
+the dark palette comes essentially free by passing
+`brightness: Brightness.dark`. Brand identity is preserved automatically.
+
+### Already correct (do not touch)
+
+| Location | Reference |
+|---|---|
+| `feed_screen.dart:94` | `Theme.of(context).colorScheme` |
+| `feed_screen.dart:111` | `Theme.of(context).textTheme.labelSmall` |
+| `empty_state.dart:20` | `Theme.of(context).textTheme.bodyMedium` |
+| `chat_screen.dart:270` | `Theme.of(context).colorScheme.error` |
+
+These are the pattern to copy.
+
+---
+
+## 2. Scope
+
+### In scope
+- A dark `ColorScheme` derived from the existing brand seed.
+- User-selectable theme mode: **System / Light / Dark**, persisted across launches.
+- Replace all 14 hardcoded colours with scheme-derived equivalents.
+- Android native launch-theme correctness (the splash currently forces light).
+- Tests covering palette selection, persistence, and contrast.
+
+### Out of scope
+- Any redesign, new layout, or restyling beyond light/dark parity.
+- Per-screen theme overrides or user-custom accent colours.
+- True-black / OLED power-saving variant (note as possible follow-up).
+- iOS native launch-screen darkening (see §6 — deliberately deferred).
+
+---
+
+## 3. Design
+
+### 3.1 Theme definitions — new file `lib/theme/app_theme.dart`
+
+Introduce a single source of truth. The seed colour moves here from
+`main.dart` and stops being an inline literal.
+
+```dart
+import 'package:flutter/material.dart';
+
+/// The claw mark's own orange (assets/icon/icon.png) — brand, not a
+/// Material default. Single source of truth for both palettes.
+const brandSeed = Color(0xFFE65733);
+
+ThemeData lightTheme() => ThemeData(
+      colorScheme: ColorScheme.fromSeed(
+        seedColor: brandSeed,
+        brightness: Brightness.light,
+      ),
+    );
+
+ThemeData darkTheme() => ThemeData(
+      colorScheme: ColorScheme.fromSeed(
+        seedColor: brandSeed,
+        brightness: Brightness.dark,
+      ),
+    );
+```
+
+### 3.2 Wiring `MaterialApp`
+
+`main.dart` gains `darkTheme` and a reactive `themeMode`. `NetClawMobileApp`
+must become a `StatefulWidget` (currently `StatelessWidget`) — or wrap the
+`MaterialApp` in a `ValueListenableBuilder` over the store, which is lighter
+and avoids touching the widget's class:
+
+```dart
+return ValueListenableBuilder<ThemeMode>(
+  valueListenable: themeModeStore.mode,
+  builder: (context, mode, _) => MaterialApp(
+    title: 'NetClaw Mobile',
+    theme: lightTheme(),
+    darkTheme: darkTheme(),
+    themeMode: mode,
+    home: const EnrollmentGate(),
+  ),
+);
+```
+
+`ThemeMode.system` is the default, so a fresh install follows the OS
+immediately with no user action.
+
+### 3.3 Persistence — new file `lib/ncfed/theme_mode_store.dart`
+
+**Follow the existing storage convention, do not invent a new one.** The app
+already persists via `path_provider` + a documents-directory-backed store
+(`EnrollmentStore`, `ConversationStore`, `MessageFeedStore` all take a
+`Directory`). `shared_preferences` is *not* currently a dependency and should
+not be added for one enum — it would be the only mechanism of its kind in the
+codebase.
+
+```dart
+class ThemeModeStore {
+  final Directory dir;
+  final ValueNotifier<ThemeMode> mode = ValueNotifier(ThemeMode.system);
+
+  ThemeModeStore(this.dir);
+
+  File get _file => File('${dir.path}/theme_mode');
+
+  Future<void> load() async { /* read; tolerate missing/corrupt → system */ }
+  Future<void> set(ThemeMode m) async { /* write + notify */ }
+}
+```
+
+Note `flutter_secure_storage` is also present but is for credentials; a UI
+preference does not belong there.
+
+**Load-order constraint:** the store must be read *before* the first frame, or
+the app flashes light then repaints dark on cold start. `main()` is currently
+synchronous:
+
+```dart
+void main() {
+  runApp(const NetClawMobileApp());
+}
+```
+
+It becomes:
+
+```dart
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final store = ThemeModeStore(await getApplicationDocumentsDirectory());
+  await store.load();
+  runApp(NetClawMobileApp(themeModeStore: store));
+}
+```
+
+`WidgetsFlutterBinding.ensureInitialized()` is mandatory here — `path_provider`
+uses a platform channel and will throw without it. Keep the store injectable so
+tests never touch the real channel, matching the documented pattern already used
+by `EnrollmentGate.documentsDirectory`, `VoiceTranscription`, and
+`ReconnectSupervisor`.
+
+### 3.4 Settings UI
+
+Add to `settings_screen.dart`, below the existing `Divider()` and the push-status
+`ListTile`. `SettingsScreen` already takes constructor-injected dependencies, so
+add `ThemeModeStore` the same way — no global lookup, no singleton.
+
+```
+Appearance
+  ○ System   ● Light   ○ Dark
+```
+
+A three-value `SegmentedButton<ThemeMode>` fits Material 3 and the screen's
+existing `SwitchListTile` idiom. Label it **Appearance**, not "Dark Mode" —
+the control has three states, and "Dark Mode: System" reads as a contradiction.
+
+---
+
+## 4. The 14 hardcoded colours
+
+Grouped by fix. **`Colors.red.shade50` / `.shade900` and `Colors.black87` are
+the real problems** — they are near-invisible or garish on a dark surface.
+
+### Group A — Error banners → `colorScheme.errorContainer` / `onErrorContainer`
+
+Identical duplicated block in two files:
+
+| File:line | Current | Replace with |
+|---|---|---|
+| `settings_screen.dart:76` | `color: Colors.red.shade50` | `scheme.errorContainer` |
+| `settings_screen.dart:78` | `TextStyle(color: Colors.red.shade900)` | `TextStyle(color: scheme.onErrorContainer)` |
+| `approvals_screen.dart:63` | `color: Colors.red.shade50` | `scheme.errorContainer` |
+| `approvals_screen.dart:65` | `TextStyle(color: Colors.red.shade900)` | `TextStyle(color: scheme.onErrorContainer)` |
+
+These two banners are byte-identical. **Extract a shared `ErrorBanner` widget**
+(`lib/screens/error_banner.dart`) rather than fixing the same code twice —
+`empty_state.dart` already establishes the precedent for small shared
+presentational widgets.
+
+### Group B — Camera/scanner overlays → keep literal, justify in comment
+
+| File:line | Current | Action |
+|---|---|---|
+| `device_scan_screen.dart:66` | `Colors.black87` | **Keep** |
+| `device_scan_screen.dart:70` | `Colors.white` | **Keep** |
+| `enrollment_screen.dart:89` | `backgroundColor: Colors.black54` | **Keep** |
+| `enrollment_screen.dart:91` | `Colors.white` | **Keep** |
+| `enrollment_screen.dart:101` | `Colors.black87` | **Keep** |
+| `enrollment_screen.dart:105` | `Colors.white` | **Keep** |
+| `enrollment_screen.dart:112` | `Colors.black45` | **Keep** |
+
+**This is a deliberate exception and the most important judgement in the spec.**
+These sit on top of a live camera preview (`mobile_scanner` QR view). The
+backdrop is whatever the camera sees, not an app surface — so scheme colours
+are *wrong* here. A scrim must stay dark and its text white in both modes to
+remain legible against arbitrary camera input.
+
+**Action:** leave the values, add a comment explaining why they are exempt, so
+a future contributor doesn't "fix" them and break legibility. Consider naming
+them `kCameraScrim` / `kOnCameraScrim` constants in `app_theme.dart` to make the
+intent explicit and greppable.
+
+### Group C — Inline text colours → scheme
+
+| File:line | Current | Replace with |
+|---|---|---|
+| `manual_enrollment_screen.dart:163` | `TextStyle(color: Colors.red)` | `scheme.error` |
+| `chat_screen.dart:374` | `TextStyle(color: Colors.red)` | `scheme.error` |
+| `chat_screen.dart:347` | `TextStyle(color: Colors.grey)` — `[Photo unavailable]` | `scheme.onSurfaceVariant` |
+| `chat_screen.dart:364` | `TextStyle(color: Colors.grey)` — `Cancelled` | `scheme.onSurfaceVariant` |
+
+`Colors.grey` is the classic dark-mode failure — it has no relationship to the
+surface it sits on. `onSurfaceVariant` is the M3 role for de-emphasised text and
+adapts correctly.
+
+Note `manual_enrollment_screen.dart:163` is *not* a camera overlay despite
+living near the enrollment flow — it is a normal form field error. Verify during
+implementation that it renders on a standard `Scaffold` surface, not over a
+preview.
+
+---
+
+## 5. Testing
+
+The repo has 24 unit tests and a real integration test; match that standard.
+
+### New: `test/theme_mode_store_test.dart`
+- Defaults to `ThemeMode.system` when no file exists.
+- Round-trips each of the three values.
+- Corrupt/garbage file contents fall back to `system` without throwing.
+- Injected temp `Directory`; no platform channel.
+
+### New: `test/app_theme_test.dart`
+- `lightTheme().colorScheme.brightness == Brightness.light`; dark likewise.
+- Both palettes derive from `brandSeed` — assert `primary` is non-default and
+  the two schemes differ.
+- **Contrast assertions** on the pairs that changed: `errorContainer` /
+  `onErrorContainer` and `surface` / `onSurfaceVariant` must clear WCAG AA
+  (4.5:1 body text) in *both* palettes. `ColorScheme.fromSeed` generally
+  guarantees this, but assert it — this is the regression that would otherwise
+  ship silently.
+
+### Extend: `test/widget_test.dart`, `chat_screen_test.dart`, `settings_screen`
+- Pump each screen under `darkTheme()` and assert no `Colors.grey`,
+  `Colors.red.shade50`, or `Colors.black87` survives outside the Group B
+  camera files.
+- Golden tests are tempting but add binary churn; assert on resolved colour
+  values instead unless the team already wants goldens.
+
+### Manual QA matrix
+Every screen — Enrollment, Manual enrollment, Device scan, Chat, Feed,
+Approvals, Settings, plus the `reconnectFailed` state and the revocation
+`SnackBar` — in **System / Light / Dark**, and an **in-flight OS toggle** while
+the app is foregrounded (verify no stale colours and no rebuild crash).
+
+---
+
+## 6. Native platform work
+
+### Android — a real bug already present
+`values-night/styles.xml` **already exists** and correctly parents
+`Theme.Black.NoTitleBar`, so the OS dark launch theme is wired up. But both
+variants set:
+
+```xml
+<item name="android:forceDarkAllowed">false</item>
+```
+
+and `flutter_native_splash` in `pubspec.yaml` hardcodes light only:
+
+```yaml
+flutter_native_splash:
+  color: "#FFFFFF"
+  android_12:
+    color: "#FFFFFF"
+```
+
+**Consequence:** on a dark-mode device the splash flashes **white** before the
+Flutter UI paints dark. Add the `flutter_native_splash` `darkColor` /
+`android_12.darkColor` keys and re-run `dart run flutter_native_splash:create`.
+`forceDarkAllowed: false` is correct and should stay — we are supplying a real
+dark theme, not asking the OS to auto-invert.
+
+Also note `colors.xml` defines only `ic_launcher_background: #FFFFFF`, and
+`pubspec.yaml` sets `adaptive_icon_background: "#FFFFFF"`. Launcher icons
+don't follow app theme, so this is acceptable — flagged only so it isn't
+mistaken for an oversight.
+
+### iOS — deferred, with reason
+`ios/Runner/Info.plist` exists but I did not inspect `LaunchScreen.storyboard`
+or confirm whether `UIUserInterfaceStyle` is pinned. Flutter's Dart-side theming
+works regardless; the risk is limited to a light launch-screen flash mirroring
+the Android issue. **Do not assume it is fine** — check for a
+`UIUserInterfaceStyle` key forcing `Light` and add a dark storyboard variant if
+the flash reproduces on device. Feature `071-ios-mobile-port` exists in
+`~/netclaw/specs/`, so the iOS surface may still be in flux; coordinate rather
+than patching blind.
+
+---
+
+## 7. Effort & sequencing
+
+| # | Task | Effort |
+|---|---|---|
+| 1 | `app_theme.dart` — seed + both palettes | 30 min |
+| 2 | `ThemeModeStore` + async `main()` | 1–1.5 h |
+| 3 | `MaterialApp` wiring via `ValueListenableBuilder` | 30 min |
+| 4 | Settings **Appearance** segmented control | 1 h |
+| 5 | Extract shared `ErrorBanner`, fix Group A | 45 min |
+| 6 | Group C inline colours (4 refs) | 30 min |
+| 7 | Group B comments / named scrim constants | 20 min |
+| 8 | Unit tests (store, theme, contrast) | 1.5–2 h |
+| 9 | Widget-test updates | 1 h |
+| 10 | Android splash `darkColor` + regen | 30 min |
+| 11 | iOS launch-screen check | 30 min–unknown |
+| 12 | Manual QA across 8 screens × 3 modes | 1 h |
+
+**Total ≈ 9–11 hours**, ~1.5 days including review. Item 11 is the only
+open-ended one.
+
+Suggested order: **1 → 3 → 6 → 5 → 2 → 4 → 8 → 9 → 10 → 11 → 12.** Doing the
+palette and the visual fixes first (1, 3, 6, 5) yields a working dark mode that
+follows the OS with no persistence layer at all — a demoable checkpoint, and
+independently shippable if persistence slips.
+
+---
+
+## 8. Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Camera overlays "fixed" to scheme colours → unreadable QR scanner | **High** | §4 Group B comments + named constants; call out explicitly in review |
+| Light-flash on cold start (async store read) | Medium | `await store.load()` before `runApp`; verify on a real dark device |
+| Android splash stays white in dark mode | Medium | `darkColor` keys + regenerate; already a latent bug |
+| `main()` becoming async breaks `integration_test/enrollment_and_ask_test.dart` | Medium | It drives `EnrollmentGate` directly; verify, and keep the store injectable |
+| Contrast regression on `onSurfaceVariant` for de-emphasised text | Low-Med | Assert WCAG AA in `app_theme_test.dart` |
+| iOS launch screen pinned to light | Unknown | Inspect before estimating; coordinate with spec 071 |
+
+---
+
+## 9. Open questions
+
+1. **True-black OLED variant** — worth a fourth mode later, or scope creep?
+2. **Goldens** — does the team want golden tests, or are resolved-colour
+   assertions sufficient? (Recommendation: the latter; less binary churn.)
+3. **iOS timing** — should this land before or after `071-ios-mobile-port`?
+4. **`shared_preferences`** — I deliberately avoided adding it. Confirm the team
+   prefers the existing `path_provider` convention over introducing a second
+   persistence mechanism.
+
+---
+
+## 10. Verification note
+
+Everything above was read from the live working tree at
+`/home/johncapobianco/netclaw/mobile/netclaw-mobile` on 2026-07-27, not
+inferred: `pubspec.yaml`, all 28 files in `lib/`, the full text of `main.dart`
+and `settings_screen.dart`, `android/app/src/main/res/values{,-night}/styles.xml`,
+`colors.xml`, and the `test/` + `integration_test/` listings. The 14-reference
+count is the exact `grep` result, enumerated in §4.
+
+**Not verified:** `ios/Runner/LaunchScreen.storyboard` and the
+`UIUserInterfaceStyle` key (§6), and whether `manual_enrollment_screen.dart:163`
+renders over a camera preview (§4 Group C). Both are flagged inline rather than
+assumed.

--- a/mobile/netclaw-mobile/MIC_HOTFIX_ANDROID_COMPAT.md
+++ b/mobile/netclaw-mobile/MIC_HOTFIX_ANDROID_COMPAT.md
@@ -1,0 +1,377 @@
+# Mic Hotfix — Android Version Compatibility Analysis
+
+**Question:** is the mic hotfix applicable and compatible with Android **15, 16,
+and 17**?
+**Answer:** Yes for **15 and 16**, with evidence below. **Android 17 cannot be
+verified** — see §6, it does not exist yet as a testable target and the SDK is
+not installed here. Claiming otherwise would be guesswork.
+
+**Analysed:** 2026-07-27 · plugin `speech_to_text` 7.4.0 (Dart + Kotlin native)
+· Flutter 3.44.8 / Dart 3.12.2
+
+> **RE-VERIFIED 2026-07-27 18:41 EDT.** The hotfix changed after the first pass
+> (two-stage `changePauseFor`, `ListenMode.dictation`), introducing new API
+> surface that the original analysis had not covered. Both are re-checked in
+> §9 and the APK has been rebuilt against the current code. Conclusions are
+> unchanged, and one new **zero-regression proof** for Android emerged.
+
+---
+
+## 1. SDK configuration as built
+
+| Setting | Value | Android release |
+|---|---|---|
+| `compileSdk` | **36** (`flutter.compileSdkVersion`) | Android 16 |
+| `targetSdk` | **36** (`flutter.targetSdkVersion`) | Android 16 |
+| `minSdk` | **24** (`flutter.minSdkVersion`) | Android 7.0 |
+| plugin `minSdkVersion` | 21 | Android 5.0 |
+| Java/Kotlin target | 17 | — |
+
+Locally installed SDK platforms: **android-34, android-35, android-36**. There is
+no android-37.
+
+So the app compiles against Android 16 and declares support from Android 7
+upward. Android 15 (API 35) and 16 (API 36) are both covered by the existing
+configuration; **no gradle change is needed for either.**
+
+---
+
+## 2. Why the fix is version-robust by construction
+
+The important finding: **`pauseFor` is enforced by two independent mechanisms**,
+one of which is entirely OS-agnostic.
+
+### Mechanism A — Dart-side timer (primary, version-independent)
+
+`speech_to_text.dart` runs its own timer and stops the session itself:
+
+```dart
+_listenTimer = Timer(minDuration, _stopOnPauseOrListen);
+...
+} else if (null != pauseFor &&
+    _elapsedSinceSpeechEvent >= pauseFor.inMilliseconds) {
+  _stop();
+}
+```
+
+This is pure Dart. It does not consult `Build.VERSION.SDK_INT`, the OEM, or the
+recognition engine. **On any Android version — 15, 16, 17, or 25 — a 3-second
+silence stops the session.** This is the mechanism that fixes the reported hang,
+and it cannot regress on a future OS release.
+
+### Mechanism B — native intent extra (secondary, engine-dependent)
+
+`SpeechToTextPlugin.kt` also forwards the value to the engine:
+
+```kotlin
+pauseFor?.also {
+    putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS, it)
+}
+```
+
+`EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS` is documented as a *hint* —
+engines may ignore it. That is fine: it is an optimisation, not the guarantee.
+Mechanism A is the guarantee.
+
+**Consequence:** even if Google's engine on a future Android ignores the hint
+entirely, the hotfix still works. That is the single most important
+forward-compatibility property here.
+
+---
+
+## 3. Every version gate in the plugin, checked
+
+Exhaustive grep of `Build.VERSION.SDK_INT` in the plugin's Kotlin:
+
+| Line | Gate | API 35 (A15) | API 36 (A16) | API 37+ |
+|---|---|---|---|---|
+| 265 | `SDK_INT < 21` → unsupported | pass | pass | pass |
+| 253 | `SDK_INT != 29` → `recognizerStops` | **true** | **true** | true |
+| 373 | `SDK_INT >= 33` → on-device check | yes | yes | yes |
+| 530 | `SDK_INT >= 31 (S)` | yes | yes | yes |
+| 623 | `SDK_INT >= 31 (S)` + `onDevice` | yes | yes | yes |
+
+**All gates are lower bounds except one, and that one is an equality test for
+API 29 only.** `brokenStopSdk = 29` — Android 10 alone has the broken-`stop()`
+workaround. Android 15, 16, and any later release take the identical modern code
+path. There is no upper bound anywhere in the plugin that a new Android version
+could trip.
+
+This is the key structural result: **15, 16 and 17 are not three different code
+paths in this plugin — they are one.**
+
+---
+
+## 4. Each fix, assessed for version sensitivity
+
+| Fix | Mechanism | Version-sensitive? |
+|---|---|---|
+| BUG 1 `pauseFor: 3s` | Dart timer (A) + intent hint (B) | **No** — A is pure Dart |
+| BUG 2 complete on `onError` | Dart completer | **No** |
+| BUG 3 `onStatus` → `doneStatus` | Dart callback | **No** (see §5 caveat) |
+| BUG 4 single `SpeechToText` | Dart instance reuse | **No** — and aligns with the plugin's own `if (_initWorked) return` idempotence |
+| BUG 5 `try/finally` + `cancel()` | Dart lifecycle | **No** |
+| BUG 6 `partialResults: true` | `EXTRA_PARTIAL_RESULTS` | Minor — see §5 |
+| Stop button | Flutter UI | **No** |
+
+**Six of seven fixes live entirely in Dart** and are therefore immune to Android
+version differences by construction. Only BUG 6 touches engine behaviour, and it
+is a hint whose absence is already tolerated.
+
+Verified compatible with the plugin's `initialize()` contract:
+
+```dart
+if (_initWorked) { return Future.value(_initWorked); }
+...
+errorListener = onError;
+statusListener = onStatus;
+```
+
+`initialize()` early-returns once it has succeeded, so `onError`/`onStatus` are
+registered **only on the first call**. Our design registers them once and routes
+completion through a mutable `_activeFinish` pointer rather than closing over a
+per-session completer. **This is not incidental — it is required** by that
+early-return, and it is the reason instance reuse (BUG 4) and the new callbacks
+(BUGs 2/3) are compatible rather than in conflict.
+
+---
+
+## 5. Residual risk found — one honest gap
+
+Tracing `_onNotifyStatus` in `speech_to_text.dart`:
+
+```dart
+case doneStatus:
+  _notifiedDone = true;
+  if (_latestResultType == ResultType.partial) return;   // <-- swallowed
+  break;
+```
+
+`_latestResultType` is initialised to `ResultType.partial` at the start of every
+`listen()`. So:
+
+- **Truly silent session** → native emits `doneNoResult` (Kotlin line ~421:
+  `false -> SpeechToTextStatus.doneNoResult.name`), which Dart maps to
+  `doneStatus` **unconditionally** with no early return. → **our `onStatus`
+  handler fires. Covered.**
+- **Partial arrived but no final** → status is swallowed by that guard, so our
+  handler does *not* fire. This path is instead rescued by the plugin's own
+  `_notifyFinalTimer` / `finalTimeout`, which promotes the last partial to a
+  final result (`_onFinalTimeout` → `toFinal()` → `_notifyResults`) — which
+  triggers our `onResult`. **Covered, but by a different mechanism than
+  intended.**
+
+**Net:** every path terminates, but via three different routes (`pauseFor` timer,
+`doneNoResult` status, `finalTimeout` promotion), plus the 32 s backstop. That is
+defence in depth rather than elegance. Worth noting in review; not a defect.
+
+---
+
+## 6. Android 17 — cannot be verified, and I will not claim it
+
+Being explicit, because this was asked directly:
+
+- **Android 17 (API 37) is not released.** Android 16 = API 36 is current, and is
+  what `flutter.targetSdkVersion` resolves to in Flutter 3.44.8.
+- **No android-37 platform is installed** on this host (34, 35, 36 only), so it
+  cannot be compiled against, let alone tested.
+- Any statement that this hotfix "works on Android 17" would be unfalsifiable
+  today.
+
+**What can be said with confidence:** the fix contains **no upper version
+bound**, and its primary mechanism is a Dart timer that never inspects the OS
+version. Structurally there is nothing for a future Android release to break.
+The plugin's only version-equality gate targets API 29, far below.
+
+**Where Android 17 could still bite** — historically plausible, worth watching:
+
+1. **Tighter mic/permission rules.** Android 14 added foreground-service audio
+   restrictions; a future release could extend them. *Current posture is
+   correct:* the mic is used only from a foreground `Activity`, and the manifest
+   declares no `FOREGROUND_SERVICE` audio type — nothing to break today.
+2. **Engine behaviour changes.** If Google's recogniser ignores
+   `EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS`, Mechanism A still stops
+   the session. **This is already handled.**
+3. **`targetSdk` bump required for Play Store.** A policy matter, not a mic
+   matter. Because `targetSdk = flutter.targetSdkVersion`, a Flutter SDK upgrade
+   moves it automatically — no code edit.
+4. **New `SpeechRecognizer` API deprecations.** Would need a plugin update, not
+   an app change. Out of our hands either way.
+
+**Recommendation:** re-test on Android 17 when a developer preview ships. Do not
+mark it "supported" until it is.
+
+---
+
+## 7. Verification performed
+
+```
+flutter analyze        → No issues found!
+flutter test           → 123/123 passed  (109 before the hotfix; +14 new)
+flutter build apk      → ✓ Built build/app/outputs/flutter-apk/app-debug.apk  (474s, exit 0)
+```
+
+**The Android build succeeds.** This is the material addition to this analysis:
+the hotfix compiles and links against `compileSdk 36` / `targetSdk 36`
+(Android 16) with `minSdk 24`, producing a real installable APK. Compatibility
+with 15 and 16 is therefore demonstrated at the toolchain level, not merely
+argued from source reading.
+
+Still **no on-device run on any Android version.** The tests cover the Dart state
+machine — where six of seven fixes live — but cannot exercise a real recogniser.
+
+### Two build warnings observed (pre-existing, not caused by the hotfix)
+
+1. **KGP deprecation:** *"Your app uses the following plugins that apply Kotlin
+   Gradle Plugin (KGP): mobile_scanner, speech_to_text — future versions of
+   Flutter will fail to build."* This is a **forward-compatibility risk on the
+   `speech_to_text` plugin itself** — precisely the dependency this hotfix relies
+   on. It does not affect Android 15/16 today, but it is the most likely thing to
+   break a future Flutter upgrade, and it is upstream of us. Track it.
+2. **SDK XML version 4 vs tooling 3:** benign command-line-tools/Android Studio
+   version skew. No action.
+
+Neither warning is introduced by these changes; both reproduce on the unmodified
+tree.
+
+**To close the remaining doubt**, the meaningful check is a build + manual mic
+test on:
+- **Android 15 (API 35)** — Justin's handset, the original reporter
+- **Android 16 (API 36)** — the compile/target level
+- **Android 17** — when it exists
+
+Expected behaviour on all: mic releases ~3 s after speech stops; stop button
+cancels immediately; two consecutive recordings both work.
+
+---
+
+## 9. Re-verification of the post-review changes (18:41 EDT)
+
+The pause-tuning revision added two things not present when §§1–8 were written.
+Both needed independent compatibility checking; neither weakens the conclusion.
+
+### 9.1 `changePauseFor()` — pure Dart, zero platform surface
+
+Measured, not assumed:
+
+```
+SDK_INT / Platform references inside changePauseFor()  →  0
+Platform-channel calls inside changePauseFor()         →  NONE
+```
+
+It only cancels and re-arms a Dart `Timer` via `_setupListenAndPause(...)`. It
+never crosses the method channel, so the native Kotlin never learns the pause
+was retightened. **Consequence: the 10 s → 5 s transition behaves identically on
+Android 15, 16, 17 and every earlier release** — it is not an OS feature at all.
+This strengthens Mechanism A from §2 rather than adding risk.
+
+One real constraint, handled: `changePauseFor` throws
+`ListenNotStartedException` when `isNotListening`. Our call site is guarded on
+`speech.isListening`, so a race (result arriving as the session ends) cannot
+throw. Version-independent.
+
+### 9.2 `ListenMode.dictation` — enum ordinal crosses the channel
+
+This one warranted care, because the value is marshalled as an **ordinal index**,
+not a name:
+
+```dart
+"listenMode": options?.listenMode.index ?? listenMode,
+```
+
+A Dart/Kotlin enum-order mismatch would silently select the wrong mode. Verified
+both declarations:
+
+| Index | Dart (`ListenMode`) | Kotlin (`ListenMode`) |
+|---|---|---|
+| 0 | `deviceDefault` | `deviceDefault` |
+| 1 | **`dictation`** | **`dictation`** |
+| 2 | `search` | `search` |
+| 3 | `confirmation` | `confirmation` |
+
+**Orders match exactly.** `dictation` → index 1 → Kotlin
+`enumValues<ListenMode>()[1]` = `dictation`. No mismatch, no risk.
+
+### 9.3 New finding — `dictation` is provably a no-op on Android
+
+The earlier caveat ("iOS-only, so no Android effect") was taken from the
+plugin's doc comment. It is now **proven from the native source**
+(`setupRecognizerIntent`, line ~668):
+
+```kotlin
+if (listenMode == ListenMode.search) {
+    putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_WEB_SEARCH)
+} else {
+    putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+}
+```
+
+Android branches on `search` **only**. `dictation` and `confirmation` both fall
+to the same `else`, yielding identical `LANGUAGE_MODEL_FREE_FORM`.
+
+**This is a zero-regression proof, not merely "no benefit":** the
+`confirmation` → `dictation` change cannot alter Android behaviour on *any*
+version, because the two values are indistinguishable to the native layer. The
+only Android-visible consequence is a cache invalidation — `previousListenMode
+!= listenMode` forces one `recognizerIntent` rebuild on the first listen after
+the change, which is exactly what that guard exists to do.
+
+iOS remains the only platform where `dictation` has effect, benefiting spec 071.
+
+### 9.4 Interaction with the instance-reuse fix (BUG 4)
+
+Worth checking, since the native layer caches a recogniser and we now reuse the
+Dart wrapper. `createRecognizer` (line ~603):
+
+```kotlin
+if ( null != speechRecognizer && onDevice == lastOnDevice ) {
+    return
+}
+```
+
+The native side **already** reuses its `SpeechRecognizer` across listens,
+recreating only when `onDevice` changes. Our single-instance Dart approach
+therefore *matches* the plugin's own native lifecycle rather than fighting it —
+the per-tap construction it replaced was the anomaly. We never set `onDevice`
+(default `false`, unchanged), so no recogniser churn is introduced.
+
+Also re-confirmed: the `SDK_INT >= 31` on-device branch is unreachable for us
+because `onDevice` is false, so it cannot differ across 15/16/17.
+
+### 9.5 Re-verification results
+
+```
+flutter analyze     → No issues found!
+flutter test        → 126/126 passed   (+3 pause-band guard tests)
+flutter build apk   → ✓ Built app-debug.apk   (9.5s incremental, exit 0)
+```
+
+APK rebuilt **against the current code**, so the artifact and the analysis now
+agree. Same two pre-existing warnings (KGP deprecation, SDK XML skew); no new
+ones.
+
+---
+
+## 8. Bottom line
+
+| Version | Status | Basis |
+|---|---|---|
+| Android 7–14 (API 24–34) | ✅ Compatible | `minSdk 24`; only API 29 has a special path, unrelated to these fixes |
+| **Android 15 (API 35)** | ✅ Compatible | All plugin gates are lower bounds; SDK installed; reporter's device |
+| **Android 16 (API 36)** | ✅ Compatible | Is the `compileSdk`/`targetSdk`; identical code path to 15 |
+| **Android 17 (API 37)** | ⚠️ **Unverifiable** | Not released, SDK not installed. No upper bound in the fix; primary mechanism is OS-agnostic Dart |
+
+Build evidence: `flutter build apk --debug` completes successfully (exit 0)
+against `compileSdk`/`targetSdk` 36 with `minSdk` 24 — rebuilt 18:41 EDT against
+the post-review code.
+
+**Post-review changes add no version sensitivity** (§9): `changePauseFor` is pure
+Dart with zero platform-channel surface, and `ListenMode.dictation` is provably
+indistinguishable from `confirmation` in the native Android path — so the
+revision cannot regress any Android version. Dart/Kotlin enum ordinals verified
+aligned.
+
+No gradle, manifest, or `minSdk` change is required for 15 or 16. The hotfix is
+version-robust because it is overwhelmingly Dart-side — but "robust by
+construction" is an argument, not a test result, and 17 should be re-tested when
+it ships.

--- a/mobile/netclaw-mobile/lib/main.dart
+++ b/mobile/netclaw-mobile/lib/main.dart
@@ -499,15 +499,17 @@ class _HomeShellState extends State<HomeShell> {
   Future<void> _confirmClearChat() async {
     final store = _conversationStore;
     if (store == null) return;
-    // Warn specifically when something is still running — the Border keeps
-    // working on it, but a cleared turn has nothing left to reconcile into, so
-    // that answer will never appear on this device.
+    // In-progress requests are now KEPT rather than destroyed. This dialog used
+    // to warn that a running request's answer "will no longer appear here" —
+    // i.e. it described the data loss instead of preventing it. Reported by a
+    // tester as a bug, and rightly so: clearing history should not silently
+    // discard work the Border is still doing.
     final extra = store.hasInProgressTurns
-        ? '\n\nA request is still in progress. The Border will finish it, but '
-            'the answer will no longer appear here.'
+        ? '\n\nRequests still in progress will be kept so their answers can '
+            'still arrive.'
         : '';
     if (!await _confirm('Clear chat history?',
-        'Deletes this conversation from this phone. Your Border keeps its own '
+        'Deletes finished requests from this phone. Your Border keeps its own '
         'audit record.$extra',
         'Clear')) {
       return;

--- a/mobile/netclaw-mobile/lib/ncfed/conversation_store.dart
+++ b/mobile/netclaw-mobile/lib/ncfed/conversation_store.dart
@@ -123,21 +123,47 @@ class ConversationStore {
   /// own audit trail (GAIT) and this does not and must not touch it, so
   /// clearing here is a display convenience, never an audit-evasion path.
   ///
-  /// In-progress turns go too. That's deliberate: the Border keeps working
-  /// and reconciliation no longer has a local row to reconcile against, so a
-  /// cleared in-flight answer simply never appears. Callers should warn when
-  /// anything is still running — see [hasInProgressTurns] and the
-  /// confirmation in `main.dart`.
-  Future<void> clear() async {
+  /// **In-progress turns are PRESERVED by default.** This previously deleted
+  /// them along with everything else, which destroyed work the Border was
+  /// still actively doing: the answer arrives, reconciliation finds no local
+  /// row to attach it to, and it is silently dropped forever. Reported by a
+  /// tester — "it clears all messages including the pending actual working
+  /// messages that are processing currently". Clearing *history* should not
+  /// cancel the *future*, and the operator asking to tidy a transcript is not
+  /// asking to throw away a running request.
+  ///
+  /// Pass `includeInProgress: true` for the old all-or-nothing behaviour — the
+  /// caller must have explicitly confirmed that intent.
+  ///
+  /// Note: preserving a turn is *not* the same as cancelling it. A request the
+  /// operator genuinely wants stopped should go through
+  /// `EdgeAskClient.cancel()`, which tells the Border to stop working; deleting
+  /// the local row never did that.
+  Future<void> clear({bool includeInProgress = false}) async {
     await load();
+    final kept = includeInProgress
+        ? const <ConversationTurn>[]
+        : _turns.where((t) => !_isTerminal(t.state)).toList();
+
     for (final turn in _turns) {
+      if (kept.contains(turn)) continue; // its photo is still on display
       final path = turn.photoPath;
       if (path == null) continue;
       final file = File(path);
       if (await file.exists()) await file.delete();
     }
-    _turns.clear();
-    final file = _file();
-    if (await file.exists()) await file.delete();
+
+    _turns
+      ..clear()
+      ..addAll(kept);
+
+    if (kept.isEmpty) {
+      final file = _file();
+      if (await file.exists()) await file.delete();
+    } else {
+      // Rewrite rather than delete, so the surviving in-flight turns are still
+      // there after a restart and can still be reconciled.
+      await _save();
+    }
   }
 }

--- a/mobile/netclaw-mobile/lib/ncfed/voice_transcription.dart
+++ b/mobile/netclaw-mobile/lib/ncfed/voice_transcription.dart
@@ -24,6 +24,10 @@ enum VoiceFailure {
 
   /// The recognition engine reported an error mid-session.
   engineError,
+
+  /// The operator tapped the mic again to abandon the recording. Not a
+  /// failure to report back at them — they know, they did it.
+  cancelled,
 }
 
 /// Outcome of one voice capture: either transcribed [text], or a [failure]
@@ -49,73 +53,204 @@ class VoiceResult {
 /// `recordAndAsk`'s request-shape guarantee without a real microphone/STT
 /// platform channel.
 class VoiceTranscription {
-  /// How long to wait for a final result before giving up. Without a bound the
-  /// completer could wait forever if the engine ended its session without ever
-  /// firing `finalResult` — the mic button would hang with no way out.
+  /// Hard ceiling on one recording. Reached only if the operator genuinely
+  /// talks for this long — [pauseFor] ends a normal request within seconds of
+  /// them stopping.
   static const listenTimeout = Duration(seconds: 30);
+
+  /// Silence tolerated **before the operator has said anything**, i.e. how long
+  /// they get to collect their thoughts after tapping the mic.
+  ///
+  /// Deliberately generous. Tapping a mic and being cut off before you have
+  /// begun is the worst possible failure — there is nothing to salvage and no
+  /// partial text to keep.
+  static const initialPauseFor = Duration(seconds: 10);
+
+  /// Silence tolerated **mid-sentence, once speech has started**, before the
+  /// session is considered complete.
+  ///
+  /// This is the fix for the reported "mic stays hanging": `pauseFor` was unset,
+  /// and `speech_to_text`'s stop check is guarded on it —
+  /// `else if (null != pauseFor && _elapsedSinceSpeechEvent >= ...) _stop()` —
+  /// so with it null the branch was unreachable and every session ran the full
+  /// [listenTimeout] regardless of when the speaker stopped. 7.4.0 is the first
+  /// release whose Android side honours `pauseFor` at all, so on earlier
+  /// versions the omission was harmless; here it was the bug.
+  ///
+  /// **Why 5s and not 3s.** Justin (the original reporter) raised that 3s risks
+  /// cutting off a slow speaker or someone pausing mid-sentence — a fair
+  /// objection, and a worse failure than a slightly late stop: a truncated
+  /// network request ("check BGP on…") is actively misleading, whereas an extra
+  /// second of waiting is merely mild. Network operators also dictate content
+  /// full of natural pauses — device names, interface IDs, IP addresses — where
+  /// people hesitate mid-utterance.
+  ///
+  /// Also note the plugin's own caveat on this value: *"On some systems, notably
+  /// Android, there is a system imposed pause of from one to three seconds that
+  /// cannot be overridden."* A 3s request therefore sat right at the floor the
+  /// platform might enforce anyway, leaving no headroom. 5s is comfortably
+  /// clear of it while still ending a finished request promptly.
+  static const pauseFor = Duration(seconds: 5);
+
+  /// One recogniser for the whole process.
+  ///
+  /// `SpeechToText()` is a thin Dart wrapper over a **single** platform-side
+  /// resource (`SpeechRecognizer` on Android, `SFSpeechRecognizer` on iOS).
+  /// Constructing a fresh wrapper per tap — as this used to — lets
+  /// `initialize()` report success while `listen()` quietly attaches to a
+  /// recogniser that is still tearing down from the previous session: no
+  /// audio captured and no error raised, which is the reported "sometimes it
+  /// just doesn't record". Android surfaces it as `ERROR_RECOGNIZER_BUSY`
+  /// when it surfaces anything at all.
+  static stt.SpeechToText? _shared;
+  static bool _ready = false;
+
+  /// Completion hook for the session in flight; null while idle.
+  ///
+  /// `onError`/`onStatus` are registered once, at `initialize()` time, and so
+  /// outlive any single recording — they have to reach the *current*
+  /// completer rather than closing over a stale one.
+  static void Function(VoiceResult)? _activeFinish;
+  static SpeechRecognitionError? _lastError;
 
   final Future<VoiceResult> Function() _listenOnce;
 
   VoiceTranscription({Future<VoiceResult> Function()? listenOnce})
       : _listenOnce = listenOnce ?? _defaultListenOnce;
 
-  static Future<VoiceResult> _defaultListenOnce() async {
-    final speech = stt.SpeechToText();
-    SpeechRecognitionError? lastError;
+  /// Abandons the recording in flight, if any. Safe to call when idle.
+  Future<void> cancel() async {
+    _activeFinish?.call(const VoiceResult.failed(VoiceFailure.cancelled, null));
+    final speech = _shared;
+    if (speech != null && speech.isListening) await speech.cancel();
+  }
 
-    final available = await speech.initialize(onError: (e) => lastError = e);
-    if (!available) {
-      // Distinguish "you said no" from "this device can't do it at all" —
-      // those need completely different responses from the operator.
-      if (!await speech.hasPermission) {
-        return const VoiceResult.failed(VoiceFailure.permissionDenied,
-            'Microphone permission is needed for voice requests.');
+  static Future<VoiceResult> _defaultListenOnce() async {
+    final speech = _shared ?? stt.SpeechToText();
+
+    if (!_ready) {
+      final available = await speech.initialize(
+        onError: (e) {
+          _lastError = e;
+          // Previously this only recorded the error. With `cancelOnError: true`
+          // the session is then cancelled, so `onResult` never fires either —
+          // leaving the completer orphaned and the UI frozen for the full
+          // timeout on *every* mid-session error. Complete immediately.
+          _activeFinish?.call(VoiceResult.failed(VoiceFailure.engineError,
+              'Speech recognition failed: ${e.errorMsg}'));
+        },
+        onStatus: (status) {
+          // A session can end cleanly having heard nothing: no final result,
+          // no error. Without this the only way out was the timeout.
+          // `finish` is idempotent, so a real result arriving first wins.
+          if (status == stt.SpeechToText.doneStatus) {
+            _activeFinish?.call(const VoiceResult.failed(
+                VoiceFailure.noSpeechDetected,
+                "Didn't catch that — try again."));
+          }
+        },
+      );
+      if (!available) {
+        // Distinguish "you said no" from "this device can't do it at all" —
+        // those need completely different responses from the operator.
+        if (!await speech.hasPermission) {
+          return const VoiceResult.failed(VoiceFailure.permissionDenied,
+              'Microphone permission is needed for voice requests.');
+        }
+        final why = _lastError?.errorMsg;
+        return VoiceResult.failed(
+            VoiceFailure.unavailable,
+            why != null
+                ? 'Speech recognition unavailable: $why'
+                : 'Speech recognition is unavailable on this device.');
       }
-      final why = lastError?.errorMsg;
-      return VoiceResult.failed(
-          VoiceFailure.unavailable,
-          why != null
-              ? 'Speech recognition unavailable: $why'
-              : 'Speech recognition is unavailable on this device.');
+      _shared = speech;
+      _ready = true;
     }
 
+    // Reclaim the recogniser if a previous session was abandoned without
+    // being stopped. Cheap when idle, and the difference between a working
+    // mic and a silently dead one when not.
+    if (speech.isListening) await speech.cancel();
+
+    _lastError = null;
     final completer = Completer<VoiceResult>();
     void finish(VoiceResult r) {
       if (!completer.isCompleted) completer.complete(r);
     }
 
-    await speech.listen(
-      onResult: (result) {
-        if (!result.finalResult) return;
-        final words = result.recognizedWords.trim();
-        finish(words.isEmpty
-            ? const VoiceResult.failed(
-                VoiceFailure.noSpeechDetected, "Didn't catch that — try again.")
-            : VoiceResult.success(words));
-      },
-      listenOptions: stt.SpeechListenOptions(
-        partialResults: false,
-        cancelOnError: true,
-        listenFor: listenTimeout,
-      ),
-    );
+    _activeFinish = finish;
+    var tightened = false;
+    try {
+      await speech.listen(
+        onResult: (result) {
+          // First sign of speech: drop from the generous [initialPauseFor] to
+          // the mid-sentence [pauseFor]. This is the plugin's documented
+          // pattern for exactly this — `changePauseFor` exists to allow "a long
+          // first pause then dynamically shortening it once the user starts
+          // speaking" — and it is why the operator can take their time starting
+          // without every finished request then waiting the full initial
+          // window. `isNotListening` would throw, so guard on it.
+          if (!tightened && speech.isListening) {
+            tightened = true;
+            speech.changePauseFor(pauseFor);
+          }
+          // Partials are enabled below purely to drive `pauseFor` and this
+          // transition; the Border still only ever sees final text, exactly as
+          // a typed request does.
+          if (!result.finalResult) return;
+          final words = result.recognizedWords.trim();
+          finish(words.isEmpty
+              ? const VoiceResult.failed(VoiceFailure.noSpeechDetected,
+                  "Didn't catch that — try again.")
+              : VoiceResult.success(words));
+        },
+        listenOptions: stt.SpeechListenOptions(
+          // Must be true whenever `pauseFor` is set. The plugin's own
+          // convenience path coerces exactly this
+          // (`partialResults: partialResults || null != pauseFor`), so an
+          // explicit SpeechListenOptions pairing `pauseFor` with
+          // `partialResults: false` bypasses that coercion and is an
+          // untested combination. Some Android engines also skip the final
+          // result entirely for very short utterances with partials off.
+          // Partials additionally power the initial->mid-sentence pause
+          // transition above.
+          partialResults: true,
+          cancelOnError: true,
+          listenFor: listenTimeout,
+          // Starts generous; tightened on first speech (see onResult).
+          pauseFor: initialPauseFor,
+          // A spoken request is a sentence ("check every core router for BGP
+          // problems"), not a keyword or a command word. The default
+          // `confirmation` mode tunes the engine for short phrases, which
+          // biases it toward finalising early — the opposite of what a slow
+          // or pausing speaker needs. iOS-only in this plugin, but correct to
+          // declare regardless.
+          listenMode: stt.ListenMode.dictation,
+        ),
+      );
 
-    // The engine can also end its session without ever producing a final
-    // result (pure silence, or an error raised after listen() returned).
-    // Both land here instead of hanging.
-    final result = await completer.future.timeout(
-      listenTimeout + const Duration(seconds: 2),
-      onTimeout: () {
-        final why = lastError?.errorMsg;
-        return why != null
-            ? VoiceResult.failed(
-                VoiceFailure.engineError, 'Speech recognition failed: $why')
-            : const VoiceResult.failed(VoiceFailure.noSpeechDetected,
-                "Didn't hear anything — try again.");
-      },
-    );
-    await speech.stop();
-    return result;
+      // Backstop only. `pauseFor` and `onStatus` should both beat this now;
+      // it remains so that a wedged engine can never hang the mic forever.
+      return await completer.future.timeout(
+        listenTimeout + const Duration(seconds: 2),
+        onTimeout: () {
+          final why = _lastError?.errorMsg;
+          return why != null
+              ? VoiceResult.failed(
+                  VoiceFailure.engineError, 'Speech recognition failed: $why')
+              : const VoiceResult.failed(VoiceFailure.noSpeechDetected,
+                  "Didn't hear anything — try again.");
+        },
+      );
+    } finally {
+      // `stop()` used to sit on the success path only, so any throw here — or
+      // a dispose mid-listen — leaked a live session, which then poisoned the
+      // *next* recording. That cascade is what made one deterministic hang
+      // look like an intermittent fault.
+      _activeFinish = null;
+      if (speech.isListening) await speech.cancel();
+    }
   }
 
   /// Records, transcribes, and sends the result through the SAME `ask()`

--- a/mobile/netclaw-mobile/lib/screens/chat_screen.dart
+++ b/mobile/netclaw-mobile/lib/screens/chat_screen.dart
@@ -135,6 +135,9 @@ class _ChatScreenState extends State<ChatScreen> {
         // tapped the mic and nothing whatsoever happened. Always say why.
         onFailure: (failure) {
           if (!mounted) return;
+          // Don't report a cancellation back at the operator who just asked
+          // for it.
+          if (failure.failure == VoiceFailure.cancelled) return;
           ScaffoldMessenger.of(context).showSnackBar(SnackBar(
             content: Text(failure.message ?? 'Voice request failed.'),
             duration: const Duration(seconds: 4),
@@ -266,10 +269,17 @@ class _ChatScreenState extends State<ChatScreen> {
                   // Visible listening state — the mic previously gave no
                   // indication it was live, so a working recording looked
                   // identical to a broken one.
-                  icon: Icon(_listening ? Icons.mic : Icons.mic_none,
+                  icon: Icon(_listening ? Icons.stop_circle : Icons.mic_none,
                       color: _listening ? Theme.of(context).colorScheme.error : null),
-                  tooltip: _listening ? 'Listening…' : 'Voice request',
-                  onPressed: _listening ? null : _recordVoice,
+                  tooltip: _listening ? 'Stop listening' : 'Voice request',
+                  // Tapping while live now CANCELS. This used to be `null`,
+                  // which disabled the button for the whole session — so a
+                  // recording that overran left the operator with no way out
+                  // at all, and abandoning the app instead is exactly what
+                  // leaked the recogniser and broke the next attempt.
+                  onPressed: _listening
+                      ? () => widget.voiceTranscription.cancel()
+                      : _recordVoice,
                 ),
                 IconButton(icon: const Icon(Icons.send), onPressed: _send),
               ],

--- a/mobile/netclaw-mobile/test/clear_and_revocation_test.dart
+++ b/mobile/netclaw-mobile/test/clear_and_revocation_test.dart
@@ -18,10 +18,19 @@ void main() {
   });
 
   group('ConversationStore.clear', () {
-    test('removes every turn and the backing file', () async {
+    // NOTE: the first two tests here previously asserted that `clear()` deleted
+    // *every* turn including pending ones, and passed — they encoded the
+    // reported bug ("it clears all messages including the pending actual
+    // working messages that are processing currently") as the expected
+    // contract. Rewritten to assert finished-only clearing; the
+    // clear-everything behaviour is now opt-in and covered separately below.
+
+    test('removes finished turns and the backing file', () async {
       final store = ConversationStore(dir);
       await store.addPending('t1', 'first');
       await store.addPending('t2', 'second');
+      await store.updateState('t1', 'completed', answerText: 'a');
+      await store.updateState('t2', 'failed');
       expect(store.turns, hasLength(2));
 
       await store.clear();
@@ -30,9 +39,76 @@ void main() {
       expect(File('${dir.path}/ncfed_conversation.json').existsSync(), isFalse);
     });
 
+    test('an in-progress turn SURVIVES a clear (regression)', () async {
+      // The reported bug. The Border keeps working on a pending/working turn,
+      // so deleting its local row means the answer arrives with nothing to
+      // reconcile into and is silently lost forever.
+      final store = ConversationStore(dir);
+      await store.addPending('done', 'finished request');
+      await store.updateState('done', 'completed', answerText: 'answer');
+      await store.addPending('running', 'still working on this');
+
+      await store.clear();
+
+      expect(store.turns, hasLength(1));
+      expect(store.turns.single.taskId, 'running');
+      expect(store.hasInProgressTurns, isTrue);
+    });
+
+    test("a 'working' turn survives too, not just 'pending'", () async {
+      final store = ConversationStore(dir);
+      await store.addPending('w1', 'ask');
+      await store.updateState('w1', 'working');
+
+      await store.clear();
+
+      expect(store.turns.single.taskId, 'w1');
+      expect(store.turns.single.state, 'working');
+    });
+
+    test('a surviving turn is still there after a restart', () async {
+      // Preserving it in memory is useless if the rewrite doesn't happen — the
+      // turn has to outlive a cold start to be reconcilable.
+      final store = ConversationStore(dir);
+      await store.addPending('t1', 'first');
+      await store.clear();
+
+      final reopened = ConversationStore(dir);
+      await reopened.load();
+      expect(reopened.turns, hasLength(1));
+      expect(reopened.turns.single.taskId, 't1');
+    });
+
+    test('includeInProgress: true clears everything, opt-in', () async {
+      final store = ConversationStore(dir);
+      await store.addPending('t1', 'first');
+      await store.addPending('t2', 'second');
+      await store.updateState('t2', 'completed', answerText: 'a');
+
+      await store.clear(includeInProgress: true);
+
+      expect(store.turns, isEmpty);
+      expect(File('${dir.path}/ncfed_conversation.json').existsSync(), isFalse);
+    });
+
+    test('a finished turn cleared alongside a survivor stays gone on restart',
+        () async {
+      final store = ConversationStore(dir);
+      await store.addPending('gone', 'old request');
+      await store.updateState('gone', 'completed', answerText: 'a');
+      await store.addPending('kept', 'in flight');
+
+      await store.clear();
+
+      final reopened = ConversationStore(dir);
+      await reopened.load();
+      expect(reopened.turns.map((t) => t.taskId), ['kept']);
+    });
+
     test('a cleared store stays empty across a simulated restart', () async {
       final store = ConversationStore(dir);
       await store.addPending('t1', 'first');
+      await store.updateState('t1', 'completed', answerText: 'a');
       await store.clear();
 
       // Fresh instance = cold start reading the same directory.

--- a/mobile/netclaw-mobile/test/conversation_store_test.dart
+++ b/mobile/netclaw-mobile/test/conversation_store_test.dart
@@ -36,7 +36,12 @@ void main() {
     expect(store.turns.single.answerText, 'done already');
   });
 
-  test('clear() deletes all turns, the persisted file, and every saved photo', () async {
+  test('clear() deletes finished turns, the persisted file, and their photos',
+      () async {
+    // Previously this added two *pending* turns and asserted clear() removed
+    // them both -- encoding the reported bug (in-flight requests destroyed) as
+    // the expected contract. Turns are marked terminal first so the test
+    // exercises what clearing history is actually for.
     final dir = await Directory.systemTemp.createTemp('ncfed_conv_test_');
     addTearDown(() => dir.delete(recursive: true));
 
@@ -45,6 +50,8 @@ void main() {
     await store.addPending('task-4', 'has a photo', photoBytes: [1, 2, 3]);
     final photoPath = store.turns.last.photoPath!;
     expect(await File(photoPath).exists(), isTrue);
+    await store.updateState('task-3', 'completed', answerText: 'done');
+    await store.updateState('task-4', 'completed', answerText: 'done');
 
     await store.clear();
 
@@ -57,5 +64,25 @@ void main() {
     final reloaded = ConversationStore(dir);
     await reloaded.load();
     expect(reloaded.turns, isEmpty);
+  });
+
+  test("clear() keeps an in-flight turn's photo on disk", () async {
+    // A preserved turn still renders in the UI, so deleting its photo would
+    // leave a broken '[Photo unavailable]' tile attached to a live request.
+    final dir = await Directory.systemTemp.createTemp('ncfed_conv_photo_keep_');
+    addTearDown(() => dir.delete(recursive: true));
+
+    final store = ConversationStore(dir);
+    await store.addPending('finished', 'old', photoBytes: [9, 9]);
+    final goneP = store.turns.last.photoPath!;
+    await store.updateState('finished', 'completed', answerText: 'a');
+    await store.addPending('inflight', 'current', photoBytes: [1, 2, 3]);
+    final keptP = store.turns.last.photoPath!;
+
+    await store.clear();
+
+    expect(await File(goneP).exists(), isFalse, reason: 'finished photo removed');
+    expect(await File(keptP).exists(), isTrue, reason: 'in-flight photo retained');
+    expect(store.turns.single.photoPath, keptP);
   });
 }

--- a/mobile/netclaw-mobile/test/voice_session_test.dart
+++ b/mobile/netclaw-mobile/test/voice_session_test.dart
@@ -1,0 +1,241 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:netclaw_mobile/ncfed/edge_ask_client.dart';
+import 'package:netclaw_mobile/ncfed/edge_client.dart';
+import 'package:netclaw_mobile/ncfed/voice_transcription.dart';
+
+/// Regression tests for the recording *session* — the paths that produced the
+/// reported "mic sometimes doesn't record / sometimes just hangs".
+///
+/// The existing `voice_transcription_test.dart` injects `listenOnce` and so
+/// deliberately stubs the whole session out; it asserts request *shape*. That
+/// left the state machine at zero coverage, which is why 109 green tests said
+/// nothing about a broken microphone. These tests model the session outcomes
+/// the plugin can actually produce and assert the contract each must satisfy:
+/// **every path terminates, and none of them leak.**
+///
+/// A full fake of `SpeechToText` would mean injecting the plugin itself (a
+/// larger refactor, tracked in BUG_mic_recording.md item 8). These cover the
+/// observable contract at the seam that exists today.
+class _RecordingEdgeRpcSource implements EdgeRpcSource {
+  final List<(String method, Map<String, dynamic> params)> calls = [];
+
+  @override
+  void on(String method, EdgeMethodHandler handler) {}
+
+  @override
+  Future<Map<String, dynamic>> call(String method, Map<String, dynamic> params,
+      {Duration timeout = const Duration(seconds: 30)}) async {
+    calls.add((method, params));
+    return {'task_id': 'task-voice-1'};
+  }
+}
+
+void main() {
+  group('session timing constants (BUG 1 — the hang)', () {
+    test('pauseFor is set, and is well under listenFor', () {
+      // The entire reported hang was `pauseFor` being null: the plugin's stop
+      // check is guarded on `null != pauseFor`, so with it unset the
+      // silence-stop branch is unreachable and every session ran the full
+      // listenFor. Guard the value's existence, not just its number.
+      expect(VoiceTranscription.pauseFor, isNotNull);
+      expect(VoiceTranscription.pauseFor, isA<Duration>());
+      expect(VoiceTranscription.pauseFor.inMilliseconds, greaterThan(0));
+      expect(VoiceTranscription.pauseFor, lessThan(VoiceTranscription.listenTimeout));
+    });
+
+    test('mid-sentence pauseFor clears the platform-imposed floor', () {
+      // The plugin documents: "On some systems, notably Android, there is a
+      // system imposed pause of from one to three seconds that cannot be
+      // overridden." A value at or under 3s sits *at* that floor with no
+      // headroom, so a slow speaker gets cut off by the platform regardless of
+      // what we ask for. Must be strictly greater than 3s.
+      expect(VoiceTranscription.pauseFor.inSeconds, greaterThan(3),
+          reason: 'must clear the 1-3s platform floor');
+      // Still bounded — beyond ~10s a finished request feels broken again.
+      expect(VoiceTranscription.pauseFor.inSeconds, lessThanOrEqualTo(10));
+    });
+
+    test('the operator gets longer to START than to pause mid-sentence', () {
+      // Two-stage pause (plugin's documented `changePauseFor` pattern: "a long
+      // first pause then dynamically shortening it once the user starts
+      // speaking"). Being cut off before saying anything is the worst failure —
+      // nothing to salvage — so the opening window must be the more generous of
+      // the two.
+      expect(VoiceTranscription.initialPauseFor,
+          greaterThan(VoiceTranscription.pauseFor));
+      expect(VoiceTranscription.initialPauseFor.inSeconds,
+          greaterThanOrEqualTo(5));
+    });
+
+    test('both pause windows stay inside the hard ceiling', () {
+      // Either window exceeding listenFor would make it unreachable and
+      // silently reintroduce the original hang.
+      expect(VoiceTranscription.initialPauseFor,
+          lessThan(VoiceTranscription.listenTimeout));
+      expect(VoiceTranscription.pauseFor,
+          lessThan(VoiceTranscription.listenTimeout));
+    });
+
+    test('listenFor remains a bounded hard ceiling', () {
+      expect(VoiceTranscription.listenTimeout.inSeconds, greaterThan(0));
+      expect(VoiceTranscription.listenTimeout.inSeconds, lessThanOrEqualTo(60));
+    });
+
+    test('a slow speaker fits: initial + mid-sentence pauses under the ceiling',
+        () {
+      // Worst realistic case — operator takes a while to start, then pauses
+      // mid-sentence recalling a device name. Both waits must fit inside
+      // listenFor or the session dies mid-request.
+      final worstCase =
+          VoiceTranscription.initialPauseFor + VoiceTranscription.pauseFor;
+      expect(worstCase, lessThan(VoiceTranscription.listenTimeout));
+    });
+  });
+
+  group('failure classification', () {
+    test('cancelled is a distinct outcome, not an error to report back', () {
+      // The operator tapping stop must not raise a "voice request failed"
+      // snackbar at the person who just asked for it.
+      expect(VoiceFailure.values, contains(VoiceFailure.cancelled));
+    });
+
+    test('a cancelled result carries no operator-facing message', () {
+      const result = VoiceResult.failed(VoiceFailure.cancelled, null);
+      expect(result.ok, isFalse);
+      expect(result.message, isNull);
+      expect(result.failure, VoiceFailure.cancelled);
+    });
+
+    test('every failure mode is representable and never looks like success', () {
+      for (final mode in VoiceFailure.values) {
+        final result = VoiceResult.failed(mode, 'why');
+        expect(result.ok, isFalse, reason: '$mode must not read as success');
+        expect(result.text, isNull, reason: '$mode must carry no text');
+      }
+    });
+  });
+
+  group('recordAndAsk contract (all six bug paths)', () {
+    test('engineError mid-session terminates and sends nothing (BUG 2)', () async {
+      // onError previously only recorded the error; with cancelOnError:true
+      // onResult then never fired either, orphaning the completer for the full
+      // 32s. Whatever the cause, the call must return and must not ask.
+      final source = _RecordingEdgeRpcSource();
+      final voice = VoiceTranscription(
+        listenOnce: () async => const VoiceResult.failed(
+            VoiceFailure.engineError, 'Speech recognition failed: busy'),
+      );
+      VoiceResult? reported;
+
+      final result = await voice
+          .recordAndAsk(EdgeAskClient(source), onFailure: (f) => reported = f)
+          .timeout(const Duration(seconds: 2));
+
+      expect(result, isNull);
+      expect(reported?.failure, VoiceFailure.engineError);
+      expect(source.calls, isEmpty, reason: 'no request may reach the Border');
+    });
+
+    test('a silent session terminates and sends nothing (BUG 3/6)', () async {
+      final source = _RecordingEdgeRpcSource();
+      final voice = VoiceTranscription(
+        listenOnce: () async => const VoiceResult.failed(
+            VoiceFailure.noSpeechDetected, "Didn't catch that — try again."),
+      );
+
+      final result = await voice
+          .recordAndAsk(EdgeAskClient(source))
+          .timeout(const Duration(seconds: 2));
+
+      expect(result, isNull);
+      expect(source.calls, isEmpty);
+    });
+
+    test('cancelling sends nothing and reports the cancellation', () async {
+      final source = _RecordingEdgeRpcSource();
+      final voice = VoiceTranscription(
+        listenOnce: () async =>
+            const VoiceResult.failed(VoiceFailure.cancelled, null),
+      );
+      VoiceResult? reported;
+
+      final result = await voice.recordAndAsk(EdgeAskClient(source),
+          onFailure: (f) => reported = f);
+
+      expect(result, isNull);
+      expect(reported?.failure, VoiceFailure.cancelled);
+      expect(source.calls, isEmpty);
+    });
+
+    test('back-to-back recordings both complete (BUG 4/5 — the cascade)',
+        () async {
+      // The reported "sometimes doesn't record" was attempt N leaking a live
+      // recogniser that silently broke attempt N+1. Sequential recordings must
+      // be independent.
+      final source = _RecordingEdgeRpcSource();
+      var call = 0;
+      final voice = VoiceTranscription(
+        listenOnce: () async {
+          call++;
+          return VoiceResult.success('request number $call');
+        },
+      );
+      final askClient = EdgeAskClient(source);
+
+      final first = await voice.recordAndAsk(askClient);
+      final second = await voice.recordAndAsk(askClient);
+
+      expect(first, isNotNull);
+      expect(second, isNotNull);
+      expect(first!.$2, 'request number 1');
+      expect(second!.$2, 'request number 2');
+      expect(source.calls, hasLength(2));
+    });
+
+    test('a whitespace-only transcription is never sent', () async {
+      final source = _RecordingEdgeRpcSource();
+      final voice = VoiceTranscription(
+        listenOnce: () async => const VoiceResult.failed(
+            VoiceFailure.noSpeechDetected, "Didn't catch that — try again."),
+      );
+
+      expect(await voice.recordAndAsk(EdgeAskClient(source)), isNull);
+      expect(source.calls, isEmpty);
+    });
+
+    test('partials are enabled but only final text reaches the Border', () async {
+      // partialResults must be true for pauseFor to work, but that must not
+      // change the wire contract: the Border still sees one {"text": ...}
+      // exactly as a typed request produces.
+      final source = _RecordingEdgeRpcSource();
+      final voice = VoiceTranscription(
+        listenOnce: () async => const VoiceResult.success('show bgp summary'),
+      );
+
+      await voice.recordAndAsk(EdgeAskClient(source));
+
+      expect(source.calls, hasLength(1));
+      expect(source.calls.single.$1, 'n2n/edge/ask');
+      expect(source.calls.single.$2, {'text': 'show bgp summary'});
+    });
+  });
+
+  group('cancel()', () {
+    test('is safe to call when idle', () async {
+      // The stop button is only shown while listening, but a race (dispose,
+      // rapid double-tap) must not throw.
+      final voice = VoiceTranscription(
+        listenOnce: () async => const VoiceResult.success('unused'),
+      );
+      await expectLater(voice.cancel(), completes);
+    });
+
+    test('is idempotent', () async {
+      final voice = VoiceTranscription(
+        listenOnce: () async => const VoiceResult.success('unused'),
+      );
+      await voice.cancel();
+      await expectLater(voice.cancel(), completes);
+    });
+  });
+}


### PR DESCRIPTION
Two bugs Justin reported on 2026-07-27, both triaged and fixed by a NetClaw Border session earlier today. The work was sitting uncommitted in the tree; I verified it independently before committing rather than trusting the write-ups.

**Verified:** `flutter analyze` clean · `flutter test` **132/132**

## 1. "Clear messages" destroyed in-flight requests

> *"when you clear messages it actually clears all messages including the pending actual working messages that are processing currently"*

`ConversationStore.clear()` deleted every turn unconditionally. The Border kept working, but with the local row gone reconciliation had nothing to attach the answer to — silently dropped, unrecoverable, invisible.

The old code **knew** this and documented it as intended, with the dialog warning that a running request's answer "will no longer appear here". It described the data loss instead of preventing it. Clearing *history* shouldn't cancel the *future*.

Now preserves non-terminal turns by default, with opt-in `includeInProgress: true`. Preserving is deliberately not cancelling — a request the operator wants stopped goes through `EdgeAskClient.cancel()`, which actually tells the Border to stop. Deleting a local row never did.

## 2. Mic hung, or silently failed to record

Android 15, Google recognition engine. Root cause found by reading `speech_to_text` 7.4.0, not inferred: **`pauseFor` was never set**, and the plugin's stop check is guarded on it —

```dart
else if (null != pauseFor && _elapsedSinceSpeechEvent >= ...) _stop()
```

With it null that branch is unreachable, so every session ran the full `listenTimeout` regardless of when the speaker stopped. 7.4.0 is also the first release whose Android side honours `pauseFor` at all — which is why the omission was harmless before and became the bug here.

The hang then **caused** the second symptom: the mic button was `onPressed: null` for the whole session, so an overrunning recording left no way out. Backgrounding the app instead leaked the recogniser and broke the next attempt — "sometimes it doesn't record".

Fixes: separate silence budgets before speech starts (generous — being cut off before you've begun leaves nothing to salvage) vs mid-sentence; tapping a live mic cancels; and a cancellation the operator asked for is no longer reported back as a failure.

The 5s mid-sentence value is deliberate. Justin objected that 3s risks clipping a slow speaker — the worse failure, since a truncated request (`"check BGP on…"`) is actively misleading where a late stop just costs a moment.

`MIC_HOTFIX_ANDROID_COMPAT.md` covers Android 15/16 with evidence and **explicitly declines to claim Android 17** — no testable target, no installed SDK, so asserting it would be guesswork.

## 3. Dark mode spec — draft only, nothing implemented

Committed so the analysis isn't lost. Finds the work unusually cheap: 20 total colour references in `lib/`, 6 already resolving through `Theme.of(context)`, leaving 14 hardcoded across 7 files. No token layer, no refactor, no new dependency. Status stays **Draft**; no theme code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)