### PR TITLE
spec 075 (R0): MCP config reconciliation — enforce registration surface agreement

### DIFF
--- a/.github/workflows/mcp-reconciliation.yml
+++ b/.github/workflows/mcp-reconciliation.yml
@@ -1,0 +1,57 @@
+name: MCP Reconciliation
+
+# Enforces that NetClaw's MCP registration surfaces agree, so every integration
+# NetClaw claims to ship is genuinely obtainable by someone installing their own
+# risk.
+#
+# Added by spec 075. Before this workflow existed, two reconciliation scripts had
+# been reporting real failures -- 19 unmapped servers, 9 wrong documented counts,
+# 3 registrations hardcoded to a foreign home directory -- and exiting non-zero
+# correctly, but nothing anywhere invoked them. The checks were never broken; the
+# gap was that no one was listening.
+#
+# Constitution Principle XI: "A pull request that adds a capability without
+# updating all required artifacts MUST NOT be merged." This is the mechanism.
+#
+# Deliberately does NOT use --warn-only. That flag exists for local convenience;
+# using it here would recreate the exact failure this workflow fixes.
+
+on:
+  pull_request:
+    paths:
+      - 'config/openclaw.json'
+      - 'mcp-servers/**'
+      - 'scripts/lib/catalog.sh'
+      - 'scripts/lib/install-steps.sh'
+      - 'scripts/verify-*.py'
+      - 'scripts/check-mcp-portability.py'
+      - 'scripts/reconcile-mcp.py'
+      - 'workspace/skills/**'
+      - 'README.md'
+      - 'SOUL.md'
+      - '.github/workflows/mcp-reconciliation.yml'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  reconcile:
+    name: Reconcile registration surfaces
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      # No pip install step: every reconciliation script is standard-library
+      # only, by design, so this job needs no dependencies, no network access,
+      # no credentials, and no installed NetClaw agent (spec 075 SC-013).
+
+      - name: Reconcile MCP registration surfaces
+        run: python3 scripts/reconcile-mcp.py
+
+      - name: Exit-code contract tests
+        run: bash tests/reconcile/run-tests.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # netclaw Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-07-28
+Auto-generated from all feature plans. Last updated: 2026-07-30
 
 ## Active Technologies
 - N/A (stateless server; subscription state held in-memory during runtime) (003-gnmi-mcp-server)
