### PR TITLE
fix(hud): stop returning plaintext secrets from /api/env/:integrationId

### DIFF
--- a/ui/netclaw-visual/server.js
+++ b/ui/netclaw-visual/server.js
@@ -1084,9 +1084,13 @@ app.get('/api/env/:integrationId', (req, res) => {
   if (!mapping) return res.status(404).json({ error: 'Unknown integration' });
 
   const envVars = parseEnvFile();
+  // Never return the cleartext value. The HUD renders `masked` and `isSet`
+  // only, and this endpoint enumerates every credential in .env on an
+  // unauthenticated listener that binds all interfaces. To change a key the
+  // operator types a new one; PUT /api/env never needs the old value echoed
+  // back, so there is no consumer for the plaintext.
   const fields = mapping.env.map((key) => ({
     key,
-    value: envVars[key] || '',
     masked: envVars[key] ? maskValue(envVars[key]) : '',
     isSet: key in envVars && envVars[key] !== '',
   }));


### PR DESCRIPTION
The endpoint returns every key in the integration's .env mapping with its cleartext value alongside the masked form:

    value: envVars[key] || '',
    masked: envVars[key] ? maskValue(envVars[key]) : '',

The HUD never reads `value`. renderEnvFields() uses `field.key`, `field.isSet` and `field.masked`, and sets the input's value to "" explicitly (src/main.js). So the plaintext has no consumer in the UI.

That matters because this endpoint enumerates credentials for every configured integration — SoT tokens, cloud keys, device passwords — and the HUD has no authentication, while server.listen(PORT) with no host binds all interfaces. Any host that can reach the port can read them:

    curl -s http://<hud-host>:3001/api/env/nautobot

Removing the field closes that without changing the UI. Editing a key still works: the operator types a new value, and PUT /api/env has never needed the old one echoed back.

Verified against this endpoint's only consumer: the config panel renders identically (placeholder from `masked`, status from `isSet`) and saving a key is unaffected.