### PR TITLE
docs(074): on-device voice playback spec — clarified, corrected, renumbered

### DIFF
--- a/specs/073-mobile-voice-playback/spec.md
+++ b/specs/073-mobile-voice-playback/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `073-mobile-voice-playback`
 **Created**: 2026-07-29
-**Status**: Draft
+**Status**: Clarified (session 2026-07-29) — ready for `/speckit.plan`
 **Input**: User description: "working VOICE PLAYBACK to messages on android — where on the device it uses local TTS and plays back the message"
 
 ## Context: what exists today
@@ -24,6 +24,16 @@ There is also a pre-existing dead end this feature must consciously decide about
 | Agent answer to a request | `ConversationTurn.answerText` (`lib/ncfed/conversation_store.dart:9`) | `chat_screen.dart` | 067 |
 | Border-pushed message | `EdgeMessage.content` where `contentType == text` (`message_feed.dart:11-22`) | `feed_screen.dart` | 066 |
 
+## Clarifications
+
+### Session 2026-07-29
+
+- Q: When speaking an answer, how should the app handle network-ops text and long machine output (routing tables, CLI dumps, dotted quads, `GigabitEthernet0/0/1`)? → A: Normalise prose phone-side for intelligibility, and skip fenced-code/tabular blocks entirely — announcing them rather than reading them. Keeps the feature mobile-only; no Border protocol work.
+- Q: Must playback keep going when the app is backgrounded or the screen locks (the US2 "phone in pocket" case)? → A: No — foreground only for this iteration. Playback stops when the app leaves the foreground. Background playback is deferred to a follow-on rather than taking on an iOS background-audio entitlement and an Android foreground service now.
+- Q: Should this feature also implement playback of Border-pushed `voice` audio (the inert Chip at `feed_screen.dart:131-135`)? → A: No — kept separate. Confirmed during clarification that the `voice` content type has **no producer anywhere in the codebase**: the daemon validates it (`bgp-daemon-v2.py:725`) but the only occurrence is a test fixture (`test_edge_push.py:156`), and the push-notification path handles `text` only (`push_notify.py:79`). The inert Chip stays; it deserves its own spec if a producer ever appears.
+- Q: What should the settings surface include (FR-011)? → A: A single auto-speak toggle, defaulting to off. No in-app rate or voice picker — both platforms already expose a system-level TTS speech rate that the synthesiser honours when not overridden, so the app inherits the operator's existing OS preference.
+- Q: Should voice playback be audible when the phone is on silent/vibrate? → A: Split by trigger — an explicit tap plays audibly even when silenced (the operator just asked for sound), while auto-speak stays silent on a silenced phone (they silenced it to avoid unrequested noise). Matches platform convention for deliberate media vs notification audio.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Hear an answer without looking at the phone (Priority: P1)
@@ -41,16 +51,21 @@ An operator with their hands and eyes occupied — up a ladder in a data centre,
 3. **Given** a turn in `pending`/`working` state with no answer yet, **When** the operator looks at that turn, **Then** no speak control is offered (there is nothing to speak).
 4. **Given** a turn whose state is `failed` or `cancelled`, **When** the operator looks at that turn, **Then** no speak control is offered.
 5. **Given** the device has no usable TTS voice installed, **When** the operator activates the speak control, **Then** they are told why nothing was spoken and what to install — never a silent no-op.
+6. **Given** the device is in silent/vibrate mode, **When** the operator activates the speak control, **Then** the answer is still audible (FR-012a).
+7. **Given** an answer containing a fenced code block or table, **When** it is spoken, **Then** the surrounding prose is spoken and the block is announced with its size and location rather than read aloud (FR-009).
+8. **Given** an answer is being spoken, **When** an incoming call takes audio focus and then ends, **Then** playback does not resume by itself and the item remains re-triggerable (FR-013).
 
 ---
 
 ### User Story 2 - Answers spoken automatically as they arrive (Priority: P2)
 
-For genuinely hands-free operation the operator should not have to tap anything: having asked by voice, the answer should simply be read out when it lands. Because an agent turn can take a while, the operator may have put the phone in a pocket by then.
+For genuinely hands-free operation the operator should not have to tap anything: having asked by voice, the answer should simply be read out when it lands. An agent turn can take a while, so the operator will typically have set the phone down — screen still on, app still open — and gone back to what they were doing.
+
+**Scope boundary**: per the 2026-07-29 clarification this applies while the app is in the **foreground**. If the operator pockets the phone and the screen locks, playback stops (FR-007). The "answer arrives while the phone is in a pocket" case is deliberately deferred — see Out of Scope.
 
 **Why this priority**: This is what makes the feature usable in the field rather than merely present. It is separated from US1 because auto-speaking is a behaviour change with real annoyance potential (speaking aloud in a meeting), so it must be operator-controlled and is therefore independently shippable behind a setting.
 