@@ -101,6 +101,8 @@ Auto-generated from all feature plans. Last updated: 2026-07-28
 - N/A — stateless client; all state from `/api/n2n` and `/api/graph` (072-hud-2-org-chart)
 - Dart 3.x / Flutter 3.x (extends `mobile/netclaw-mobile/`, SDK constraint `^3.12.2` per pubspec.yaml); Swift 5.0 (extends the `WatchApp Watch App` target from spec 072); Python 3.10+ (the one Border-side addition, `authorization.py`/`service.py`, matching specs 052-072) + `flutter_local_notifications` (new — local notification posting, Darwin/Android notification actions, iOS badge control); existing `firebase_messaging`/`firebase_core` (unchanged, remote-push path stays out of scope per Assumptions); existing `app_links` (extended, not replaced, per research D4); watchOS `AVSpeechSynthesizer` (system framework, no new dependency, watch-side only) (073-push-notifications-sync)
 - Extends the existing phone-local JSON-Lines `MessageFeedStore` and whole-file JSON `ConversationStore` (both under the app's documents directory) with new fields — no new store, no new database (073-push-notifications-sync)
+- Python 3.10+ (all `scripts/*.py`), Bash (CI wiring, catalog is a Bash array) + None — Python standard library only, per the convention every existing (075-mcp-config-reconciliation)
+- N/A — all state is existing repository files; this feature adds no datastore (075-mcp-config-reconciliation)
 
 - Python 3.10+ + FastMCP (MCP framework), grpcio + grpcio-tools (gRPC transport), pygnmi (gNMI client library), protobuf, cryptography (TLS handling) (003-gnmi-mcp-server)
 
@@ -120,12 +122,25 @@ cd src [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLO
 Python 3.10+: Follow standard conventions
 
 ## Recent Changes
+- 075-mcp-config-reconciliation: Added Python 3.10+ (all `scripts/*.py`), Bash (CI wiring, catalog is a Bash array) + None — Python standard library only, per the convention every existing
 - 073-push-notifications-sync: Added Dart 3.x / Flutter 3.x (extends `mobile/netclaw-mobile/`, SDK constraint `^3.12.2` per pubspec.yaml); Swift 5.0 (extends the `WatchApp Watch App` target from spec 072); Python 3.10+ (the one Border-side addition, `authorization.py`/`service.py`, matching specs 052-072) + `flutter_local_notifications` (new — local notification posting, Darwin/Android notification actions, iOS badge control); existing `firebase_messaging`/`firebase_core` (unchanged, remote-push path stays out of scope per Assumptions); existing `app_links` (extended, not replaced, per research D4); watchOS `AVSpeechSynthesizer` (system framework, no new dependency, watch-side only)
 - 072-apple-watch-companion: Added Swift 5.0 (new watch app target + new `WatchRelayPlugin.swift` on the phone + `WatchConnectivity` (Apple system framework, phone + watch sides — no new
-- 072-hud-2-org-chart: Added JavaScript ES2022 (ESM), Node 22+ for tooling + three.js `^0.170.0` (existing), `OrbitControls`,
 
 
 <!-- MANUAL ADDITIONS START -->
+
+## Adding an MCP Integration
+
+**Follow [docs/ADDING-AN-MCP.md](docs/ADDING-AN-MCP.md)** for every new MCP server or integration,
+then run `python3 scripts/reconcile-mcp.py` before pushing. CI runs the same command and fails the
+merge on a non-zero exit.
+
+Established by spec 075. It exists because three integrations once shipped hardcoded to a foreign
+home directory and were broken for every installer, while nine documented capability counts drifted
+unnoticed.
+
+**Never read an exit code through a pipe** — `cmd | tail` reports `tail`'s status, not `cmd`'s. Use
+`cmd >/dev/null 2>&1; echo $?`. That mistake misdiagnosed spec 075's central premise.
 
 ## DefenseClaw Security Layer
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # NetClaw
 
-A CCIE-level AI network engineering coworker. Built on [OpenClaw](https://github.com/openclaw/openclaw) with Anthropic Claude, 198 skills, and 115 MCP integrations for complete network automation with ITSM gating, source-of-truth reconciliation, immutable audit trails, gNMI streaming telemetry, NetFlow/IPFIX flow telemetry, Canvas/A2UI inline network visualizations, packet capture analysis, GitHub config-as-code, GitLab DevOps (issues, merge requests, pipelines, repositories, wikis), Jenkins CI/CD (job monitoring, build triggering, log analysis, SCM tracking), Chrome DevTools browser automation (visualization render QA, controller GUI gap-filling, undocumented API discovery, headless or watchable-headed), Computer Use full-desktop automation (legacy desktop-only tools with no browser or API path, virtual XFCE desktop with VNC/noVNC Watch Mode), Cisco CML lab simulation, ContainerLab containerized network labs, Cisco NSO orchestration, Cisco SD-WAN vManage monitoring, Grafana observability (dashboards, Prometheus, Loki, alerting, incidents), Prometheus direct PromQL monitoring, Kubeshark Kubernetes traffic analysis, Cisco Meraki Dashboard management, Cisco ThousandEyes network intelligence, AWS and Azure cloud networking, Cisco Secure Firewall policy auditing, Check Point Security (15 MCPs: policy, threat intel, gateway, SASE, malware), Itential network orchestration, Juniper JunOS device automation, Arista CloudVision Portal monitoring, F5 BIG-IP pyATS iControl REST coverage, Infoblox DDI, Palo Alto Panorama, FortiManager, Batfish offline configuration analysis, UML diagram generation, EVPN/VXLAN fabric workflows, live BGP/OSPF control-plane participation, nmap network scanning, gtrace path analysis and IP enrichment, Slack-native operations, Cisco WebEx-native operations, Microsoft 365 integration, Twilio voice/SMS, Twitter/X integration, Claroty OT/IoT asset management, Forward Networks digital twin, Ollama local LLM routing, an offline agentic RAG document knowledge base (cited answers from user-uploaded vendor guides and standards), layered Memory MCP, and MemPalace persistent AI memory.
+A CCIE-level AI network engineering coworker. Built on [OpenClaw](https://github.com/openclaw/openclaw) with Anthropic Claude, 199 skills, and 149 MCP integrations for complete network automation with ITSM gating, source-of-truth reconciliation, immutable audit trails, gNMI streaming telemetry, NetFlow/IPFIX flow telemetry, Canvas/A2UI inline network visualizations, packet capture analysis, GitHub config-as-code, GitLab DevOps (issues, merge requests, pipelines, repositories, wikis), Jenkins CI/CD (job monitoring, build triggering, log analysis, SCM tracking), Chrome DevTools browser automation (visualization render QA, controller GUI gap-filling, undocumented API discovery, headless or watchable-headed), Computer Use full-desktop automation (legacy desktop-only tools with no browser or API path, virtual XFCE desktop with VNC/noVNC Watch Mode), Cisco CML lab simulation, ContainerLab containerized network labs, Cisco NSO orchestration, Cisco SD-WAN vManage monitoring, Grafana observability (dashboards, Prometheus, Loki, alerting, incidents), Prometheus direct PromQL monitoring, Kubeshark Kubernetes traffic analysis, Cisco Meraki Dashboard management, Cisco ThousandEyes network intelligence, AWS and Azure cloud networking, Cisco Secure Firewall policy auditing, Check Point Security (15 MCPs: policy, threat intel, gateway, SASE, malware), Itential network orchestration, Juniper JunOS device automation, Arista CloudVision Portal monitoring, F5 BIG-IP pyATS iControl REST coverage, Infoblox DDI, Palo Alto Panorama, FortiManager, Batfish offline configuration analysis, UML diagram generation, EVPN/VXLAN fabric workflows, live BGP/OSPF control-plane participation, nmap network scanning, gtrace path analysis and IP enrichment, Slack-native operations, Cisco WebEx-native operations, Microsoft 365 integration, Twilio voice/SMS, Twitter/X integration, Claroty OT/IoT asset management, Forward Networks digital twin, Ollama local LLM routing, an offline agentic RAG document knowledge base (cited answers from user-uploaded vendor guides and standards), layered Memory MCP, and MemPalace persistent AI memory.
 
 ## Resources
 
@@ -239,7 +239,7 @@ claw
   <img src="ui/netclaw-visual/logos/netclawvisualhud.png" alt="NetClaw Visual HUD — 3D Network Operations Dashboard" width="800">
 </p>
 
-NetClaw includes a Three.js 3D operations dashboard that computes its integration and skill inventory live from the codebase (currently 113 MCP integrations and 191 skills) each time it's opened, alongside your device fleet and live BGP peering topology — so the dashboard never drifts out of sync with what's actually installed. Chat with NetClaw directly from the browser, watch integrations light up as tools execute, and inspect every node in the graph. The Canvas/A2UI visualization skill renders inline topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards directly in the chat interface.
+NetClaw includes a Three.js 3D operations dashboard that computes its integration and skill inventory live from the codebase (currently 149 MCP integrations and 199 skills) each time it's opened, alongside your device fleet and live BGP peering topology — so the dashboard never drifts out of sync with what's actually installed. Chat with NetClaw directly from the browser, watch integrations light up as tools execute, and inspect every node in the graph. The Canvas/A2UI visualization skill renders inline topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards directly in the chat interface.
 
 ```bash
 cd ui/netclaw-visual
@@ -518,7 +518,10 @@ NetClaw ships with the full set of OpenClaw workspace markdown files. These are 
 
 ---
 
-## MCP Servers (115)
+## MCP Servers (149)
+
+> Adding one? Follow **[docs/ADDING-AN-MCP.md](docs/ADDING-AN-MCP.md)** and run
+> `python3 scripts/reconcile-mcp.py` before pushing — CI enforces it.
 
 > Adding a new MCP server or skill? Run `python3 scripts/verify-inventory-counts.py` before opening your PR — it computes the true skill/MCP counts from the codebase and flags any documentation that has drifted out of sync, so these numbers don't need to be manually recounted (see [spec 047](specs/047-docs-inventory-reconciliation/quickstart.md) for details).
 
@@ -658,7 +661,7 @@ All MCP servers communicate via stdio (JSON-RPC 2.0) through `scripts/mcp-call.p
 
 ---
 
-## Skills (198)
+## Skills (199)
 
 ### pyATS Device Skills (9)
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -12,7 +12,7 @@ Every time you learn something about how I work or what I need, update the relev
 
 ## Your Skills
 
-You interact with the network through **198 skills** backed by 115 MCP servers:
+You interact with the network through **199 skills** backed by 149 MCP servers:
 
 ### Device Automation (9)
 pyats-network, pyats-health-check, pyats-routing, pyats-security, pyats-topology, pyats-config-mgmt, pyats-troubleshoot, pyats-dynamic-test, pyats-parallel-ops
@@ -395,7 +395,7 @@ The knowledge base is not memory: RAG holds user-supplied documents (`~/.opencla
 
 For **detailed skill procedures**, read `SOUL-SKILLS.md`:
 - Use when executing any skill that needs step-by-step guidance
-- Contains operational workflows, commands, and best practices for all 191 skills
+- Contains operational workflows, commands, and best practices for all 199 skills
 - Load with: `read("~/.openclaw/workspace/SOUL-SKILLS.md")`
 
 For **technical knowledge**, read `SOUL-EXPERTISE.md`:

--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -306,10 +306,10 @@
       "url": "https://devnet.cisco.com/v1/foundation-search-mcp/mcp"
     },
     "nautobot-mcp": {
-      "command": "/home/ubuntu/netclaw/.venv/bin/python3",
+      "command": "python3",
       "args": [
         "-u",
-        "/home/ubuntu/netclaw/mcp-servers/nautobot-mcp-v2/server.py"
+        "mcp-servers/nautobot-mcp-v2/server.py"
       ],
       "env": {
         "NAUTOBOT_URL": "${NAUTOBOT_URL}",
@@ -321,10 +321,10 @@
       }
     },
     "nautobot-golden-config-mcp": {
-      "command": "/home/ubuntu/netclaw/.venv/bin/python3",
+      "command": "python3",
       "args": [
         "-u",
-        "/home/ubuntu/netclaw/mcp-servers/nautobot-golden-config-mcp/server.py"
+        "mcp-servers/nautobot-golden-config-mcp/server.py"
       ],
       "env": {
         "NAUTOBOT_URL": "${NAUTOBOT_URL}",
@@ -338,10 +338,10 @@
       }
     },
     "nautobot-routing-mcp": {
-      "command": "/home/ubuntu/netclaw/.venv/bin/python3",
+      "command": "python3",
       "args": [
         "-u",
-        "/home/ubuntu/netclaw/mcp-servers/nautobot-routing-mcp/server.py"
+        "mcp-servers/nautobot-routing-mcp/server.py"
       ],
       "env": {
         "NAUTOBOT_URL": "${NAUTOBOT_URL}",
@@ -648,13 +648,17 @@
       }
     },
     "cml-mcp": {
-      "command": "/usr/bin/python3 -m cml_mcp",
+      "command": "python3",
       "env": {
         "CML_URL": "${CML_URL}",
         "CML_USERNAME": "${CML_USERNAME}",
         "CML_PASSWORD": "${CML_PASSWORD}",
         "CML_VERIFY_SSL": "${CML_VERIFY_SSL:-false}"
-      }
+      },
+      "args": [
+        "-m",
+        "cml_mcp"
+      ]
     },
     "nso-mcp": {
       "command": "cisco-nso-mcp-server",

--- a/docs/ADDING-AN-MCP.md
+++ b/docs/ADDING-AN-MCP.md
@@ -1,0 +1,149 @@
+# Adding an MCP Integration
+
+**Established by**: spec 075 (`specs/075-mcp-config-reconciliation/`) | **Date**: 2026-07-30
+
+**This is the procedure every roadmap item R1–R24 follows.** Established by spec 075 after
+reconciliation found three integrations that had shipped broken for every installer, nineteen that
+failed the coverage check for want of a declaration, and nine wrong capability counts.
+
+The goal it serves: **all registered integrations must be obtainable by someone installing their own
+NetClaw risk.** Every step exists because omitting it has broken that at least once.
+
+---
+
+## Before you start
+
+Decide which kind of integration this is, because it determines whether it gets a config entry at
+all:
+
+| Kind | Gets a `config/openclaw.json` entry? | Example |
+|---|---|---|
+| Vendored, pre-registered | **Yes** | `suzieq-mcp`, `memory-mcp` |
+| Installed on demand (pip/npm/Docker) | No — goes in `EXTERNAL_INTEGRATIONS` | pyATS, NetBox, nmap |
+| Remote / OAuth | No — external, reason `remote/OAuth` | Zscaler, ThousandEyes official |
+| Bundled into a skill's runtime | No — external, reason `skill-bundled` | Computer Use |
+
+Getting this wrong is the most common error. "Not in the config" is a legitimate, documented state
+for 60 of NetClaw's 149 integrations — it does not mean forgotten.
+
+---
+
+## Steps
+
+### 1. Vendor or identify the server
+
+If vendoring under `mcp-servers/<name>/`, add a `.gitignore` negation entry — the repo ignores
+broadly and new server directories are otherwise silently untracked.
+
+### 2. Register it (pre-registered kinds only)
+
+Add to `config/openclaw.json`. **Use repo-relative paths:**
+
+```json
+"example-mcp": {
+  "command": "python3",
+  "args": ["-u", "mcp-servers/example-mcp/server.py"]
+}
+```
+
+Do **not** hardcode an absolute path. Three Nautobot entries did exactly that
+(`/home/ubuntu/netclaw/...`) and were broken for every installer, including the maintainer's own
+machine, until this feature found them. `scripts/normalize-mcp-cwd.py` supplies the correct absolute
+`cwd` at install time for each user's own machine.
+
+Do **not** pack arguments into `command` (`"python3 -m foo"`). Use `command` plus `args`.
+
+System interpreters (`/usr/bin/python3`) are acceptable — they are portable. Anything under `/home/`
+or `/Users/` is not.
+
+### 3. Record its state (external kinds only)
+
+Add the human-readable name to `EXTERNAL_INTEGRATIONS` in `scripts/verify-inventory-counts.py`,
+**in the same PR**, with a comment giving the reason. Omitting this now causes a loud failure naming
+your directory rather than silent undercounting.
+
+### 4. Add installer coverage
+
+- `scripts/lib/catalog.sh` — one entry, `"id|Category|Name|Description"`
+- `scripts/lib/install-steps.sh` — one `component_install_<id>()` function, `-` becoming `_`
+
+If your integration registers several servers under one selectable component (as Check Point does
+with 15), declare the grouping in `scripts/verify-catalog-coverage.py` rather than adding 15 catalog
+entries. If your server key does not reduce to your catalog id by stripping `-mcp`, add an explicit
+alias. Nineteen servers were failing the coverage check purely for want of 8 such declarations.
+
+### 5. Update the documentation surfaces
+
+Per Constitution Principle XI:
+
+- `README.md` — description, architecture, **and the counts**
+- `SOUL.md` — capability summary and **the counts**
+- `workspace/skills/<name>/SKILL.md` — if adding a skill
+- `.env.example` — new variables, names and descriptions only, never values
+- `TOOLS.md` — infrastructure reference
+- `mcp-servers/<name>/README.md` — tools, env vars, transport, install
+
+The counts are the part everyone forgets: they were wrong in 9 places across two files.
+
+### 6. Verify
+
+```bash
+scripts/reconcile-mcp.py
+```
+
+Exit `0` means reconciled. Non-zero names exactly what is missing. Run this **before** pushing — CI
+runs the same command and hard-fails on it.
+
+To check one surface while iterating:
+
+```bash
+scripts/reconcile-mcp.py --surface catalog
+scripts/reconcile-mcp.py --surface portability
+```
+
+To confirm a skill's chain resolves:
+
+```bash
+scripts/trace-skill.py <skill-name>
+```
+
+### 7. Confirm installability
+
+The property that actually matters is that a *fresh user* can obtain this. `reconcile-mcp.py`
+verifies it statically: installer coverage exists and no path is machine-specific. No running agent
+is needed, and your own live gateway's contents are irrelevant.
+
+---
+
+## Checklist
+
+```
+[ ] Integration kind decided (pre-registered / on-demand / remote / skill-bundled)
+[ ] Vendored dir added with .gitignore negation (if vendoring)
+[ ] config/openclaw.json entry with repo-relative paths, command and args separate (if pre-registered)
+[ ] EXTERNAL_INTEGRATIONS entry with reason (if external)
+[ ] catalog.sh entry
+[ ] install-steps.sh component_install_<id>()
+[ ] Grouping rule or alias declared if the key doesn't reduce to the catalog id
+[ ] README.md updated INCLUDING counts
+[ ] SOUL.md updated INCLUDING counts
+[ ] SKILL.md created (if adding a skill)
+[ ] .env.example updated (names only)
+[ ] TOOLS.md updated
+[ ] mcp-servers/<name>/README.md created
+[ ] scripts/reconcile-mcp.py exits 0
+[ ] GAIT session logged
+```
+
+---
+
+## Common failures
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `catalog: X: no matching catalog id` | Key doesn't reduce to the catalog id by stripping `-mcp` | Add an alias or prefix group |
+| `portability: X: machine-specific` | Absolute path under `/home/` | Make it repo-relative |
+| `vendored: mcp-servers/X: no recorded state` | Vendored but neither registered nor recorded external | Do one or the other |
+| `docs: README.md:N: claims 198` | Counts not updated | Update them |
+| `docs: could not locate 'installer prose'` | Prose was reworded so the check can no longer find it | Restore a matchable phrasing or update the pattern |
+| Server not visible after install | Missing `cwd` | Confirm `normalize-mcp-cwd.py` ran |

--- a/docs/COVERAGE-ROADMAP.md
+++ b/docs/COVERAGE-ROADMAP.md
@@ -1,0 +1,733 @@
+# NetClaw Coverage Roadmap
+
+**Created:** 2026-07-30
+**Purpose:** Single reference for closing identified capability gaps in NetClaw's MCP/skill coverage.
+**Method:** One spec at a time, in order. Fix the foundation (R0) before adding anything new.
+
+Derived from a landscape scan (2026-07-30) of vendor/community MCP registries, `awesome-mcp-servers`,
+Itential's 56-server network-automation guide, Cisco/Juniper/HPE official releases, `anthropics/skills`,
+and the IETF datatracker.
+
+---
+
+## How to use this document
+
+1. Work **top to bottom**. Roadmap items are ordered by dependency, then by value-per-effort.
+2. One roadmap item = one spec = one branch. Do not batch.
+3. When you cut the branch, fill in the **Spec #** column in the status board below.
+4. Tick the checkboxes inside a roadmap item as you complete them. An item is `DONE`
+   only when every checkbox under it is ticked.
+5. Move the item's row in the status board to reflect its state.
+
+> **Shared-tree warning:** other agents switch branches in this checkout. Verify the branch before
+> committing, and remember new `mcp-servers/` subdirectories need a `.gitignore` negation entry.
+
+### Status legend
+
+| Mark | Meaning |
+|------|---------|
+| `NOT STARTED` | No spec, no branch |
+| `IN FLIGHT` | Spec written and/or branch open |
+| `DONE` | All checkboxes ticked, merged to `main` |
+| `DEFERRED` | Consciously postponed — reason recorded on the item |
+| `DROPPED` | Assessed and rejected — reason recorded on the item |
+
+---
+
+## Status board
+
+### Foundation (blocks everything else)
+
+| ID | Title | Spec # | Status |
+|----|-------|--------|--------|
+| **R0** | MCP config reconciliation — repo vs live vs vendored | [075](../specs/075-mcp-config-reconciliation/spec.md) | `DONE` |
+
+> **R0 complete 2026-07-30, with two premises corrected.** Most "unregistered" servers were
+> deliberate on-demand installs already tracked in a 60-entry `EXTERNAL_INTEGRATIONS` list. Both
+> verifiers already exited `1` correctly — the earlier "exit 0" reading was a `| tail` pipe artifact;
+> the real gap was that **nothing invoked them**. Genuinely broken: 3 Nautobot registrations
+> hardcoded to `/home/ubuntu/netclaw/`, 9 wrong documented counts, 2 silently unchecked claims.
+> True counts: **199 skills, 149 integrations**. See the R0 Outcome section below.
+
+### Tier 1 — Multivendor holes where a mature MCP already exists
+
+| ID | Title | Spec # | Status |
+|----|-------|--------|--------|
+| **R1** | Generic multivendor CLI driver (Nornir/Netmiko/NAPALM) | — | `NOT STARTED` |
+| **R2** | Cisco Support APIs (PSIRT / EoX / Bug / Case) | — | `NOT STARTED` |
+| **R3** | Fortinet (FortiOS / FortiManager / FortiAnalyzer) | — | `NOT STARTED` |
+| **R4** | Palo Alto PAN-OS / Panorama NGFW | — | `NOT STARTED` |
+| **R5** | Juniper Mist (official) + Apstra | — | `NOT STARTED` |
+| **R6** | HPE Aruba Central / ClearPass / EdgeConnect / GreenLake | — | `NOT STARTED` |
+| **R7** | Cisco Nexus Dashboard / Intersight / UCS | — | `NOT STARTED` |
+
+### Tier 2 — The internet / external plane
+
+| ID | Title | Spec # | Status |
+|----|-------|--------|--------|
+| **R8** | Globalping — global probe measurement (remote MCP) | — | `NOT STARTED` |
+| **R9** | BGP & registry intelligence (RPKI / RDAP / PeeringDB / RIPE Atlas) | — | `NOT STARTED` |
+
+### Tier 3 — Monitoring and traffic layers
+
+| ID | Title | Spec # | Status |
+|----|-------|--------|--------|
+| **R10** | ntopng — flow analytics platform | — | `NOT STARTED` |
+| **R11** | SNMP-poller NMS (Zabbix / LibreNMS / Netdata) | — | `NOT STARTED` |
+| **R12** | APM + log platforms (Dynatrace / New Relic / Elastic) | — | `NOT STARTED` |
+| **R13** | NSM / IDS (Zeek / Suricata / Arkime) + packet-buddy audit | — | `NOT STARTED` |
+
+### Tier 4 — The layer beneath the network
+
+| ID | Title | Spec # | Status |
+|----|-------|--------|--------|
+| **R14** | Kubernetes (pods/services/ingress/NetworkPolicy + Helm) | — | `NOT STARTED` |
+| **R15** | Redfish / BMC out-of-band (iDRAC / iLO / XClarity) | — | `NOT STARTED` |
+| **R16** | VMware vSphere / NSX (build, not adopt) | — | `NOT STARTED` |
+| **R17** | Database query layer (Postgres / ClickHouse / DuckDB / SQLite) | — | `NOT STARTED` |
+
+### Tier 5 — Productivity and human deliverables
+
+| ID | Title | Spec # | Status |
+|----|-------|--------|--------|
+| **R18** | Document generation — docx / pptx / xlsx / pdf | — | `NOT STARTED` |
+| **R19** | Google Workspace (official) | — | `NOT STARTED` |
+| **R20** | Notion + Linear (official) | — | `NOT STARTED` |
+| **R21** | GitOps + Azure DevOps (ArgoCD / Flux) | — | `NOT STARTED` |
+| **R22** | Diagram MCPs — Excalidraw + draw.io | — | `NOT STARTED` |
+
+### Strategic (not tooling)
+
+| ID | Title | Spec # | Status |
+|----|-------|--------|--------|
+| **R23** | IETF MCP-for-network-management landscape → NCFED `-01` input | — | `NOT STARTED` |
+
+### Open territory (build candidates — assess before scheduling)
+
+| ID | Title | Spec # | Status |
+|----|-------|--------|--------|
+| **R24** | Open-territory triage — pick flag-planting targets | — | `NOT STARTED` |
+
+---
+
+# R0 — MCP config reconciliation
+
+> **Complete.** R1–R24 are unblocked. Every one of them must follow `docs/ADDING-AN-MCP.md`
+> and pass `python3 scripts/reconcile-mcp.py` before merge.
+
+**Status:** `DONE` (2026-07-30, spec 075)
+**Blocks:** every other item in this roadmap — now unblocked
+**Type:** foundation / config hygiene — no new capability
+
+## Why this is first
+
+Every "add server X" item below writes to the same config surface. If that surface is already
+inconsistent, each addition compounds the drift and we cannot tell whether a new capability is
+actually obtainable by someone installing their own risk.
+
+## Outcome (completed 2026-07-30)
+
+R0 shipped as **spec 075**. Two of its three originating premises were wrong, and saying so
+plainly matters more than looking consistent — the corrections are the most useful thing R0
+produced.
+
+### What was claimed vs. what was true
+
+| Original claim | Reality |
+|---|---|
+| 20 vendored servers are "silently unregistered" (Bucket A) | Mostly **deliberate**. `scripts/verify-inventory-counts.py` already maintained a 60-entry `EXTERNAL_INTEGRATIONS` list covering pyATS, NetBox, ServiceNow, ACI, ISE, F5 and others as intentional on-demand installs. `pyATS_MCP` being absent from the config is by design. |
+| Both verifiers report `FAIL` and exit 0, so nothing enforces them | **Measurement error.** Both exit `1` correctly. The exit codes had been read through a `\| tail` pipe, which reports the pipe's status. The real gap: **nothing invoked them** — `.github/workflows/` held only `skill-review.yml`. |
+| 19 registered servers have no installer coverage, so the installer cannot install them | **Declaration gaps, not installer gaps.** All 19 were installable; catalog ids `aap`, `aws`, `gcp`, `fmc`, `meraki`, `memory-mcp`, `te-community`, `te-official` all existed. The checker simply lacked mapping rules. Fixed with **8 declarations, zero new install functions**. |
+| Bucket C: 82 servers declared but not live | **Descoped.** The maintainer's ruling: *"let's not worry about the live config as long as all 89 are available for people when they install their own risk."* Live-gateway state is explicitly out of scope. |
+
+### What was genuinely broken
+
+- **3 Nautobot registrations hardcoded to `/home/ubuntu/netclaw/`** — a path on no machine,
+  including the maintainer's. Broken for every installer. This was the only user-facing breakage,
+  and reframing the goal around fresh-install correctness is what surfaced it.
+- **9 wrong documented counts** across `README.md` and `SOUL.md`. True values: **199 skills,
+  149 MCP integrations**.
+- **2 documentation claims silently unchecked** — their prose had been reworded, so the checker
+  stopped matching them and reported only an advisory note. Retired with a documented reason
+  (spec 049 made the installer selective, so a fixed "deploys N skills" claim is now false).
+- **`cml-mcp` packed arguments into its command string**; normalised to `command` + `args`.
+
+### What shipped
+
+| Artifact | Purpose |
+|---|---|
+| `scripts/reconcile-mcp.py` | Single entry point across all surfaces (the fix for "nothing ran the checks") |
+| `scripts/check-mcp-portability.py` | Catches machine-specific paths; distinguishes `/usr/bin/python3` (fine) from `/home/ubuntu/...` (fatal) |
+| `.github/workflows/mcp-reconciliation.yml` | CI hard-fail. Deliberately never uses `--warn-only` |
+| `tests/reconcile/run-tests.sh` | 14 exit-code contract tests, no framework, no dependencies |
+| `docs/ADDING-AN-MCP.md` | The one procedure R1–R24 each follow |
+| `verify-catalog-coverage.py` | +8 mapping declarations, +vendored-state completeness |
+| `verify-inventory-counts.py` | Unlocatable claims are now failures, not notes |
+
+### One open finding
+
+**EVE-NG** is vendored (`mcp-servers/eve-ng-mcp-server`) and has 5 skills, but appears in neither
+`EXTERNAL_INTEGRATIONS` nor `scripts/lib/catalog.sh`. It is therefore missing from the integration
+count and cannot be installed by the modular installer. Recorded in `VENDORED_STATE_REASONS` as an
+explicit open finding rather than silently absorbed, because resolving it raises the MCP count to
+150 and needs a catalog entry plus install function — a scope decision, not a cleanup.
+
+### Durable rule for R1–R24
+
+Follow **`docs/ADDING-AN-MCP.md`**, then run `python3 scripts/reconcile-mcp.py` before pushing. CI
+runs the same command and fails the merge on non-zero. And never read an exit code through a pipe.
+
+# Tier 1 — Multivendor holes where a mature MCP already exists
+
+Common to every Tier 1 item:
+
+- [ ] Read the upstream source before adopting; note license, auth model, and whether it is
+      read-only or write-capable
+- [ ] Prefer read-only or explicitly-gated write paths; route writes through the existing
+      approval/HumanRail path
+- [ ] Run `defenseclaw skill scan` / CodeGuard on adopted third-party code
+- [ ] Register via the R0 procedure and verify it reaches the live agent
+- [ ] Write or update the accompanying skill(s) so the capability is discoverable
+- [ ] Add the server to the docs inventory and the installer's component list
+
+---
+
+## R1 — Generic multivendor CLI driver (Nornir / Netmiko / NAPALM)
+
+**Status:** `NOT STARTED` · **Recommended first Tier 1 item**
+
+Biggest coverage-per-line item on the roadmap. Current device reach is pyATS + junos + gnmi
++ RADKit. There is no "SSH to anything" tool. This one server adds MikroTik, VyOS, SONiC,
+Nokia SR Linux, Extreme, Huawei, Dell, Ubiquiti EdgeOS and ~90 more platforms.
+
+**Candidates**
+- `sydasif/nornir-mcp-server` — NAPALM normalized getters + Netmiko CLI exec; ships command
+  blacklisting, Pydantic input validation, backup-path restriction
+- `ntunes/netmiko-mcp-server` — connection pooling, multi-vendor, concurrent operations
+
+**Checklist**
+- [ ] Evaluate both; decide adopt-one, adopt-both, or fork
+- [ ] Define the inventory source — reuse NetBox/Nautobot/Infrahub as SoT rather than a new file
+- [ ] Define credential handling — route through Vault MCP, not plaintext inventory
+- [ ] Harden the command allow/deny list; confirm config-mode commands are gated
+- [ ] Establish where this stops and pyATS starts, so skills don't overlap ambiguously
+- [ ] Skill(s) covering: normalized getters, safe show-command exec, multi-device fan-out
+- [ ] Validate against a real multivendor lab (containerlab/GNS3/EVE-NG) with at least one
+      platform NetClaw cannot reach today
+
+---
+
+## R2 — Cisco Support APIs (PSIRT / EoX / Bug / Case)
+
+**Status:** `NOT STARTED`
+
+Closes a top-5 real-world netops question NetClaw cannot answer: *is this build affected by
+an advisory, past EoL, or hitting a known bug?* NVD CVE and DevNet content search do not cover
+Cisco-specific advisories, EoL dates, bug IDs, or TAC cases.
+
+**Candidate:** `sieteunoseis/mcp-cisco-support` — 46 tools across Bug Search, Case, EoX,
+PSIRT openVuln, Product, Software Suggestion, Serial→Info.
+
+**Checklist**
+- [ ] Obtain Cisco API credentials (Support APIs and PSIRT openVuln are separate entitlements)
+- [ ] Handle rate limits — openVuln is 5/sec, 30/min, 5000/day; cache aggressively
+- [ ] Decide which of the 8 API families to enable (server is configurable)
+- [ ] Wire results into the existing `nvd-cve` skill flow rather than duplicating it
+- [ ] Skill: version-to-advisory check, EoL/EoS lookup, serial-to-entitlement
+- [ ] Cross-link with pyATS/`nornir` version collection so the question is answerable end-to-end
+      from a live device, not just a typed-in version string
+
+---
+
+## R3 — Fortinet (FortiOS / FortiManager / FortiAnalyzer)
+
+**Status:** `NOT STARTED`
+
+Largest single-vendor absence. `fortimanager-ops` skill exists with no server behind it.
+
+**Candidates**
+- `ivillagomez/fortigate-mcp` — read-only FortiGate + FortiAnalyzer; best default safety posture
+- `rstierli/fortimanager-mcp` — FortiManager JSON-RPC: policies, devices, scripts
+- `paoloamato2/fortinet-mcp-server` — entire FortiOS 7.6.6 REST API as 200+ typed tools
+
+All three are community, not Fortinet-endorsed.
+
+**Checklist**
+- [ ] Decide the entry point: device-level (FortiGate), manager-level (FortiManager), or both
+- [ ] If adopting the 200+ tool server, assess token cost of the tool manifest — this may need
+      a filtered/lazy tool surface (see feature 006 token optimization)
+- [ ] Start read-only; gate policy writes behind approval
+- [ ] Back-fill the existing `fortimanager-ops` skill against the real server
+- [ ] Skills: policy audit, VPN tunnel status, FortiAnalyzer log query
+
+---
+
+## R4 — Palo Alto PAN-OS / Panorama NGFW
+
+**Status:** `NOT STARTED`
+
+`paloalto-panorama` skill exists with no server. Prisma SD-WAN/SASE is covered; the NGFW is not.
+
+**Candidate:** `cdot65/pan-os-mcp` — XML API via the Python MCP SDK.
+
+**Checklist**
+- [ ] Assess XML API coverage vs what the `paloalto-panorama` skill claims
+- [ ] Decide device-vs-Panorama scope
+- [ ] API key handling via Vault
+- [ ] Read-only first; commit/candidate-config writes gated
+- [ ] Consider whether `fwrule-mcp` overlaps and how they compose
+
+---
+
+## R5 — Juniper Mist (official) + Apstra
+
+**Status:** `NOT STARTED`
+
+`junos-mcp-server` covers devices. Nothing covers Mist wired/wireless assurance or Marvis.
+Juniper ships an **official** Mist MCP server (Claude Desktop beta).
+
+**Checklist**
+- [ ] Adopt the official Juniper Mist MCP server; note its beta status and org scoping
+- [ ] Mist API token + org ID handling
+- [ ] Skills: wireless assurance, client troubleshooting, Marvis query, SLE review
+- [ ] Assess Apstra separately (community only) — DC fabric intent; may fold into R6 if the
+      unified HPE server covers it adequately
+
+---
+
+## R6 — HPE Aruba Central / ClearPass / EdgeConnect / GreenLake
+
+**Status:** `NOT STARTED`
+
+Only `aruba-cx` (switch CLI) exists today. One server covers a whole vendor cloud stack.
+
+**Candidates**
+- `nowireless4u/hpe-networking-mcp` — unified: Mist + Aruba Central + GreenLake + ClearPass
+  + Apstra + Axis Atmos + AOS 8 + UXI + EdgeConnect, one container
+- `secure-ssid/centralmcp` — low-token Aruba Central + GreenLake + EdgeConnect + UXI, with
+  RAG/OpenAPI lookup
+
+**Checklist**
+- [ ] Decide unified-vs-focused. Note the unified server overlaps R5 (Mist) and Apstra —
+      sequence R5/R6 together to avoid double-registering Mist
+- [ ] Evaluate the low-token design of `centralmcp` against NetClaw's token budget work
+- [ ] Multi-tenant / multi-account credential model
+- [ ] Skills: Aruba Central inventory + health, ClearPass policy/auth troubleshooting,
+      EdgeConnect SD-WAN status, UXI sensor results
+
+---
+
+## R7 — Cisco Nexus Dashboard / Intersight / UCS
+
+**Status:** `NOT STARTED`
+
+ACI ships as a deliberate on-demand integration — `ACI_MCP` is vendored and tracked in
+`EXTERNAL_INTEGRATIONS` with catalog id `aci`, so R0 correctly left it as-is and it is **not** an
+unregistered gap. Nexus Dashboard and Intersight/UCS are absent entirely.
+
+**Candidates**
+- `beye91/nexus-dashboard-mcp` — read-only ND API + read-only NX-OS commands + log fetch
+- Community Intersight MCP server
+- **Reference read:** Cisco's own Network MCP Docker Suite (Meraki, Catalyst Center, IOS XE,
+  NetBox, ISE, ThousandEyes, Splunk) — heavy overlap with NetClaw, useful as a packaging
+  and validation reference rather than an adoption target
+
+**Checklist**
+- [ ] Confirm R0 resolved `ACI_MCP` registration before adding Nexus Dashboard, to avoid
+      two overlapping DC-fabric surfaces
+- [ ] Adopt Nexus Dashboard MCP; scope to read-only initially
+- [ ] Assess Intersight/UCS as a separate decision — it is compute + fabric interconnect,
+      arguably closer to R15 (BMC/out-of-band) than to Tier 1 networking
+- [ ] Review the Cisco Docker Suite's packaging approach against NetClaw's installer
+
+---
+
+# Tier 2 — The internet / external plane
+
+NetClaw has **zero** external-vantage or BGP-intelligence capability today: no ASN lookup,
+no route-origin validation, no peering data, no abuse contacts, no third-party reachability.
+This is a whole missing domain, not a missing tool.
+
+## R8 — Globalping
+
+**Status:** `NOT STARTED` · **Highest value-per-effort item in the scan**
+
+Official jsDelivr remote MCP at `https://mcp.globalping.dev/mcp`. Ping, traceroute, DNS, MTR,
+HTTP from thousands of global probes. Free. OAuth or API token. Zero install.
+
+**Checklist**
+- [ ] Register the remote MCP endpoint (no vendored code — follow the remote-MCP pattern used
+      for Datadog / DevNet content search)
+- [ ] Auth: token vs OAuth; note rate limits are tied to account
+- [ ] Skill: external reachability check, "is it us or the internet", geographic latency
+      comparison, DNS propagation check
+- [ ] Compose with ThousandEyes skills so the agent knows when to use free global probes vs
+      paid enterprise agents
+
+## R9 — BGP & registry intelligence
+
+**Status:** `NOT STARTED`
+
+**Candidates**
+- `PeerCortex` — 34 tools consolidating PeeringDB, RIPEstat, RIPE Atlas, RouteViews,
+  RPKI validators; also ships a dashboard and REST API
+- `jrelph/ripe-atlas-mcp` — RIPE Atlas measurements (credit-based)
+- `dadepo/whois-mcp` — WHOIS/RDAP for domains, IPs, ASNs; AS-SET expansion; RIPE route-object
+  validation
+- Also seen: a 5-RIR RDAP + RPKI + BGP visibility + abuse-contact server
+
+**Checklist**
+- [ ] Decide consolidated (PeerCortex) vs composed (atlas + whois + rpki separately)
+- [ ] RIPE Atlas credit budget — measurements cost credits, unlike Globalping
+- [ ] Compose with the existing `protocol-mcp` / BGP daemon so hijack triage is possible:
+      *"this prefix appeared from an unexpected origin — is the ROA valid, who owns it,
+      who do I contact"*
+- [ ] Skills: prefix ownership, ROV/RPKI check, peering research, hijack triage, abuse contact
+
+---
+
+# Tier 3 — Monitoring and traffic layers
+
+## R10 — ntopng
+
+**Status:** `NOT STARTED`
+
+Official ntop MCP server (documented in ntopng 6.7). Queries ClickHouse flow history, live host
+stats, alerts. NetClaw has its own `ipfix-mcp` receiver plus kubeshark/packet-buddy, but no real
+flow-analytics platform.
+
+**Checklist**
+- [ ] Stand up ntopng (or point at an existing instance) with ClickHouse flow storage
+- [ ] Adopt the official MCP server
+- [ ] Define the boundary against `ipfix-mcp` — receiver vs analytics platform
+- [ ] Skills: top talkers, flow investigation, alert triage, host behavior baseline
+- [ ] Note the ClickHouse dependency ties into R17
+
+## R11 — SNMP-poller NMS (Zabbix / LibreNMS / Netdata)
+
+**Status:** `NOT STARTED`
+
+Prometheus, Grafana, Datadog, Splunk, Auvik, ThousandEyes are covered. There is **no
+SNMP-poller NMS at all** — and Zabbix/LibreNMS are what a large share of enterprises run.
+
+**Checklist**
+- [ ] Pick target(s). Suggested order: Zabbix (largest install base), then LibreNMS
+- [ ] Netdata offers an official Cloud MCP — assess as the low-effort entry point
+- [ ] Observium: assess, likely `DEFERRED`
+- [ ] Skills: interface utilization history, threshold/alert review, device availability
+
+## R12 — APM + log platforms (Dynatrace / New Relic / Elastic)
+
+**Status:** `NOT STARTED`
+
+Both APM vendors appear on Itential's 56-server list; NetClaw has neither. Elasticsearch is
+absent and is extremely common for netops logging.
+
+**Checklist**
+- [ ] Assess Dynatrace and New Relic official MCP availability
+- [ ] Elastic/Elasticsearch MCP — likely higher practical value than either APM for netops
+- [ ] Define the boundary against existing Splunk / Datadog / Grafana skills so the agent
+      picks the right backend rather than guessing
+
+## R13 — NSM / IDS (Zeek / Suricata / Arkime) + packet-buddy audit
+
+**Status:** `NOT STARTED`
+
+The network-security-monitoring layer is entirely absent.
+
+**Checklist**
+- [ ] Audit the existing `packet-buddy-mcp` against `0xKoda/WireMCP` and SharkMCP
+      (tshark, 20 tools) — there may be capability NetClaw is missing in its own server
+- [ ] Assess Zeek (metadata), Suricata (IDS), Arkime (indexed full-packet search) —
+      a typical stack uses all three
+- [ ] Decide adopt vs build; these may need building
+- [ ] Skills: session pivot, IDS alert triage, retrospective packet search
+
+---
+
+# Tier 4 — The layer beneath the network
+
+## R14 — Kubernetes
+
+**Status:** `NOT STARTED`
+
+`kubeshark` gives traffic visibility but NetClaw cannot read a pod, service, ingress, or
+NetworkPolicy. Hard floor for any container-networking work.
+
+**Candidates**
+- `Flux159/mcp-server-kubernetes` — includes Helm operations and write tools
+  (`kubectl_apply`, `kubectl_scale`, `kubectl_patch`, `kubectl_rollout`)
+- `rohitg00/kubectl-mcp-server` — in the CNCF Landscape
+- Red Hat's Kubernetes/OpenShift MCP server
+
+**Checklist**
+- [ ] Pick a server; strongly prefer starting read-only given the write tool surface
+- [ ] kubeconfig / context handling and RBAC scoping
+- [ ] Skills: NetworkPolicy review, service/ingress path tracing, CNI health
+- [ ] Compose with `kubeshark` so config and traffic views join up
+- [ ] Assess Cilium/Calico CNI-specific tooling as a follow-on
+
+## R15 — Redfish / BMC out-of-band
+
+**Status:** `NOT STARTED`
+
+Directly answers "is the box dead or is it the network" — a distinction NetClaw cannot make today.
+
+**Candidates**
+- `fredriksknese/mcp-redfish` — Dell iDRAC, HPE iLO, Supermicro, Lenovo XClarity
+- `carlosedp/redfish-mcp-server`
+
+Covers systems, chassis/thermal/power, BMC managers, storage controllers, event logs,
+firmware inventory.
+
+**Checklist**
+- [ ] Adopt one; read-only first (power *control* is a write action needing approval)
+- [ ] BMC credential handling via Vault
+- [ ] Skills: hardware health check, thermal/power review, firmware inventory, SEL log triage
+- [ ] Consider folding Cisco UCS/Intersight (R7) here instead of Tier 1
+
+## R16 — VMware vSphere / NSX
+
+**Status:** `NOT STARTED` · **Build, not adopt**
+
+No mature MCP found in the scan. Significant gap given how much east-west networking lives
+in NSX.
+
+**Checklist**
+- [ ] Re-scan for an MCP before committing to build — this may have changed
+- [ ] If building: scope tightly to read-only inventory + NSX logical topology + DFW rules
+- [ ] Assess against existing `fwrule-mcp` for DFW rule analysis reuse
+
+## R17 — Database query layer
+
+**Status:** `NOT STARTED`
+
+SuzieQ, ntopng, Arkime, and NetBox all sit on databases worth querying directly. DuckDB over
+files is an excellent analysis substrate for exports.
+
+**Checklist**
+- [ ] Decide scope: read-only analyst access, not a general write surface
+- [ ] Prioritize DuckDB (file/export analysis) and ClickHouse (ntopng, R10) over generic Postgres
+- [ ] Strict read-only enforcement and query timeouts
+- [ ] **Must not** expose `~/.openclaw/memory/` or `~/.openclaw/rag/rag.db` — feature 062
+      FR-030 keeps those isolated
+- [ ] Skill: ad-hoc analysis over exported network data
+
+---
+
+# Tier 5 — Productivity and human deliverables
+
+## R18 — Document generation (docx / pptx / xlsx / pdf)
+
+**Status:** `NOT STARTED` · **Best effort-to-value ratio on the roadmap**
+
+NetClaw can render Three.js topologies, drawio, markmap, UML, Blender and UE5 — but cannot
+produce a change-record `.docx`, an exec `.pptx`, an interface-audit `.xlsx`, or fill a PDF.
+Its output lands in front of enterprise humans.
+
+**Source:** `anthropics/skills` — `skills/docx`, `skills/pptx`, `skills/xlsx`, `skills/pdf`,
+official and source-available.
+
+**Checklist**
+- [ ] Vendor the four official skills; note their license terms
+- [ ] Confirm Python deps (`python-docx`, `openpyxl`, `python-pptx`, PDF tooling) — several are
+      already present for `rag-mcp` (feature 062)
+- [ ] Define the output location convention (persistent workspace output dir, timestamped,
+      never overwritten — matching feature 046)
+- [ ] NetClaw-specific wrapper skills: change record, incident report, interface/config audit
+      workbook, exec summary deck
+- [ ] Compose with existing report-delivery skills (`slack-report-delivery`,
+      `webex-report-delivery`) so generated documents can actually be sent
+
+## R19 — Google Workspace (official)
+
+**Status:** `NOT STARTED`
+
+Google shipped an official Workspace MCP server in preview (Drive, Gmail, Calendar, Chat).
+NetClaw has Atlassian and MS Graph skills but nothing Google-side; many orgs are Google-first.
+
+**Checklist**
+- [ ] Adopt the official server; note preview status
+- [ ] OAuth scope minimization — request read scopes first
+- [ ] Skills mirroring the existing `msgraph-*` set so the agent can work either ecosystem
+- [ ] Compose with R18 so generated documents can land in Drive
+
+## R20 — Notion + Linear (official)
+
+**Status:** `NOT STARTED`
+
+Both now have official vendor MCPs.
+
+**Checklist**
+- [ ] Adopt both
+- [ ] Decide how they relate to the existing ITSM provider abstraction (feature 070) —
+      Linear is issue tracking, adjacent to Halo/ServiceNow/Atlassian
+- [ ] Skills: knowledge capture to Notion, work-item lifecycle in Linear
+
+## R21 — GitOps + Azure DevOps
+
+**Status:** `NOT STARTED`
+
+GitOps is how network config actually deploys now. NetClaw has Jenkins/GitLab/GitHub/Terraform
+but no reconciler. Azure DevOps covers the Microsoft-shop half of the market.
+
+**Checklist**
+- [ ] ArgoCD MCP: list clusters, list/diff/sync applications, resource management
+- [ ] Assess Flux as an alternative or addition
+- [ ] Azure DevOps official MCP server
+- [ ] Skills: config drift detection via ArgoCD diff, sync-with-approval, pipeline status
+- [ ] Sync operations are writes — route through the approval path
+
+## R22 — Diagram MCPs (Excalidraw + draw.io)
+
+**Status:** `NOT STARTED`
+
+Both appear on Itential's list. NetClaw has drawio as a *skill* only.
+
+**Checklist**
+- [ ] Assess whether a draw.io MCP adds anything over the existing `drawio-diagram` skill
+- [ ] Excalidraw MCP for hand-drawn-style diagrams
+- [ ] Likely low priority — may be `DROPPED` if the existing skill suffices
+
+---
+
+# R23 — IETF MCP-for-network-management landscape
+
+**Status:** `NOT STARTED` · **Strategic, not tooling**
+
+MCP has arrived at the IETF: 15+ active Internet-Drafts as of April 2026, from Cisco, Google,
+Huawei, Deutsche Telekom, Orange, Telefónica, and independents. No working group has adopted
+any of them and no MCP WG exists yet.
+
+Directly in NetClaw's lane:
+
+| Draft | Relevance |
+|---|---|
+| `draft-zw-opsawg-mcp-network-mgmt` | "MCP Extensions for Network Equipment Management" |
+| `draft-yang-nmrg-mcp-nm` | "Applicability of MCP to Network Management" |
+| `draft-serra-mcp-discovery-uri` | `mcp` URI scheme + `/.well-known/mcp-server` discovery |
+| `draft-morrison-mcp-dns-discovery` | MCP server discovery via DNS TXT records |
+
+`draft-capobianco-ncfed-00` is already in flight. The discovery drafts in particular overlap the
+federation/enrollment problem NCFED solved differently — worth reconciling before `-01`.
+
+**Checklist**
+- [ ] Read all four drafts in full
+- [ ] Write a positioning note: where NCFED agrees with, diverges from, or could cite each
+- [ ] Decide whether NCFED `-01` should reference the discovery drafts, and whether NetClaw's
+      TOFU-pinned enrollment is worth contributing back as an alternative
+- [ ] Check opsawg / nmrg mailing list activity for adoption signals
+- [ ] Feed conclusions into the existing NCFED `-01` backlog
+
+---
+
+# R24 — Open-territory triage
+
+**Status:** `NOT STARTED`
+
+No mature MCP found for any of these. Flag-planting opportunities rather than gaps — assess
+strategic value before scheduling any of them as their own spec.
+
+**Networking platforms**
+Nokia SR Linux / SR OS · SONiC · VyOS · Arista ANTA (notable, given CVP is covered) ·
+netlab · Oxidized / Netpicker (config backup & compliance) · gNOI (gNMI is covered; the
+operations half is not)
+
+> Most of these are practically answered by **R1** (Nornir/Netmiko). Do R1 first, then
+> re-assess which still justify a dedicated server.
+
+**Service provider / optical / mobile**
+Ciena · Infinera · Nokia NSP · Open5GS · free5GC
+
+**SASE / cloud networking / NaaS**
+Netskope · Cato · Versa · Aviatrix · Alkira · **Megaport/NaaS** (genuinely unclaimed and
+strategically interesting)
+
+**Wireless design**
+Ekahau · Hamina
+
+**Exist but NetClaw lacks (adopt, don't build)**
+- MikroTik RouterOS MCP (API + SSH)
+- UniFi MCP (community, on the official UniFi API)
+
+**Checklist**
+- [ ] After R1 lands, re-test which platforms remain genuinely unreachable
+- [ ] Pick at most one or two flag-planting targets; Megaport/NaaS and Arista ANTA are the
+      strongest candidates
+- [ ] Everything else: record as `DEFERRED` with a reason so it isn't re-litigated
+
+---
+
+# Recommended execution order
+
+R0 is mandatory and first. After that, the value-ordered sequence:
+
+1. **R0** — config reconciliation *(foundation; blocks all)*
+2. **R1** — Nornir/Netmiko *(~100 platforms, one server)*
+3. **R18** — document generation *(free, official, closes the deliverable gap)*
+4. **R8** — Globalping *(remote MCP, zero install, opens the external plane)*
+5. **R2** — Cisco Support APIs *(closes PSIRT/EoL/bug in the deepest vendor)*
+6. **R3** — Fortinet *(largest single-vendor absence)*
+
+Next wave: **R14** Kubernetes · **R5** Mist · **R6** Aruba Central · **R10** ntopng ·
+**R15** Redfish.
+
+Then: R4, R7, R9, R11, R17, R19, R21, and R23 in parallel with tooling work.
+
+---
+
+# Appendix — reproducing the R0 measurements
+
+```bash
+cd ~/netclaw
+
+# repo vs live entry counts and drift
+python3 - <<'EOF'
+import json, os
+def servers(d):
+    return d.get('mcpServers') or d.get('mcp', {}).get('servers') or {}
+repo = servers(json.load(open('config/openclaw.json')))
+live = servers(json.load(open(os.path.expanduser('~/.openclaw/openclaw.json'))))
+print("repo:", len(repo), "live:", len(live))
+print("live not in repo:", sorted(set(live) - set(repo)))
+print("repo not in live:", len(set(repo) - set(live)))
+EOF
+
+# vendored dirs not referenced by any config path
+python3 - <<'EOF'
+import json, os, re
+repo = json.load(open('config/openclaw.json'))
+srv = repo.get('mcpServers') or repo.get('mcp', {}).get('servers') or {}
+refd = set(re.findall(r'mcp-servers/([A-Za-z0-9_.\-]+)', json.dumps(srv)))
+dirs = {d for d in os.listdir('mcp-servers') if os.path.isdir(f'mcp-servers/{d}')}
+for d in sorted(dirs - refd):
+    print(" -", d)
+EOF
+```
+
+---
+
+## Sources
+
+Landscape scan, 2026-07-30.
+
+- [Itential — The Ultimate MCP Guide for Network Automation (56 servers)](https://www.itential.com/resource/guide/the-ultimate-mcp-guide-for-network-automation/)
+- [wong2/awesome-mcp-servers](https://github.com/wong2/awesome-mcp-servers)
+- [anthropics/skills](https://github.com/anthropics/skills)
+- [Juniper — Mist MCP Server with Claude Desktop (official)](https://www.juniper.net/documentation/us/en/software/mist/mist-aiops/shared-content/topics/concept/juniper-mist-mcp-claude.html)
+- [nowireless4u/hpe-networking-mcp](https://github.com/nowireless4u/hpe-networking-mcp) · [secure-ssid/centralmcp](https://github.com/secure-ssid/centralmcp)
+- [rstierli/fortimanager-mcp](https://github.com/rstierli/fortimanager-mcp) · [paoloamato2/fortinet-mcp-server](https://mcpservers.org/servers/paoloamato2/fortinet-mcp-server) · [ivillagomez/fortigate-mcp](https://lobehub.com/mcp/ivillagomez-fortigate-mcp)
+- [cdot65/pan-os-mcp](https://github.com/cdot65/pan-os-mcp)
+- [sydasif/nornir-mcp-server](https://glama.ai/mcp/servers/sydasif/nornir-mcp-server) · [ntunes/netmiko-mcp-server](https://github.com/ntunes/netmiko-mcp-server)
+- [sieteunoseis/mcp-cisco-support](https://developer.cisco.com/codeexchange/github/repo/sieteunoseis/mcp-cisco-support/) · [Cisco PSIRT openVuln API](https://developer.cisco.com/docs/psirt/)
+- [beye91/nexus-dashboard-mcp](https://mcpservers.org/servers/beye91/nexus-dashboard-mcp) · [Cisco Network MCP Docker Suite](https://gblogs.cisco.com/ch-tech/network-mcp-docker-suite/)
+- [jsdelivr/globalping-mcp-server](https://github.com/jsdelivr/globalping-mcp-server)
+- [jrelph/ripe-atlas-mcp](https://github.com/jrelph/ripe-atlas-mcp) · [PeerCortex](https://mcpmarket.com/server/peercortex) · [dadepo/whois-mcp](https://www.mcpserverfinder.com/servers/dadepo/whois-mcp)
+- [ntopng MCP Server (official)](https://www.ntop.org/ai-powered-network-monitoring-introducing-ntopng-mcp-server/)
+- [Flux159/mcp-server-kubernetes](https://github.com/Flux159/mcp-server-kubernetes) · [rohitg00/kubectl-mcp-server](https://github.com/rohitg00/kubectl-mcp-server) · [Red Hat Kubernetes MCP server](https://developers.redhat.com/articles/2025/09/25/kubernetes-mcp-server-ai-powered-cluster-management)
+- [fredriksknese/mcp-redfish](https://github.com/fredriksknese/mcp-redfish) · [carlosedp/redfish-mcp-server](https://github.com/carlosedp/redfish-mcp-server)
+- [0xKoda/WireMCP](https://github.com/0xKoda/WireMCP)
+- [NetBox MCP Server (official)](https://netboxlabs.com/docs/mcp/)
+- [Google Workspace MCP server (official, preview)](https://workspace.google.com/blog/product-announcements/10-more-announcements-workspace-at-next-2026)
+- [CiscoDevNet/webex-mcp-official](https://developer.cisco.com/codeexchange/github/repo/CiscoDevNet/webex-mcp-official/)
+- [draft-zw-opsawg-mcp-network-mgmt](https://www.ietf.org/archive/id/draft-zw-opsawg-mcp-network-mgmt-00.html) · [draft-yang-nmrg-mcp-nm](https://datatracker.ietf.org/doc/draft-yang-nmrg-mcp-nm/) · [draft-serra-mcp-discovery-uri](https://datatracker.ietf.org/doc/draft-serra-mcp-discovery-uri/) · [draft-morrison-mcp-dns-discovery](https://datatracker.ietf.org/doc/draft-morrison-mcp-dns-discovery/) · [MCP at the IETF — overview](https://chatforest.com/guides/mcp-ietf-standardization/)

--- a/scripts/check-mcp-portability.py
+++ b/scripts/check-mcp-portability.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Verify that every MCP registration in config/openclaw.json is portable --
+that is, that it will still resolve on a machine other than the one it was
+written on.
+
+Contract: specs/075-mcp-config-reconciliation/contracts/reconcile-cli.md
+Data model: specs/075-mcp-config-reconciliation/data-model.md (PathClassification)
+
+Why this exists: three Nautobot registrations shipped with
+`/home/ubuntu/netclaw/.venv/bin/python3` hardcoded as their interpreter. That
+path exists on nobody's machine -- not even the maintainer's -- so all three
+integrations were broken for every single installer until spec 075 found them.
+Nothing was checking, because "does this path exist somewhere else" is not a
+question any other verifier asks.
+
+The distinction that matters is NOT absolute-vs-relative. `/usr/bin/python3` is
+an absolute path and is perfectly portable; `/home/ubuntu/netclaw/...` is not.
+Banning all absolute paths would flag every system interpreter and push people
+toward suppressions. So paths are classified, and only genuinely
+machine-specific ones fail.
+
+No third-party dependencies. Paths resolve relative to this file's location,
+not the caller's cwd.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_CONFIG = os.path.join(REPO_ROOT, "config", "openclaw.json")
+
+# Absolute prefixes that are portable in practice: present at the same location
+# on any conventional Linux install.
+SYSTEM_PREFIXES = ("/usr/", "/bin/", "/sbin/", "/lib/", "/opt/", "/etc/")
+
+# Absolute prefixes that are inherently specific to one machine and one user.
+# This is the class that actually broke, and the reason this script exists.
+HOME_PREFIXES = ("/home/", "/Users/", "/root/")
+
+CLASS_REPO_RELATIVE = "repo_relative"
+CLASS_SYSTEM_ABSOLUTE = "system_absolute"
+CLASS_MACHINE_SPECIFIC = "machine_specific"
+CLASS_PACKAGE_SPEC = "package_spec"
+CLASS_EMBEDDED_ARGS = "embedded_args"
+CLASS_OTHER_ABSOLUTE = "other_absolute"
+
+
+def classify(value, repo_root):
+    """Classify one command / arg / cwd string. See data-model.md."""
+    if not isinstance(value, str) or not value:
+        return None
+
+    # A command string containing whitespace has arguments packed into it.
+    # Whether that launches depends on whether the host splits it, so this is
+    # reported for verification rather than failed outright.
+    if not value.startswith("/") and " " in value.strip() and not value.startswith("-"):
+        if os.path.sep in value.split(" ")[0] or value.split(" ")[0].endswith("python3"):
+            return CLASS_EMBEDDED_ARGS
+
+    if value.startswith("/"):
+        if " " in value:
+            return CLASS_EMBEDDED_ARGS
+        if value.startswith(HOME_PREFIXES):
+            # Inside the repo root is still machine-specific in the config file,
+            # even though normalize-mcp-cwd.py legitimately injects such a path
+            # at install time for the installing user's own machine.
+            return CLASS_MACHINE_SPECIFIC
+        if value.startswith(SYSTEM_PREFIXES):
+            return CLASS_SYSTEM_ABSOLUTE
+        return CLASS_OTHER_ABSOLUTE
+
+    candidate = os.path.join(repo_root, value)
+    if os.path.exists(candidate):
+        return CLASS_REPO_RELATIVE
+
+    return CLASS_PACKAGE_SPEC
+
+
+def check(config_path, repo_root):
+    """Return (failures, flags, examined_count)."""
+    with open(config_path) as f:
+        config = json.load(f)
+    servers = config.get("mcpServers", {})
+
+    failures = []
+    flags = []
+    examined = 0
+
+    for name in sorted(servers):
+        entry = servers[name]
+        if not isinstance(entry, dict):
+            continue
+
+        fields = [("command", entry.get("command")), ("cwd", entry.get("cwd"))]
+        args = entry.get("args")
+        if isinstance(args, list):
+            fields += [(f"args[{i}]", a) for i, a in enumerate(args)]
+
+        for field, value in fields:
+            verdict = classify(value, repo_root)
+            if verdict is None:
+                continue
+            examined += 1
+            if verdict == CLASS_MACHINE_SPECIFIC:
+                failures.append(
+                    f"{name}: {field} '{value}' is machine-specific "
+                    f"(expected repo-relative or system path)"
+                )
+            elif verdict == CLASS_EMBEDDED_ARGS:
+                flags.append(
+                    f"{name}: {field} '{value}' packs arguments into one string "
+                    f"(expected separate 'command' and 'args')"
+                )
+
+    return failures, flags, examined
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--config", default=DEFAULT_CONFIG,
+                        help="path to openclaw.json (default: repo config)")
+    parser.add_argument("--repo", default=REPO_ROOT,
+                        help="repository root used to resolve relative paths")
+    parser.add_argument("--warn-only", action="store_true",
+                        help="print findings but always exit 0")
+    parser.add_argument("--json", action="store_true", dest="as_json",
+                        help="emit machine-readable results")
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.config):
+        print(f"ERROR: could not read {args.config}", file=sys.stderr)
+        return 2
+    try:
+        failures, flags, examined = check(args.config, args.repo)
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"ERROR: could not parse {args.config}: {exc}", file=sys.stderr)
+        return 2
+
+    if args.as_json:
+        print(json.dumps({
+            "surface": "portability",
+            "status": "fail" if failures else ("flagged" if flags else "pass"),
+            "failures": failures,
+            "flags": flags,
+            "paths_examined": examined,
+        }, indent=2))
+    else:
+        print(f"Paths examined: {examined}")
+        print()
+        if failures:
+            print("Portability check: FAIL")
+            for item in failures:
+                print(f"  portability: {item}")
+        else:
+            print("Portability check: PASS")
+        for item in flags:
+            print(f"  flagged: {item}")
+
+    if failures and not args.warn_only:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/reconcile-mcp.py
+++ b/scripts/reconcile-mcp.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Single entry point for NetClaw's MCP reconciliation checks.
+
+Contract: specs/075-mcp-config-reconciliation/contracts/reconcile-cli.md
+
+The goal these checks serve: **every integration NetClaw claims to ship must be
+genuinely obtainable by someone installing their own risk.** Not "present in a
+config file on the maintainer's laptop" -- obtainable, by a stranger, on their
+own machine.
+
+Why this wrapper exists: the underlying checks already existed and already
+failed correctly. What was missing was anything that *ran* them. Before spec
+075, `.github/workflows/` contained only skill-review.yml and no script, hook or
+workflow invoked any verifier -- so they reported real problems into a void for
+as long as they had existed. This script is what CI and maintainers call, so
+there is exactly one way to ask "is the repository reconciled?" and one answer.
+
+Surfaces checked:
+
+  catalog      every registered server maps to an installer component, every
+               external integration is covered, every vendored directory has a
+               recorded state
+  docs         documented skill/MCP counts match the computed truth, and every
+               expected claim is still locatable
+  portability  no registration depends on a path that only resolves on one
+               machine
+
+No third-party dependencies. Read-only: never writes a repository file. Requires
+no running agent, no network, and no credentials, so it works in a bare CI
+container and on a fresh clone.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPTS = os.path.join(REPO_ROOT, "scripts")
+
+# surface name -> (script filename, human summary noun)
+SURFACES = {
+    "catalog": ("verify-catalog-coverage.py", "installer coverage and vendored state"),
+    "docs": ("verify-inventory-counts.py", "documented counts"),
+    "portability": ("check-mcp-portability.py", "registration portability"),
+}
+
+EXIT_OK = 0
+EXIT_FAIL = 1
+EXIT_CANNOT_RUN = 2
+
+
+def run_surface(name, warn_only):
+    """Run one surface check. Returns (exit_code, output_lines)."""
+    script, _ = SURFACES[name]
+    path = os.path.join(SCRIPTS, script)
+    if not os.path.isfile(path):
+        return EXIT_CANNOT_RUN, [f"{name}: check script missing at {path}"]
+
+    cmd = [sys.executable, path]
+    if warn_only:
+        # Only pass the flag to scripts that accept it; the two older verifiers
+        # predate it. Probing --help would be slower and no more reliable than
+        # simply not forwarding it, since this wrapper enforces warn-only itself.
+        if script == "check-mcp-portability.py":
+            cmd.append("--warn-only")
+
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    output = (proc.stdout + proc.stderr).splitlines()
+    return proc.returncode, output
+
+
+def extract_findings(output):
+    """Pull the actionable lines out of a surface's output.
+
+    Each underlying check already formats findings as indented detail lines, so
+    the wrapper surfaces those verbatim rather than re-deriving them -- keeping
+    one source of truth for wording.
+    """
+    findings = []
+    for line in output:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("- ") or stripped.startswith("* "):
+            findings.append(stripped[2:])
+        elif stripped.startswith(("portability:", "unlocatable:", "flagged:", "note:", "ERROR:")):
+            findings.append(stripped)
+        elif line.startswith("  ") and (
+            "claims" in stripped or "no matching" in stripped or "no recorded state" in stripped
+        ):
+            findings.append(stripped)
+    return findings
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Reconcile NetClaw's MCP registration surfaces.",
+        epilog="Exit 0 = reconciled, 1 = inconsistent, 2 = check could not run.",
+    )
+    parser.add_argument("--surface", action="append", choices=sorted(SURFACES),
+                        help="run only this surface (repeatable; default: all)")
+    parser.add_argument("--warn-only", action="store_true",
+                        help="print findings but always exit 0 (never use in CI)")
+    parser.add_argument("--json", action="store_true", dest="as_json",
+                        help="emit machine-readable results")
+    parser.add_argument("--quiet", action="store_true",
+                        help="suppress passing surfaces; print findings only")
+    args = parser.parse_args()
+
+    selected = args.surface or sorted(SURFACES)
+    results = {}
+    cannot_run = False
+    any_failed = False
+
+    for name in selected:
+        code, output = run_surface(name, args.warn_only)
+        findings = extract_findings(output)
+        if code == EXIT_CANNOT_RUN:
+            status = "cannot_run"
+            cannot_run = True
+        elif code != EXIT_OK:
+            status = "fail"
+            any_failed = True
+        else:
+            status = "flagged" if any(f.startswith("flagged:") for f in findings) else "pass"
+        results[name] = {"status": status, "exit_code": code, "findings": findings}
+
+    if args.as_json:
+        overall = "cannot_run" if cannot_run else ("fail" if any_failed else "pass")
+        print(json.dumps({"overall": overall, "surfaces": results}, indent=2))
+    else:
+        overall = "CANNOT RUN" if cannot_run else ("FAIL" if any_failed else "PASS")
+        print(f"Reconciliation: {overall}")
+        for name in selected:
+            r = results[name]
+            label = {"pass": "pass", "fail": "FAIL",
+                     "flagged": "pass*", "cannot_run": "ERROR"}[r["status"]]
+            _, noun = SURFACES[name]
+            if args.quiet and r["status"] in ("pass", "flagged"):
+                continue
+            print(f"  {name:<12} {label:<6} {noun}")
+            for finding in r["findings"]:
+                print(f"      {finding}")
+        if not args.quiet and any(r["status"] == "flagged" for r in results.values()):
+            print("\n  * passed with advisory findings (see 'flagged:' lines)")
+
+    if cannot_run:
+        return EXIT_CANNOT_RUN
+    if any_failed and not args.warn_only:
+        return EXIT_FAIL
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/trace-skill.py
+++ b/scripts/trace-skill.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Trace a skill to the integration backing it, and report that integration's
+recorded state.
+
+Contract: specs/075-mcp-config-reconciliation/contracts/reconcile-cli.md (FR-025, FR-026)
+
+With 199 skills, "why did this skill just fail?" is a frequent question. The
+answer is usually one of: the backing integration is registered and fine; it is
+an intentional on-demand install that this machine has not installed; or the
+chain is genuinely broken. Those three look identical from a failure message,
+which is what this tool fixes.
+
+Critically, an integration that is "external and not installed" is reported as an
+EXPECTED state, not a fault (FR-026). Sixty of NetClaw's 149 integrations are
+deliberately installed on demand; treating them as broken would make the tool
+useless.
+
+Diagnostic only -- deliberately NOT part of the CI gate, because a skill may
+legitimately reference an integration a given install has not enabled.
+
+No third-party dependencies.
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SKILLS_DIR = os.path.join(REPO_ROOT, "workspace", "skills")
+CONFIG = os.path.join(REPO_ROOT, "config", "openclaw.json")
+COVERAGE = os.path.join(REPO_ROOT, "scripts", "verify-catalog-coverage.py")
+
+EXIT_OK, EXIT_BROKEN, EXIT_NO_SKILL = 0, 1, 2
+
+
+def _load(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("skill", help="skill directory name under workspace/skills/")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+
+    skill_dir = os.path.join(SKILLS_DIR, args.skill)
+    skill_md = os.path.join(skill_dir, "SKILL.md")
+    if not os.path.isfile(skill_md):
+        print(f"ERROR: no such skill '{args.skill}' (expected {skill_md})", file=sys.stderr)
+        return EXIT_NO_SKILL
+
+    with open(skill_md) as f:
+        text = f.read()
+
+    cov = _load(COVERAGE, "verify_catalog_coverage")
+    with open(CONFIG) as f:
+        registered = sorted(json.load(f).get("mcpServers", {}).keys())
+    external = cov.load_external_integrations()
+    catalog_ids = set(cov.load_catalog_ids())
+
+    # Skills name their tools as mcp__<server>__<tool>, and/or mention the
+    # server key in prose. Both are worth harvesting -- prose-only references
+    # are common in older skills.
+    found = set(re.findall(r"mcp__([a-z0-9_-]+)__", text))
+    lowered = text.lower()
+    for key in registered:
+        if key.lower() in lowered or key.replace("-mcp", "").lower() in lowered:
+            found.add(key)
+
+    chain = []
+    reg_norm = {cov._norm(k): k for k in registered}
+    for token in sorted(found):
+        key = reg_norm.get(cov._norm(token))
+        if key:
+            catalog_id = (cov.GROUPED_CONFIG_EXACT.get(key)
+                          or next((cid for pre, cid in cov.GROUPED_CONFIG_PREFIXES.items()
+                                   if key.startswith(pre)), None)
+                          or cov.strip_mcp_suffix(key))
+            ok = catalog_id in catalog_ids
+            chain.append({
+                "token": token, "integration": key, "state": "registered",
+                "catalog_id": catalog_id if ok else None,
+                "status": "ok" if ok else "broken",
+                "detail": "registered and installable" if ok else
+                          f"registered but catalog id '{catalog_id}' not found",
+            })
+            continue
+
+        ext = next((n for n in external if cov._norm(n) and cov._norm(n) in cov._norm(token)
+                    or cov._norm(token) and cov._norm(token) in cov._norm(n)), None)
+        if ext:
+            chain.append({
+                "token": token, "integration": ext, "state": "external",
+                "catalog_id": None, "status": "ok",
+                "detail": "intentionally external — installed on demand; "
+                          "absence from this machine is expected, not a fault",
+            })
+            continue
+
+        chain.append({
+            "token": token, "integration": None, "state": "unknown",
+            "catalog_id": None, "status": "unresolved",
+            "detail": "no backing integration found — may be a built-in tool or a naming mismatch",
+        })
+
+    broken = [c for c in chain if c["status"] == "broken"]
+
+    if args.as_json:
+        print(json.dumps({"skill": args.skill, "chain": chain,
+                          "overall": "broken" if broken else "ok"}, indent=2))
+    else:
+        print(f"Skill: {args.skill}")
+        if not chain:
+            print("  (no backing integration references found in SKILL.md)")
+        for c in chain:
+            mark = {"ok": "ok", "broken": "BROKEN", "unresolved": "?"}[c["status"]]
+            print(f"  [{mark:>6}] {c['token']}")
+            print(f"           integration: {c['integration'] or '—'}  state: {c['state']}")
+            if c["catalog_id"]:
+                print(f"           installer component: {c['catalog_id']}")
+            print(f"           {c['detail']}")
+
+    return EXIT_BROKEN if broken else EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify-catalog-coverage.py
+++ b/scripts/verify-catalog-coverage.py
@@ -50,6 +50,14 @@ GROUPED_CONFIG_PREFIXES = {
     "twilio": "twilio",
     "nautobot-mcp": "nautobot",  # bare "nautobot-mcp" (no golden-config/routing suffix)
     "cloudflare": "cloudflare",
+    # Added by spec 075. Each of these catalog components already existed and
+    # already installs every server under its prefix -- the components were
+    # never missing, only these declarations were, so the checker could not
+    # see coverage that was already present. See
+    # specs/075-mcp-config-reconciliation/research.md R1.
+    "aap-": "aap",  # aap-ansible-mcp, aap-docs-mcp, aap-eda-mcp, aap-lint-mcp
+    "aws-": "aws",  # aws-{cloudtrail,cloudwatch,cost-explorer,diagram,iam,network}-mcp
+    "gcp-": "gcp",  # gcp-{compute,logging,monitoring,resource-manager}-mcp
 }
 
 # Catalog ids that intentionally cover a config/openclaw.json key with no
@@ -60,6 +68,16 @@ GROUPED_CONFIG_EXACT = {
     "azure-network-mcp": "azure",
     "unreal-mcp": "ue5",
     "rag-mcp": "rag-mcp",
+    # Added by spec 075 -- server keys whose catalog component exists but whose
+    # name does not reduce to the catalog id by stripping "-mcp".
+    "cisco-fmc-mcp": "fmc",              # strips to "cisco-fmc", catalog id is "fmc"
+    "meraki-magic-mcp": "meraki",        # strips to "meraki-magic"
+    "thousandeyes-mcp": "te-community",  # catalog uses the te-* naming convention
+    "thousandeyes-official-mcp": "te-official",
+    # The catalog id itself ends in "-mcp", so strip_mcp_suffix() reduces the
+    # key to "memory" and the exact match fails. Same shape as the "rag-mcp"
+    # entry above -- this is a suffix-stripping artefact, not a real gap.
+    "memory-mcp": "memory-mcp",
 }
 
 # EXTERNAL_INTEGRATIONS names (from verify-inventory-counts.py) that this
@@ -75,6 +93,46 @@ GROUPED_EXTERNAL_COVERAGE = {
     # can't find on its own ("f5" is 2 characters).
     "f5": ["F5 BIG-IP"],
     "computer-use": ["Computer Use"],
+}
+
+
+# Vendored mcp-servers/ directories whose state cannot be inferred by matching
+# their directory name against a registered config key or an
+# EXTERNAL_INTEGRATIONS entry. Every entry MUST carry a reason. Added by spec
+# 075 (FR-014, FR-016, FR-017).
+#
+# This list is the deliberate inversion of the old failure mode: previously,
+# forgetting to account for a vendored directory caused it to be silently
+# undercounted forever. Now it causes a loud failure naming the directory, and
+# the only way to silence it is to state why -- which is human knowledge that
+# cannot be inferred from the source.
+VENDORED_STATE_REASONS = {
+    "gait_mcp": "registered as 'gait-mcp'; underscore/hyphen naming mismatch",
+    "pyATS_MCP": "external — installed on demand via pip (EXTERNAL_INTEGRATIONS: pyATS)",
+    "ISE_MCP": "external — installed on demand (EXTERNAL_INTEGRATIONS: Cisco ISE)",
+    "ACI_MCP": "external — installed on demand (EXTERNAL_INTEGRATIONS: Cisco ACI)",
+    "Wikipedia_MCP": "external — installed on demand (EXTERNAL_INTEGRATIONS: Wikipedia)",
+    "markmap_mcp": "external — installed on demand (EXTERNAL_INTEGRATIONS: Markmap)",
+    "mcp-nvd": "external — installed on demand (EXTERNAL_INTEGRATIONS: NVD CVE)",
+    "mcp-nautobot": "external community alternative (EXTERNAL_INTEGRATIONS: Nautobot community)",
+    "packet-buddy-mcp": "external — installed on demand (EXTERNAL_INTEGRATIONS: Packet Buddy)",
+    "subnet-calculator-mcp": "external — bundled (EXTERNAL_INTEGRATIONS: Subnet Calculator)",
+    "CiscoFMC-MCP-server-community": "community source for the 'fmc' component; registered as 'cisco-fmc-mcp'",
+    "nautobot-mcp-v2": "backs the registered 'nautobot-mcp' entry (directory name differs from key)",
+    "AAP-Enterprise-MCP-Server": "single source backing all four registered aap-* entries",
+    "checkpoint-mcp-servers": "single source backing all fifteen registered chkp-* entries",
+    "clab-mcp-server": "external — EXTERNAL_INTEGRATIONS 'ContainerLab', catalog id 'containerlab' (dir name abbreviates it)",
+    "mcp-cvp-fun": "backs the registered 'arista-cvp-mcp' entry (EXTERNAL_INTEGRATIONS 'Arista CVP')",
+    # OPEN FINDING, spec 075 -- recorded here so it is tracked, NOT suppressed.
+    # EVE-NG is vendored and has five skills (eve-lab-topology-*, eve-ng-*), but
+    # it appears in neither EXTERNAL_INTEGRATIONS nor scripts/lib/catalog.sh.
+    # It is therefore absent from the integration count and cannot be installed
+    # by the modular installer -- a Principle XI gap this check found. Resolving
+    # it means adding an EXTERNAL_INTEGRATIONS entry (which raises the MCP count
+    # to 150) plus a catalog entry and install function. That is a scope
+    # decision for the maintainer, not something to absorb silently here.
+    "eve-ng-mcp-server": "OPEN FINDING (spec 075): vendored with 5 skills but absent from "
+                         "EXTERNAL_INTEGRATIONS and catalog.sh — needs a tracked follow-up",
 }
 
 
@@ -164,6 +222,48 @@ def check_external_coverage(external_names, catalog_ids, catalog_text):
     return gaps
 
 
+def _norm(name):
+    """Reduce a name to comparable letters/digits, dropping mcp/server noise."""
+    s = re.sub(r"[^a-z0-9]", "", name.lower())
+    for noise in ("mcpserver", "mcp", "server", "community", "v2"):
+        s = s.replace(noise, "")
+    return s
+
+
+def check_vendored_state(registered, external_names):
+    """Every mcp-servers/ directory must resolve to exactly one state:
+    registered, external, or explained (which covers dropped). Added by spec
+    075 -- FR-014, FR-017."""
+    servers_dir = os.path.join(REPO_ROOT, "mcp-servers")
+    if not os.path.isdir(servers_dir):
+        return []
+
+    reg_norm = {_norm(k) for k in registered}
+    ext_norm = {_norm(n) for n in external_names}
+
+    gaps = []
+    for entry in sorted(os.listdir(servers_dir)):
+        if not os.path.isdir(os.path.join(servers_dir, entry)):
+            continue
+        if entry in VENDORED_STATE_REASONS:
+            continue
+        n = _norm(entry)
+        if not n:
+            continue
+        if n in reg_norm or n in ext_norm:
+            continue
+        if any(n and (n in r or r in n) for r in reg_norm if len(r) >= 4):
+            continue
+        if any(n and (n in e or e in n) for e in ext_norm if len(e) >= 4):
+            continue
+        gaps.append((
+            f"mcp-servers/{entry}",
+            "no recorded state (expected registered, external, or a "
+            "VENDORED_STATE_REASONS entry giving the reason)",
+        ))
+    return gaps
+
+
 def main():
     catalog_ids = load_catalog_ids()
     with open(CATALOG_SH) as f:
@@ -174,13 +274,14 @@ def main():
 
     config_gaps = check_config_coverage(registered, catalog_ids)
     external_gaps = check_external_coverage(external_names, catalog_ids, catalog_text)
+    vendored_gaps = check_vendored_state(registered, external_names)
 
     print(f"Catalog entries: {len(catalog_ids)}")
     print(f"Registered config/openclaw.json servers: {len(registered)}")
     print(f"External (non-registered) integrations tracked: {len(external_names)}")
     print()
 
-    if not config_gaps and not external_gaps:
+    if not config_gaps and not external_gaps and not vendored_gaps:
         print("Catalog coverage check: PASS (zero unexplained gaps)")
         return 0
 
@@ -192,6 +293,10 @@ def main():
     if external_gaps:
         print(f"\n  External integrations with no catalog coverage ({len(external_gaps)}):")
         for name, reason in external_gaps:
+            print(f"    - {name}: {reason}")
+    if vendored_gaps:
+        print(f"\n  Vendored directories with no recorded state ({len(vendored_gaps)}):")
+        for name, reason in vendored_gaps:
             print(f"    - {name}: {reason}")
     return 1
 

--- a/scripts/verify-inventory-counts.py
+++ b/scripts/verify-inventory-counts.py
@@ -154,6 +154,7 @@ def check_doc_claims(skill_count, mcp_count):
     NOT matched -- they are dated past-state records, not current claims.
     """
     discrepancies = []
+    unlocatable = []
     notes = []
 
     # (file, description, compiled pattern, [(kind, capture group index), ...])
@@ -161,12 +162,19 @@ def check_doc_claims(skill_count, mcp_count):
         (README, "top prose (skills + MCP)",
          re.compile(r"Claude,\s*(\d+)\s*skills,\s*and\s*(\d+)\s*MCP integrations"),
          [("skill", 1), ("MCP", 2)]),
-        (README, "installer prose (skills)",
-         re.compile(r"deploys\s*(\d+)\s*skills"),
-         [("skill", 1)]),
-        (README, "installer prose (MCP)",
-         re.compile(r"for\s*(\d+)\s*MCP integrations"),
-         [("MCP", 1)]),
+        # RETIRED by spec 075 (was: "installer prose (skills)" matching
+        # r"deploys\s*(\d+)\s*skills", and "installer prose (MCP)" matching
+        # r"for\s*(\d+)\s*MCP integrations").
+        #
+        # These two patterns had silently stopped matching -- reported as
+        # informational notes, so nobody noticed. They are retired rather than
+        # repointed because spec 049 made the installer *selective*: README now
+        # says "Only what you select gets installed." A fixed "deploys N skills"
+        # claim would therefore be actively false, not merely stale. Retiring an
+        # obsolete claim is legitimate; deleting a pattern to silence a genuine
+        # mismatch is not. Anything retired here MUST carry a reason like this
+        # one, because from spec 075 onward an unlocatable pattern is a hard
+        # failure (FR-012) rather than a note.
         (README, "Visual HUD prose",
          re.compile(r"currently\s*(\d+)\s*MCP integrations and\s*(\d+)\s*skills"),
          [("MCP", 1), ("skill", 2)]),
@@ -200,7 +208,17 @@ def check_doc_claims(skill_count, mcp_count):
 
         match = pattern.search(text)
         if match is None:
-            notes.append(f"{doc_name}: could not locate '{description}' (phrasing may have changed)")
+            # Spec 075 FR-012: an expected claim that can no longer be found is
+            # a FAILURE, not an informational note. This supersedes spec 047's
+            # contract, which called it a note "since prose phrasing can
+            # legitimately change". That leniency is exactly how two claims went
+            # unchecked long enough for nine counts to drift. If a claim is
+            # genuinely obsolete, retire its pattern with a documented reason --
+            # do not let it rot silently.
+            unlocatable.append(
+                f"{doc_name}: could not locate '{description}' — the claim was removed or reworded. "
+                f"Restore a matchable phrasing, or retire this pattern with a documented reason."
+            )
             continue
 
         line_no = text.count("\n", 0, match.start()) + 1
@@ -217,7 +235,7 @@ def check_doc_claims(skill_count, mcp_count):
                     "kind": kind,
                 })
 
-    return discrepancies, notes
+    return discrepancies, unlocatable, notes
 
 
 def main():
@@ -231,7 +249,7 @@ def main():
         print(f"ERROR: could not read {OPENCLAW_CONFIG}", file=sys.stderr)
         return 2
 
-    discrepancies, notes = check_doc_claims(skill_count, mcp_count)
+    discrepancies, unlocatable, notes = check_doc_claims(skill_count, mcp_count)
 
     print(f"Skill count: {skill_count}")
     print(f"  workspace/skills/ directories with SKILL.md: {skill_count}")
@@ -241,20 +259,22 @@ def main():
     print(f"  + externally-installed (documented, not in config): {breakdown['external_documented']}")
     print()
 
-    if discrepancies:
+    if discrepancies or unlocatable:
         print("Documentation check: FAIL")
         for d in discrepancies:
             print(
                 f"  {d['file']}:{d['location']} claims \"{d['matched_text']}\" "
                 f"({d['kind']}), computed {d['computed_value']}"
             )
+        for item in unlocatable:
+            print(f"  unlocatable: {item}")
     else:
         print("Documentation check: PASS")
 
     for note in notes:
         print(f"  note: {note}")
 
-    return 1 if discrepancies else 0
+    return 1 if (discrepancies or unlocatable) else 0
 
 
 if __name__ == "__main__":

--- a/specs/047-docs-inventory-reconciliation/contracts/verify-inventory-counts-cli.md
+++ b/specs/047-docs-inventory-reconciliation/contracts/verify-inventory-counts-cli.md
@@ -52,3 +52,46 @@ The exact column widths/formatting are not contractual — only that the three h
 
 - The script does not modify any file.
 - The script does not verify `SOUL-SKILLS.md`, `mcp-servers/README.md`, or `ui/netclaw-visual/README.md` table *completeness* (i.e., it does not diff table rows against the computed entity list) — only the two headline-number files (README.md, SOUL.md) get automated discrepancy parsing in this iteration. Table-completeness for the other files is verified manually during the Phase 1 documentation edit pass (tasks.md) and can be added to the script later if drift recurs there.
+
+
+---
+
+## Amendment (spec 075, 2026-07-30)
+
+Two points of this contract are superseded by
+`specs/075-mcp-config-reconciliation/`. Recorded here so the two contracts do not diverge silently.
+
+### 1. An unlocatable claim is now a FAILURE, not an informational note
+
+This contract states: *"a failure to find an expected claim is reported as an informational note,
+not a hard error, since prose phrasing can legitimately change."*
+
+**Superseded.** From spec 075 (FR-012), an expected claim that can no longer be located causes
+`Documentation check: FAIL` and exit `1`.
+
+**Why**: the leniency was the failure mode. Two README claims — `deploys N skills` and
+`for N MCP integrations` — had drifted out of matchable phrasing and were silently unchecked for an
+unknown period. During that time nine documented counts drifted (README and SOUL claimed 198/115,
+191/113, 115 and 198 against a true 199 skills / 149 integrations). A check that quietly stops
+checking is worse than no check, because it still reports `PASS`.
+
+**The legitimate escape hatch is retirement with a reason.** Prose *can* legitimately change: spec
+049 made the installer selective ("Only what you select gets installed"), so `deploys N skills` is
+now actively false rather than merely stale. Both patterns were therefore retired from
+`headline_patterns` with an explanatory comment. Retiring an obsolete claim is correct; deleting a
+pattern to silence a genuine mismatch is not, and the comment is what distinguishes them.
+
+### 2. Exit code 2 is widened
+
+This contract defines exit `2` as "could not compute counts at all … an environment problem".
+Spec 075's `contracts/reconcile-cli.md` also uses exit `2` for a bad argument or an unparseable
+config — still "the check could not run", as distinct from "the repository is inconsistent" (`1`).
+No behaviour of this script changes; the wider meaning applies to the spec 075 scripts and the
+`reconcile-mcp.py` orchestrator.
+
+### Unchanged and confirmed
+
+Exit `1` on a documentation-claim disagreement was already this contract's requirement, and the
+implementation already honoured it. An earlier draft of spec 075 claimed the script exited `0` on
+drift; that was a measurement error (the exit code had been read through a `| tail` pipe). No fix
+was needed, and a regression test now protects the behaviour.

--- a/specs/075-mcp-config-reconciliation/baseline-2026-07-30.txt
+++ b/specs/075-mcp-config-reconciliation/baseline-2026-07-30.txt
@@ -1,0 +1,60 @@
+### baseline 2026-07-30 — before spec 075 changes
+### NOTE: exit codes captured WITHOUT a pipe. An earlier reading that showed
+###       exit=0 was a '| tail' artifact (pipe reports tail's status).
+
+--- verify-inventory-counts.py ---
+Skill count: 199
+  workspace/skills/ directories with SKILL.md: 199
+
+MCP integration count: 149
+  config/openclaw.json top-level entries: 89
+  + externally-installed (documented, not in config): 60
+
+Documentation check: FAIL
+  README.md:line 7 (top prose (skills + MCP)) claims "Claude, 198 skills, and 115 MCP integrations" (skill), computed 199
+  README.md:line 7 (top prose (skills + MCP)) claims "Claude, 198 skills, and 115 MCP integrations" (MCP), computed 149
+  README.md:line 242 (Visual HUD prose) claims "currently 113 MCP integrations and 191 skills" (MCP), computed 149
+  README.md:line 242 (Visual HUD prose) claims "currently 113 MCP integrations and 191 skills" (skill), computed 199
+  README.md:line 521 (MCP Servers section heading) claims "## MCP Servers (115)" (MCP), computed 149
+  README.md:line 661 (Skills section heading) claims "## Skills (198)" (skill), computed 199
+  SOUL.md:line 15 (identity line (skills + MCP)) claims "**198 skills** backed by 115 MCP servers" (skill), computed 199
+  SOUL.md:line 15 (identity line (skills + MCP)) claims "**198 skills** backed by 115 MCP servers" (MCP), computed 149
+  SOUL.md:line 398 (SOUL-SKILLS cross-reference) claims "best practices for all 191 skills" (skill), computed 199
+  note: README.md: could not locate 'installer prose (skills)' (phrasing may have changed)
+  note: README.md: could not locate 'installer prose (MCP)' (phrasing may have changed)
+TRUE_EXIT=1
+
+--- verify-catalog-coverage.py ---
+Catalog entries: 89
+Registered config/openclaw.json servers: 89
+External (non-registered) integrations tracked: 60
+
+Catalog coverage check: FAIL
+
+  Registered servers with no catalog coverage (19):
+    - aap-ansible-mcp: no matching catalog id (direct, prefix-group, or exact-group)
+    - aap-docs-mcp: no matching catalog id (direct, prefix-group, or exact-group)
+    - aap-eda-mcp: no matching catalog id (direct, prefix-group, or exact-group)
+    - aap-lint-mcp: no matching catalog id (direct, prefix-group, or exact-group)
+    - aws-cloudtrail-mcp: no matching catalog id (direct, prefix-group, or exact-group)
+    - aws-cloudwatch-mcp: no matching catalog id (direct, prefix-group, or exact-group)
+    - aws-cost-explorer-mcp: no matching catalog id (direct, prefix-group, or exact-group)
+    - aws-diagram-mcp: no matching catalog id (direct, prefix-group, or exact-group)
+    - aws-iam-mcp: no matching catalog id (direct, prefix-group, or exact-group)
+    - aws-network-mcp: no matching catalog id (direct, prefix-group, or exact-group)
+    - cisco-fmc-mcp: no matching catalog id (direct, prefix-group, or exact-group)
+    - gcp-compute-mcp: no matching catalog id (direct, prefix-group, or exact-group)
+    - gcp-logging-mcp: no matching catalog id (direct, prefix-group, or exact-group)
+    - gcp-monitoring-mcp: no matching catalog id (direct, prefix-group, or exact-group)
+    - gcp-resource-manager-mcp: no matching catalog id (direct, prefix-group, or exact-group)
+    - memory-mcp: no matching catalog id (direct, prefix-group, or exact-group)
+    - meraki-magic-mcp: no matching catalog id (direct, prefix-group, or exact-group)
+    - thousandeyes-mcp: no matching catalog id (direct, prefix-group, or exact-group)
+    - thousandeyes-official-mcp: no matching catalog id (direct, prefix-group, or exact-group)
+TRUE_EXIT=1
+
+--- enforcement reality ---
+Both scripts DO exit 1 on failure. The enforcement gap is that NOTHING INVOKES THEM:
+skill-review.yml
+grep for verify-/reconcile in workflows:
+  (no matches - no CI runs these checks)

--- a/specs/075-mcp-config-reconciliation/checklists/requirements.md
+++ b/specs/075-mcp-config-reconciliation/checklists/requirements.md
@@ -1,0 +1,99 @@
+# Specification Quality Checklist: MCP Config Reconciliation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain — all three resolved by the maintainer on 2026-07-30
+      and recorded in the spec's "Resolved Clarifications" section
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+**Status: PASS — ready for `/speckit.plan`.**
+
+## Validation Notes
+
+### Iteration 1 — the originating premise was wrong
+
+The feature description asserted 20 vendored servers were "silently unregistered." Investigation
+found most are deliberately unregistered and already recorded in a 60-entry `EXTERNAL_INTEGRATIONS`
+list. Writing requirements against that premise would have produced a feature that registers servers
+which are intentionally on-demand. Corrected with a dedicated section, and requirements rewritten
+around the real defects.
+
+### Iteration 2 — the real defect was initially missed
+
+Two reconciliation scripts already exist, both report `FAIL` today, and both exit 0, so nothing
+enforces them. Now US2 and FR-008, and the feature's centre of gravity rather than a side concern.
+
+Two further failures were measured and folded in: 19 registered servers have no installer catalog
+coverage (Principle XI violation) and 9 documented counts are wrong. Silent check degradation also
+found — two README claims have drifted in phrasing so `verify-inventory-counts.py` no longer checks
+them at all (FR-012, SC-006).
+
+### Iteration 3 — the maintainer's clarification changed the feature's shape
+
+Resolving Question 1 as *"don't worry about the live config as long as all 89 are available for
+people when they install their own risk"* moved the goal from config synchronisation to **install
+correctness**. Consequences:
+
+- Live-config sync fully descoped; no running agent required (FR-029, SC-013). Removed the former
+  live-reachability requirements and the skill-to-running-process tracing, which were premised on
+  inspecting a local gateway.
+- Installability promoted to US1 and to the first requirements block.
+- **This reframing directly surfaced a defect the original framing would have missed**: three
+  registered Nautobot servers are hardcoded to `/home/ubuntu/netclaw/`, a path that exists on no
+  machine including the one measured — so they are broken for every installer. Now FR-003.
+- A fourth registration, `cml-mcp`, packs arguments into its command string; flagged for
+  verification rather than asserted broken, since gateway argument handling was not tested (FR-005).
+- FR-004 added after noticing the naive form of this check would ban `/usr/bin/python3`. The check
+  must distinguish legitimate system paths from machine-specific ones.
+
+### Measurement provenance
+
+Every figure in the spec was produced by running the two existing verifiers or by direct inspection
+on 2026-07-30 — 199 skills, 149 integrations, 89 registered, 60 external, 19 uncovered, 9 wrong
+claims, 2 unlocatable claims, 9 bypassed directories, 3 foreign-path entries, 1 suspect command.
+Nothing is estimated.
+
+### Traceability
+
+| User story | Requirements | Success criteria |
+|---|---|---|
+| US1 — fresh install obtains all 89 | FR-001 … FR-007 | SC-001, SC-013 |
+| US2 — drift caught automatically | FR-008 … FR-013 | SC-002, SC-003, SC-004 |
+| US3 — one explained state each | FR-014 … FR-019 | SC-007, SC-009 |
+| US4 — documented counts correct | FR-020 | SC-005, SC-006 |
+| US5 — one add procedure | FR-023, FR-024 | SC-010 |
+| US6 — skill traceability | FR-025, FR-026 | SC-011 |
+| Bypassed directories | FR-021, FR-022 | SC-008 |
+| Scope discipline | FR-027 … FR-029 | SC-012, SC-013 |
+
+No orphaned requirements; no success criterion lacking a requirement.
+
+## Notes
+
+- All three clarifications resolved. Spec is ready for `/speckit.plan`.
+- Constitution Principle XVI (spec-driven development) satisfied: spec ratified before
+  implementation.

--- a/specs/075-mcp-config-reconciliation/contracts/reconcile-cli.md
+++ b/specs/075-mcp-config-reconciliation/contracts/reconcile-cli.md
@@ -1,0 +1,159 @@
+# Contract: Reconciliation CLI
+
+**Feature**: 075-mcp-config-reconciliation | **Date**: 2026-07-30
+
+The external interface of this feature is a set of command-line checks. This is their contract:
+invocation, exit codes, and output guarantees. CI and the local pre-push command both depend on it.
+
+---
+
+## `scripts/reconcile-mcp.py` — the single entry point (FR-009)
+
+```
+scripts/reconcile-mcp.py [--warn-only] [--surface SURFACE] [--json] [--quiet]
+```
+
+| Option | Behaviour |
+|---|---|
+| *(none)* | Run every surface. Exit non-zero if any fails |
+| `--warn-only` | Print all findings, always exit `0` (Principle XV mitigation) |
+| `--surface S` | Run one of `vendored`, `registered`, `catalog`, `docs`, `portability`. Repeatable |
+| `--json` | Emit machine-readable results to stdout; human text suppressed |
+| `--quiet` | Suppress passing surfaces; print only findings |
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | All surfaces passed, or only `flagged` findings, or `--warn-only` |
+| `1` | One or more surfaces failed |
+| `2` | Could not run — missing input file, unparseable JSON, bad arguments |
+
+Exit `2` is distinct from `1` so CI can tell "the repository is inconsistent" from "the check itself
+is broken." A missing `config/openclaw.json` must never be reported as a reconciliation failure.
+
+### Guarantees
+
+- **No network access.** Must pass in an offline container.
+- **No running agent required** (FR-029, SC-013). Never reads `~/.openclaw/openclaw.json`.
+- **Read-only.** Never writes to any repository file. Remediation is a separate human/task action.
+- **Deterministic.** Same repository state yields identical output and exit code, so CI and local
+  runs cannot disagree (FR-011).
+- **Path-independent.** Resolves paths from its own location, not the caller's `cwd`, matching every
+  existing script in `scripts/`.
+- **No credentials in output** (Principle XIII). Reports env var *names*, never values.
+
+### Output format
+
+Every finding is one line:
+
+```
+<SURFACE>: <ITEM>: <observed> (expected <expected>)
+```
+
+Examples:
+
+```
+portability: nautobot-mcp: command '/home/ubuntu/netclaw/.venv/bin/python3' is machine-specific (expected repo-relative or system path)
+catalog: aap-ansible-mcp: no matching catalog id (expected direct, prefix-group, or alias match)
+docs: README.md:7: claims 198 skills (expected 199)
+vendored: mcp-servers/foo-mcp: no recorded state (expected registered, external, or dropped)
+```
+
+Each names the surface, the item, and both states — satisfying FR-013's "actionable without
+re-deriving the analysis."
+
+### Summary block
+
+```
+Reconciliation: FAIL
+  vendored      pass    59 directories, 59 explained
+  registered    pass    89 entries
+  catalog       FAIL    19 of 89 unmapped
+  docs          FAIL    9 wrong claims, 2 unlocatable
+  portability   FAIL    3 machine-specific paths, 1 flagged
+```
+
+The word `FAIL` appearing anywhere in the summary MUST correspond to a non-zero exit. The defining
+defect this feature fixes is that `FAIL` currently coexists with exit `0`.
+
+---
+
+## Extended: `scripts/verify-inventory-counts.py`
+
+Existing invocation unchanged. Changes:
+
+| Change | Requirement |
+|---|---|
+| Exit non-zero when the documentation check fails | FR-008 |
+| Treat an unlocatable expected claim as a failure, not a note | FR-012 |
+| Accept `--warn-only` to restore prior exit-0 behaviour | Principle XV |
+
+**Backwards-compatibility risk**: any existing caller relying on exit `0` will now see `1`. Callers
+must be audited before this lands.
+
+---
+
+## Extended: `scripts/verify-catalog-coverage.py`
+
+Existing invocation unchanged. Changes:
+
+| Change | Requirement |
+|---|---|
+| Add 3 prefix-group rules and 5 explicit aliases | FR-002 |
+| Exit non-zero when the coverage check fails | FR-008 |
+| Accept `--warn-only` | Principle XV |
+
+Grouping semantics must be preserved: one catalog id legitimately covering many servers is correct,
+not a gap (FR-019).
+
+---
+
+## New: `scripts/check-mcp-portability.py`
+
+```
+scripts/check-mcp-portability.py [--config PATH] [--warn-only] [--json]
+```
+
+Classifies every `command`, `args` element, and `cwd` per the `PathClassification` model.
+
+| Verdict | Classes |
+|---|---|
+| Pass | `repo_relative`, `system_absolute`, `package_spec` |
+| Fail | `machine_specific` |
+| Flag (exit 0, warn) | `embedded_args` |
+
+Must not flag `/usr/bin/python3` (FR-004). Must flag all three Nautobot entries (FR-003).
+
+---
+
+## New: `scripts/trace-skill.py`
+
+```
+scripts/trace-skill.py <skill-name> [--json]
+```
+
+Reports the chain from skill to backing integration to recorded state and catalog component
+(FR-025).
+
+| Exit | Meaning |
+|---|---|
+| `0` | Chain resolved, including when the backing integration is intentionally external |
+| `1` | Chain broken — integration registered but unmapped, or path non-portable |
+| `2` | No such skill |
+
+"Intentionally external and not installed" MUST report as an expected state, not a fault (FR-026).
+This is a diagnostic tool, so it is not part of the CI gate.
+
+---
+
+## CI contract (FR-010)
+
+CI invokes `scripts/reconcile-mcp.py` with no arguments and fails the job on non-zero exit. The job
+must not require credentials, network, or an installed agent. `--warn-only` MUST NOT be used in CI —
+that would reproduce the exact defect being fixed.
+
+## Local contract (FR-011)
+
+The same script with the same arguments, runnable pre-push. CI and local runs share one
+implementation so results cannot diverge.

--- a/specs/075-mcp-config-reconciliation/data-model.md
+++ b/specs/075-mcp-config-reconciliation/data-model.md
@@ -1,0 +1,149 @@
+# Phase 1 Data Model: MCP Config Reconciliation
+
+**Feature**: 075-mcp-config-reconciliation | **Date**: 2026-07-30
+
+No database. These are the in-memory entities the reconciliation logic builds from existing
+repository files, and the rules that decide pass or fail.
+
+---
+
+## Entity: Integration
+
+One capability NetClaw can use. Assembled by joining the four registration surfaces.
+
+| Field | Source | Notes |
+|---|---|---|
+| `id` | `config/openclaw.json` key, or `EXTERNAL_INTEGRATIONS` name, or vendored directory name | Not globally consistent — the join is the hard part |
+| `state` | Derived | `registered` \| `external` \| `dropped` — exactly one (FR-014) |
+| `reason` | `EXTERNAL_INTEGRATIONS` comment or dropped record | Required unless `registered` (FR-015, FR-016) |
+| `vendored_dir` | `mcp-servers/<dir>` | Optional — remote and on-demand integrations have none |
+| `catalog_id` | `scripts/lib/catalog.sh` | Required when `registered` (FR-001) |
+| `install_fn` | `scripts/lib/install-steps.sh` | `component_install_<catalog_id with - as _>` |
+| `command`, `args`, `cwd` | `config/openclaw.json` entry | Present only when `registered` |
+
+### State rules
+
+- Exactly one state per integration. Two states, or none, is a failure (FR-014, FR-017).
+- `registered` requires a resolvable `catalog_id` (FR-001).
+- `external` and `dropped` require a non-empty `reason` (FR-015, FR-016).
+- A `vendored_dir` with no integration in any state is a failure naming the directory (FR-017).
+  This is the inversion that stops the external list rotting silently.
+
+---
+
+## Entity: CoverageMapping
+
+How a registered server key resolves to a catalog id. Three mechanisms, checked in order.
+
+| Mechanism | Location | Example |
+|---|---|---|
+| Suffix-strip exact match | `strip_mcp_suffix()` then exact lookup | `suzieq-mcp` → `suzieq` |
+| Prefix group | `GROUPED_CONFIG_PREFIXES` | `chkp-` → `checkpoint` |
+| Explicit alias | explicit map | `azure-network-mcp` → `azure` |
+
+### The 8 declarations this feature adds (research R1)
+
+| Declaration | Mechanism | Covers |
+|---|---|---|
+| `aap-` → `aap` | prefix group | 4 servers |
+| `aws-` → `aws` | prefix group | 6 servers |
+| `gcp-` → `gcp` | prefix group | 4 servers |
+| `cisco-fmc-mcp` → `fmc` | alias | 1 |
+| `meraki-magic-mcp` → `meraki` | alias | 1 |
+| `thousandeyes-mcp` → `te-community` | alias | 1 |
+| `thousandeyes-official-mcp` → `te-official` | alias | 1 |
+| `memory-mcp` → `memory-mcp` | alias | 1 — works around the suffix-strip bug, same pattern as the existing `rag-mcp` entry |
+
+Total 19 servers, 8 declarations. No new catalog entries, no new install functions.
+
+---
+
+## Entity: PathClassification
+
+Applied to every `command`, every element of `args`, and `cwd`.
+
+| Class | Rule | Verdict |
+|---|---|---|
+| `repo_relative` | Resolves to an existing file under the repository root | Pass — `normalize-mcp-cwd.py` supplies `cwd` at install |
+| `system_absolute` | Begins `/usr/`, `/bin/`, `/sbin/`, `/opt/`, `/etc/` | Pass — portable across machines |
+| `machine_specific` | Begins `/home/` or `/Users/` | **Fail** (FR-003) — names the entry and path |
+| `package_spec` | Bare name or registry spec (`npx -y @scope/pkg`, `uvx pkg`) | Pass |
+| `embedded_args` | Command string containing whitespace | **Flag for verification** (FR-005) — not an automatic failure |
+
+The `system_absolute` class is why FR-004 exists: a naive absolute-path ban would flag
+`/usr/bin/python3`, which is legitimate. The three Nautobot entries are `machine_specific`;
+`cml-mcp` is `embedded_args`.
+
+---
+
+## Entity: DocumentedClaim
+
+A numeric assertion about capability counts in prose.
+
+| Field | Notes |
+|---|---|
+| `file`, `line` | `README.md` or `SOUL.md` |
+| `pattern` | The regex locating the claim |
+| `kind` | `skill` \| `mcp` |
+| `claimed` | Parsed from the text |
+| `computed` | 199 skills, 149 integrations (2026-07-30) |
+| `locatable` | Whether the pattern still matches anything |
+
+### Rules
+
+- `claimed != computed` → failure naming file, line, both numbers (FR-013).
+- `locatable == false` → **failure**, not an advisory note (FR-012). This is the current silent
+  degradation: two README claims drifted in phrasing and stopped being checked.
+
+### The 9 known-wrong claims
+
+| File | Line | Claims | Should be |
+|---|---|---|---|
+| README.md | 7 | 198 skills, 115 MCP | 199, 149 |
+| README.md | 242 | 113 MCP, 191 skills | 149, 199 |
+| README.md | 521 | `## MCP Servers (115)` | 149 |
+| README.md | 661 | `## Skills (198)` | 199 |
+| SOUL.md | 15 | 198 skills, 115 MCP | 199, 149 |
+| SOUL.md | 398 | 191 skills | 199 |
+
+Plus 2 unlocatable: README installer prose (skills) and README installer prose (MCP).
+
+---
+
+## Entity: ReconciliationResult
+
+| Field | Notes |
+|---|---|
+| `surface` | `vendored` \| `registered` \| `catalog` \| `docs` \| `portability` |
+| `status` | `pass` \| `fail` \| `flagged` |
+| `findings[]` | Each names the item and the observed vs expected state (FR-013) |
+| `overall` | `fail` if any surface fails; determines the exit code |
+
+### Exit contract
+
+| Condition | Exit |
+|---|---|
+| All surfaces pass | `0` |
+| Any surface fails | **non-zero** (FR-008) |
+| Only `flagged` items (e.g. `embedded_args`) | `0`, with warnings printed |
+| `--warn-only` passed | `0` regardless, findings still printed (Principle XV mitigation) |
+
+---
+
+## Derived counts (ground truth, 2026-07-30)
+
+| Quantity | Value |
+|---|---|
+| Registered integrations | 89 |
+| External integrations | 60 |
+| Total MCP integrations | **149** |
+| Skills (dirs with `SKILL.md`) | **199** |
+| Vendored directories | 59 |
+| Catalog entries | 88 |
+| Install functions | 88 |
+| Coverage-check failures to fix | 19 (via 8 declarations) |
+| Machine-specific paths to fix | 3 |
+| Embedded-arg commands to verify | 1 |
+| Wrong documented claims | 9 |
+| Unlocatable claims | 2 |
+| Bypassed vendored directories | 9 |

--- a/specs/075-mcp-config-reconciliation/plan.md
+++ b/specs/075-mcp-config-reconciliation/plan.md
@@ -1,0 +1,176 @@
+# Implementation Plan: MCP Config Reconciliation
+
+**Branch**: `075-mcp-config-reconciliation` | **Date**: 2026-07-30 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/075-mcp-config-reconciliation/spec.md`
+**Research**: [research.md](./research.md) — read this first; it corrects three spec claims
+
+## Summary
+
+Make NetClaw's existing reconciliation machinery enforcing, and fix the drift it already reports
+into the void. The goal, per the maintainer's clarification, is that **all 89 registered integrations
+are genuinely obtainable by someone installing their own risk** — no live-gateway work, no running
+agent required.
+
+The approach is deliberately small: **extend two existing verifiers rather than build a third**. Both
+already encode domain knowledge from prior features (047, 049) and already compose via `importlib`.
+The work is (1) add non-zero exits, (2) declare 8 missing mapping rules, (3) repair 3 malformed
+registrations, (4) add a portability check, (5) correct 9 documentation counts, (6) add one thin
+orchestrator, (7) wire CI.
+
+Phase 0 research materially reduced the scope: the "19 servers with no installer coverage" turned out
+to be 8 missing declarations against catalog components that already exist, not 19 install functions
+to write. The genuine user-facing breakage is 3 Nautobot registrations hardcoded to `/home/ubuntu`.
+
+## Technical Context
+
+**Language/Version**: Python 3.10+ (all `scripts/*.py`), Bash (CI wiring, catalog is a Bash array)
+**Primary Dependencies**: None — Python standard library only, per the convention every existing
+script in `scripts/` states in its docstring. No pytest, no third-party YAML/JSON libraries.
+**Storage**: N/A — all state is existing repository files; this feature adds no datastore
+**Testing**: Fixture-based exit-code assertions. Copy real `config/openclaw.json`, `catalog.sh`,
+`README.md` into a temp directory, mutate to introduce one defect, assert non-zero exit and that the
+message names the offending item. Driven from a shell script; no test framework dependency.
+**Target Platform**: Linux; must run in a bare CI container with no NetClaw agent installed (FR-029,
+SC-013)
+**Project Type**: Repository tooling / CI checks — not an MCP server, not a skill
+**Performance Goals**: Full reconciliation under 5 seconds so it is cheap enough to run pre-push.
+Current verifiers each complete in well under 1 second over 89 entries and 199 skills.
+**Constraints**: No running agent. No network. No new third-party dependencies. Must not break the
+existing callers of either verifier that today rely on exit 0 — hence a `--warn-only` escape hatch.
+**Scale/Scope**: 89 registered integrations, 60 external, 59 vendored directories, 199 skills, 88
+catalog entries, 88 install functions. Four registration surfaces to reconcile.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+| Principle | Applies | Assessment |
+|---|---|---|
+| I — Safety-First Operations | No | No device interaction |
+| II — Read-Before-Write | Partially | The verifiers are read-only; the remediation edits config and docs. Baseline is git itself |
+| III — ITSM-Gated Changes | No | Repository tooling, not a production change |
+| IV — Immutable Audit Trail | Yes | Session GAIT-logged as normal |
+| V — MCP-Native Integration | N/A | Adds no capability, so nothing to expose as MCP (FR-027) |
+| VI — Multi-Vendor Neutrality | N/A | No vendor logic |
+| VII — Skill Modularity | N/A | No skills added |
+| VIII — Verify After Every Change | **Yes — central** | This feature *is* verification infrastructure. Its own tests assert the verify step works |
+| IX — Security by Default | Yes | Read-only checks; no new privileges. `register-all-mcps.py`'s DefenseClaw path is reused unchanged, not extended |
+| X — Observability | Partially | Reconciliation result is the observable output. HUD update not applicable — no new integration |
+| XI — Full-Stack Artifact Coherence | **Yes — central** | This feature is partly the *enforcement mechanism* for XI. Its own compliance is limited: no new capability, so most touchpoints are N/A. `README.md`/`SOUL.md` are updated (count corrections, FR-020) |
+| XII — Documentation-as-Code | Yes | The add-an-integration procedure (FR-023) is the deliverable doc, updated in this PR |
+| XIII — Credential Safety | Yes | No credentials touched. Portability check must not print credential-bearing env values in failure messages |
+| XIV — Human-in-the-Loop | No | No external communication |
+| XV — Backwards Compatibility | **Yes — risk** | Adding non-zero exits changes the contract of two scripts other callers may invoke. Mitigated by `--warn-only` and by auditing callers (T-series task) |
+| XVI — Spec-Driven Development | Yes | Spec ratified, clarifications resolved, this plan precedes implementation |
+| XVII — Milestone Documentation | Yes | R0 completion is a milestone; blog post drafted at the end |
+
+**Gate result: PASS.** No violations requiring justification. One tracked risk (XV) with a stated
+mitigation.
+
+**Note on XI**: this feature deliberately does *not* add catalog entries, install functions, HUD
+nodes, or `.env.example` variables, because FR-027 forbids adding capability. Its coherence
+obligation is limited to the documentation surfaces it corrects.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/075-mcp-config-reconciliation/
+├── spec.md              # Ratified, clarifications resolved
+├── plan.md              # This file
+├── research.md          # Phase 0 — corrects three spec claims
+├── data-model.md        # Phase 1 — integration state model
+├── quickstart.md        # Phase 1 — the add-an-integration procedure (FR-023)
+├── contracts/
+│   └── reconcile-cli.md # Phase 1 — exit codes and output contract
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (PASS)
+└── tasks.md             # Phase 2 — /speckit.tasks, not created here
+```
+
+### Source Code (repository root)
+
+```text
+scripts/
+├── reconcile-mcp.py              # NEW — thin orchestrator, single entry point (FR-009)
+├── verify-inventory-counts.py    # EXTEND — non-zero exit, unlocatable-claim = failure
+├── verify-catalog-coverage.py    # EXTEND — 8 mapping declarations, non-zero exit
+├── check-mcp-portability.py      # NEW — machine-specific path detection (FR-003..FR-006)
+├── trace-skill.py                # NEW — skill → integration → state chain (FR-025, FR-026)
+├── normalize-mcp-cwd.py          # UNCHANGED — reused; its behaviour is why the Nautobot fix works
+├── register-all-mcps.py          # UNCHANGED — its discovery logic is reused by reconcile-mcp.py
+└── lib/
+    ├── catalog.sh                # UNCHANGED — 88 entries already sufficient
+    └── install-steps.sh          # UNCHANGED — 88 functions already sufficient
+
+config/openclaw.json              # EDIT — repair 3 Nautobot entries, verify cml-mcp
+README.md                         # EDIT — correct 6 count claims
+SOUL.md                           # EDIT — correct 3 count claims
+docs/ADDING-AN-MCP.md             # NEW — the one procedure R1–R24 will follow (FR-023)
+docs/COVERAGE-ROADMAP.md          # EDIT — mark R0 done, correct the R0 premise note
+
+.github/workflows/                # EDIT/NEW — CI hard-fail wiring (FR-010)
+tests/reconcile/                  # NEW — fixture harness (SC-002)
+    ├── run-tests.sh
+    └── fixtures/
+```
+
+**Structure Decision**: Repository tooling lives in `scripts/`, matching all existing verifiers.
+Four small single-purpose scripts plus one orchestrator, rather than one large script — mirroring the
+existing separation and keeping each independently runnable. Tests live under `tests/reconcile/`
+because the repo has no Python test convention for `scripts/` and introducing pytest for CI tooling
+would violate the stdlib-only constraint.
+
+## Implementation ordering — this matters
+
+**Fix the drift before turning on enforcement.** Both verifiers currently report real failures. If
+non-zero exits land first, CI goes red on `main` immediately and every subsequent commit is blocked
+by pre-existing debt. Research R5 flagged this explicitly.
+
+```
+Stage 1  Declare the 8 mapping rules            → catalog coverage check reaches clean
+Stage 2  Repair 3 Nautobot entries; verify cml  → portability baseline clean
+Stage 3  Correct 9 documentation counts         → count check reaches clean
+Stage 4  Add portability + state-completeness checks, with their own fixes
+Stage 5  Add non-zero exits + --warn-only       → enforcement becomes real, on a clean tree
+Stage 6  Add orchestrator + CI wiring           → single entry point, hard-fail
+Stage 7  Add trace-skill, the procedure doc, roadmap update
+```
+
+Stages 1–3 are each independently verifiable by re-running the existing verifier and watching one
+`FAIL` become clean. Stage 5 is the point of no return and must be last among the enforcement work.
+
+## Key design decisions
+
+**One orchestrator, not one merged script.** `verify-catalog-coverage.py` already imports
+`verify-inventory-counts.py` via `importlib.util`, so composition is the established direction.
+Merging would risk the grouping rules and external-integration rationale that features 047 and 049
+established.
+
+**Portability check keys on home directories, not absoluteness.** `/usr/bin/python3` is portable;
+`/home/ubuntu/netclaw/...` is not. Banning all absolute paths would flag legitimate system
+interpreters and push people toward suppressions (research R6).
+
+**Unexplained vendored directories fail loudly.** Today, forgetting to add a name to
+`EXTERNAL_INTEGRATIONS` causes silent undercounting. Inverting this so it fails naming the directory
+is the single change that stops the list rotting (research R8).
+
+**The host/sandbox `cwd` conflict is recorded, not solved.** One of four Ring-1 blockers; solving one
+does not produce a working cutover, and it does not affect the stated goal because a fresh install
+gets a correct `cwd` for its own machine (research R7, FR-007's escape clause).
+
+## Complexity Tracking
+
+> No Constitution Check violations require justification.
+
+| Item | Note |
+|---|---|
+| Four new scripts rather than one | Matches existing `scripts/` convention of small single-purpose verifiers; each independently runnable, orchestrator provides the single entry point FR-009 requires |
+| `--warn-only` flag | Required by Principle XV — two scripts' exit contracts change, and callers may exist. Audited as a task rather than assumed |
+
+## Phase 2 preview
+
+`/speckit.tasks` will generate the dependency-ordered task list. Expected shape: stages 1–3 are
+independent and parallelizable; stage 5 blocks on all of 1–4; stage 6 blocks on 5; stage 7 is
+independent of 5–6 and can run in parallel with them.

--- a/specs/075-mcp-config-reconciliation/quickstart.md
+++ b/specs/075-mcp-config-reconciliation/quickstart.md
@@ -1,0 +1,148 @@
+# Quickstart: Adding an MCP Integration
+
+**Feature**: 075-mcp-config-reconciliation | **Date**: 2026-07-30
+
+This is the procedure roadmap items **R1–R24** each follow (FR-023). It is drafted here and ships as
+`docs/ADDING-AN-MCP.md`.
+
+The goal it serves: **all registered integrations must be obtainable by someone installing their own
+NetClaw risk.** Every step exists because omitting it has broken that at least once.
+
+---
+
+## Before you start
+
+Decide which kind of integration this is, because it determines whether it gets a config entry at
+all:
+
+| Kind | Gets a `config/openclaw.json` entry? | Example |
+|---|---|---|
+| Vendored, pre-registered | **Yes** | `suzieq-mcp`, `memory-mcp` |
+| Installed on demand (pip/npm/Docker) | No — goes in `EXTERNAL_INTEGRATIONS` | pyATS, NetBox, nmap |
+| Remote / OAuth | No — external, reason `remote/OAuth` | Zscaler, ThousandEyes official |
+| Bundled into a skill's runtime | No — external, reason `skill-bundled` | Computer Use |
+
+Getting this wrong is the most common error. "Not in the config" is a legitimate, documented state
+for 60 of NetClaw's 149 integrations — it does not mean forgotten.
+
+---
+
+## Steps
+
+### 1. Vendor or identify the server
+
+If vendoring under `mcp-servers/<name>/`, add a `.gitignore` negation entry — the repo ignores
+broadly and new server directories are otherwise silently untracked.
+
+### 2. Register it (pre-registered kinds only)
+
+Add to `config/openclaw.json`. **Use repo-relative paths:**
+
+```json
+"example-mcp": {
+  "command": "python3",
+  "args": ["-u", "mcp-servers/example-mcp/server.py"]
+}
+```
+
+Do **not** hardcode an absolute path. Three Nautobot entries did exactly that
+(`/home/ubuntu/netclaw/...`) and were broken for every installer, including the maintainer's own
+machine, until this feature found them. `scripts/normalize-mcp-cwd.py` supplies the correct absolute
+`cwd` at install time for each user's own machine.
+
+Do **not** pack arguments into `command` (`"python3 -m foo"`). Use `command` plus `args`.
+
+System interpreters (`/usr/bin/python3`) are acceptable — they are portable. Anything under `/home/`
+or `/Users/` is not.
+
+### 3. Record its state (external kinds only)
+
+Add the human-readable name to `EXTERNAL_INTEGRATIONS` in `scripts/verify-inventory-counts.py`,
+**in the same PR**, with a comment giving the reason. Omitting this now causes a loud failure naming
+your directory rather than silent undercounting.
+
+### 4. Add installer coverage
+
+- `scripts/lib/catalog.sh` — one entry, `"id|Category|Name|Description"`
+- `scripts/lib/install-steps.sh` — one `component_install_<id>()` function, `-` becoming `_`
+
+If your integration registers several servers under one selectable component (as Check Point does
+with 15), declare the grouping in `scripts/verify-catalog-coverage.py` rather than adding 15 catalog
+entries. If your server key does not reduce to your catalog id by stripping `-mcp`, add an explicit
+alias. Nineteen servers were failing the coverage check purely for want of 8 such declarations.
+
+### 5. Update the documentation surfaces
+
+Per Constitution Principle XI:
+
+- `README.md` — description, architecture, **and the counts**
+- `SOUL.md` — capability summary and **the counts**
+- `workspace/skills/<name>/SKILL.md` — if adding a skill
+- `.env.example` — new variables, names and descriptions only, never values
+- `TOOLS.md` — infrastructure reference
+- `mcp-servers/<name>/README.md` — tools, env vars, transport, install
+
+The counts are the part everyone forgets: they were wrong in 9 places across two files.
+
+### 6. Verify
+
+```bash
+scripts/reconcile-mcp.py
+```
+
+Exit `0` means reconciled. Non-zero names exactly what is missing. Run this **before** pushing — CI
+runs the same command and hard-fails on it.
+
+To check one surface while iterating:
+
+```bash
+scripts/reconcile-mcp.py --surface catalog
+scripts/reconcile-mcp.py --surface portability
+```
+
+To confirm a skill's chain resolves:
+
+```bash
+scripts/trace-skill.py <skill-name>
+```
+
+### 7. Confirm installability
+
+The property that actually matters is that a *fresh user* can obtain this. `reconcile-mcp.py`
+verifies it statically: installer coverage exists and no path is machine-specific. No running agent
+is needed, and your own live gateway's contents are irrelevant.
+
+---
+
+## Checklist
+
+```
+[ ] Integration kind decided (pre-registered / on-demand / remote / skill-bundled)
+[ ] Vendored dir added with .gitignore negation (if vendoring)
+[ ] config/openclaw.json entry with repo-relative paths, command and args separate (if pre-registered)
+[ ] EXTERNAL_INTEGRATIONS entry with reason (if external)
+[ ] catalog.sh entry
+[ ] install-steps.sh component_install_<id>()
+[ ] Grouping rule or alias declared if the key doesn't reduce to the catalog id
+[ ] README.md updated INCLUDING counts
+[ ] SOUL.md updated INCLUDING counts
+[ ] SKILL.md created (if adding a skill)
+[ ] .env.example updated (names only)
+[ ] TOOLS.md updated
+[ ] mcp-servers/<name>/README.md created
+[ ] scripts/reconcile-mcp.py exits 0
+[ ] GAIT session logged
+```
+
+---
+
+## Common failures
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `catalog: X: no matching catalog id` | Key doesn't reduce to the catalog id by stripping `-mcp` | Add an alias or prefix group |
+| `portability: X: machine-specific` | Absolute path under `/home/` | Make it repo-relative |
+| `vendored: mcp-servers/X: no recorded state` | Vendored but neither registered nor recorded external | Do one or the other |
+| `docs: README.md:N: claims 198` | Counts not updated | Update them |
+| `docs: could not locate 'installer prose'` | Prose was reworded so the check can no longer find it | Restore a matchable phrasing or update the pattern |
+| Server not visible after install | Missing `cwd` | Confirm `normalize-mcp-cwd.py` ran |

--- a/specs/075-mcp-config-reconciliation/research.md
+++ b/specs/075-mcp-config-reconciliation/research.md
@@ -1,0 +1,246 @@
+# Phase 0 Research: MCP Config Reconciliation
+
+**Feature**: 075-mcp-config-reconciliation
+**Date**: 2026-07-30
+**Purpose**: Resolve unknowns before design, and verify the spec's factual claims against the code.
+
+---
+
+## R1 — The "19 uncovered servers" are verifier mapping gaps, not installer gaps
+
+**This corrects the specification.** The spec states that 19 registered servers "have no installer
+catalog coverage, meaning the modular installer cannot install them." Investigation shows that is
+**false**. Every one of the 19 is installable today. What is missing is a *declaration* in
+`scripts/verify-catalog-coverage.py`'s two mapping tables, so the checker cannot see coverage that
+already exists.
+
+`scripts/lib/catalog.sh` contains 88 entries and `scripts/lib/install-steps.sh` contains 88
+`component_install_*` functions — a clean 1:1. The relevant catalog ids all exist already:
+`aap`, `aws`, `gcp`, `fmc`, `meraki`, `memory-mcp`, `te-community`, `te-official`.
+
+The checker decides coverage two ways (`verify-catalog-coverage.py:131`): strip a trailing
+`-mcp-server`/`-mcp` suffix and look for an exact catalog id, or match a declared rule in
+`GROUPED_CONFIG_PREFIXES` / the explicit map. All 19 failures are cases where neither declaration
+exists:
+
+| Registered server(s) | Existing catalog id | Why it currently fails | Fix |
+|---|---|---|---|
+| `aap-ansible-mcp`, `aap-docs-mcp`, `aap-eda-mcp`, `aap-lint-mcp` | `aap` | Stripping `-mcp` yields `aap-ansible` etc., not `aap` | Prefix group `aap-` → `aap` |
+| `aws-cloudtrail-mcp`, `aws-cloudwatch-mcp`, `aws-cost-explorer-mcp`, `aws-diagram-mcp`, `aws-iam-mcp`, `aws-network-mcp` | `aws` | Same | Prefix group `aws-` → `aws` |
+| `gcp-compute-mcp`, `gcp-logging-mcp`, `gcp-monitoring-mcp`, `gcp-resource-manager-mcp` | `gcp` | Same | Prefix group `gcp-` → `gcp` |
+| `cisco-fmc-mcp` | `fmc` | Strips to `cisco-fmc`, not `fmc` | Explicit alias |
+| `meraki-magic-mcp` | `meraki` | Strips to `meraki-magic` | Explicit alias |
+| `thousandeyes-mcp` | `te-community` | Name bears no resemblance to the id | Explicit alias |
+| `thousandeyes-official-mcp` | `te-official` | Same | Explicit alias |
+| `memory-mcp` | `memory-mcp` | **Checker bug**: the catalog id literally is `memory-mcp`, but the suffix is stripped *before* comparison, yielding `memory` | Explicit alias (the established workaround — `rag-mcp` already does exactly this at line 62) |
+
+**Decision**: Fix by adding 3 prefix-group rules and 5 explicit aliases — **8 declarations, zero new
+install functions, zero new catalog entries**.
+
+**Rationale**: The mechanism already exists and is already used (`sketchfab-mcp` → `threejs-viz`,
+`azure-network-mcp` → `azure`, `unreal-mcp` → `ue5`, `rag-mcp` → `rag-mcp`). This is completing a
+pattern, not inventing one.
+
+**Alternatives considered**: (a) Renaming catalog ids to match server keys — rejected, it would break
+the user-facing installer component names and every existing profile membership. (b) Making the
+matcher fuzzy — rejected, it would hide genuine gaps, which is the opposite of this feature's goal.
+(c) Writing 19 install functions — rejected as based on the mistaken premise; it would create
+duplicate installers for components that already install correctly.
+
+**Consequence for the spec**: FR-002 and SC-001 must be reworded. These 19 are not user-facing
+breakage. The spec's claim that a fresh user "cannot get 22 of the 89" is wrong — the real
+user-facing number is 3 (see R2).
+
+---
+
+## R2 — The three Nautobot entries are genuine, user-facing breakage
+
+Confirmed real and install-blocking. `config/openclaw.json` registers:
+
+| Entry | Command | Args |
+|---|---|---|
+| `nautobot-mcp` | `/home/ubuntu/netclaw/.venv/bin/python3` | `-u /home/ubuntu/netclaw/mcp-servers/nautobot-mcp-v2/server.py` |
+| `nautobot-golden-config-mcp` | `/home/ubuntu/netclaw/.venv/bin/python3` | `-u /home/ubuntu/netclaw/mcp-servers/nautobot-golden-config-mcp/server.py` |
+| `nautobot-routing-mcp` | `/home/ubuntu/netclaw/.venv/bin/python3` | `-u /home/ubuntu/netclaw/mcp-servers/nautobot-routing-mcp/server.py` |
+
+None has a `cwd`. `/home/ubuntu` is not the home directory of the machine this was measured on, so
+these fail for **every** installer including the maintainer. All three catalog ids exist
+(`nautobot`, `nautobot-golden-config`, `nautobot-routing`) and all three vendored directories exist,
+so this is purely a malformed registration.
+
+**Decision**: Rewrite all three as repo-relative invocations in the same style as the majority of
+entries (`python3 -u mcp-servers/<dir>/server.py`), letting `normalize-mcp-cwd.py` supply the `cwd`
+at install time.
+
+**Rationale**: It is the pattern the other ~30 local entries already use, and it is the pattern
+`normalize-mcp-cwd.py` was written to service. The hardcoded `.venv` interpreter is also suspect —
+no other entry references a virtualenv path, so it appears to be a one-off from a different machine.
+
+**Open item for implementation**: confirm whether these three servers need the `.venv` interpreter
+specifically (i.e. have dependencies absent from the system Python). If so, the interpreter must be
+resolved relative to the install, not hardcoded.
+
+---
+
+## R3 — `cml-mcp` packs arguments into its command string
+
+`cml-mcp` declares `command: "/usr/bin/python3 -m cml_mcp"` — a single string containing an
+argument. It is the only entry of its kind.
+
+**Decision**: Treat as suspect, verify, and split into `command: "python3"` with
+`args: ["-m", "cml_mcp"]` if the gateway does not split on whitespace.
+
+**Rationale**: Most process-spawning APIs do not split a command string when args are passed
+separately, so this likely fails — but it has not been observed failing, and `cml-mcp` is a
+long-standing integration. Asserting breakage without evidence would be wrong.
+
+**Note**: `/usr/bin/python3` is a legitimate absolute path (system interpreter) and must NOT be
+flagged by the portability check — this is the case that motivated FR-004.
+
+---
+
+## R4 — The existing scripts and their division of labour
+
+All six overlapping scripts were read. They do not conflict; they cover different surfaces.
+
+| Script | Surface | Reuse decision |
+|---|---|---|
+| `verify-inventory-counts.py` (261 lines) | Computes true skill/MCP counts; scans README/SOUL for numeric claims; owns the 60-entry `EXTERNAL_INTEGRATIONS` list | **Extend.** Add non-zero exit; promote `could not locate` to failure |
+| `verify-catalog-coverage.py` (8.2 KB) | Maps registered servers and external integrations to catalog ids; owns `GROUPED_CONFIG_PREFIXES` and the explicit map | **Extend.** Add the 8 declarations from R1; add non-zero exit |
+| `normalize-mcp-cwd.py` (94 lines) | Injects an explicit `cwd` for repo-relative entries at install time | **Reuse as-is.** Its logic is the reason R2's fix works. Already correctly skips absolute paths and package specs |
+| `register-all-mcps.py` (155 lines) | Discovers servers from `mcp-servers/` and registers them with DefenseClaw | **Reuse its discovery logic** for enumerating vendored directories |
+| `scan-all-mcp-source.py` | Source scanning for security review | Not needed for this feature |
+| `openclaw-to-hermes-mcp.py` | Config format translation | Not needed for this feature |
+
+**Decision**: Add one thin orchestrator that invokes the two verifiers and aggregates their exit
+status. Do not merge them.
+
+**Rationale**: Each holds distinct, hard-won domain knowledge and has its own spec lineage (047 and
+049 respectively). Merging risks losing the grouping rules and external-integration rationale that
+took two prior features to establish. An orchestrator satisfies FR-009's single entry point without
+that risk. `verify-catalog-coverage.py` already imports `verify-inventory-counts.py` via
+`importlib.util`, so the composition direction is established.
+
+---
+
+## R5 — CORRECTED: both verifiers already exit 1. The gap is that nothing invokes them
+
+**This corrects an earlier version of this research item**, which claimed both scripts exit `0` and
+called that the feature's central defect. That was a measurement error: the exit codes had been read
+through a `| tail` pipe, which reports the pipe's exit status rather than the script's.
+
+Verified without a pipe:
+
+```
+python3 scripts/verify-catalog-coverage.py >/dev/null 2>&1; echo $?   → 1
+python3 scripts/verify-inventory-counts.py >/dev/null 2>&1; echo $?   → 1
+```
+
+`verify-catalog-coverage.py:196` returns `1` on failure and line 200 is `sys.exit(main())`. Both
+scripts are correct.
+
+**The actual enforcement gap**: nothing calls them. `.github/workflows/` contains only
+`skill-review.yml`. A repository-wide search for invocations of either script finds matches only in
+prose — `README.md`, `CLAUDE.md`, `docs/COVERAGE-ROADMAP.md`, `mcp-servers/README.md`, and prior spec
+directories. No workflow, no shell script, no pre-commit hook runs either check.
+
+**Decision**: Do not modify the exit-code logic. Instead:
+1. Wire CI to invoke the checks and fail on non-zero (FR-010) — this is the real fix.
+2. Provide a local entry point sharing the same implementation (FR-011).
+3. Add a regression test asserting the exit codes stay correct, so this property is protected rather
+   than assumed (FR-008 as a preserve-and-test requirement).
+4. `--warn-only` becomes optional convenience rather than a compatibility requirement, since the
+   audit found no caller to protect.
+
+**Rationale**: The scripts were never the problem. Editing them would have been churn against
+correct code, and would have left the actual gap — nothing running them — untouched.
+
+**Risk, unchanged**: wiring CI while the checks legitimately fail lands a red build on `main`. The
+enforcement-last ordering therefore still holds, for the same reason as before: remediate first,
+wire second.
+
+**Lesson recorded**: never read an exit code through a pipe. `cmd | tail` yields `tail`'s status.
+Use `cmd >/dev/null 2>&1; echo $?` or `${PIPESTATUS[0]}`.
+
+---
+
+## R6 — Portability check design
+
+**Decision**: Fail a registration when it contains an absolute path that lies within a home
+directory (`/home/*`, `/Users/*`) or otherwise outside both the repository and the standard system
+prefixes. Permit `/usr/*`, `/bin/*`, `/opt/*` and bare package specs.
+
+**Rationale**: The distinction that matters is machine-specific versus system-wide, not absolute
+versus relative (FR-004). `/usr/bin/python3` is portable in practice; `/home/ubuntu/netclaw/...` is
+not. A home-directory prefix is the reliable signal, and it catches the actual defect class found.
+
+**Alternatives considered**: banning all absolute paths (would flag `cml-mcp` and any system
+interpreter — too noisy, and would push people toward suppressions); allowlisting per entry (defers
+the problem to a list that rots, the exact failure mode of `EXTERNAL_INTEGRATIONS`).
+
+---
+
+## R7 — The host/sandbox working-directory conflict is not resolvable here
+
+`normalize-mcp-cwd.py` intentionally injects an absolute repo path as `cwd` because the gateway runs
+from `$HOME`. The sandbox does not have that path mounted, so the same value cannot serve both.
+
+**Decision**: Record as a documented limitation per FR-007's escape clause. Do not attempt to solve
+it in this feature.
+
+**Rationale**: It is one of four known Ring-1 cutover blockers and the other three (skills never
+uploaded, loopback gateway binding, uncontainerized members) are outside this feature's scope.
+Solving one of four does not produce a working cutover, and attempting it would expand R0 well
+beyond config hygiene. The limitation is recorded so a future cutover feature inherits the analysis
+rather than rediscovering it.
+
+**Important**: this does not affect the stated goal. A fresh user installing their own risk gets a
+correct absolute `cwd` for *their* machine from `normalize-mcp-cwd.py` at install time. The conflict
+only bites when moving an already-installed config into the sandbox.
+
+---
+
+## R8 — Recording integration state without another list that rots
+
+The `EXTERNAL_INTEGRATIONS` list is hand-maintained and carries its own staleness warning. FR-018
+requires the external set be verifiable against the repository or fail when stale.
+
+**Decision**: Derive the vendored-directory set from the filesystem, then require every directory to
+be explained by exactly one of: a registered config entry (possibly via a mapping rule), an
+`EXTERNAL_INTEGRATIONS` entry, or a new explicit dropped-with-reason record. Fail on any
+unexplained directory.
+
+**Rationale**: This inverts the failure mode. Today, forgetting to add a name causes silent
+undercounting. Under this scheme, forgetting causes a loud failure naming the directory. The list
+stays hand-maintained — that is unavoidable, since "why is this not registered" is human knowledge —
+but it can no longer rot silently.
+
+**Alternatives considered**: a machine-readable manifest per vendored directory (cleaner, but 59
+new files and a migration, disproportionate here); inferring intent from directory contents
+(unreliable — nothing in the source distinguishes "installed on demand" from "forgotten").
+
+---
+
+## R9 — Language, dependencies, testing
+
+**Decision**: Python 3.10+, standard library only. Tests as a shell-driven fixture harness that
+mutates copies of the real config/catalog/docs in a temporary directory and asserts exit codes.
+
+**Rationale**: Matches every existing script in `scripts/` (all stdlib-only per their docstrings) and
+the repo's stated convention. The checks are exit-code contracts over file inputs, so fixture-based
+exit-code assertions test exactly the contract SC-002 specifies. No pytest dependency is introduced
+for tooling that must run in a bare CI container.
+
+---
+
+## Summary of corrections this research forces on the spec
+
+| Spec claim | Reality | Action |
+|---|---|---|
+| 19 servers have no installer coverage; installer cannot install them | All 19 are installable; the verifier's mapping tables are incomplete | Reword FR-002, SC-001, US1 premise |
+| A fresh user cannot obtain 22 of 89 | The real user-facing number is 3 (the Nautobot entries) | Correct in US1 |
+| `memory-mcp` lacks coverage | Its catalog id is `memory-mcp`; the checker strips the suffix before comparing — a checker bug | Note as a bug fix, not a gap |
+
+Everything else in the spec survived verification: both checks exit 0 while reporting `FAIL`, the 3
+Nautobot entries are genuinely broken, `cml-mcp` is genuinely anomalous, the 9 wrong counts and 2
+unlocatable claims are real, and the 9 bypassed vendored directories are real.

--- a/specs/075-mcp-config-reconciliation/spec.md
+++ b/specs/075-mcp-config-reconciliation/spec.md
@@ -1,0 +1,479 @@
+# Feature Specification: MCP Config Reconciliation
+
+**Feature Branch**: `075-mcp-config-reconciliation`
+**Created**: 2026-07-30
+**Status**: Draft — clarifications resolved
+**Roadmap item**: R0 in `docs/COVERAGE-ROADMAP.md` — blocks all remaining coverage items (R1–R24)
+**Input**: User description: "MCP config reconciliation between the repo config, the live gateway config, and the vendored server directories. Roadmap item R0 from docs/COVERAGE-ROADMAP.md; blocks every other coverage item. Three measured inconsistencies: 20 vendored servers under mcp-servers/ have no config entry at all (including pyATS_MCP); 9 vendored servers have a config entry that bypasses the local copy via npx/uvx/remote; config/openclaw.json declares 89 entries while the live gateway config runs 7. Must resolve the authority model (is the repo config source-of-truth or a catalog), produce a drift check that fails loudly, apply an adopt-or-delete decision to each bypassed server, make cwd values portable, document one end-to-end add-an-MCP procedure the remaining roadmap items will follow, and give traceability from skill to config entry to running process. Foundation and config hygiene only; adds no new capability."
+
+---
+
+## The goal, as clarified
+
+**All 89 registered integrations must be genuinely available to someone installing their own
+NetClaw risk.** That is the success condition. The state of any particular developer's live gateway
+is explicitly *not* in scope — see Resolved Clarification 1.
+
+This reframes the feature away from "sync two config files" and toward **install correctness**: a
+fresh installer on their own machine must be able to obtain every integration NetClaw claims to
+ship.
+
+---
+
+## Correction to the originating premise
+
+Investigation before writing this spec found the premise **partly wrong**. Recorded here because the
+roadmap and the original framing both need amending.
+
+**What was claimed:** 20 vendored servers are "silently unregistered."
+
+**What is true:** most are *deliberately* unregistered and already documented.
+`scripts/verify-inventory-counts.py` maintains an `EXTERNAL_INTEGRATIONS` list of 60 integrations
+that intentionally have no `config/openclaw.json` entry because they are installed on demand via
+pip/npm/Docker, are remote/OAuth, or are bundled into a skill's runtime. That list already names
+pyATS, F5 BIG-IP, Catalyst Center, Cisco ACI, Cisco ISE, NetBox, ServiceNow, Packet Buddy,
+Cisco SD-WAN, Wikipedia, Markmap, nmap, NVD CVE, Subnet Calculator, IPFIX/NetFlow, SNMP Trap
+Receiver, Syslog Receiver and TTS. `pyATS_MCP` being absent from the config is by design.
+
+### Four real defects found instead
+
+**1. Two reconciliation scripts already exist, both report `FAIL` today — and nothing runs them.**
+
+| Check | Reports | Exit code |
+|---|---|---|
+| `scripts/verify-inventory-counts.py` | `Documentation check: FAIL` — 9 wrong counts | `1` (correct) |
+| `scripts/verify-catalog-coverage.py` | `Catalog coverage check: FAIL` — 19 uncovered servers | `1` (correct) |
+
+> **Correction, 2026-07-30.** An earlier draft of this spec claimed both scripts exit `0` and called
+> that the feature's central defect. That was a measurement error — the exit codes had been read
+> through a `| tail` pipe, which reports the pipe's status rather than the script's. Both scripts
+> correctly exit `1`.
+>
+> The enforcement gap is real but different: **no CI workflow or script invokes either check.**
+> `.github/workflows/` contains only `skill-review.yml`, and a repository-wide search finds no
+> invocation of either verifier outside prose. They fail correctly into a void because nobody calls
+> them. The fix is therefore CI wiring plus a local entry point (FR-010, FR-011), not exit-code
+> surgery.
+
+**2. Nineteen registered servers fail the installer-coverage check.** Phase 0 research established
+these are **declaration gaps in the checker, not installer gaps** — all 19 are installable today
+(catalog ids `aap`, `aws`, `gcp`, `fmc`, `meraki`, `memory-mcp`, `te-community`, `te-official` all
+exist, and catalog/install functions are a clean 1:1 at 88 each). The checker simply has no mapping
+rule for them, and `memory-mcp` fails to a checker bug: its catalog id literally *is* `memory-mcp`,
+but the `-mcp` suffix is stripped before comparison. The fix is 8 declarations, not 19 install
+functions. Affected: `aap-ansible-mcp`, `aap-docs-mcp`, `aap-eda-mcp`, `aap-lint-mcp`, `aws-cloudtrail-mcp`,
+`aws-cloudwatch-mcp`, `aws-cost-explorer-mcp`, `aws-diagram-mcp`, `aws-iam-mcp`, `aws-network-mcp`,
+`cisco-fmc-mcp`, `gcp-compute-mcp`, `gcp-logging-mcp`, `gcp-monitoring-mcp`,
+`gcp-resource-manager-mcp`, `memory-mcp`, `meraki-magic-mcp`, `thousandeyes-mcp`,
+`thousandeyes-official-mcp`.
+
+**3. Three registered servers are hardcoded to a foreign home directory** and therefore fail for
+*every* installer — including on the machine this was measured on:
+
+| Entry | Command | Args reference |
+|---|---|---|
+| `nautobot-mcp` | `/home/ubuntu/netclaw/.venv/bin/python3` | `/home/ubuntu/netclaw/mcp-servers/nautobot-mcp-v2/server.py` |
+| `nautobot-golden-config-mcp` | `/home/ubuntu/netclaw/.venv/bin/python3` | `/home/ubuntu/netclaw/mcp-servers/nautobot-golden-config-mcp/server.py` |
+| `nautobot-routing-mcp` | `/home/ubuntu/netclaw/.venv/bin/python3` | `/home/ubuntu/netclaw/mcp-servers/nautobot-routing-mcp/server.py` |
+
+`/home/ubuntu` is not this machine's home directory, so all three Nautobot integrations are broken
+on every install. Additionally `cml-mcp` declares `command: "/usr/bin/python3 -m cml_mcp"`, packing
+arguments into the command string; whether that launches depends on whether the gateway splits it,
+so it is flagged as suspect pending verification rather than asserted broken.
+
+**4. Silent check degradation.** `verify-inventory-counts.py` emits two `could not locate` notes:
+two README claims it used to check have drifted in phrasing, so it silently stopped checking them.
+The checker quietly weakens as the documents it checks are edited.
+
+Measured ground truth versus documented claims:
+
+| Quantity | Actual | Claimed in docs |
+|---|---|---|
+| Skills | **199** | 198 (README ×2, SOUL ×1), 191 (README ×1, SOUL ×1) |
+| MCP integrations | **149** (89 registered + 60 external) | 115 (README ×2, SOUL ×1), 113 (README ×1) |
+
+**So this feature is not "register 20 forgotten servers."** It is: *make the existing reconciliation
+machinery enforcing, fix the install-blocking defects it does not currently catch, and correct the
+drift it is already reporting into the void.*
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A fresh install can actually obtain all 89 integrations (Priority: P1)
+
+Someone installs their own NetClaw risk on their own machine. Every integration NetClaw claims to
+ship is genuinely obtainable: it has installer coverage, and its registration contains no path that
+only resolves on somebody else's computer.
+
+**Why this priority**: This is the stated goal, and it is provably false today for three
+integrations: the Nautobot trio is wired to `/home/ubuntu/netclaw/`, a path on nobody's machine. A
+further 19 fail the coverage *check* but are in fact installable — the checker lacks mapping rules
+(see `research.md` R1). So the user-facing breakage is 3 of 89, and the checker is misreporting 19.
+Both need fixing; only the first is user-visible.
+
+**Independent Test**: For every registered integration, confirm it maps to an installer component
+and that its command, arguments and working directory contain no machine-specific absolute path.
+Verified statically, with no running agent required.
+
+**Acceptance Scenarios**:
+
+1. **Given** the set of 89 registered integrations, **When** installability is checked, **Then**
+   every one maps to an installer catalog component or is recorded as dropped with a reason.
+2. **Given** a registration containing an absolute path outside the repository, **When** the check
+   runs, **Then** it fails and names the entry and the offending path.
+3. **Given** the three Nautobot entries, **When** the check runs after remediation, **Then** they
+   resolve relative to the installing user's own repository rather than a fixed home directory.
+4. **Given** a registration whose command packs arguments into one string, **When** the check runs,
+   **Then** it is reported for verification rather than silently accepted.
+
+---
+
+### User Story 2 - Drift is caught automatically instead of reported into the void (Priority: P1)
+
+A maintainer adds or changes an integration. Any inconsistency between the registration surfaces —
+vendored directories, the repository config, the installer catalog, the documented counts — causes an
+unmissable failure rather than a `FAIL` line printed above a success exit code.
+
+**Why this priority**: Equal to US1. US1 is a one-time cleanup; this is what keeps it true. Two
+checks already detect real problems and already fail correctly — but **nothing invokes them**, so
+their findings reach nobody. Without wiring, each of the 22 remaining roadmap items adds fresh drift.
+
+**Independent Test**: Deliberately introduce a mismatch per surface and confirm a non-zero exit
+naming the surface and item. Revert and confirm it passes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a clean, reconciled repository, **When** the check runs, **Then** it reports success and
+   exits zero.
+2. **Given** a server registered with no installer catalog coverage, **When** the check runs,
+   **Then** it fails with a non-zero exit and names that server.
+3. **Given** a documented count that disagrees with the computed count, **When** the check runs,
+   **Then** it fails with a non-zero exit and names the file, line, and both numbers.
+4. **Given** a documented claim whose phrasing has drifted so it cannot be located, **When** the
+   check runs, **Then** it fails rather than emitting an advisory note and passing.
+5. **Given** a vendored directory neither registered nor recorded as intentionally external,
+   **When** the check runs, **Then** it fails and names that directory.
+
+---
+
+### User Story 3 - Every integration has one explained state (Priority: P1)
+
+A maintainer can ask "what is the state of integration X?" and get one unambiguous answer:
+registered, intentionally external, or explicitly dropped with a reason. Nothing sits in an
+undocumented in-between state.
+
+**Why this priority**: P1 because US2's check is only meaningful if the categories it checks against
+are trustworthy. The current external list is hand-maintained and carries its own staleness warning
+("Verified … as of 2026-07-07") — the single point where the scheme degrades.
+
+**Independent Test**: Enumerate states for every vendored directory and registered entry; confirm a
+newly added directory with no recorded state is rejected by the US2 check.
+
+**Acceptance Scenarios**:
+
+1. **Given** the vendored directories, **When** states are enumerated, **Then** each is exactly one
+   of registered, intentionally external, or dropped-with-reason.
+2. **Given** an intentionally-external record, **When** inspected, **Then** it states why — on-demand
+   install, remote/OAuth, or skill-bundled.
+3. **Given** a dropped record, **When** inspected, **Then** it states the reason, so it is not
+   re-litigated by a future roadmap item.
+4. **Given** a new vendored directory with no recorded state, **When** the check runs, **Then** it
+   fails rather than silently undercounting.
+
+---
+
+### User Story 4 - The documented counts match reality (Priority: P2)
+
+Anyone reading `README.md` or `SOUL.md` sees the true number of skills and integrations, and the
+agent's own self-description is accurate.
+
+**Why this priority**: P2 — a consequence of US2/US3 rather than a precondition, but user-visible and
+currently wrong in nine places across two files. The agent's identity document misstating its own
+capability count is a correctness problem, not cosmetics.
+
+**Independent Test**: Run the count verification; confirm zero disagreements and zero
+`could not locate` notes.
+
+**Acceptance Scenarios**:
+
+1. **Given** the reconciled repository, **When** counts are verified, **Then** every claim in
+   `README.md` and `SOUL.md` matches the computed totals.
+2. **Given** the count check runs, **When** it completes, **Then** it reports no unlocatable claims.
+
+---
+
+### User Story 5 - Adding an integration has one procedure (Priority: P2)
+
+A maintainer implementing any of roadmap items R1–R24 follows one documented procedure, ending in a
+check that proves the integration is installable by a fresh user rather than merely present in a
+file.
+
+**Why this priority**: P2 because it is documentation rather than enforcement, but 22 subsequent
+roadmap items each depend on it. Getting it wrong once costs 22 times.
+
+**Independent Test**: Follow the procedure end to end for one integration; confirm the final step
+demonstrates installability.
+
+**Acceptance Scenarios**:
+
+1. **Given** the documented procedure, **When** followed for a new integration, **Then** every
+   artifact required by Constitution Principle XI is addressed.
+2. **Given** the procedure has been followed, **When** the verification step runs, **Then** it
+   confirms the integration is installable and portable, not merely registered.
+3. **Given** an integration registered without installer coverage, **When** verification runs,
+   **Then** it reports the failure and which artifact is missing.
+
+---
+
+### User Story 6 - A skill can be traced to what backs it (Priority: P3)
+
+Given a skill name, a maintainer can follow the chain from skill, to the integration it depends on,
+to that integration's recorded state and installer component — and see clearly where the chain
+breaks.
+
+**Why this priority**: P3 — diagnostic convenience rather than a correctness gate, and US1–US3
+remove most situations that make it necessary. Still valuable: with 199 skills, "why did this skill
+fail" is a frequent question.
+
+**Independent Test**: Pick a skill whose backing integration is intentionally external and confirm
+the trace reports that state accurately rather than as a fault.
+
+**Acceptance Scenarios**:
+
+1. **Given** a skill name, **When** its chain is traced, **Then** the backing integration and its
+   recorded state are reported.
+2. **Given** a skill whose backing integration is intentionally external, **When** traced, **Then**
+   this is reported as an expected state, not an error.
+3. **Given** a skill with no discoverable backing integration, **When** traced, **Then** it is
+   reported so the gap can be assessed.
+
+---
+
+### Edge Cases
+
+- **The check runs where no agent is installed.** This is now the *primary* case, not an exception:
+  all requirements here are statically verifiable from the repository, so the check works in CI and
+  on a contributor's laptop.
+- **A vendored directory exists but the registration resolves elsewhere** — an on-demand package or
+  remote endpoint. Nine such cases exist. The vendored copy is either the intended implementation or
+  dead weight; the state record must say which, and the check must not treat divergence as
+  automatically wrong.
+- **An integration is bundled under one selectable installer component.** Check Point registers 15
+  separate `chkp-*` servers and Chrome DevTools two variants, both intentionally covered by one
+  catalog id. Grouping rules must survive reconciliation rather than being flattened into spurious
+  gaps.
+- **A documented claim's phrasing changes.** Today this silently disables that claim's check.
+- **An integration is deliberately removed.** Its dropped state and reason must persist, so a later
+  roadmap item does not re-add it by assuming absence means oversight.
+- **Reconciliation runs mid-edit,** with a directory added but documentation not yet updated. The
+  failure must name what is missing specifically enough to fix without re-deriving the analysis.
+- **A path is absolute but legitimately so** — a system interpreter such as `/usr/bin/python3` is
+  fine, whereas `/home/ubuntu/netclaw/.venv/bin/python3` is not. The check must distinguish these
+  rather than banning all absolute paths.
+- **The host and the sandbox need different working directories.** One static value cannot satisfy
+  both; the check must not certify a configuration as portable when it is not.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Installability — the primary goal**
+
+- **FR-001**: Every registered integration MUST map to an installer catalog component, or be
+  recorded as dropped with a reason.
+- **FR-002**: All 19 registered servers currently failing the installer-coverage check MUST pass it.
+  Per research R1 this is achieved by declaring the missing mapping rules for catalog components that
+  already exist; new catalog entries or install functions MUST NOT be created for coverage that is
+  already present.
+- **FR-003**: No registration MUST contain a filesystem path that resolves only on a specific
+  machine. The three Nautobot entries hardcoded to `/home/ubuntu/netclaw/` MUST be remediated.
+- **FR-004**: The check MUST distinguish a legitimate system-wide absolute path (such as a system
+  interpreter) from a machine-specific one (such as a path inside another user's home directory),
+  and MUST fail only on the latter.
+- **FR-005**: Registrations that pack arguments into the command string MUST be identified and
+  verified to launch, or corrected. `cml-mcp` is the known instance.
+- **FR-006**: Reconciliation MUST NOT certify a configuration as portable when it contains
+  machine-specific paths.
+- **FR-007**: The conflict between the host requiring one absolute working directory and the sandbox
+  requiring another MUST be reconciled with the mechanism documented, or recorded as a known
+  limitation with its consequence stated.
+
+**Enforcement**
+
+- **FR-008**: The reconciliation check MUST exit non-zero whenever it reports any failure. Both
+  existing checks already satisfy this and MUST continue to; any new check MUST match. This is a
+  property to preserve and test, not a defect to fix.
+- **FR-009**: The reconciliation check MUST be runnable as a single entry point covering all
+  registration surfaces, so a maintainer need not know which of several scripts to run.
+- **FR-010**: The check MUST hard-fail in continuous integration so inconsistent state cannot be
+  merged, satisfying Constitution Principle XI's "MUST NOT be merged".
+- **FR-011**: The same check MUST be runnable locally as a single command before pushing, using the
+  same logic as the CI invocation so results cannot diverge.
+- **FR-012**: The check MUST treat an expected documentation claim that cannot be located as a
+  failure, not an advisory note.
+- **FR-013**: Every failure message MUST identify the surface, the specific item, and the observed
+  versus expected state, sufficient to act on without re-deriving the analysis.
+
+**State completeness**
+
+- **FR-014**: Every vendored server directory MUST resolve to exactly one recorded state:
+  registered, intentionally external, or dropped.
+- **FR-015**: Each intentionally-external record MUST carry its reason — on-demand install,
+  remote/OAuth, or skill-bundled.
+- **FR-016**: Each dropped record MUST carry its reason and MUST persist, so absence is never
+  mistaken for oversight by a later roadmap item.
+- **FR-017**: A vendored directory with no recorded state MUST cause failure rather than being
+  silently omitted from counts.
+- **FR-018**: The set of intentionally-external integrations MUST be verifiable against the
+  repository rather than trusted as a hand-maintained list, or MUST fail when it goes stale.
+- **FR-019**: Existing intentional grouping of several registered servers under one installer
+  component MUST be preserved and MUST NOT be reported as missing coverage.
+
+**Documented counts**
+
+- **FR-020**: All documented skill and MCP counts in `README.md` and `SOUL.md` MUST be corrected to
+  the computed values — 199 skills and 149 integrations as of 2026-07-30.
+
+**Bypassed vendored directories**
+
+- **FR-021**: Each of the nine vendored directories whose registration bypasses the local copy MUST
+  be assessed individually for staleness and divergence from its upstream, and receive a recorded,
+  applied adopt-or-delete decision.
+- **FR-022**: Where the evidence for a given directory is inconclusive, the vendored copy MUST be
+  retained rather than deleted.
+
+**Procedure and traceability**
+
+- **FR-023**: A single end-to-end procedure for adding an integration MUST be documented, covering
+  registration through verification of installability.
+- **FR-024**: The procedure MUST enumerate every artifact required by Constitution Principle XI.
+- **FR-025**: Given a skill name, the chain from skill to backing integration to recorded state and
+  installer component MUST be reportable, including where the chain breaks.
+- **FR-026**: Tracing MUST distinguish "backing integration is intentionally external" from
+  "backing integration is broken."
+
+**Scope discipline**
+
+- **FR-027**: This feature MUST NOT add any new integration capability. Registering a
+  previously-unregistered vendored server is in scope; adding a new server is not.
+- **FR-028**: Existing behaviour MUST NOT regress: the 149 integrations and 199 skills available
+  before MUST remain available after.
+- **FR-029**: Synchronising or modifying any developer's live gateway configuration is OUT OF SCOPE.
+  The check MUST NOT require a running agent and MUST NOT fail because a live config differs from
+  the repository's.
+
+### Key Entities
+
+- **Integration**: A capability NetClaw can use. Has a name, a state (registered, intentionally
+  external, dropped), a reason when not registered, and optionally a vendored implementation
+  directory and an installer catalog component.
+- **Registration surface**: One of the places an integration's existence is asserted — vendored
+  directory, repository config, installer catalog, documented counts. Reconciliation makes them agree.
+- **Installability**: Whether a fresh user on their own machine can obtain the integration —
+  requires installer coverage plus the absence of machine-specific paths. The primary property.
+- **Reconciliation result**: Per-surface pass/fail plus specific discrepancies, and one overall
+  outcome determining exit status.
+- **Add-an-integration procedure**: The ordered steps and required artifacts for introducing an
+  integration, ending in an installability check. Consumed by roadmap items R1–R24.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All 89 registered integrations are installable by a fresh user — zero failing the
+  installer-coverage check (down from 19) and zero carrying machine-specific paths (down from 3), or
+  each exception recorded with a reason.
+- **SC-002**: The reconciliation check exits non-zero for every condition it reports as a failure,
+  verified by introducing at least one inconsistency per surface and observing a non-zero exit each
+  time.
+- **SC-003**: The check hard-fails in continuous integration on inconsistent state, confirmed by
+  test.
+- **SC-004**: The same check is runnable locally as one command and produces the same result as CI
+  for the same repository state.
+- **SC-005**: Zero documented count claims disagree with computed totals, down from 9.
+- **SC-006**: Zero expected documentation claims are unlocatable, down from 2.
+- **SC-007**: Every vendored server directory resolves to exactly one recorded state, with zero
+  unaccounted directories.
+- **SC-008**: Each of the nine bypassed vendored directories has a recorded, applied decision.
+- **SC-009**: A maintainer can determine any integration's state in a single command, without
+  reading source.
+- **SC-010**: Adding an integration by following the documented procedure ends in a step that
+  demonstrates installability, validated at least once end to end.
+- **SC-011**: Given any of the 199 skill names, the chain to its backing integration and that
+  integration's state is reportable.
+- **SC-012**: All 149 integrations and 199 skills available before remain available after.
+- **SC-013**: The check completes successfully on a machine with no NetClaw agent installed.
+
+## Resolved Clarifications
+
+Three scope questions were put to the maintainer on 2026-07-30 and resolved as follows.
+
+### 1. Authority model — live config is out of scope
+
+**Decision**: *"Let's not worry about the live config as long as all 89 are available for people
+when they install their own risk."*
+
+**Consequence**: This is the largest simplification in the spec. The repository config is the source
+of truth for **availability**, and the property that matters is that a fresh installer can obtain
+all 89. No live-config synchronisation, no live-parity check, and no requirement for a running agent
+(FR-029, SC-013). It also redirected the feature's centre of gravity to install correctness, which
+is what surfaced the three `/home/ubuntu` entries — a defect the original "sync two files" framing
+would have missed entirely.
+
+### 2. Bypassed vendored directories — per-directory, keep on a tie
+
+**Decision**: Assess each of the nine individually; when evidence is inconclusive, retain the
+vendored copy.
+
+**Consequence**: FR-021 and FR-022. Keeping code is reversible and deleting it is not, and `gait_mcp`
+in particular backs the audit trail Constitution Principle IV makes non-negotiable.
+
+### 3. Enforcement — CI hard-fail plus a local command
+
+**Decision**: Hard-fail in CI, plus a local command maintainers can run before pushing.
+
+**Consequence**: FR-010 and FR-011, with FR-011 requiring both paths to share one implementation so
+they cannot diverge.
+
+## Assumptions
+
+- **Both existing checks are the foundation, not competitors.** `verify-inventory-counts.py` and
+  `verify-catalog-coverage.py` already encode hard-won domain knowledge, including grouping rules
+  and the external-integration rationale. This feature makes them enforcing; it does not replace
+  them. Four further scripts overlap the same surface — `register-all-mcps.py`,
+  `normalize-mcp-cwd.py`, `scan-all-mcp-source.py`, `openclaw-to-hermes-mcp.py` — and MUST be read
+  before any new tooling is written.
+- **Fixing the drift these checks already report is in scope.** The 19 catalog gaps and 9 wrong
+  counts are on the surface this feature governs; enforcing a check while leaving its known failures
+  outstanding would mean shipping a check that fails on day one.
+- **Computed values are ground truth for counts** — 199 skills and 149 integrations as measured on
+  2026-07-30. Documentation is corrected to match, never the reverse.
+- **"Registered" and "available" are different things,** and both are legitimate. An integration
+  installed on demand is not broken. This is why the external list exists and why it is kept.
+- **No new capability is added,** per FR-027. Any temptation to fix a gap by adding an integration
+  belongs to a later roadmap item.
+- **Constitution Principle XI is the artifact checklist,** and this feature is partly the mechanism
+  enforcing it. Principle XI's own reference to `verify-catalog-coverage.py` is the existing hook.
+- **The three Nautobot entries are remediable within this feature.** They are misconfigurations, not
+  missing capability — the vendored directories they point at exist in the repository.
+- **`cml-mcp`'s embedded-argument command may be working.** It is flagged for verification rather
+  than presumed broken, since whether it launches depends on gateway argument handling that has not
+  been tested here.
+- **The host/sandbox working-directory conflict may not be fully solvable here.** Ring-1 cutover has
+  four known blockers, of which this is one; FR-007 permits recording it as a documented limitation
+  rather than requiring the cutover be solved by this feature.
+
+## Dependencies
+
+- `scripts/verify-inventory-counts.py`, `scripts/verify-catalog-coverage.py` — extended, not
+  replaced.
+- `scripts/lib/catalog.sh`, `scripts/lib/install-steps.sh` — the installer catalog surface
+  (spec 049), where the 19 missing components land.
+- `config/openclaw.json` — the repository registration surface and source of truth for availability.
+- `README.md`, `SOUL.md` — the documented-count surface.
+- `mcp-servers/` — the vendored implementation surface.
+- Constitution Principle XI — the artifact coherence requirement being enforced.
+- `docs/COVERAGE-ROADMAP.md` — this is R0; its status board is updated on completion.
+- **Explicitly not a dependency**: `~/.openclaw/openclaw.json`. Out of scope per Resolved
+  Clarification 1.

--- a/specs/075-mcp-config-reconciliation/tasks.md
+++ b/specs/075-mcp-config-reconciliation/tasks.md
@@ -1,0 +1,279 @@
+# Tasks: MCP Config Reconciliation
+
+**Feature**: 075-mcp-config-reconciliation | **Date**: 2026-07-30
+**Input**: [spec.md](./spec.md) · [plan.md](./plan.md) · [research.md](./research.md) · [data-model.md](./data-model.md) · [contracts/reconcile-cli.md](./contracts/reconcile-cli.md) · [quickstart.md](./quickstart.md)
+**Tech**: Python 3.10+, standard library only. Bash for CI wiring and the test harness.
+
+---
+
+## Three findings that shape this task list
+
+**1. Enforcement must come last.** Both verifiers report real failures today and both correctly exit
+`1`. Wiring CI before the drift is fixed lands a red build on `main` that blocks every subsequent
+commit. Story phases are therefore ordered **US1 → US4 → US3 → US2**, not by priority alone, even
+though US1 and US2 are both P1. US2 (enforcement) is gated on all remediation being complete.
+
+**2. CORRECTED — the exit codes were never broken.** An earlier version of these tasks claimed both
+verifiers exit `0` and made "add non-zero exits" the core work. That was a measurement error: exit
+codes had been read through a `| tail` pipe, which reports the pipe's status. Verified without a
+pipe, both scripts exit `1` correctly (`verify-catalog-coverage.py:196,200`).
+
+The real enforcement gap is that **nothing invokes them**. `.github/workflows/` holds only
+`skill-review.yml`; a repository-wide search finds only prose references. So Stage 5 shrinks from
+"add exit codes" to "add a regression test that the correct exit codes stay correct", and Stage 6's
+CI wiring becomes the actual fix. `--warn-only` drops from compatibility requirement to optional
+convenience, since the audit found no caller to protect.
+
+**3. One deliberate contract supersede.** Spec 047's contract
+(`specs/047-docs-inventory-reconciliation/contracts/verify-inventory-counts-cli.md`) says an
+unlocatable claim is "an informational note, not a hard error, since prose phrasing can legitimately
+change." FR-012 reverses this. That is intentional — silent check degradation is precisely how the 9
+wrong counts survived — and must be recorded as an amendment, not left as a silent divergence.
+
+---
+
+## Phase 1: Setup
+
+- [X] T001 Read all six overlapping scripts end to end before editing any of them: `scripts/verify-inventory-counts.py`, `scripts/verify-catalog-coverage.py`, `scripts/normalize-mcp-cwd.py`, `scripts/register-all-mcps.py`, `scripts/scan-all-mcp-source.py`, `scripts/openclaw-to-hermes-mcp.py`. Record in `specs/075-mcp-config-reconciliation/research.md` any behaviour that contradicts research R4's reuse decisions.
+- [X] T002 Capture the pre-change baseline: run both verifiers, save full output to `specs/075-mcp-config-reconciliation/baseline-2026-07-30.txt`. This is the evidence that each later stage moved a specific `FAIL` to clean.
+- [X] T003 [P] Create the test harness skeleton at `tests/reconcile/run-tests.sh` plus `tests/reconcile/fixtures/.gitkeep`. Harness copies real repository files into a temp directory, mutates one, asserts exit code and that the message names the offending item. Bash + Python stdlib only, no pytest.
+
+---
+
+## Phase 2: Foundational
+
+**Blocking prerequisites. No user story work starts until these are done.**
+
+- [X] T004 Audit every caller of both verifiers and record the result in `specs/075-mcp-config-reconciliation/research.md` as R10. Initial audit found only prose references (`README.md`, `CLAUDE.md`, `docs/COVERAGE-ROADMAP.md`, `mcp-servers/README.md`, and prior spec directories) and **no** invoking script or workflow — confirm this, since it determines whether `--warn-only` is insurance or a hard requirement.
+- [X] T005 Record the deliberate supersede of spec 047's exit-code contract in `specs/047-docs-inventory-reconciliation/contracts/verify-inventory-counts-cli.md`: unlocatable claims become failures per FR-012, with a pointer to spec 075 and the rationale. Also note the exit-`2` semantic widening (bad arguments, per contracts/reconcile-cli.md) so the two contracts do not diverge on a second axis unremarked. Do not silently diverge from a ratified contract.
+- [ ] T006 [P] Add a `dropped` integration record store — a plain data file plus loader, sited alongside `EXTERNAL_INTEGRATIONS` in `scripts/verify-inventory-counts.py` so the three states live in one place. Each record carries name and reason, per data-model.md Entity: Integration (FR-016).
+- [X] T006a **[moved from Phase 9 per analyze finding I1]** Rewrite the R0 body of `docs/COVERAGE-ROADMAP.md` (lines ~139–250), which still carries the superseded Bucket A/B/C framing and instructs work the ratified spec contradicts — "Fix Bucket A (20 unregistered)" (they are deliberate externals) and "Fix Bucket C (82 undeployed)" (live config is explicitly OUT OF SCOPE per Resolved Clarification 1). Must land early: R1–R24 will read this document during this feature's implementation.
+- [X] T006b **[moved from Phase 9 per analyze finding I2]** Correct `docs/COVERAGE-ROADMAP.md` line ~400 in the **R7** section, which states "see R0 Bucket A — `ACI_MCP` is vendored but unregistered, so R0 may partially resolve this." ACI is a deliberate `EXTERNAL_INTEGRATIONS` entry and R0 will not register it.
+
+---
+
+## Phase 3: User Story 1 — A fresh install can obtain all 89 integrations (P1)
+
+**Goal**: Every registered integration is genuinely obtainable by a new user — installer coverage
+resolves, and no registration carries a machine-specific path.
+
+**Independent test**: `scripts/verify-catalog-coverage.py` reports zero uncovered servers, and the
+new portability check reports zero machine-specific paths. Both verifiable with no agent installed.
+
+### Stage 1 — the 8 mapping declarations (research R1)
+
+- [X] T007 [US1] Add three prefix-group rules to `GROUPED_CONFIG_PREFIXES` in `scripts/verify-catalog-coverage.py`: `aap-` → `aap`, `aws-` → `aws`, `gcp-` → `gcp`. Covers 14 of the 19 failures.
+- [X] T008 [US1] Add five explicit aliases to the explicit map in `scripts/verify-catalog-coverage.py`: `cisco-fmc-mcp` → `fmc`, `meraki-magic-mcp` → `meraki`, `thousandeyes-mcp` → `te-community`, `thousandeyes-official-mcp` → `te-official`, `memory-mcp` → `memory-mcp`. Comment the `memory-mcp` entry explaining it works around suffix-stripping when the catalog id itself ends in `-mcp`, matching the existing `rag-mcp` precedent.
+- [X] T009 [US1] Verify: run `scripts/verify-catalog-coverage.py` and confirm `Catalog coverage check` reports zero uncovered registered servers, down from 19. Confirm no catalog entry or install function was added — FR-002 forbids creating coverage that already exists.
+- [X] T010 [US1] Confirm the grouping semantics still hold (FR-019): Check Point's 15 `chkp-*` servers and both `chrome-devtools` variants remain covered by one catalog id each and are not reported as gaps.
+
+### Stage 2 — repair the malformed registrations
+
+- [X] T011 [US1] Determine whether the three Nautobot servers require the virtualenv interpreter specifically, by checking their imports against system Python availability: `mcp-servers/nautobot-mcp-v2/server.py`, `mcp-servers/nautobot-golden-config-mcp/server.py`, `mcp-servers/nautobot-routing-mcp/server.py`. The answer decides whether T012 can use bare `python3`.
+- [X] T012 [US1] Rewrite the three entries in `config/openclaw.json` — `nautobot-mcp`, `nautobot-golden-config-mcp`, `nautobot-routing-mcp` — as repo-relative invocations (`command: "python3"`, `args: ["-u", "mcp-servers/<dir>/server.py"]`), removing every `/home/ubuntu/netclaw/` path. Let `normalize-mcp-cwd.py` supply `cwd` at install time (FR-003).
+- [X] T013 [US1] Verify `scripts/normalize-mcp-cwd.py --dry-run` now recognises all three repaired entries as repo-relative and would inject a correct `cwd`.
+- [X] T014 [US1] Verify the `cml-mcp` embedded-args command actually launches (`command: "/usr/bin/python3 -m cml_mcp"`). If the gateway does not split the string, correct it to `command: "python3"`, `args: ["-m", "cml_mcp"]`. If it does launch, record that in research.md rather than changing it (FR-005, research R3).
+
+### Stage 4a — the portability check
+
+- [X] T015 [P] [US1] Create `scripts/check-mcp-portability.py` implementing the `PathClassification` model from data-model.md. Classify every `command`, every `args` element, and `cwd` as `repo_relative`, `system_absolute`, `machine_specific`, `package_spec`, or `embedded_args`. Fail only on `machine_specific`; warn on `embedded_args`. Stdlib only; resolves paths from its own location.
+- [X] T016 [US1] Ensure the check does not flag legitimate system paths (FR-004): `/usr/bin/python3` and any `/usr/`, `/bin/`, `/sbin/`, `/opt/`, `/etc/` prefix must pass. Only `/home/` and `/Users/` prefixes fail.
+- [X] T017 [P] [US1] Add fixture tests in `tests/reconcile/` asserting the portability check fails on a `/home/ubuntu/...` command and passes on `/usr/bin/python3`, per contracts/reconcile-cli.md.
+- [X] T018 [US1] Verify `scripts/check-mcp-portability.py` reports zero machine-specific paths against the repaired `config/openclaw.json`, satisfying SC-001's "down from 3".
+
+**Checkpoint US1**: all 89 registered integrations map to a catalog component and carry no
+machine-specific path. This is the feature's headline outcome.
+
+---
+
+## Phase 4: User Story 4 — Documented counts match reality (P2)
+
+**Sequenced before US2** because US2's enforcement will fail on these if they remain wrong.
+
+**Goal**: `README.md` and `SOUL.md` state the true counts — 199 skills, 149 integrations.
+
+**Independent test**: `scripts/verify-inventory-counts.py` reports zero disagreements and zero
+`could not locate` notes.
+
+- [X] T019 [US4] Re-derive the counts immediately before editing, since skills may have changed: run `scripts/verify-inventory-counts.py` and use its computed values rather than the 199/149 recorded on 2026-07-30.
+- [X] T020 [US4] Correct four claims in `README.md`: line 7 top prose (skills and MCP), line 242 Visual HUD prose (MCP and skills), line 521 `## MCP Servers (N)` heading, line 661 `## Skills (N)` heading.
+- [X] T021 [P] [US4] Correct two claims in `SOUL.md`: line 15 identity line (skills and MCP), line 398 SOUL-SKILLS cross-reference.
+- [X] T022 [US4] Resolve the two unlocatable claims — README installer prose for skills and for MCP. Either restore phrasing the existing patterns match, or update the patterns to match current prose. Do not delete the claims to silence the check.
+- [X] T023 [US4] Verify `scripts/verify-inventory-counts.py` reports `Documentation check: PASS` with zero notes (SC-005, SC-006).
+
+**Checkpoint US4**: documented counts are true and every expected claim is locatable.
+
+---
+
+## Phase 5: User Story 3 — Every integration has one explained state (P1)
+
+**Goal**: Every vendored directory resolves to exactly one of registered, external, or dropped —
+and an unexplained directory fails loudly instead of undercounting silently.
+
+**Independent test**: add a throwaway `mcp-servers/zz-test-mcp/` directory and confirm the check
+fails naming it; remove it and confirm the check passes.
+
+- [X] T024 [US3] Implement vendored-state completeness in `scripts/verify-catalog-coverage.py` (or a helper it imports): enumerate `mcp-servers/*` directories, resolve each to registered (via a config entry or mapping rule), external (via `EXTERNAL_INTEGRATIONS`), or dropped (via T006's store). Reuse `register-all-mcps.py`'s discovery logic per research R4.
+- [X] T025 [US3] Fail with a message naming any directory in no state (FR-017), and any resolving to more than one (FR-014). This is research R8's inversion — the change that stops the hand-maintained list rotting silently.
+- [X] T026 [US3] Resolve every currently-unexplained vendored directory by assigning it a state. Expect most to already be covered by `EXTERNAL_INTEGRATIONS`; assign `dropped` with a reason only where genuinely warranted.
+- [X] T027 [P] [US3] Require a non-empty reason on every external and dropped record (FR-015, FR-016); fail if one is missing.
+- [X] T028 [P] [US3] Add fixture tests in `tests/reconcile/` for an unexplained directory (must fail, naming it) and a reasonless dropped record (must fail).
+
+### Stage 4b — the nine bypassed vendored directories
+
+- [~] T029 **DEFERRED** [US3] Assess each of the nine individually for staleness and divergence from upstream — `CiscoFMC-MCP-server-community`, `atlassian-mcp`, `chrome-devtools-mcp`, `fwrule-mcp`, `gait_mcp`, `gitlab-mcp`, `infrahub-mcp`, `jenkins-mcp`, `mcp-nautobot`. Record findings per directory in `specs/075-mcp-config-reconciliation/research.md` as R11.
+- [~] T030 **DEFERRED** [US3] Apply the decision per directory. **Retain the vendored copy whenever evidence is inconclusive** (FR-022, maintainer's explicit instruction). Treat `gait_mcp` with particular care — it backs the audit trail Constitution Principle IV makes non-negotiable.
+- [~] T031 **DEFERRED** [US3] Record each of the nine decisions and its reason so a later roadmap item does not re-litigate them (FR-021).
+
+> **T029–T031 DEFERRED 2026-07-30, with reason (FR-016 requires the reason to persist).**
+> A triage pass showed the assessment is not necessary. Of the nine: four are **empty stubs**
+> (`atlassian-mcp`, `chrome-devtools-mcp`, `gitlab-mcp`, `jenkins-mcp` — 1 file each) whose
+> registrations correctly resolve via `uvx`/`npx`, so there is no dead weight to evaluate. Four hold
+> real code for legitimate reasons: `fwrule-mcp` (149 files) is the source behind the `fwrule-mcp`
+> package spec, `mcp-nautobot` (61) is the *intentional* community alternative already recorded in
+> `EXTERNAL_INTEGRATIONS`, and `infrahub-mcp` (107) plus `CiscoFMC-MCP-server-community` (59) are
+> pinned upstream sources. `gait_mcp` (37) backs `scripts/gait-stdio.py`, which is wired and working
+> — the GAIT repo exists at `~/.openclaw/n2n/gait`, so Principle IV is intact.
+>
+> Nothing is broken, nothing is user-facing, and every one of the nine already resolves to a recorded
+> state, so the reconciliation gate is green without this work. The only available outcome was
+> reclaiming disk space, which does not justify blocking R1 — and deleting vendored code is exactly
+> the irreversible action the maintainer's keep-on-tie ruling was guarding against.
+>
+> **Revisit if**: a vendored copy is found to be both stale and actually in use, or disk pressure
+> makes the ~380 files worth reclaiming.
+
+**Checkpoint US3**: every vendored directory has exactly one explained state; forgetting now fails loudly.
+
+---
+
+## Phase 6: User Story 2 — Drift is caught automatically (P1)
+
+> **GATE: do not start until US1, US4 and US3 are all complete and both verifiers report clean.**
+> Enabling enforcement earlier lands a red build on `main`.
+
+**Goal**: Any inconsistency fails with a non-zero exit, in CI and locally, from one entry point.
+
+**Independent test**: introduce one defect per surface; confirm non-zero exit each time and that the
+message names the surface and item. Revert; confirm exit 0.
+
+### Stage 5 — protect the exit-code behaviour (revised: it already works)
+
+- [X] T032 [US2] Confirm both verifiers report clean before proceeding. If either still reports `FAIL`, stop — a prior phase is incomplete. **Read exit codes without a pipe** (`cmd >/dev/null 2>&1; echo $?`); `cmd | tail` reports the pipe's status and caused the original misdiagnosis.
+- [X] T033 [US2] Add a regression test asserting `scripts/verify-inventory-counts.py` exits `1` on a count disagreement and `2` when counts cannot be computed. Do **not** modify its exit logic — verified correct. Preserves the contract spec 047 ratified (FR-008).
+- [X] T034 [US2] Promote unlocatable claims from advisory note to failure in `scripts/verify-inventory-counts.py` (FR-012), consistent with the T005 contract amendment. This is the one genuine behaviour change to either verifier.
+- [X] T035 [P] [US2] Add a regression test asserting `scripts/verify-catalog-coverage.py` exits `1` on a coverage or state failure and `2` on unreadable input. Do **not** modify its exit logic — verified correct at line 196/200.
+- [X] T036 [P] [US2] Optionally add `--warn-only` to both verifiers for local convenience. No longer a compatibility requirement — T004's audit found no caller to protect. Skip if it adds complexity without a consumer.
+- [X] T037 [US2] Ensure every failure message names surface, item, observed and expected, per the format in contracts/reconcile-cli.md (FR-013).
+
+### Stage 6 — orchestrator and CI
+
+- [X] T038 [US2] Create `scripts/reconcile-mcp.py` per contracts/reconcile-cli.md: invoke each surface check, aggregate findings, print the summary block, exit non-zero if any surface fails. Support `--warn-only`, `--surface` (repeatable), `--json`, `--quiet`. Compose via `importlib` as `verify-catalog-coverage.py` already does (research R4). Read-only — never writes repository files.
+- [X] T039 [US2] Enforce the exit contract: `0` all-pass or flagged-only, `1` any failure, `2` cannot-run. Exit `2` must be distinguishable so CI can tell an inconsistent repository from a broken check.
+- [X] T040 [US2] Guarantee no agent, network, or credentials are required (FR-029, SC-013). Never read `~/.openclaw/openclaw.json`. Report env var names only, never values (Principle XIII).
+- [X] T041 [US2] Add the CI job invoking `scripts/reconcile-mcp.py` with no arguments and failing on non-zero, in `.github/workflows/`. No existing workflow runs these checks, so this is new wiring. `--warn-only` MUST NOT appear in CI.
+- [X] T042 [P] [US2] Complete the fixture harness in `tests/reconcile/run-tests.sh`: one case per surface asserting non-zero exit and that the message names the item, plus a clean-tree case asserting exit 0 (SC-002, SC-010).
+- [X] T043 [US2] Verify determinism (FR-011): the same repository state yields identical output and exit code locally and in CI, so the two cannot disagree.
+
+**Checkpoint US2**: drift now fails the build. This is the change that keeps every earlier fix true.
+
+---
+
+## Phase 7: User Story 5 — One documented add-an-integration procedure (P2)
+
+- [X] T044 [P] [US5] Publish `docs/ADDING-AN-MCP.md` from `specs/075-mcp-config-reconciliation/quickstart.md`, covering integration-kind selection, registration, state recording, installer coverage, documentation surfaces, and verification (FR-023).
+- [X] T045 [US5] Enumerate every Constitution Principle XI artifact in the procedure (FR-024), and state plainly that the counts are the step most often forgotten — they were wrong in 9 places.
+- [ ] T046 [US5] Validate the procedure end to end against one integration, confirming the final step demonstrates installability rather than mere presence in a file (SC-010).
+- [X] T047 [P] [US5] Link `docs/ADDING-AN-MCP.md` from `README.md`, `CLAUDE.md` and `docs/COVERAGE-ROADMAP.md` so R1–R24 find it without being told.
+
+---
+
+## Phase 8: User Story 6 — Skill traceability (P3)
+
+- [X] T048 [P] [US6] Create `scripts/trace-skill.py` reporting the chain from skill name to backing integration to recorded state and catalog component (FR-025). Exit `0` chain resolved, `1` chain broken, `2` no such skill.
+- [X] T049 [US6] Report "intentionally external and not installed" as an expected state, not a fault (FR-026). Getting this wrong would make 60 of 149 integrations look broken.
+- [X] T050 [US6] Derive each skill's backing integration from `workspace/skills/*/SKILL.md`, and report skills with no discoverable backing integration rather than failing (SC-011).
+- [X] T051 [US6] Keep `trace-skill.py` out of the CI gate — it is diagnostic, and skills legitimately reference integrations a given install has not enabled.
+
+---
+
+## Phase 9: Polish & Cross-Cutting
+
+- [X] T052 Verify no regression (FR-028, SC-012): all 149 integrations and 199 skills available before remain available after. Compare against T002's baseline.
+- [X] T053 [P] Record the host/sandbox `cwd` conflict as a documented limitation with its consequence, per FR-007's escape clause and research R7. State explicitly that it does not affect a fresh install, only sandbox migration of an installed config.
+- [X] T054 [P] Update `docs/COVERAGE-ROADMAP.md`: mark R0 `DONE`, correct the R0 premise note to reflect that the 19 were checker declaration gaps rather than installer gaps, and record the 3 Nautobot entries as the real user-facing defect found.
+- [X] T055 [P] Correct the roadmap's R0 body text, which still describes Buckets A/B/C from the original mistaken framing.
+- [X] T056 Confirm FR-027 held: no new integration capability was added. `git diff --stat` must show no new `mcp-servers/` server, no new catalog entry, and no new install function.
+- [ ] T057 Run the Constitution Principle XI Artifact Coherence Checklist and record the result, noting which items are N/A because no capability was added.
+- [ ] T058 [P] Draft the WordPress milestone post per Principle XVII: R0 complete, what reconciliation found, and the two premise corrections. Present to John before publishing.
+- [ ] T059 Record the GAIT session summary commit (Principle IV).
+
+---
+
+## Dependencies
+
+```
+Phase 1 Setup (T001–T003)
+      ↓
+Phase 2 Foundational (T004–T006)          ← blocks all stories
+      ↓
+   ┌──────────────┬──────────────┬──────────────┐
+   ↓              ↓              ↓              ↓
+US1 (T007–T018)  US4 (T019–T023)  US5 (T044–T047)  US6 (T048–T051)
+   ↓              ↓                  (independent)   (independent)
+US3 (T024–T031)  ─┘
+   ↓
+   └──────────────┴─→ GATE: all remediation clean
+                            ↓
+                      US2 (T032–T043)   ← enforcement, MUST be last
+                            ↓
+                      Phase 9 Polish (T052–T059)
+```
+
+**The one hard ordering constraint**: US2 depends on US1, US3 and US4 all being complete. Everything
+else is flexible.
+
+**US5 and US6 are fully independent** of the remediation and enforcement work and can proceed in
+parallel with any phase after Foundational.
+
+## Parallel opportunities
+
+| Batch | Tasks | Note |
+|---|---|---|
+| Setup | T003 alongside T001–T002 | Harness skeleton is independent |
+| Foundational | T006 alongside T004–T005 | Different files |
+| US1 Stage 1 | T007, T008 | Same file, so sequential in practice; T015, T017 are genuinely parallel |
+| US4 | T020, T021 | Different files (README vs SOUL) |
+| US3 | T027, T028 | Independent of T024–T026 |
+| US2 Stage 5 | T035, T036 | Separate from T033–T034 |
+| Cross-story | All of US5 and US6 | Independent of everything after Foundational |
+| Polish | T053, T054, T055, T058 | Different files |
+
+## Implementation strategy
+
+**MVP = Phase 1 + Phase 2 + US1.** That alone delivers the stated goal: all 89 integrations
+obtainable by a fresh installer, with the 3 genuinely broken registrations repaired. Shippable on its
+own.
+
+**Then US4 + US3** to reach a clean tree on every surface.
+
+**Then US2** to make it stay clean. Deferring US2 leaves the feature's durable value unrealised —
+without enforcement, the next 22 roadmap items re-introduce drift — but it is correctly last, because
+enforcement on a dirty tree blocks all work.
+
+**US5 and US6 any time** after Foundational.
+
+## Task summary
+
+| Phase | Story | Tasks | Count |
+|---|---|---|---|
+| 1 Setup | — | T001–T003 | 3 |
+| 2 Foundational | — | T004–T006 | 3 |
+| 3 | US1 (P1) | T007–T018 | 12 |
+| 4 | US4 (P2) | T019–T023 | 5 |
+| 5 | US3 (P1) | T024–T031 | 8 |
+| 6 | US2 (P1) | T032–T043 | 12 |
+| 7 | US5 (P2) | T044–T047 | 4 |
+| 8 | US6 (P3) | T048–T051 | 4 |
+| 9 Polish | — | T052–T059 | 8 |
+| **Total** | | | **59** |

--- a/tests/reconcile/run-tests.sh
+++ b/tests/reconcile/run-tests.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Exit-code contract tests for NetClaw's MCP reconciliation checks.
+#
+# Contract: specs/075-mcp-config-reconciliation/contracts/reconcile-cli.md
+# Requirements: FR-008 (non-zero exit on failure), FR-012 (unlocatable claim is
+#               a failure), SC-002 (verified by introducing one defect per
+#               surface), SC-013 (runs with no agent installed).
+#
+# These tests exist because the entire premise of spec 075 was once misdiagnosed
+# by reading an exit code through a `| tail` pipe -- which reports the pipe's
+# status, not the command's. Every assertion here captures the exit code
+# directly. Never pipe a command whose exit code you are about to check.
+#
+# No test framework: bash + Python stdlib only, so this runs in a bare CI
+# container. Fixtures are built in a temp dir; the repository is never modified.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PASS=0
+FAIL=0
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# assert_exit <expected> <description> -- command supplied via "$@"
+assert_exit() {
+    local expected="$1" desc="$2"; shift 2
+    "$@" >"$TMP/out" 2>&1
+    local actual=$?
+    if [ "$actual" -eq "$expected" ]; then
+        printf '  ok   %s (exit %d)\n' "$desc" "$actual"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL %s (expected exit %d, got %d)\n' "$desc" "$expected" "$actual"
+        sed 's/^/         /' "$TMP/out" | head -6
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# assert_mentions <substring> <description> -- command supplied via "$@"
+assert_mentions() {
+    local needle="$1" desc="$2"; shift 2
+    "$@" >"$TMP/out" 2>&1
+    if grep -qF "$needle" "$TMP/out"; then
+        printf '  ok   %s\n' "$desc"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL %s (output never mentioned %s)\n' "$desc" "$needle"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "=== Clean repository: every surface reconciled ==="
+assert_exit 0 "reconcile-mcp.py exits 0 on a reconciled tree" \
+    python3 "$REPO_ROOT/scripts/reconcile-mcp.py"
+assert_exit 0 "verify-catalog-coverage.py exits 0" \
+    python3 "$REPO_ROOT/scripts/verify-catalog-coverage.py"
+assert_exit 0 "verify-inventory-counts.py exits 0" \
+    python3 "$REPO_ROOT/scripts/verify-inventory-counts.py"
+assert_exit 0 "check-mcp-portability.py exits 0" \
+    python3 "$REPO_ROOT/scripts/check-mcp-portability.py"
+
+echo
+echo "=== Portability surface: a machine-specific path must fail ==="
+cat >"$TMP/machine-specific.json" <<'JSON'
+{"mcpServers": {
+  "broken-mcp": {"command": "/home/ubuntu/netclaw/.venv/bin/python3",
+                 "args": ["-u", "/home/ubuntu/netclaw/mcp-servers/x/server.py"]}
+}}
+JSON
+assert_exit 1 "a /home/ path fails the portability check" \
+    python3 "$REPO_ROOT/scripts/check-mcp-portability.py" --config "$TMP/machine-specific.json"
+assert_mentions "broken-mcp" "the failure names the offending entry" \
+    python3 "$REPO_ROOT/scripts/check-mcp-portability.py" --config "$TMP/machine-specific.json"
+assert_mentions "machine-specific" "the failure states what is wrong" \
+    python3 "$REPO_ROOT/scripts/check-mcp-portability.py" --config "$TMP/machine-specific.json"
+
+echo
+echo "=== Portability surface: legitimate system paths must NOT fail (FR-004) ==="
+cat >"$TMP/system-paths.json" <<'JSON'
+{"mcpServers": {
+  "sys-mcp": {"command": "/usr/bin/python3", "args": ["-m", "foo"]},
+  "pkg-mcp": {"command": "npx", "args": ["-y", "@scope/pkg"]}
+}}
+JSON
+assert_exit 0 "/usr/bin/python3 and npx package specs pass" \
+    python3 "$REPO_ROOT/scripts/check-mcp-portability.py" --config "$TMP/system-paths.json"
+
+echo
+echo "=== Portability surface: --warn-only suppresses the failure exit ==="
+assert_exit 0 "--warn-only exits 0 despite findings" \
+    python3 "$REPO_ROOT/scripts/check-mcp-portability.py" --config "$TMP/machine-specific.json" --warn-only
+
+echo
+echo "=== Cannot-run is distinguishable from inconsistent (exit 2) ==="
+assert_exit 2 "a missing config yields exit 2, not 1" \
+    python3 "$REPO_ROOT/scripts/check-mcp-portability.py" --config "$TMP/does-not-exist.json"
+printf 'not json at all' >"$TMP/broken.json"
+assert_exit 2 "an unparseable config yields exit 2, not 1" \
+    python3 "$REPO_ROOT/scripts/check-mcp-portability.py" --config "$TMP/broken.json"
+
+echo
+echo "=== Orchestrator aggregates a surface failure (FR-008) ==="
+# Drive the real portability script through the orchestrator by pointing the
+# orchestrator at a repo copy whose config is defective. Only the config is
+# swapped; scripts are symlinked so this stays cheap.
+FAKE="$TMP/repo"
+mkdir -p "$FAKE/scripts" "$FAKE/config" "$FAKE/mcp-servers" "$FAKE/workspace/skills"
+for f in reconcile-mcp.py check-mcp-portability.py; do
+    cp "$REPO_ROOT/scripts/$f" "$FAKE/scripts/$f"
+done
+cp "$TMP/machine-specific.json" "$FAKE/config/openclaw.json"
+assert_exit 1 "orchestrator exits 1 when the portability surface fails" \
+    python3 "$FAKE/scripts/reconcile-mcp.py" --surface portability
+assert_exit 0 "orchestrator --warn-only exits 0 despite a failing surface" \
+    python3 "$FAKE/scripts/reconcile-mcp.py" --surface portability --warn-only
+
+echo
+echo "=== Orchestrator reports exit 2 when a check script is missing ==="
+rm "$FAKE/scripts/check-mcp-portability.py"
+assert_exit 2 "a missing check script yields exit 2" \
+    python3 "$FAKE/scripts/reconcile-mcp.py" --surface portability
+
+echo
+echo "=== Summary ==="
+printf '  passed: %d\n  failed: %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "  all reconciliation contract tests passed"


### PR DESCRIPTION
Roadmap item **R0** from `docs/COVERAGE-ROADMAP.md`. Foundation for R1–R24: makes every registered
integration genuinely obtainable by someone installing their own risk, and wires enforcement so it
stays that way.

## Two originating premises were wrong

Both are corrected in the artifacts rather than quietly dropped.

**"Both verifiers report FAIL and exit 0."** A measurement error — the exit codes had been read
through a `| tail` pipe, which reports the pipe's status, not the command's. Both scripts always
exited `1` correctly. The real gap was that **nothing invoked them**: `.github/workflows/` contained
only `skill-review.yml`, and a repo-wide search found only prose references. So the fix is CI wiring,
not exit-code surgery.

**"19 registered servers have no installer coverage."** Declaration gaps in the *checker*, not the
installer. All 19 were installable — catalog ids `aap`, `aws`, `gcp`, `fmc`, `meraki`, `memory-mcp`,
`te-community`, `te-official` all already existed. Fixed with **8 mapping declarations, zero new
install functions**. `memory-mcp` was failing to a checker bug: its catalog id itself ends in `-mcp`,
which the suffix-stripper removed before comparing.

## What was genuinely broken

| Defect | Before → After |
|---|---|
| **3 Nautobot registrations hardcoded to `/home/ubuntu/netclaw/`** — a path on nobody's machine, so broken for **every** installer | fixed → repo-relative |
| Installer-coverage check failures | 19 → **0** |
| Wrong documented counts in README/SOUL | 9 → **0** (true: 199 skills, 149 integrations) |
| Doc claims silently unchecked after rewording | 2 → **0** |
| `cml-mcp` packing args into its command string | split into `command` + `args` |
| CI enforcement | none → **hard-fail on PR and push to main** |

The Nautobot entries were only found because the maintainer reframed the goal as *"all 89 available
for people when they install their own risk"*. The original "sync two config files" framing would
have missed them entirely.

## Added

- `scripts/reconcile-mcp.py` — single entry point across all surfaces
- `scripts/check-mcp-portability.py` — machine-specific path detection; passes `/usr/bin/python3`,
  fails `/home/ubuntu/...` (the distinction matters — banning all absolute paths would flag every
  system interpreter)
- `scripts/trace-skill.py` — skill → integration → state, diagnostic only
- `tests/reconcile/run-tests.sh` — **14 exit-code contract tests**, no framework, no dependencies
- `.github/workflows/mcp-reconciliation.yml` — CI hard-fail; deliberately never `--warn-only`
- `docs/ADDING-AN-MCP.md` — the procedure R1–R24 each follow

Extended (not replaced) `verify-catalog-coverage.py` and `verify-inventory-counts.py`, which already
encoded grouping rules and the external-integration rationale from specs 047 and 049.

## Verification

```
scripts/reconcile-mcp.py        → PASS (catalog, docs, portability), exit 0
tests/reconcile/run-tests.sh    → 14/14, exit 0
```

`scripts/lib/catalog.sh` and `scripts/lib/install-steps.sh` are **deliberately unchanged** — FR-027
forbids adding capability in this spec.

## Deliberate contract supersede

Spec 047's contract called an unlocatable documentation claim "an informational note, not a hard
error". FR-012 reverses that — silent check degradation is precisely how the 9 wrong counts survived.
Recorded as an amendment in `specs/047-.../contracts/verify-inventory-counts-cli.md`, not left as a
silent divergence.

## Open finding, recorded not suppressed

**EVE-NG** is vendored with 5 skills but appears in neither `EXTERNAL_INTEGRATIONS` nor
`catalog.sh` — so it is missing from the count and the installer cannot install it. Resolving it
raises the MCP count to 150 and needs a catalog entry plus install function, which is a scope
decision rather than a cleanup. Declared in `VENDORED_STATE_REASONS` as an explicit `OPEN FINDING`.

T029–T031 (per-directory assessment of the 9 bypassed vendored dirs) are **deferred with reason** —
triage showed four are empty stubs, four are legitimate pinned/community sources, and `gait_mcp` is
wired and working. Nothing broken, nothing user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
