### PR TITLE
fix(mobile): enable core library desugaring — Android build is broken on main

### DIFF
--- a/mobile/netclaw-mobile/android/app/build.gradle.kts
+++ b/mobile/netclaw-mobile/android/app/build.gradle.kts
@@ -43,6 +43,13 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        // Required by flutter_local_notifications (spec 073): it uses
+        // java.time APIs that do not exist below API 26, so the build fails
+        // outright without desugaring —
+        // "Dependency ':flutter_local_notifications' requires core library
+        // desugaring to be enabled for :app". Not optional and not a warning:
+        // every Android build, debug and release, fails until this is set.
+        isCoreLibraryDesugaringEnabled = true
     }
 
     defaultConfig {
@@ -96,4 +103,13 @@ kotlin {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    // Pairs with isCoreLibraryDesugaringEnabled above. Version pinned to the
+    // one flutter_local_notifications' own setup documentation specifies for
+    // the 19+ line, rather than tracking latest — the desugaring library is
+    // coupled to AGP, and a mismatch fails the build in a much less obvious
+    // place than the flag being absent does.
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 }


### PR DESCRIPTION
## Android cannot currently be built at all

Every Android build on `main` fails, debug and release alike:

```
Execution failed for task ':app:checkReleaseAarMetadata'.
> An issue was found when checking AAR metadata:
    1. Dependency ':flutter_local_notifications' requires core library
       desugaring to be enabled for :app.
```

`flutter_local_notifications` arrived with spec 073 (`5e9ecc1`, #191) and uses `java.time` APIs that don't exist below API 26, so it requires desugaring. The flag and its paired dependency were never added.

This is not a deferrable warning — there is **no way to produce an APK** until it's fixed, which also blocks any Play upload.

## Fix

- `isCoreLibraryDesugaringEnabled = true` in `compileOptions`
- the matching `coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")` dependency

The desugar version is **pinned to what `flutter_local_notifications`' own setup docs specify** for its 19+ line rather than tracking latest, because that library is coupled to AGP and a mismatch fails in a much less obvious place than the missing flag does.

## Verification

`flutter build apk --release` → **✓ Built app-release.apk (72.6MB)**, on the same tree where it failed before this change.

Found while building a tester package — the failure is what stopped that package from being produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)