-**Independent Test**: Enable the auto-speak setting, submit a request, put the phone down, and confirm the answer is spoken on arrival with no interaction. Disable the setting and confirm silence.
+**Independent Test**: Enable the auto-speak setting, submit a request, set the phone down with the screen on, and confirm the answer is spoken on arrival with no interaction. Disable the setting and confirm silence.
 
 **Acceptance Scenarios**:
 
@@ -58,6 +73,8 @@ For genuinely hands-free operation the operator should not have to tap anything:
 2. **Given** auto-speak is disabled (the default), **When** an answer arrives, **Then** nothing is spoken and the US1 manual control remains available.
 3. **Given** auto-speak is enabled and an answer is already being spoken, **When** a second answer arrives, **Then** the answers are spoken one after another without overlapping or being dropped.
 4. **Given** auto-speak is enabled, **When** the operator opens a historical turn from a previous session, **Then** old answers are not re-spoken on load.
+5. **Given** auto-speak is enabled and the device is in silent/vibrate mode, **When** an answer arrives, **Then** it is **not** spoken, and the operator can still see that the answer arrived and was not read aloud (FR-012a, FR-014).
+6. **Given** auto-speak is enabled and an answer is being spoken, **When** the app is backgrounded or the screen locks, **Then** playback stops (FR-007).
 
 ---
 
@@ -80,9 +97,10 @@ The Border pushes messages the operator did not ask for — alerts, notification
 
 - **Microphone interlock (critical).** What happens if playback starts while the recogniser is listening? Spoken output would be captured as input, transcribing NetClaw's own answer back into the next request. `chat_screen.dart` already tracks `_listening` and `voice_transcription.dart` exposes `cancel()`/`finishNow()`, so the state needed for an interlock exists — the spec requires one (FR-006).
 - **Domain text is hostile to naive TTS.** Answers routinely contain IP addresses, prefix lengths, MAC addresses, interface names (`GigabitEthernet0/0/1`), AS numbers, and pasted CLI/table output. A synthesiser reading `10.0.0.1/24` as "ten point zero point zero point one slash twenty-four" is tolerable; one reading a 40-line routing table verbatim is useless and cannot be interrupted fast enough to matter. See FR-008/FR-009.
-- **Interruptions.** Incoming call, another app taking audio focus, alarm, navigation prompt.
-- **Lifecycle.** App backgrounded, screen locked, or the screen disposed mid-utterance. `chat_screen.dart:58-67` already releases the mic on dispose; playback needs the equivalent.
-- **Audio routing.** Bluetooth headset, wired headphones, car audio, speakerphone, silent/vibrate mode. Does silent mode suppress playback the operator explicitly requested?
+- **Interruptions.** Incoming call, another app taking audio focus, alarm, navigation prompt — resolved by FR-013: yield, then stay stopped rather than resume.
+- **Lifecycle.** App backgrounded, screen locked, or the screen disposed mid-utterance — resolved by FR-007: playback stops. `chat_screen.dart:58-67` already releases the mic on dispose; playback needs the equivalent.
+- **Audio routing.** Bluetooth headset, wired headphones, car audio, speakerphone. Silent/vibrate is resolved by FR-012a (tap plays, auto-speak stays quiet); routing itself is left to the platform's current output selection.
+- **Auto-speak while silenced.** The operator must be able to tell an answer arrived and was *not* spoken, rather than assuming the feature is broken (FR-012a + FR-014).
 - **Very long answers.** Is there a ceiling, a summary, or is the whole thing read?
 - **Empty/whitespace-only answer text.**
 - **Rapid repeated activation** of the speak control.
@@ -98,13 +116,16 @@ The Border pushes messages the operator did not ask for — alerts, notification
 - **FR-004**: Operators MUST be able to stop in-progress playback at any time.
 - **FR-005**: The app MUST NOT offer a playback control where there is no speakable text (turns without an answer; non-text Feed content).
 - **FR-006**: The app MUST NOT play synthesised audio while the microphone is open for speech recognition, so that output is never captured as input.
-- **FR-007**: The app MUST stop playback when the owning screen is disposed and when the app leaves the foreground [NEEDS CLARIFICATION: should playback continue in the background — arguably desirable for the "phone in pocket" case in US2 — or stop? Background audio has real platform cost: an iOS background audio mode entitlement and an Android foreground service, both of which affect app review and battery].
-- **FR-008**: The app MUST make network-operations text intelligible when spoken, rather than passing raw text to the synthesiser unmodified [NEEDS CLARIFICATION: how far should normalisation go? Options range from none, to punctuation/pacing hints for dotted-quad and interface names, to skipping fenced code and tabular blocks entirely. This materially changes scope and needs a decision before planning].
-- **FR-009**: The app MUST handle answers whose bulk is machine output rather than prose [NEEDS CLARIFICATION: read in full, truncate at a ceiling, or speak a spoken-form summary? A spoken summary would require Border-side support — the phone has only the final answer text — which would widen this feature beyond the mobile client].
+- **FR-007**: The app MUST stop playback when the owning screen is disposed and when the app leaves the foreground (including screen lock). Playback is a foreground-only capability in this iteration; the app MUST NOT declare an iOS background-audio mode or run an Android foreground service for playback. This mirrors the existing microphone discipline, where `chat_screen.dart:58-67` releases the mic on dispose.
+- **FR-008**: The app MUST normalise answer text on the phone before synthesis so that network-operations identifiers are intelligible when heard — at minimum dotted-quad addresses, prefix lengths, and interface names must be spoken with pacing and grouping that a listener can transcribe back correctly without seeing the screen. Raw text MUST NOT be passed to the synthesiser unmodified.
+- **FR-009**: The app MUST NOT read fenced-code or tabular blocks aloud. It MUST instead announce each such block's presence and size and state that it is available on screen (e.g. "routing table omitted, 40 lines, shown on screen"), then continue with the surrounding prose. Rationale: reading a 40-line table aloud is unusable and cannot be interrupted fast enough to matter, so the feature declines to do badly what it cannot do well.
+- **FR-009a**: All normalisation and block-skipping MUST happen on the phone. This feature MUST NOT require any change to the Border's answer text or wire format. A Border-generated spoken summary was considered and deliberately rejected for this iteration as scope-widening; it remains a possible follow-on.
 - **FR-010**: The app MUST report to the operator when playback cannot proceed (no voice/engine available, permission or platform failure) rather than failing silently. This follows the precedent set for the microphone, where a silent failure was explicitly called out as the worst outcome (`voice_transcription.dart`: *"tapped the mic and nothing whatsoever happened. Always say why."*).
-- **FR-011**: Auto-speak (US2) MUST be operator-controllable and MUST default to **off**, so no existing installation starts speaking aloud after an update.
+- **FR-011**: Auto-speak (US2) MUST be operator-controllable via a single persisted toggle in Settings and MUST default to **off**, so no existing installation starts speaking aloud after an update.
+- **FR-011a**: The app MUST NOT provide its own speech-rate or voice-selection controls, and MUST NOT override the platform's configured speech rate. Both platforms already expose a system-level TTS rate that the synthesiser honours when not overridden; the app inherits whatever the operator has already chosen there.
 - **FR-012**: When multiple items are queued for playback, the app MUST speak them sequentially without overlap or loss.
-- **FR-013**: The app MUST yield the audio session to higher-priority audio (calls, alarms) and MUST NOT resume silently in a way that surprises the operator [NEEDS CLARIFICATION: on regaining focus — resume, restart the utterance, or stay stopped?].
+- **FR-012a**: Playback audibility MUST depend on how it was triggered. An **operator-initiated** playback (US1/US3 tap) MUST be audible even when the device is in silent/vibrate mode. An **auto-spoken** answer (US2) MUST stay silent when the device is in silent/vibrate mode, surfacing only the FR-014 visual indicator. Rationale: a deliberate request for sound that produces silence looks broken, while unrequested speech from a phone the operator deliberately silenced is a trust problem.
+- **FR-013**: The app MUST yield the audio session to higher-priority audio (calls, alarms, navigation). On regaining audio focus it MUST **stay stopped** rather than resume or restart, leaving the operator to re-trigger playback; automatic resumption after an interruption is the "surprising" behaviour this requirement exists to prevent. The partially-spoken item MUST remain re-triggerable from the UI.
 - **FR-014**: Playback state MUST be visible in the UI, so the operator can tell what is speaking and that a control did something.
 
 ### Privacy Requirements
@@ -117,7 +138,7 @@ The Border pushes messages the operator did not ask for — alerts, notification
 
 - **Speakable item**: a unit of text offered for playback, derived from either a `ConversationTurn.answerText` or a text `EdgeMessage.content`. Carries the text, a stable identity (so the UI can show *which* item is speaking), and its origin surface.
 - **Playback session**: the app's single logical speaking channel — at most one utterance audible at a time, with a queue behind it and a well-defined interaction with the microphone.
-- **Voice playback preference**: operator-set, persisted, per-installation; at minimum the US2 auto-speak toggle. [NEEDS CLARIFICATION: also rate/pitch/voice selection, or is a single toggle sufficient for v1?]
+- **Voice playback preference**: a single operator-set, persisted, per-installation boolean — the US2 auto-speak toggle, default off. Rate, pitch and voice are deliberately **not** app-level state; they are inherited from the platform (FR-011a).
 
 ## Success Criteria *(mandatory)*
 
@@ -131,10 +152,13 @@ The Border pushes messages the operator did not ask for — alerts, notification
 - **SC-006**: Answers containing IP addresses and interface names are intelligible to an operator hearing them for the first time, without needing the screen to disambiguate.
 - **SC-007**: Behaviour is equivalent on Android and iOS for every acceptance scenario above.
 - **SC-008**: An installation that does not enable auto-speak behaves exactly as it did before this feature.
+- **SC-009**: An answer containing a routing table is spoken in bounded time proportional to its prose, not its table length — a table-heavy answer never produces minutes of unusable audio.
+- **SC-010**: With auto-speak enabled and the phone silenced, no audio is produced across repeated answer arrivals, and the operator can still tell answers arrived.
 
 ## Out of Scope
 
-- **Playback of `MessageContentType.voice` audio.** The dead `Chip` at `feed_screen.dart:131-135` is a real gap, but playing Border-supplied base64 audio is *media playback*, not local synthesis — a different dependency and a different set of questions. Recorded here so it is not lost; it deserves its own spec. [NEEDS CLARIFICATION: confirm the operator agrees this stays separate — it is arguably the more obvious reading of "voice playback of messages", and the two could reasonably ship together.]
+- **Playback of `MessageContentType.voice` audio.** Confirmed out of scope in clarification. Playing Border-supplied base64 audio is *media playback*, not local synthesis — a different dependency and its own unanswered questions (codec, streaming vs download, caching, retention, which would collide with FR-017). Decisive factor: **the `voice` content type has no producer.** The daemon validates it at `bgp-daemon-v2.py:725`, but the only occurrence in the tree is a test fixture at `test_edge_push.py:156` (`"ZmFrZSB2b2ljZSBieXRlcw=="` — "fake voice bytes"), and the push-notification fallback handles `text` only (`push_notify.py:79`). The inert `Chip` therefore stays as-is; implementing a player for content nothing sends would be speculative. Worth its own spec if a producer ever appears.
+- **Background / locked-screen playback.** Settled in clarification: playback is foreground-only here (FR-007). Continuing through backgrounding or screen lock would deliver US2's "answer arrives while the phone is in a pocket" case, but costs an iOS `UIBackgroundModes: audio` entitlement and an Android foreground service with a persistent notification and declared service type — app-review and battery consequences that should be taken on deliberately, once the field workflow has been validated, not speculatively. **This is the most likely follow-on to this feature.**
 - **Voice playback on the Apple Watch.** Feature 072's `WatchRelay` already exposes `watch/feed` and `watch/history`, so the watch has the text and this is a natural follow-on, but the watch is a separate target with its own audio session and constraints.
 - **Server/Border-side synthesis**, including the existing Twilio voice path (feature 043). This feature is strictly on-device.
 - **Wake-word or fully conversational hands-free operation.**
@@ -144,7 +168,7 @@ The Border pushes messages the operator did not ask for — alerts, notification
 
 - Operators run OS versions with a usable built-in TTS engine and at least one installed local voice. Absence is handled per FR-010 rather than by bundling a voice.
 - English is the only language that must be supported for v1.
-- The existing `ConversationStore` and `MessageFeedStore` are the sources of speakable text; no new Border-side protocol work is required — **unless FR-009 resolves toward Border-generated spoken summaries**, which would change that and should be settled during clarification.
+- The existing `ConversationStore` and `MessageFeedStore` are the sources of speakable text; **no new Border-side protocol work is required** (settled in clarification — see FR-009a).
 - The Border's answer text is unchanged by this feature; any speech-oriented normalisation happens on the phone.
 - No new push, enrollment, or federation behaviour is involved.
 
@@ -155,8 +179,22 @@ The Border pushes messages the operator did not ask for — alerts, notification
 
 ## Open Questions for Clarification
 
-1. **Background playback** (FR-007) — is the "phone in pocket" case in US2 required? It is the difference between an in-app convenience and a platform-entitlement change.
-2. **Normalisation depth** (FR-008) and **long machine output** (FR-009) — the largest scope lever in this spec.
-3. **Scope of `voice` message playback** — genuinely separate feature, or expected in the same delivery?
-4. **Settings surface** (FR-011) — bare auto-speak toggle, or rate/voice controls too?
-5. **Silent/vibrate mode** — does an explicitly requested playback override it?
+**None blocking.** All five questions raised in the initial draft were resolved in the 2026-07-29 clarification session:
+
+| Question | Resolved by |
+|---|---|
+| Normalisation depth | FR-008 |
+| Long machine output | FR-009, FR-009a |
+| Background / locked-screen playback | FR-007, Out of Scope |
+| Scope of `voice` audio playback | Out of Scope (no producer exists) |
+| Settings surface | FR-011, FR-011a |
+| Silent/vibrate mode | FR-012a |
+| Audio-focus regain behaviour | FR-013 (resolved by decision, not asked) |
+
+Deferred to planning (Phase 0 research, not spec-level ambiguity):
+
+- **Which TTS package**, and what on-device guarantee each platform actually provides (FR-016). The STT path's `EXTRA_PREFER_OFFLINE` enforcement must not be assumed to have a synthesis equivalent — this needs verifying against current platform behaviour before FR-001/FR-015 can be called satisfied.
+- **Exact normalisation rules** for identifier classes beyond dotted-quad, prefix length and interface name (FR-008) — the requirement fixes the intent and the acceptance bar; the specific transformations are an implementation detail with test coverage.
+- **Precise latency target** for SC-002.
+
+Ready for `/speckit.plan`.

--- a/specs/073-mobile-voice-playback/spec.md
+++ b/specs/073-mobile-voice-playback/spec.md
@@ -7,15 +7,27 @@
 
 ## Context: what exists today
 
-NetClaw Mobile can already **listen** but cannot **speak**. Verified against the tree at time of writing:
+The **phone** can already **listen** but cannot **speak**. Verified against `main` at `e02d679`:
 
 - `pubspec.yaml` declares `speech_to_text: ^7.4.0` and **no** text-to-speech or audio-playback package (`flutter_tts`, `just_audio`, `audioplayers` all absent).
-- An exhaustive sweep of `lib/`, `test/`, `android/`, `ios/` for `flutter_tts|FlutterTts|TextToSpeech|speak(|AudioPlayer` returns **zero** hits.
-- `lib/ncfed/voice_transcription.dart` (feature 067, extended by in-flight work on `main`) is input-only: microphone → text → `edge_ask_client`.
+- No Dart-side synthesis exists anywhere in `lib/`. The only TTS in the repo is `ios/WatchApp Watch App/SpeechPlayback.swift`, which is watchOS-only and not reachable from Flutter — see the subsection below.
+- `lib/ncfed/voice_transcription.dart` (feature 067, hardened by PR #195) is input-only: microphone → text → `edge_ask_client`.
 
-So the voice loop is currently half-open: the operator can speak a request, but the answer is text-only and must be read on screen.
+So the voice loop is half-open **on the phone**: the operator can speak a request, but the answer is text-only and must be read on screen.
+
+> **Correction.** An earlier draft of this section asserted that a sweep for TTS returned zero hits across `lib/`, `test/`, `android/` and `ios/`. That was true of the working tree it was run against, but that tree was 8 commits behind `origin/main` and the search pattern did not include `AVSpeechSynthesizer`. Watch-side synthesis did in fact already exist. The phone-side conclusion is unaffected.
 
 There is also a pre-existing dead end this feature must consciously decide about: `MessageContentType.voice` already exists in `lib/ncfed/message_feed.dart:6`, and `lib/screens/feed_screen.dart:131-135` renders such a message as an inert `Chip(label: Text('Voice message'))`. The Border can therefore push base64 audio that the app can display but **physically cannot play**. See "Out of Scope" — this is adjacent but not the same capability.
+
+### Relationship to `073-push-notifications-sync` (read this first)
+
+**Two specs share the number 073.** `specs/073-push-notifications-sync` was merged into `main` (PR #191, commit `5e9ecc1`) while this spec was being drafted. The collision is cosmetic — the specs cover different surfaces — but the number should be treated as ambiguous in conversation, and this spec's FR numbers are **not** aligned with that one's (both define an `FR-017`, meaning different things).
+
+**That feature already shipped voice playback — on the watch.** `mobile/netclaw-mobile/ios/WatchApp Watch App/SpeechPlayback.swift` wraps `AVSpeechSynthesizer` for the watch's Feed/History/Ask views (its US4, FR-017–FR-019). So "NetClaw can speak" is now partly true, and the earlier claim in this spec that watch playback was an unimplemented follow-on was wrong.
+
+What that does **not** change: the **phone** still has no synthesis capability. The only dependency `5e9ecc1` added was `flutter_local_notifications`; there is still no Dart-side TTS package, and `SpeechPlayback.swift` is watchOS-only and unreachable from Flutter. Every claim in the section above holds for the phone, which is this spec's entire scope.
+
+What it does change: the watch implementation is now **prior art with a deliberate design position**, and this spec must either match it or justify differing. See FR-012b and Out of Scope.
 
 ### Two speakable surfaces
 
@@ -75,6 +87,7 @@ For genuinely hands-free operation the operator should not have to tap anything:
 4. **Given** auto-speak is enabled, **When** the operator opens a historical turn from a previous session, **Then** old answers are not re-spoken on load.
 5. **Given** auto-speak is enabled and the device is in silent/vibrate mode, **When** an answer arrives, **Then** it is **not** spoken, and the operator can still see that the answer arrived and was not read aloud (FR-012a, FR-014).
 6. **Given** auto-speak is enabled and an answer is being spoken, **When** the app is backgrounded or the screen locks, **Then** playback stops (FR-007).
+7. **Given** auto-speak is enabled on the phone and a paired Apple Watch is present, **When** an answer arrives and is auto-spoken on the phone, **Then** the watch speaks nothing — preserving `073-push-notifications-sync`'s FR-018 (FR-012b).
 
 ---
 
@@ -125,6 +138,14 @@ The Border pushes messages the operator did not ask for — alerts, notification
 - **FR-011a**: The app MUST NOT provide its own speech-rate or voice-selection controls, and MUST NOT override the platform's configured speech rate. Both platforms already expose a system-level TTS rate that the synthesiser honours when not overridden; the app inherits whatever the operator has already chosen there.
 - **FR-012**: When multiple items are queued for playback, the app MUST speak them sequentially without overlap or loss.
 - **FR-012a**: Playback audibility MUST depend on how it was triggered. An **operator-initiated** playback (US1/US3 tap) MUST be audible even when the device is in silent/vibrate mode. An **auto-spoken** answer (US2) MUST stay silent when the device is in silent/vibrate mode, surfacing only the FR-014 visual indicator. Rationale: a deliberate request for sound that produces silence looks broken, while unrequested speech from a phone the operator deliberately silenced is a trust problem.
+- **FR-012b**: The phone's auto-speak (US2) MUST NOT cause the **watch** to speak. `073-push-notifications-sync`'s FR-018 requires that watch read-aloud "never trigger automatically", and the two devices share a conversation store via `WatchRelay` — so an auto-speak trigger that reached the watch through that shared path would violate that invariant from the outside. Auto-speak is a phone-local behaviour and MUST stay one.
+
+  **Why the phone may auto-speak at all when the watch may not.** Both specs are protecting the same thing — the watch spec's stated reason for on-demand-only is "to avoid surprising or embarrassing the operator in a quiet room" — but they reach it differently, and the difference is justified by the device rather than being an oversight:
+
+  - The **watch** is worn on the body and cannot be set down or silenced independently, so a blanket prohibition is the only reliable guarantee. It has no opt-in.
+  - The **phone** reaches the same guarantee through two mechanisms the watch lacks: auto-speak is **off by default and opt-in** (FR-011), and even when enabled it is **suppressed entirely in silent/vibrate mode** (FR-012a). An operator who has not opted in, or who has silenced the device, gets exactly the watch's behaviour.
+
+  This divergence is therefore deliberate. If it is ever judged to be inconsistency rather than device-appropriate design, the correct resolution is to drop US2 from this spec — not to relax the watch's FR-018.
 - **FR-013**: The app MUST yield the audio session to higher-priority audio (calls, alarms, navigation). On regaining audio focus it MUST **stay stopped** rather than resume or restart, leaving the operator to re-trigger playback; automatic resumption after an interruption is the "surprising" behaviour this requirement exists to prevent. The partially-spoken item MUST remain re-triggerable from the UI.
 - **FR-014**: Playback state MUST be visible in the UI, so the operator can tell what is speaking and that a control did something.
 
@@ -154,12 +175,13 @@ The Border pushes messages the operator did not ask for — alerts, notification
 - **SC-008**: An installation that does not enable auto-speak behaves exactly as it did before this feature.
 - **SC-009**: An answer containing a routing table is spoken in bounded time proportional to its prose, not its table length — a table-heavy answer never produces minutes of unusable audio.
 - **SC-010**: With auto-speak enabled and the phone silenced, no audio is produced across repeated answer arrivals, and the operator can still tell answers arrived.
+- **SC-011**: The watch's existing on-demand read-aloud behaviour is unchanged by this feature — it still speaks only on an explicit tap, and never as a side effect of phone auto-speak.
 
 ## Out of Scope
 
 - **Playback of `MessageContentType.voice` audio.** Confirmed out of scope in clarification. Playing Border-supplied base64 audio is *media playback*, not local synthesis — a different dependency and its own unanswered questions (codec, streaming vs download, caching, retention, which would collide with FR-017). Decisive factor: **the `voice` content type has no producer.** The daemon validates it at `bgp-daemon-v2.py:725`, but the only occurrence in the tree is a test fixture at `test_edge_push.py:156` (`"ZmFrZSB2b2ljZSBieXRlcw=="` — "fake voice bytes"), and the push-notification fallback handles `text` only (`push_notify.py:79`). The inert `Chip` therefore stays as-is; implementing a player for content nothing sends would be speculative. Worth its own spec if a producer ever appears.
 - **Background / locked-screen playback.** Settled in clarification: playback is foreground-only here (FR-007). Continuing through backgrounding or screen lock would deliver US2's "answer arrives while the phone is in a pocket" case, but costs an iOS `UIBackgroundModes: audio` entitlement and an Android foreground service with a persistent notification and declared service type — app-review and battery consequences that should be taken on deliberately, once the field workflow has been validated, not speculatively. **This is the most likely follow-on to this feature.**
-- **Voice playback on the Apple Watch.** Feature 072's `WatchRelay` already exposes `watch/feed` and `watch/history`, so the watch has the text and this is a natural follow-on, but the watch is a separate target with its own audio session and constraints.
+- **Voice playback on the Apple Watch — already implemented, not a follow-on.** Delivered by `073-push-notifications-sync` (US4/FR-017–FR-019, `SpeechPlayback.swift`) and merged in `5e9ecc1`. This spec does not touch it, must not regress it, and must not reach it via the shared conversation store (FR-012b). An earlier draft of this document listed watch playback as an unimplemented natural follow-on; that was incorrect and is corrected here.
 - **Server/Border-side synthesis**, including the existing Twilio voice path (feature 043). This feature is strictly on-device.
 - **Wake-word or fully conversational hands-free operation.**
 - **Changes to speech-to-text.** The in-flight `voice_transcription.dart` work on `main` is a separate concern; this feature consumes the existing input path unchanged.
@@ -176,6 +198,7 @@ The Border pushes messages the operator did not ask for — alerts, notification
 
 - A Flutter TTS capability wrapping Android `TextToSpeech` and iOS `AVSpeechSynthesizer`. No such package is currently in `pubspec.yaml`; selecting one (and confirming its on-device guarantees per FR-016) is a Phase 0 research task.
 - Existing: `ConversationStore`/`ConversationTurn` (067), `MessageFeedStore`/`EdgeMessage` (066), `VoiceTranscription` (067, for the FR-006 interlock), `chat_screen.dart`, `feed_screen.dart`, `settings_screen.dart` (for FR-011).
+- **Must not regress**: `073-push-notifications-sync`'s watch read-aloud (`SpeechPlayback.swift`) and the `WatchRelay` path that feeds it (FR-012b, SC-011).
 
 ## Open Questions for Clarification
 
@@ -190,6 +213,11 @@ The Border pushes messages the operator did not ask for — alerts, notification
 | Settings surface | FR-011, FR-011a |
 | Silent/vibrate mode | FR-012a |
 | Audio-focus regain behaviour | FR-013 (resolved by decision, not asked) |
+| Auto-speak vs the watch's never-automatic rule | FR-012b (raised after the session, on discovering the merged watch implementation) |
+
+**One decision left for the operator, not a blocking ambiguity:** whether the phone/watch auto-speak divergence documented in FR-012b is accepted as device-appropriate design. If not, the resolution is to drop US2 rather than relax the watch's FR-018. Everything else in this spec is independent of that choice — US1 and US3 stand either way.
+
+**Recommended housekeeping (not blocking):** renumber this spec to the next free number so `073` stops being ambiguous. Deferred because it would rename the directory, branch and PR mid-review.
 
 Deferred to planning (Phase 0 research, not spec-level ambiguity):
 

--- a/specs/074-mobile-voice-playback/spec.md
+++ b/specs/074-mobile-voice-playback/spec.md
@@ -1,6 +1,6 @@
 # Feature Specification: On-Device Voice Playback of Messages (Android + iOS)
 
-**Feature Branch**: `073-mobile-voice-playback`
+**Feature Branch**: `074-mobile-voice-playback`
 **Created**: 2026-07-29
 **Status**: Clarified (session 2026-07-29) — ready for `/speckit.plan`
 **Input**: User description: "working VOICE PLAYBACK to messages on android — where on the device it uses local TTS and plays back the message"
@@ -21,7 +21,9 @@ There is also a pre-existing dead end this feature must consciously decide about
 
 ### Relationship to `073-push-notifications-sync` (read this first)
 
-**Two specs share the number 073.** `specs/073-push-notifications-sync` was merged into `main` (PR #191, commit `5e9ecc1`) while this spec was being drafted. The collision is cosmetic — the specs cover different surfaces — but the number should be treated as ambiguous in conversation, and this spec's FR numbers are **not** aligned with that one's (both define an `FR-017`, meaning different things).
+**This spec was originally numbered 073 and has been renumbered to 074.** `specs/073-push-notifications-sync` was merged into `main` (PR #191, commit `5e9ecc1`) while this spec was being drafted, so two `073-*` spec directories briefly coexisted. That was not cosmetic: `.specify/scripts/bash/common.sh` resolves the feature directory by matching a branch's numeric prefix against `specs/<prefix>-*` and **hard-errors on multiple matches**, so every speckit command on a `073-*` branch failed with `ERROR: Multiple spec directories found with prefix '073'`. Renumbering to 074 fixes that.
+
+Note that FR numbers are still **not** aligned between the two specs — both define an `FR-017`, meaning different things (here: never persist synthesised audio; there: the watch's read-aloud control). Always qualify which spec an FR belongs to.
 
 **That feature already shipped voice playback — on the watch.** `mobile/netclaw-mobile/ios/WatchApp Watch App/SpeechPlayback.swift` wraps `AVSpeechSynthesizer` for the watch's Feed/History/Ask views (its US4, FR-017–FR-019). So "NetClaw can speak" is now partly true, and the earlier claim in this spec that watch playback was an unimplemented follow-on was wrong.
 
@@ -215,9 +217,9 @@ The Border pushes messages the operator did not ask for — alerts, notification
 | Audio-focus regain behaviour | FR-013 (resolved by decision, not asked) |
 | Auto-speak vs the watch's never-automatic rule | FR-012b (raised after the session, on discovering the merged watch implementation) |
 
-**One decision left for the operator, not a blocking ambiguity:** whether the phone/watch auto-speak divergence documented in FR-012b is accepted as device-appropriate design. If not, the resolution is to drop US2 rather than relax the watch's FR-018. Everything else in this spec is independent of that choice — US1 and US3 stand either way.
+**Accepted 2026-07-29:** the phone/watch auto-speak divergence documented in FR-012b is confirmed as device-appropriate design, not an inconsistency. US2 stands. The watch's `073-push-notifications-sync` FR-018 prohibition remains untouched, and FR-012b's guard against phone auto-speak reaching the watch is binding.
 
-**Recommended housekeeping (not blocking):** renumber this spec to the next free number so `073` stops being ambiguous. Deferred because it would rename the directory, branch and PR mid-review.
+**Renumbered 2026-07-29:** this spec moved from `073` to `074` (directory and branch), resolving the prefix collision that was breaking every speckit command.
 
 Deferred to planning (Phase 0 research, not spec-level ambiguity):
 


### PR DESCRIPTION
Replaces #194 (same work, renumbered branch — see below for why the rename was necessary).

Spec for **on-device (local TTS) voice playback of messages** on the NetClaw Mobile **phone**, Android + iOS. Documentation only; no implementation, no dependency added.

## Why the phone needs this

The phone can listen but cannot speak. `pubspec.yaml` has `speech_to_text` and no TTS package; there is no Dart-side synthesis anywhere in `lib/`. So the voice loop opened by 067/068 is half-open — an operator can speak a request but must read the answer on screen, defeating the hands-free case that justified speech-to-text.

**Note:** voice playback *does* already exist on the **watch** (`SpeechPlayback.swift`, from #191). The phone-side gap is real and unaffected — `5e9ecc1` added only `flutter_local_notifications`, and `SpeechPlayback.swift` is watchOS-only and unreachable from Flutter. An earlier draft of this spec wrongly claimed watch playback was unimplemented; that claim is corrected *and its withdrawal recorded in the document* rather than quietly edited away.

## Scope

Three independently shippable slices: **P1** tap-to-hear an answer · **P2** auto-speak on arrival (default off) · **P3** Feed messages.

## Decisions (clarification session 2026-07-29)

| Area | Decision |
|---|---|
| Spoken text (FR-008/009/009a) | Normalise prose phone-side; **refuse to read code/tables**, announce them instead. No Border change. |
| Background playback (FR-007) | **Foreground only** — declines an iOS `UIBackgroundModes: audio` entitlement and an Android foreground service |
| `voice` audio playback | Out of scope, **on evidence**: the content type has no producer |
| Settings (FR-011/011a) | One auto-speak toggle, default off; inherit the OS speech rate |
| Silent mode (FR-012a) | Explicit tap plays; auto-speak stays quiet |
| Audio-focus regain (FR-013) | Stay stopped, don't auto-resume |

Two worth reviewer attention:

**The dominant scope lever is text, not audio.** Answers carry dotted quads, `GigabitEthernet0/0/1`, and pasted CLI tables. Reading a 40-line routing table aloud is unusable and can't be interrupted fast enough to matter, so the feature declines to do badly what it can't do well. A Border-generated spoken summary was considered and rejected as scope-widening.

**Privacy is a continuation, not a new question.** `voice_transcription.dart` forces on-device recognition because spoken requests carry hostnames, interface IDs and IPs. Answers carry the same data and more, so a cloud voice would reopen the hole the input path was hardened against. FR-016 warns against assuming TTS has an enforcement equivalent to STT's `EXTRA_PREFER_OFFLINE` — Phase 0 must verify, not assume.

## Reconciled against #191's watch behaviour (FR-012b)

That spec's **FR-018** forbids watch read-aloud from ever triggering automatically. This spec's **US2** auto-speaks on arrival. Both protect the same thing — its stated reason is "to avoid surprising or embarrassing the operator in a quiet room" — but reach it differently, and the divergence is **accepted as device-appropriate**:

- The **watch** is body-worn, can't be set down or silenced independently, and has no opt-in → blanket prohibition is its only guarantee.
- The **phone** gets there via two mechanisms the watch lacks: opt-in and off by default (FR-011), and fully suppressed in silent mode (FR-012a). An operator who hasn't opted in gets exactly the watch's behaviour.

FR-012b adds the guard that matters operationally: **phone auto-speak MUST NOT cause the watch to speak.** The devices share a conversation store via `WatchRelay`, so a trigger reaching the watch that way would violate FR-018 from the outside. If the divergence is ever rejected, the stated resolution is to drop US2 — not to relax FR-018.

## Why renumbered 073 → 074

Not cosmetic. #191 merged while this was drafted, leaving two `073-*` spec directories. `.specify/scripts/bash/common.sh` resolves a feature dir by matching the branch's numeric prefix against `specs/<prefix>-*` and **hard-errors on multiple matches**:

```
ERROR: Multiple spec directories found with prefix '073':
       073-mobile-voice-playback 073-push-notifications-sync
```

Every speckit command on a `073-*` branch was failing; `/speckit.plan` would have failed outright. `check-prerequisites.sh` resolves correctly again after the rename.

FR numbers remain unaligned between the two specs — both define an `FR-017` meaning different things — so FRs should always be qualified by spec.

## Status

`Clarified` — zero `NEEDS CLARIFICATION` markers, ready for `/speckit.plan`. Three items explicitly deferred to Phase 0 research (TTS package choice and its on-device guarantee; exact normalisation rules; SC-002 latency target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)