### PR TITLE
spec 076 (R1): Multivendor CLI driver — isolated venv, command filter, inventory, routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -581,3 +581,27 @@ RAG_MAX_ROUNDS=3
 # HALO_TIMEOUT=30                                  # request timeout seconds (default: 30)
 # HALO_PAGE_SIZE=50                                # list page size (default 50, cap 100)
 # HALO_MAX_PAGES=20                                # max pages per list call (default: 20)
+
+# ---------------------------------------------------------------------------
+# Multivendor CLI Driver (spec 076) — ~90 platform families via Nornir/NAPALM/Netmiko
+# Read-only by default. Cisco/Juniper stay with pyATS/junos-mcp.
+# ---------------------------------------------------------------------------
+# Inventory source: live_sot | generated | operator | auto (default auto)
+MULTIVENDOR_INVENTORY_SOURCE=
+# Operator-authored inventory. The server NEVER writes to this file.
+MULTIVENDOR_INVENTORY_PATH=
+# Generated inventory cache. Rendered from a source of truth; OVERWRITTEN on refresh.
+MULTIVENDOR_GENERATED_PATH=
+# Expose write tools at all. Absent from tools/list unless set (default off).
+MULTIVENDOR_WRITE_ENABLED=
+# Concurrency bound for fleet queries (default 10 — devices often cap sessions at 5-15)
+MULTIVENDOR_MAX_WORKERS=
+# Per-device timeout in seconds (default 30)
+MULTIVENDOR_TIMEOUT_S=
+# Credentials. NEVER put these in an inventory file. Vault preferred; these are the
+# documented fallback and are fully supported (Vault is not required).
+MULTIVENDOR_USERNAME=
+MULTIVENDOR_PASSWORD=
+MULTIVENDOR_ENABLE=
+# Per-reference overrides for per-device/site/platform credentials, e.g.
+# MULTIVENDOR_EDGE_SITE_USERNAME / MULTIVENDOR_EDGE_SITE_PASSWORD for credential_ref "edge-site"

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ mcp-servers/*
 !mcp-servers/syslog-mcp/
 !mcp-servers/snmptrap-mcp/
 !mcp-servers/ipfix-mcp/
+!mcp-servers/multivendor-cli-mcp/
+# ...but never track its dedicated virtualenv (spec 076 FR-030a)
+mcp-servers/multivendor-cli-mcp/.venv/
 !mcp-servers/gns3-mcp-server/
 !mcp-servers/eve-ng-mcp-server/
 !mcp-servers/prisma-sdwan-mcp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # netclaw Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-07-30
+Auto-generated from all feature plans. Last updated: 2026-07-31
 
 ## Active Technologies
 - N/A (stateless server; subscription state held in-memory during runtime) (003-gnmi-mcp-server)
@@ -103,6 +103,8 @@ Auto-generated from all feature plans. Last updated: 2026-07-30
 - Extends the existing phone-local JSON-Lines `MessageFeedStore` and whole-file JSON `ConversationStore` (both under the app's documents directory) with new fields — no new store, no new database (073-push-notifications-sync)
 - Python 3.10+ (all `scripts/*.py`), Bash (CI wiring, catalog is a Bash array) + None — Python standard library only, per the convention every existing (075-mcp-config-reconciliation)
 - N/A — all state is existing repository files; this feature adds no datastore (075-mcp-config-reconciliation)
+- Python — **interpreter choice is a live decision, not a default** (see R7). + `nornir` 3.5.0, `napalm` 5.2.0, `netmiko` (>=4,<5 per `nornir-netmiko`), (076-multivendor-cli-driver)
+- No database. A generated inventory cache on disk (regenerable, credential-free); an (076-multivendor-cli-driver)
 
 - Python 3.10+ + FastMCP (MCP framework), grpcio + grpcio-tools (gRPC transport), pygnmi (gNMI client library), protobuf, cryptography (TLS handling) (003-gnmi-mcp-server)
 
@@ -122,9 +124,9 @@ cd src [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLO
 Python 3.10+: Follow standard conventions
 
 ## Recent Changes
+- 076-multivendor-cli-driver: Added Python — **interpreter choice is a live decision, not a default** (see R7). + `nornir` 3.5.0, `napalm` 5.2.0, `netmiko` (>=4,<5 per `nornir-netmiko`),
 - 075-mcp-config-reconciliation: Added Python 3.10+ (all `scripts/*.py`), Bash (CI wiring, catalog is a Bash array) + None — Python standard library only, per the convention every existing
 - 073-push-notifications-sync: Added Dart 3.x / Flutter 3.x (extends `mobile/netclaw-mobile/`, SDK constraint `^3.12.2` per pubspec.yaml); Swift 5.0 (extends the `WatchApp Watch App` target from spec 072); Python 3.10+ (the one Border-side addition, `authorization.py`/`service.py`, matching specs 052-072) + `flutter_local_notifications` (new — local notification posting, Darwin/Android notification actions, iOS badge control); existing `firebase_messaging`/`firebase_core` (unchanged, remote-push path stays out of scope per Assumptions); existing `app_links` (extended, not replaced, per research D4); watchOS `AVSpeechSynthesizer` (system framework, no new dependency, watch-side only)
-- 072-apple-watch-companion: Added Swift 5.0 (new watch app target + new `WatchRelayPlugin.swift` on the phone + `WatchConnectivity` (Apple system framework, phone + watch sides — no new
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # NetClaw
 
-A CCIE-level AI network engineering coworker. Built on [OpenClaw](https://github.com/openclaw/openclaw) with Anthropic Claude, 199 skills, and 149 MCP integrations for complete network automation with ITSM gating, source-of-truth reconciliation, immutable audit trails, gNMI streaming telemetry, NetFlow/IPFIX flow telemetry, Canvas/A2UI inline network visualizations, packet capture analysis, GitHub config-as-code, GitLab DevOps (issues, merge requests, pipelines, repositories, wikis), Jenkins CI/CD (job monitoring, build triggering, log analysis, SCM tracking), Chrome DevTools browser automation (visualization render QA, controller GUI gap-filling, undocumented API discovery, headless or watchable-headed), Computer Use full-desktop automation (legacy desktop-only tools with no browser or API path, virtual XFCE desktop with VNC/noVNC Watch Mode), Cisco CML lab simulation, ContainerLab containerized network labs, Cisco NSO orchestration, Cisco SD-WAN vManage monitoring, Grafana observability (dashboards, Prometheus, Loki, alerting, incidents), Prometheus direct PromQL monitoring, Kubeshark Kubernetes traffic analysis, Cisco Meraki Dashboard management, Cisco ThousandEyes network intelligence, AWS and Azure cloud networking, Cisco Secure Firewall policy auditing, Check Point Security (15 MCPs: policy, threat intel, gateway, SASE, malware), Itential network orchestration, Juniper JunOS device automation, Arista CloudVision Portal monitoring, F5 BIG-IP pyATS iControl REST coverage, Infoblox DDI, Palo Alto Panorama, FortiManager, Batfish offline configuration analysis, UML diagram generation, EVPN/VXLAN fabric workflows, live BGP/OSPF control-plane participation, nmap network scanning, gtrace path analysis and IP enrichment, Slack-native operations, Cisco WebEx-native operations, Microsoft 365 integration, Twilio voice/SMS, Twitter/X integration, Claroty OT/IoT asset management, Forward Networks digital twin, Ollama local LLM routing, an offline agentic RAG document knowledge base (cited answers from user-uploaded vendor guides and standards), layered Memory MCP, and MemPalace persistent AI memory.
+A CCIE-level AI network engineering coworker. Built on [OpenClaw](https://github.com/openclaw/openclaw) with Anthropic Claude, 200 skills, and 150 MCP integrations for complete network automation with ITSM gating, source-of-truth reconciliation, immutable audit trails, gNMI streaming telemetry, NetFlow/IPFIX flow telemetry, Canvas/A2UI inline network visualizations, packet capture analysis, GitHub config-as-code, GitLab DevOps (issues, merge requests, pipelines, repositories, wikis), Jenkins CI/CD (job monitoring, build triggering, log analysis, SCM tracking), Chrome DevTools browser automation (visualization render QA, controller GUI gap-filling, undocumented API discovery, headless or watchable-headed), Computer Use full-desktop automation (legacy desktop-only tools with no browser or API path, virtual XFCE desktop with VNC/noVNC Watch Mode), Cisco CML lab simulation, ContainerLab containerized network labs, Cisco NSO orchestration, Cisco SD-WAN vManage monitoring, Grafana observability (dashboards, Prometheus, Loki, alerting, incidents), Prometheus direct PromQL monitoring, Kubeshark Kubernetes traffic analysis, Cisco Meraki Dashboard management, Cisco ThousandEyes network intelligence, AWS and Azure cloud networking, Cisco Secure Firewall policy auditing, Check Point Security (15 MCPs: policy, threat intel, gateway, SASE, malware), Itential network orchestration, Juniper JunOS device automation, Arista CloudVision Portal monitoring, F5 BIG-IP pyATS iControl REST coverage, Infoblox DDI, Palo Alto Panorama, FortiManager, Batfish offline configuration analysis, UML diagram generation, EVPN/VXLAN fabric workflows, live BGP/OSPF control-plane participation, nmap network scanning, gtrace path analysis and IP enrichment, Slack-native operations, Cisco WebEx-native operations, Microsoft 365 integration, Twilio voice/SMS, Twitter/X integration, Claroty OT/IoT asset management, Forward Networks digital twin, Ollama local LLM routing, an offline agentic RAG document knowledge base (cited answers from user-uploaded vendor guides and standards), layered Memory MCP, and MemPalace persistent AI memory.
 
 ## Resources
 
@@ -239,7 +239,7 @@ claw
   <img src="ui/netclaw-visual/logos/netclawvisualhud.png" alt="NetClaw Visual HUD — 3D Network Operations Dashboard" width="800">
 </p>
 
-NetClaw includes a Three.js 3D operations dashboard that computes its integration and skill inventory live from the codebase (currently 149 MCP integrations and 199 skills) each time it's opened, alongside your device fleet and live BGP peering topology — so the dashboard never drifts out of sync with what's actually installed. Chat with NetClaw directly from the browser, watch integrations light up as tools execute, and inspect every node in the graph. The Canvas/A2UI visualization skill renders inline topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards directly in the chat interface.
+NetClaw includes a Three.js 3D operations dashboard that computes its integration and skill inventory live from the codebase (currently 150 MCP integrations and 200 skills) each time it's opened, alongside your device fleet and live BGP peering topology — so the dashboard never drifts out of sync with what's actually installed. Chat with NetClaw directly from the browser, watch integrations light up as tools execute, and inspect every node in the graph. The Canvas/A2UI visualization skill renders inline topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards directly in the chat interface.
 
 ```bash
 cd ui/netclaw-visual
@@ -518,7 +518,7 @@ NetClaw ships with the full set of OpenClaw workspace markdown files. These are 
 
 ---
 
-## MCP Servers (149)
+## MCP Servers (150)
 
 > Adding one? Follow **[docs/ADDING-AN-MCP.md](docs/ADDING-AN-MCP.md)** and run
 > `python3 scripts/reconcile-mcp.py` before pushing — CI enforces it.
@@ -661,7 +661,7 @@ All MCP servers communicate via stdio (JSON-RPC 2.0) through `scripts/mcp-call.p
 
 ---
 
-## Skills (199)
+## Skills (200)
 
 ### pyATS Device Skills (9)
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -12,7 +12,7 @@ Every time you learn something about how I work or what I need, update the relev
 
 ## Your Skills
 
-You interact with the network through **199 skills** backed by 149 MCP servers:
+You interact with the network through **200 skills** backed by 150 MCP servers:
 
 ### Device Automation (9)
 pyats-network, pyats-health-check, pyats-routing, pyats-security, pyats-topology, pyats-config-mgmt, pyats-troubleshoot, pyats-dynamic-test, pyats-parallel-ops
@@ -395,7 +395,7 @@ The knowledge base is not memory: RAG holds user-supplied documents (`~/.opencla
 
 For **detailed skill procedures**, read `SOUL-SKILLS.md`:
 - Use when executing any skill that needs step-by-step guidance
-- Contains operational workflows, commands, and best practices for all 199 skills
+- Contains operational workflows, commands, and best practices for all 200 skills
 - Load with: `read("~/.openclaw/workspace/SOUL-SKILLS.md")`
 
 For **technical knowledge**, read `SOUL-EXPERTISE.md`:

--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -1020,6 +1020,13 @@
         "-u",
         "scripts/gait-stdio.py"
       ]
+    },
+    "multivendor-cli-mcp": {
+      "command": "mcp-servers/multivendor-cli-mcp/.venv/bin/python",
+      "args": [
+        "-u",
+        "mcp-servers/multivendor-cli-mcp/server.py"
+      ]
     }
   }
 }

--- a/docs/COVERAGE-ROADMAP.md
+++ b/docs/COVERAGE-ROADMAP.md
@@ -41,6 +41,43 @@ and the IETF datatracker.
 | ID | Title | Spec # | Status |
 |----|-------|--------|--------|
 | **R0** | MCP config reconciliation — repo vs live vs vendored | [075](../specs/075-mcp-config-reconciliation/spec.md) | `DONE` |
+| **R0a** | **Dependency-pin hazards — do this NEXT** | — | `NOT STARTED` |
+
+> ### R0a — two latent breakages that make fresh installs fail
+>
+> Found while implementing R1 (spec 076 research R7 and R14). Neither affects an existing working
+> install, which is exactly why both went unnoticed — they break *new* installs only.
+>
+> **1. `mcp 2.0.0` removed `mcp.server.fastmcp`.** Verified: the 2.0.0 wheel contains **zero**
+> `mcp/server/fastmcp/` files, and does not declare `fastmcp` as a dependency, so there is no
+> re-export. Seven servers pin `mcp` with no upper bound *and* import that module, so all seven
+> resolve 2.x and fail on import on a fresh install today:
+>
+> | Server | Current pin |
+> |---|---|
+> | `claroty-mcp` | `mcp>=1.0.0` |
+> | `protocol-mcp` | `mcp>=1.0.0` |
+> | `suzieq-mcp` | `mcp>=1.0.0` |
+> | **`n2n-mcp`** | `mcp>=1.0.0` — **one of the 7 live servers, backs the federation** |
+> | `thousandeyes-mcp-community` | `mcp>=1.13` |
+> | `nautobot-mcp-v2` | `mcp>=1.0.0` |
+> | `uml-mcp` | `mcp>=1.2.0` |
+>
+> Fix: pin `mcp>=…,<2` in each, or migrate to the standalone `fastmcp` distribution. Spec 076 already
+> pins `<2` for its own server, so the pattern is established.
+>
+> **2. `pip3` and `python3` can be different interpreters.** On the development host, `pip3` targets a
+> stranded Python 3.13 `site-packages` while `python3` is 3.14.4 — carrying two different
+> `cryptography` versions. `scripts/lib/install-steps.sh` contains **186 `pip install` invocations**;
+> any bare `pip3` lands where the servers cannot import from. Same defect class as the hardcoded
+> interpreter paths R0 fixed.
+>
+> Also worth folding in: **Python 3.14 has no `ensurepip`** on this host (`python3.14-venv` is not
+> installed), so `python3 -m venv` fails outright. Spec 076 works around it with `virtualenv`.
+>
+> **Why next**: R2–R24 each add a server, and every one inherits both hazards. Fixing them once is
+> cheaper than seven times, and a broken fresh install undermines R0's whole "available to people when
+> they install their own risk" goal.
 
 > **R0 complete 2026-07-30, with two premises corrected.** Most "unregistered" servers were
 > deliberate on-demand installs already tracked in a 60-entry `EXTERNAL_INTEGRATIONS` list. Both
@@ -53,7 +90,7 @@ and the IETF datatracker.
 
 | ID | Title | Spec # | Status |
 |----|-------|--------|--------|
-| **R1** | Generic multivendor CLI driver (Nornir/Netmiko/NAPALM) | [076](../specs/076-multivendor-cli-driver/spec.md) | `IN FLIGHT` |
+| **R1** | Generic multivendor CLI driver (Nornir/Netmiko/NAPALM) | [076](../specs/076-multivendor-cli-driver/spec.md) | `IN FLIGHT` — Phases 1–2 of 9 done. **SC-001 BLOCKED**: the only lab is CML with 4 Cisco devices, i.e. exactly the platforms this server routes away. Needs containerlab (SR Linux / SONiC / VyOS — free container images) |
 | **R2** | Cisco Support APIs (PSIRT / EoX / Bug / Case) | — | `NOT STARTED` |
 | **R3** | Fortinet (FortiOS / FortiManager / FortiAnalyzer) | — | `NOT STARTED` |
 | **R4** | Palo Alto PAN-OS / Panorama NGFW | — | `NOT STARTED` |

--- a/docs/COVERAGE-ROADMAP.md
+++ b/docs/COVERAGE-ROADMAP.md
@@ -53,7 +53,7 @@ and the IETF datatracker.
 
 | ID | Title | Spec # | Status |
 |----|-------|--------|--------|
-| **R1** | Generic multivendor CLI driver (Nornir/Netmiko/NAPALM) | — | `NOT STARTED` |
+| **R1** | Generic multivendor CLI driver (Nornir/Netmiko/NAPALM) | [076](../specs/076-multivendor-cli-driver/spec.md) | `IN FLIGHT` |
 | **R2** | Cisco Support APIs (PSIRT / EoX / Bug / Case) | — | `NOT STARTED` |
 | **R3** | Fortinet (FortiOS / FortiManager / FortiAnalyzer) | — | `NOT STARTED` |
 | **R4** | Palo Alto PAN-OS / Panorama NGFW | — | `NOT STARTED` |

--- a/mcp-servers/multivendor-cli-mcp/README.md
+++ b/mcp-servers/multivendor-cli-mcp/README.md
@@ -1,0 +1,201 @@
+# Multivendor CLI Driver — MCP Server
+
+**Spec**: 076 (roadmap R1) | **Transport**: stdio | **Server id**: `multivendor-cli`
+**Status**: read-only tool surface; device tools land in spec 076 Phases 4-6
+
+Reaches ~90 platform families NetClaw's Cisco/Juniper-specific servers cannot.
+
+Onboarding for the server that reaches the ~90 platforms NetClaw's other device servers cannot.
+
+---
+
+## Which server should answer? Read this first
+
+This server is **not** a replacement for `pyATS` or `junos-mcp`. Platform-first routing:
+
+| Your device | Use |
+|---|---|
+| Cisco IOS / IOS-XE / NX-OS / IOS-XR | **`pyATS`** — far richer, ~2000 Genie parsers |
+| Juniper Junos | **`junos-mcp`** — PyEZ/NETCONF |
+| Streaming telemetry, any vendor | **`gnmi-mcp`** |
+| No direct reachability | **`radkit-mcp`** |
+| MikroTik, VyOS, SONiC, SR Linux, Extreme, Huawei, Dell, EdgeOS, … | **this server** |
+| "Compare BGP neighbours across Cisco *and* Arista *and* Nokia" | **this server** (read-only) |
+
+The last row is the exception worth understanding: NAPALM normalizes output across vendors, so this
+server is the right tool when a question *spans* vendors even if a dedicated server exists for some of
+them. It answers those **read-only**.
+
+**It will refuse configuration writes on Cisco and Juniper**, naming the correct server. That is
+deliberate — one write path per platform is what makes "verify the change" mean something.
+
+---
+
+## Step 1 — Install
+
+```bash
+./scripts/install.sh          # select "Multivendor CLI Driver"
+```
+
+The install creates a **dedicated virtualenv** for this server. That is not incidental: `napalm` and
+`netmiko` pull `cryptography`, which NetClaw's federation stack uses for X.509 certificate issuance. A
+version conflict would break certificate handling rather than this server, so the dependencies stay
+isolated.
+
+If you install manually, note that on some hosts `pip3` and `python3` are **different interpreters**
+pointing at different site-packages. Always use the venv's own pip:
+
+```bash
+/usr/bin/python3 -m venv mcp-servers/multivendor-cli-mcp/.venv
+mcp-servers/multivendor-cli-mcp/.venv/bin/python -m pip install -r \
+    mcp-servers/multivendor-cli-mcp/requirements.txt
+```
+
+Verify nothing shared moved:
+
+```bash
+/usr/bin/python3 -c "import importlib.metadata as m; print(m.version('cryptography'))"
+```
+
+Same version before and after, or stop and investigate.
+
+---
+
+## Step 2 — Choose an inventory source
+
+Three supported. Pick the one matching what you already run.
+
+### Option A — Live source of truth (preferred)
+
+You run NetBox, Nautobot, or Infrahub. Devices are read at call time, so inventory **cannot drift**.
+
+```bash
+MULTIVENDOR_INVENTORY_SOURCE=live_sot
+NETBOX_URL=https://netbox.example.com
+NETBOX_TOKEN=...            # in .env, never committed
+```
+
+### Option B — Generated from a source of truth
+
+You have a source of truth but need offline or air-gapped operation. An inventory file is rendered from
+it at install and on refresh.
+
+```bash
+MULTIVENDOR_INVENTORY_SOURCE=generated
+MULTIVENDOR_GENERATED_PATH=~/.openclaw/multivendor/inventory.generated.yaml
+```
+
+> **This file is a cache.** It carries a generated marker and **will be overwritten** on refresh. Do not
+> hand-edit it — your edits will be lost. If you want a file you control, use Option C.
+
+### Option C — Operator-authored
+
+No source of truth. You write and maintain the inventory yourself, the same way you maintain a pyATS
+`testbed.yaml`.
+
+```bash
+MULTIVENDOR_INVENTORY_SOURCE=operator
+MULTIVENDOR_INVENTORY_PATH=~/.openclaw/multivendor/inventory.yaml
+```
+
+```yaml
+# inventory.yaml — hostnames and platforms only. NO credentials.
+edge-mt-01:
+  hostname: 10.0.0.1
+  platform: mikrotik_routeros
+  groups: [edge, site-hq]
+  credential_ref: default        # a REFERENCE, resolved at runtime
+fw-vyos-01:
+  hostname: 10.0.0.2
+  platform: vyos
+  groups: [edge, site-hq]
+  credential_ref: default
+```
+
+**The server never writes to this file.** A generated-inventory refresh cannot touch it.
+
+`auto` (the default) tries live, then generated, then operator — and every result tells you which one
+answered, so a stale cache never masquerades as live.
+
+**Your pyATS `testbed.yaml` is not an inventory source.** It assumes Cisco, and its platforms
+(`iosxe`, `nxos`, `iosxr`) are exactly the ones routed to `pyATS` instead.
+
+---
+
+## Step 3 — Credentials
+
+**Never in the inventory file.** Two supported paths:
+
+```bash
+# Preferred: Vault
+VAULT_ADDR=https://vault.example.com
+VAULT_NAMESPACE=netclaw
+
+# Fallback: environment variables in .env (gitignored)
+MULTIVENDOR_USERNAME=netops
+MULTIVENDOR_PASSWORD=...
+```
+
+Vault is **not required.** If you have no Vault — likely if you chose Option C — environment variables
+are fully supported. Both keep secrets off disk in any inventory file, which is the actual requirement.
+
+Every result reports which path supplied the credential, so you can audit a deployment's posture.
+
+---
+
+## Step 4 — Verify
+
+```bash
+python3 scripts/reconcile-mcp.py          # must exit 0
+```
+
+Then, from NetClaw:
+
+```
+"list my multivendor devices"
+"check reachability of edge-mt-01"
+"get interfaces and facts for fw-vyos-01"
+"show me BGP neighbours across the edge group"
+```
+
+`check_reachability` is the right first call on a new device — it separates *unreachable* from
+*authentication failed* from *the platform in your inventory is wrong*, which need three different fixes.
+
+---
+
+## Step 5 — Understand the safety model before enabling writes
+
+Read-only is the default and write tools are **not exposed at all** until you opt in:
+
+```bash
+MULTIVENDOR_WRITE_ENABLED=true
+```
+
+Filtering is enforced **server-side**, in this order:
+
+1. Reject any command containing `;` `&&` `||` `>` `<` `` ` `` `$(`
+2. Reject a denylisted first token — per platform, because destructive syntax differs (VyOS `delete`,
+   MikroTik `/system reset-configuration`, SR Linux `tools system configuration`, SONiC `config erase`)
+3. In read-only mode, reject anything not starting with `show` / `display` / `get`
+
+Chaining is rejected **first** and that ordering is deliberate: `show version; write erase` would pass
+an allowlist check on its first token.
+
+With writes enabled, every change is: capture baseline → require approval → apply → **verify actual
+state against expected via structured diff** → roll back on failure. Verification compares state, not
+whether the command returned successfully.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `status: denied`, `denied_reason` mentions chaining | Command contained `;` or `&&` | Send commands separately |
+| `status: denied` in read-only mode | Verb not in the allowlist | Use a `show`-class command, or enable write mode deliberately |
+| `status: platform_mismatch` | Inventory platform ≠ what the device reports | Fix the source of truth; wrong driver gives confusing output |
+| `status: auth_failed` | Credentials resolved but rejected | Check Vault path or env vars — note this is *not* unreachable |
+| `apply_config` returns `refused` | Cisco/Junos device | Use `pyATS` or `junos-mcp`; this server is read-only there by design |
+| `available: false` on a getter | Platform's NAPALM driver lacks it | Use `run_command` for the raw equivalent — the gap is reported, not hidden |
+| My generated inventory edits vanished | It is a cache | Move to Option C, an operator-authored file the server never writes |
+| `source_used` is `generated`, not `live_sot` | Source of truth was unreachable | Check `fallback_reason`; results may be stale |

--- a/mcp-servers/multivendor-cli-mcp/credentials.py
+++ b/mcp-servers/multivendor-cli-mcp/credentials.py
@@ -1,0 +1,165 @@
+"""Credential resolution: Vault preferred, environment as documented fallback.
+
+Spec 076 FR-018, FR-018a, FR-019, FR-020. Constitution Principle XIII.
+
+Two rules define this module:
+
+1. **Vault is preferred but NOT required.** An operator running an
+   operator-authored inventory with no source of truth almost certainly has no
+   Vault either. Requiring it would make this server stricter than every other
+   NetClaw server (pyATS already supports env-var credentials alongside
+   VAULT_ADDR) while excluding exactly the operators the inventory design just
+   made first-class.
+
+2. **A credential is NEVER read from an inventory file** — any of the three
+   sources. Inventory carries a credential *reference*; this module turns that
+   reference into a secret at runtime and never writes it anywhere.
+
+Per-device, per-site and per-platform credentials are supported via that
+reference (FR-020). A single global credential is not a realistic assumption for
+a mixed network, which is the whole premise of this server.
+
+The secret value never appears in a tool result, a log line, or an audit record.
+Only the reference and which path resolved it (FR-018a) — enough to audit a
+deployment's posture, never enough to leak it.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class CredentialPath(str, Enum):
+    VAULT = "vault"
+    ENVIRONMENT = "environment"
+
+
+class CredentialError(RuntimeError):
+    """Resolution failed. Message names the reference and the paths tried —
+    never any secret material."""
+
+
+@dataclass
+class Credential:
+    """A resolved credential.
+
+    `username`/`password`/`enable`/`key_file` are secret. `__repr__` is
+    overridden so a stray log statement or traceback cannot leak them — a real
+    failure mode, not a theoretical one.
+    """
+    username: str
+    password: str | None = field(default=None, repr=False)
+    enable: str | None = field(default=None, repr=False)
+    key_file: str | None = None
+    path: CredentialPath = CredentialPath.ENVIRONMENT
+    ref: str = "default"
+
+    def __repr__(self) -> str:  # pragma: no cover - defensive
+        return (f"Credential(ref={self.ref!r}, path={self.path.value!r}, "
+                f"username={self.username!r}, secrets=<redacted>)")
+
+    __str__ = __repr__
+
+    def posture(self) -> dict:
+        """Inspectable, non-secret description for tool results (FR-018a)."""
+        return {
+            "credential_ref": self.ref,
+            "credential_path": self.path.value,
+            "username": self.username,
+            "has_password": self.password is not None,
+            "has_enable": self.enable is not None,
+            "key_file": self.key_file,
+        }
+
+
+def _env(*names: str) -> str | None:
+    for n in names:
+        v = os.environ.get(n)
+        if v:
+            return v
+    return None
+
+
+def _from_environment(ref: str) -> Credential | None:
+    """Resolve from environment variables.
+
+    Reference-scoped variables are checked first so per-device, per-site and
+    per-platform credentials work (FR-020): a ref of `edge-site` looks for
+    MULTIVENDOR_EDGE_SITE_USERNAME before the generic
+    MULTIVENDOR_USERNAME. That is what makes one inventory able to span
+    devices with different credentials.
+    """
+    scoped = ref.replace("-", "_").replace(".", "_").upper()
+    username = _env(f"MULTIVENDOR_{scoped}_USERNAME", "MULTIVENDOR_USERNAME")
+    if not username:
+        return None
+    return Credential(
+        username=username,
+        password=_env(f"MULTIVENDOR_{scoped}_PASSWORD", "MULTIVENDOR_PASSWORD"),
+        enable=_env(f"MULTIVENDOR_{scoped}_ENABLE", "MULTIVENDOR_ENABLE"),
+        key_file=_env(f"MULTIVENDOR_{scoped}_KEY_FILE", "MULTIVENDOR_KEY_FILE"),
+        path=CredentialPath.ENVIRONMENT,
+        ref=ref,
+    )
+
+
+def _from_vault(ref: str) -> Credential | None:
+    """Resolve from Vault, if configured and reachable.
+
+    Returns None rather than raising when Vault is simply not configured —
+    absence of Vault is an expected deployment, not an error (FR-018).
+
+    Deliberately not implemented against a Vault client here: NetClaw already
+    has a vault-mcp integration and the established pattern is to route secret
+    access through it rather than embedding a second client. Wiring that up is
+    a Phase 3 follow-up task; until then this returns None and resolution falls
+    through to the environment, which is a documented supported path — not a
+    silent downgrade, because `path` in the result says which was used.
+    """
+    if not os.environ.get("VAULT_ADDR"):
+        return None
+    return None
+
+
+def resolve(ref: str | None = None) -> Credential:
+    """Resolve a credential reference. Vault first, then environment.
+
+    Raises CredentialError naming the reference and the paths tried when neither
+    yields a credential. The message contains no secret material.
+    """
+    ref = ref or "default"
+
+    cred = _from_vault(ref)
+    if cred is not None:
+        return cred
+
+    cred = _from_environment(ref)
+    if cred is not None:
+        return cred
+
+    vault_configured = bool(os.environ.get("VAULT_ADDR"))
+    tried = "vault, environment" if vault_configured else "environment (VAULT_ADDR unset)"
+    raise CredentialError(
+        f"could not resolve credential reference {ref!r}; tried: {tried}. "
+        f"Set MULTIVENDOR_USERNAME/MULTIVENDOR_PASSWORD (or the "
+        f"MULTIVENDOR_{ref.replace('-', '_').upper()}_* variants for this "
+        f"reference) in a gitignored .env, or configure Vault. "
+        f"Credentials must never be placed in an inventory file."
+    )
+
+
+def looks_like_secret_field(name: str) -> bool:
+    """Whether an inventory field name looks like credential material.
+
+    Used to reject inventory records carrying secrets (FR-017d). Errs toward
+    false positives: refusing a legitimately-named field costs one rename, while
+    accepting a real secret on disk violates Principle XIII.
+    """
+    lowered = name.lower()
+    return any(marker in lowered for marker in (
+        "password", "passwd", "secret", "token", "apikey", "api_key",
+        "private_key", "privatekey", "enable_password", "enable_secret",
+        "credential", "passphrase",
+    )) and lowered not in ("credential_ref", "credentialref")

--- a/mcp-servers/multivendor-cli-mcp/inventory/sources.py
+++ b/mcp-servers/multivendor-cli-mcp/inventory/sources.py
@@ -1,0 +1,269 @@
+"""Device inventory from exactly three sources, with attribution.
+
+Spec 076 FR-017 through FR-017e, FR-020, FR-021. Clarified with the maintainer
+2026-07-30.
+
+    live_sot   NetBox / Nautobot / Infrahub, queried at call time. Preferred,
+               because it cannot drift.
+    generated  Rendered FROM a source of truth for offline/air-gapped use.
+               A CACHE — the server overwrites it on refresh.
+    operator   Written and maintained by the operator, for operators with no
+               source of truth. The server NEVER writes to it.
+
+The distinction between the two file-based sources is the part that matters, and
+the reason it is enforced in code rather than documented in prose: conflating
+them is what produces "the refresh wiped my edits". A generated file carries a
+marker; an operator file must not. Refresh only ever touches the former.
+
+`pyATS`'s `testbed.yaml` is explicitly NOT a source (FR-017e). It assumes Cisco,
+and its `os:` values are precisely the platforms routing sends elsewhere — so
+deriving inventory from it would mostly yield devices this server declines to
+act on.
+
+No source may contain credential material (FR-017d). Records carrying
+secret-shaped fields are rejected, naming the device and field.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+from credentials import looks_like_secret_field
+
+# Marker written into generated inventories so a refresh can distinguish its own
+# output from an operator's file. Without this, "regenerate" is indistinguishable
+# from "destroy the operator's work".
+GENERATED_MARKER = "_netclaw_generated"
+
+
+class Source(str, Enum):
+    LIVE_SOT = "live_sot"
+    GENERATED = "generated"
+    OPERATOR = "operator"
+
+
+class InventoryError(RuntimeError):
+    """Inventory could not be loaded, or contains something it must not."""
+
+
+@dataclass
+class Device:
+    name: str
+    hostname: str
+    platform: str | None
+    credential_ref: str = "default"
+    groups: list[str] = field(default_factory=list)
+    source: Source = Source.OPERATOR
+    owning_server: str = "multivendor-cli"
+
+    def public(self) -> dict:
+        """Non-secret representation for tool results. Never includes a secret,
+        because the record never held one."""
+        return {
+            "name": self.name,
+            "hostname": self.hostname,
+            "platform": self.platform,
+            "groups": list(self.groups),
+            "credential_ref": self.credential_ref,
+            "source": self.source.value,
+            "owning_server": self.owning_server,
+        }
+
+
+def _reject_secrets(name: str, record: dict) -> None:
+    """Reject an inventory record carrying credential material (FR-017d)."""
+    offending = [k for k in record if looks_like_secret_field(k)]
+    if offending:
+        raise InventoryError(
+            f"device {name!r} carries credential field(s) {offending} in its inventory "
+            f"record. Credentials must never appear in any inventory source — use "
+            f"'credential_ref' and supply the secret via Vault or a gitignored .env "
+            f"(Constitution Principle XIII)."
+        )
+
+
+def _parse_records(raw: dict, source: Source) -> list[Device]:
+    devices: list[Device] = []
+    from routing import owner_of  # local import: avoids a cycle at module load
+
+    for name, record in raw.items():
+        if name == GENERATED_MARKER:
+            continue
+        if not isinstance(record, dict):
+            raise InventoryError(f"device {name!r}: expected a mapping, got {type(record).__name__}")
+        _reject_secrets(name, record)
+        hostname = record.get("hostname") or record.get("ip") or record.get("address")
+        if not hostname:
+            raise InventoryError(f"device {name!r}: no hostname/ip/address")
+        platform = record.get("platform") or record.get("os") or record.get("device_type")
+        devices.append(Device(
+            name=name,
+            hostname=str(hostname),
+            platform=str(platform) if platform else None,
+            credential_ref=str(record.get("credential_ref", "default")),
+            groups=list(record.get("groups", []) or []),
+            source=source,
+            owning_server=owner_of(platform),
+        ))
+    return devices
+
+
+def _load_file(path: Path, source: Source) -> list[Device]:
+    if not path.is_file():
+        raise InventoryError(f"inventory file not found: {path}")
+    text = path.read_text()
+    try:
+        raw = json.loads(text)
+    except json.JSONDecodeError:
+        raw = _minimal_yaml(text, path)
+    if not isinstance(raw, dict):
+        raise InventoryError(f"{path}: expected a mapping of device-name -> record")
+    return _parse_records(raw, source)
+
+
+def _minimal_yaml(text: str, path: Path) -> dict:
+    """Parse the small YAML subset an inventory needs, without a YAML dependency.
+
+    Supports two levels of `key: value` plus `[a, b]` lists — which is the whole
+    shape documented in quickstart.md. PyYAML is deliberately not a dependency of
+    this module: inventory loading is on the safety-critical path and the fewer
+    parsers involved, the fewer surprises. A richer document is a signal the
+    operator wants the live source instead.
+    """
+    result: dict = {}
+    current: dict | None = None
+    for lineno, line in enumerate(text.splitlines(), 1):
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        stripped = line.strip()
+        if ":" not in stripped:
+            raise InventoryError(f"{path}:{lineno}: expected 'key: value', got {stripped!r}")
+        key, _, value = stripped.partition(":")
+        key, value = key.strip(), value.strip()
+        if indent == 0:
+            current = {}
+            result[key] = current if value == "" else value
+            if value != "":
+                current = None
+            continue
+        if current is None:
+            raise InventoryError(f"{path}:{lineno}: indented entry with no parent device")
+        if value.startswith("[") and value.endswith("]"):
+            current[key] = [v.strip().strip("'\"") for v in value[1:-1].split(",") if v.strip()]
+        else:
+            current[key] = value.strip("'\"")
+    return result
+
+
+def is_generated(path: Path) -> bool:
+    """Whether a file was produced by this server (and may be overwritten)."""
+    if not path.is_file():
+        return False
+    return GENERATED_MARKER in path.read_text()
+
+
+def load_operator(path: Path) -> list[Device]:
+    """Load an operator-authored inventory. Read-only, always (FR-017b)."""
+    devices = _load_file(path, Source.OPERATOR)
+    if is_generated(path):
+        raise InventoryError(
+            f"{path} carries the generated marker {GENERATED_MARKER!r}, so it is a cache "
+            f"this server overwrites on refresh — not a file to hand-maintain. Point "
+            f"MULTIVENDOR_INVENTORY_PATH at a file you own, or use "
+            f"MULTIVENDOR_INVENTORY_SOURCE=generated."
+        )
+    return devices
+
+
+def load_generated(path: Path) -> list[Device]:
+    """Load a generated inventory cache."""
+    devices = _load_file(path, Source.GENERATED)
+    if not is_generated(path):
+        raise InventoryError(
+            f"{path} lacks the generated marker, so it looks operator-authored. Refusing "
+            f"to treat it as a cache — a refresh would destroy it. Use "
+            f"MULTIVENDOR_INVENTORY_SOURCE=operator."
+        )
+    return devices
+
+
+def load_live_sot() -> list[Device]:
+    """Query NetBox / Nautobot / Infrahub at call time.
+
+    Not implemented in this phase. Raises so `auto` falls through to a file
+    source rather than silently reporting an empty fleet — an empty inventory and
+    an unreachable source of truth must never look the same (FR-017b/c).
+    """
+    raise InventoryError(
+        "live source-of-truth inventory is not implemented yet (spec 076 T018); "
+        "set MULTIVENDOR_INVENTORY_SOURCE=operator or =generated"
+    )
+
+
+@dataclass
+class Resolution:
+    devices: list[Device]
+    source: Source
+    fallback_reason: str | None = None
+
+
+def resolve(preferred: str | None = None) -> Resolution:
+    """Resolve inventory from the configured source, falling back in order.
+
+    Order is live -> generated -> operator (FR-017b). The result always names the
+    source that answered, and gives a reason when it was not the preferred one,
+    so a stale cache is never mistaken for live data (FR-017c).
+    """
+    preferred = (preferred or os.environ.get("MULTIVENDOR_INVENTORY_SOURCE") or "auto").lower()
+    gen_path = Path(os.environ.get(
+        "MULTIVENDOR_GENERATED_PATH",
+        os.path.expanduser("~/.openclaw/multivendor/inventory.generated.yaml")))
+    op_path_raw = os.environ.get("MULTIVENDOR_INVENTORY_PATH")
+    op_path = Path(op_path_raw) if op_path_raw else None
+
+    if preferred == Source.LIVE_SOT.value:
+        return Resolution(load_live_sot(), Source.LIVE_SOT)
+    if preferred == Source.GENERATED.value:
+        return Resolution(load_generated(gen_path), Source.GENERATED)
+    if preferred == Source.OPERATOR.value:
+        if op_path is None:
+            raise InventoryError(
+                "MULTIVENDOR_INVENTORY_SOURCE=operator but MULTIVENDOR_INVENTORY_PATH is unset")
+        return Resolution(load_operator(op_path), Source.OPERATOR)
+
+    # auto: try each in order, recording why we moved on.
+    reasons: list[str] = []
+    for loader, source in ((load_live_sot, Source.LIVE_SOT),
+                           (lambda: load_generated(gen_path), Source.GENERATED),
+                           (lambda: load_operator(op_path), Source.OPERATOR) if op_path
+                           else (None, Source.OPERATOR)):
+        if loader is None:
+            reasons.append("operator: MULTIVENDOR_INVENTORY_PATH unset")
+            continue
+        try:
+            devices = loader()
+        except InventoryError as exc:
+            reasons.append(f"{source.value}: {exc}")
+            continue
+        return Resolution(
+            devices, source,
+            fallback_reason="; ".join(reasons) if reasons else None,
+        )
+
+    raise InventoryError("no inventory source available — tried: " + "; ".join(reasons))
+
+
+def find(devices: list[Device], name: str) -> Device:
+    """Look up one device, reporting absence rather than guessing (FR-021)."""
+    for d in devices:
+        if d.name == name:
+            return d
+    raise InventoryError(
+        f"device {name!r} is not present in any inventory source; it is not guessed at "
+        f"or defaulted. Add it to your source of truth or inventory file."
+    )

--- a/mcp-servers/multivendor-cli-mcp/policy/filter.py
+++ b/mcp-servers/multivendor-cli-mcp/policy/filter.py
@@ -1,0 +1,169 @@
+"""Server-side command filtering.
+
+Spec 076 FR-022, FR-023, FR-029. Contract:
+specs/076-multivendor-cli-driver/contracts/mcp-tools.md
+Safety model ported from the archived, MIT-licensed sydasif/nornir-mcp-server
+(research R1).
+
+This is the safety-critical module. Everything else in this server can be wrong
+in ways that produce a bad answer; this module being wrong produces a changed or
+broken network.
+
+Two properties are non-negotiable:
+
+1. **Enforcement is here, in the server** — never in skill documentation
+   (FR-029). Documentation describes policy; it cannot enforce it, because an
+   agent can phrase a request any way it likes.
+
+2. **Chaining is rejected FIRST** (contract: "Order is contractual"). This is
+   the whole ballgame. `show version; write erase` begins with an allowlisted
+   token, so any implementation that checks the allowlist before checking for
+   chaining will permit it. That single ordering mistake defeats every other
+   rule in this file.
+
+Evaluation order:
+
+    1. reject if the command contains a chaining/redirection construct
+    2. reject if the command's first token (or command prefix) is denylisted
+    3. in read-only mode, reject unless the first token is allowlisted
+    4. permit
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+from .platform_deny import READ_ONLY_PREFIXES, deny_tokens_for, is_modelled
+
+
+class Mode(str, Enum):
+    READ_ONLY = "read_only"
+    WRITE_ENABLED = "write_enabled"
+
+
+class DenyRule(str, Enum):
+    """Which rule rejected a command. Surfaced so an operator can distinguish a
+    policy refusal from a device error, and know which knob to turn."""
+    CHAINING = "chaining"
+    DENYLIST = "denylist"
+    NOT_READ_ONLY = "not_read_only"
+    EMPTY = "empty"
+    TOO_LONG = "too_long"
+
+
+@dataclass(frozen=True)
+class Verdict:
+    allowed: bool
+    rule: DenyRule | None = None
+    detail: str | None = None
+    platform_modelled: bool = True
+
+    @property
+    def denied_reason(self) -> str | None:
+        if self.allowed:
+            return None
+        return f"{self.rule.value}: {self.detail}"
+
+
+# Constructs that let one command become several, or reach the filesystem or a
+# shell. Each is a bypass of every rule that follows it, which is why this check
+# runs first and rejects rather than sanitises.
+#
+# `|` is deliberately NOT here. On network devices a single pipe is a display
+# filter (`show running-config | include bgp`) and blocking it would break
+# ordinary read-only use. `||` IS blocked, as shell-style OR.
+CHAINING_PATTERNS: tuple[tuple[str, str], ...] = (
+    (";", "command separator"),
+    ("&&", "shell AND"),
+    ("||", "shell OR"),
+    ("`", "command substitution (backtick)"),
+    ("$(", "command substitution"),
+    (">", "output redirection"),
+    ("<", "input redirection"),
+    ("\n", "embedded newline"),
+    ("\r", "embedded carriage return"),
+    ("&", "background execution"),
+)
+
+MAX_COMMAND_LEN = 512
+
+
+def _normalise(command: str) -> str:
+    """Collapse whitespace and lowercase for comparison.
+
+    Not a sanitiser — nothing here makes an unsafe command safe. Normalisation
+    exists so `SHOW   VERSION` and `show version` are treated identically, so a
+    denylist cannot be evaded by case or spacing.
+    """
+    return re.sub(r"\s+", " ", command.strip()).lower()
+
+
+def _first_token(normalised: str) -> str:
+    return normalised.split(" ", 1)[0] if normalised else ""
+
+
+def evaluate(command: str, platform: str | None = None,
+             mode: Mode = Mode.READ_ONLY) -> Verdict:
+    """Evaluate one command against policy. Returns a Verdict, never raises.
+
+    `mode` defaults to READ_ONLY so a caller that forgets to pass it gets the
+    safe behaviour rather than the permissive one (FR-022).
+    """
+    modelled = is_modelled(platform)
+
+    if not command or not command.strip():
+        return Verdict(False, DenyRule.EMPTY, "empty command", modelled)
+
+    if len(command) > MAX_COMMAND_LEN:
+        return Verdict(False, DenyRule.TOO_LONG,
+                       f"command exceeds {MAX_COMMAND_LEN} characters", modelled)
+
+    # ---- Step 1: chaining. MUST be first. See module docstring. ----
+    for token, description in CHAINING_PATTERNS:
+        if token in command:
+            return Verdict(
+                False, DenyRule.CHAINING,
+                f"contains {description} ({token!r}); send commands separately",
+                modelled,
+            )
+
+    normalised = _normalise(command)
+    first = _first_token(normalised)
+
+    # ---- Step 2: denylist, on the first token or a multi-word prefix ----
+    for denied in deny_tokens_for(platform):
+        if " " in denied:
+            # multi-word destructive form, e.g. "write erase", "/system reset-configuration"
+            if normalised == denied or normalised.startswith(denied + " "):
+                return Verdict(False, DenyRule.DENYLIST,
+                               f"{denied!r} is destructive on platform {platform!r}",
+                               modelled)
+        elif first == denied:
+            return Verdict(False, DenyRule.DENYLIST,
+                           f"{denied!r} is a destructive verb", modelled)
+
+    # ---- Step 3: read-only allowlist ----
+    if mode is Mode.READ_ONLY and first not in READ_ONLY_PREFIXES:
+        return Verdict(
+            False, DenyRule.NOT_READ_ONLY,
+            f"{first!r} is not a read-only verb; server is in read-only mode",
+            modelled,
+        )
+
+    # ---- Step 4: permit ----
+    return Verdict(True, None, None, modelled)
+
+
+def assert_allowed(command: str, platform: str | None = None,
+                   mode: Mode = Mode.READ_ONLY) -> None:
+    """Raise PermissionError unless the command is allowed.
+
+    For call sites that must not proceed. Used by the tool layer *before* a
+    connection is opened, so a denied command never establishes a session
+    (FR-029, contract mcp-tools.md).
+    """
+    verdict = evaluate(command, platform, mode)
+    if not verdict.allowed:
+        raise PermissionError(verdict.denied_reason)

--- a/mcp-servers/multivendor-cli-mcp/policy/platform_deny.py
+++ b/mcp-servers/multivendor-cli-mcp/policy/platform_deny.py
@@ -1,0 +1,119 @@
+"""Per-platform destructive-command vocabulary.
+
+Spec 076 FR-023, research R6.
+
+Why this file exists: the NetClaw Constitution names `write erase`, `reload` and
+`format flash:` as forbidden operations. Those are all **Cisco** syntax. This
+server reaches ~90 platform families whose destructive commands look nothing
+like that — VyOS wipes config with `delete`, MikroTik with
+`/system reset-configuration`, SR Linux with `tools system configuration`, SONiC
+with `config erase`. A Cisco-shaped denylist would therefore be worse than
+useless here: it would look like protection while blocking nothing on the very
+platforms this server exists to reach.
+
+Two layers, because neither alone is sufficient:
+
+  UNIVERSAL_DENY   destructive verbs common enough to block everywhere, even on
+                   a platform we have not explicitly modelled. This is the
+                   fail-safe for the long tail: a platform absent from
+                   PLATFORM_DENY still gets baseline protection.
+
+  PLATFORM_DENY    per-family additions, keyed by the platform identifier used
+                   in the inventory.
+
+Matching is on the command's **first token** (after normalisation), not a
+substring search. `show reload-reason` must not be blocked because it contains
+"reload"; `reload` as the verb must be. Chaining is handled separately and
+earlier — see policy/filter.py, which rejects it before any of this runs.
+"""
+
+from __future__ import annotations
+
+# Destructive verbs blocked on every platform, including unmodelled ones.
+# Deliberately conservative: a false positive costs an operator one retry with
+# write mode enabled, a false negative can cost a network.
+UNIVERSAL_DENY: frozenset[str] = frozenset({
+    # Constitution's explicit forbidden operations
+    "reload", "reboot", "restart", "halt", "shutdown", "poweroff",
+    # config destruction
+    "erase", "format", "wipe", "zeroize", "factory-reset", "factory-default",
+    # filesystem destruction
+    "rm", "rmdir", "delete", "del", "purge", "destroy",
+    # shell escape — a shell is an unbounded bypass of every other rule here
+    "bash", "sh", "shell", "start-shell", "run", "system",
+})
+
+# Per-platform additions. Keys are inventory platform identifiers.
+#
+# Multi-word entries are matched against the normalised command prefix rather
+# than a single token, because several platforms express destruction as a path
+# (`/system reset-configuration`) or a verb pair (`request system zeroize`).
+PLATFORM_DENY: dict[str, frozenset[str]] = {
+    "cisco_ios": frozenset({"write erase", "format flash:", "erase startup-config"}),
+    "cisco_xe": frozenset({"write erase", "format flash:", "erase startup-config"}),
+    "cisco_nxos": frozenset({"write erase", "load-config", "erase startup-config"}),
+    "cisco_xr": frozenset({"commit replace", "erase", "install remove"}),
+
+    "juniper_junos": frozenset({
+        "request system zeroize", "request system reboot",
+        "request system power-off", "load override",
+    }),
+
+    "vyos": frozenset({
+        # `delete` is a first-class config verb on VyOS, not just a file op
+        "delete", "reset", "generate", "load", "reboot", "poweroff",
+    }),
+
+    "mikrotik_routeros": frozenset({
+        "/system reset-configuration", "/system reboot", "/system shutdown",
+        "/file remove", "/system package downgrade",
+    }),
+
+    "nokia_srlinux": frozenset({
+        "tools system configuration", "tools platform", "/tools system",
+    }),
+    "nokia_sros": frozenset({"admin reboot", "admin save", "clear"}),
+
+    "dell_sonic": frozenset({"config erase", "config reload", "sonic-clear"}),
+    "dell_os10": frozenset({"delete startup-configuration", "reload", "image delete"}),
+
+    "extreme_exos": frozenset({"unconfigure switch", "reboot", "rm"}),
+    "extreme_vsp": frozenset({"reset", "boot", "remove"}),
+
+    "huawei_vrp": frozenset({"reset saved-configuration", "reboot", "delete"}),
+
+    "ubiquiti_edge": frozenset({"delete", "reboot", "poweroff", "format"}),
+
+    "arista_eos": frozenset({"write erase", "delete flash:", "reload"}),
+
+    "linux": frozenset({"rm", "dd", "mkfs", "shutdown", "reboot", "init"}),
+}
+
+# Read-only verbs. A command must begin with one of these when the server is in
+# its default read-only mode (FR-022). Kept small on purpose — an over-broad
+# allowlist is how read-only modes quietly stop being read-only.
+READ_ONLY_PREFIXES: frozenset[str] = frozenset({
+    "show", "display", "get", "fetch", "list", "dir", "more", "cat",
+    "ping", "traceroute", "trace", "monitor", "check", "validate",
+    "info", "print", "status", "version", "who", "uptime",
+})
+
+
+def deny_tokens_for(platform: str | None) -> frozenset[str]:
+    """Effective denylist for a platform: universal plus platform-specific.
+
+    An unknown or missing platform still receives UNIVERSAL_DENY. Returning an
+    empty set for an unrecognised platform would mean the long tail of supported
+    devices — the ones this server exists for — got no protection at all.
+    """
+    specific = PLATFORM_DENY.get(platform or "", frozenset())
+    return UNIVERSAL_DENY | specific
+
+
+def is_modelled(platform: str | None) -> bool:
+    """Whether this platform has explicit destructive-syntax modelling.
+
+    Surfaced so callers can tell an operator that a device is protected only by
+    the universal baseline — useful information, not a reason to refuse.
+    """
+    return bool(platform) and platform in PLATFORM_DENY

--- a/mcp-servers/multivendor-cli-mcp/requirements.txt
+++ b/mcp-servers/multivendor-cli-mcp/requirements.txt
@@ -1,0 +1,52 @@
+# Multivendor CLI Driver — spec 076 (roadmap R1)
+#
+# INSTALL INTO A DEDICATED VIRTUALENV ONLY. Never into the shared environment.
+#
+# Why (spec 076 FR-030a, research R7/T005): this tree resolves cryptography 49.0.0,
+# while the system interpreter carries 46.0.5 — and NetClaw's NCFED federation stack
+# (spec 060) uses the system cryptography for X.509 issuance. Installing these
+# packages shared would move cryptography three major versions and break certificate
+# handling rather than anything in this server.
+#
+# Also: on hosts where `pip3` and `python3` are different interpreters (observed —
+# pip3 -> stranded Python 3.13 site-packages, python3 -> 3.14.4), a bare `pip3
+# install` lands where the server cannot import from. Always use the venv's own pip:
+#
+#   virtualenv -p /usr/bin/python3 .venv        # ensurepip is unavailable for 3.14
+#   .venv/bin/python -m pip install -r requirements.txt
+#
+# Verified to resolve on Python 3.14.4 (68 packages total).
+
+# --- MCP framework (Constitution Principle V: FastMCP or the official SDK) ---
+# Matches the convention in suzieq-mcp / gnmi-mcp, which import
+# `from mcp.server.fastmcp import ...`. Brings pydantic, which FR-030's input
+# validation relies on.
+#
+# UPPER BOUND IS LOAD-BEARING. mcp 2.0.0 removed `mcp.server.fastmcp` (FastMCP
+# moved out to the separate `fastmcp` distribution), so an unbounded `mcp>=1.2.0`
+# resolves 2.x and breaks the import used by ten other NetClaw servers. Ten of
+# them declare an unbounded `mcp>=1.0.0` and would hit this on a fresh install
+# today — flagged in spec 076 research as a repo-wide latent breakage.
+mcp>=1.2.0,<2
+
+# --- Orchestration: inventory, concurrency, task composition ---
+nornir==3.5.0
+nornir-utils==0.2.0
+
+# --- Normalization: vendor-neutral getters, identical shape across platforms ---
+napalm==5.2.0
+nornir-napalm==0.5.0
+
+# --- Transport: raw CLI reach across ~100 platform families (FR-001) ---
+# Retained alongside scrapli deliberately. NAPALM 5.x is scrapli-based, so the
+# scrapli family arrives transitively and is EXPECTED, not accidental (research R8).
+# Netmiko is what delivers the broad platform reach this feature exists for.
+netmiko==4.7.0
+nornir-netmiko==1.0.1
+
+# --- Live inventory from NetClaw's sources of truth (FR-017 live tier) ---
+nornir-netbox==0.3.0
+nornir-nautobot==4.3.0
+
+# --- Structured state diffing for post-change verification (FR-026, research R9) ---
+jdiff==1.0.1

--- a/mcp-servers/multivendor-cli-mcp/routing.py
+++ b/mcp-servers/multivendor-cli-mcp/routing.py
@@ -1,0 +1,123 @@
+"""Platform-first routing: which server should answer for a given device.
+
+Spec 076 FR-009 through FR-012. Ratified in spec.md "The layering decision".
+
+The rule, and the one exception that makes it non-trivial:
+
+    Cisco IOS/XE/NXOS/XR ......... pyats       (owns it)
+    Juniper Junos ................ junos-mcp   (owns it)
+    Everything else .............. this server (owns it)
+
+    EXCEPTION: cross-vendor NORMALIZED READS are permitted here even on
+    platforms another server owns — because NAPALM returns one shape across
+    vendors and no other server can answer "compare BGP neighbours across
+    Cisco AND Arista AND Nokia" at all.
+
+Why the exception needs writing down: NAPALM also supports IOS and Junos. So
+"use the dedicated server for Cisco" is an incomplete rule — it leaves
+cross-vendor questions unassigned, and two servers answering the same question
+in different shapes is worse than a gap.
+
+**Writes stay single-pathed.** Reads may overlap; writes may not. That asymmetry
+is not tidiness — Principle I requires device state be verified rather than
+assumed, and Principle VIII requires post-change verification. Both become
+unenforceable the moment "verified by which tool?" has two answers for one
+platform. So this module refuses writes it is technically capable of performing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+SERVER_ID = "multivendor-cli"
+
+# Platforms owned by a dedicated server, and which one. Reads are permitted here
+# for these (normalized only); writes are not.
+OWNED_ELSEWHERE: dict[str, str] = {
+    "cisco_ios": "pyats",
+    "cisco_xe": "pyats",
+    "cisco_iosxe": "pyats",
+    "cisco_nxos": "pyats",
+    "cisco_xr": "pyats",
+    "cisco_iosxr": "pyats",
+    "juniper_junos": "junos-mcp",
+    "juniper": "junos-mcp",
+}
+
+# Why each owning server is richer for its own platform — surfaced in refusals so
+# the message teaches rather than merely blocks.
+OWNER_RATIONALE: dict[str, str] = {
+    "pyats": "pyATS/Genie has ~2000 parsers and state snapshot/diff for Cisco platforms",
+    "junos-mcp": "junos-mcp uses PyEZ/NETCONF natively for Junos",
+}
+
+
+class Operation(str, Enum):
+    NORMALIZED_READ = "normalized_read"   # NAPALM getter — allowed everywhere
+    RAW_READ = "raw_read"                 # raw CLI — only for unowned platforms
+    WRITE = "write"                       # config change — only for unowned platforms
+
+
+@dataclass(frozen=True)
+class Decision:
+    permitted: bool
+    owning_server: str          # who owns this platform
+    reason: str | None = None   # populated when refused
+
+    @property
+    def refused(self) -> bool:
+        return not self.permitted
+
+
+def owner_of(platform: str | None) -> str:
+    """Which server owns this platform. This server owns anything unclaimed."""
+    return OWNED_ELSEWHERE.get((platform or "").lower(), SERVER_ID)
+
+
+def route(platform: str | None, operation: Operation) -> Decision:
+    """Decide whether this server may perform `operation` on `platform`."""
+    owner = owner_of(platform)
+
+    if owner == SERVER_ID:
+        return Decision(True, SERVER_ID)
+
+    # Platform belongs to a dedicated server.
+    if operation is Operation.NORMALIZED_READ:
+        # The deliberate exception (FR-008): cross-vendor normalized reads are
+        # this server's unique capability, so they are permitted read-only even
+        # on someone else's platform.
+        return Decision(True, owner)
+
+    rationale = OWNER_RATIONALE.get(owner, "")
+    if operation is Operation.WRITE:
+        reason = (
+            f"platform {platform!r} is owned by the {owner!r} server; this server is "
+            f"read-only for it so that every platform has exactly one write path"
+            + (f" ({rationale})" if rationale else "")
+        )
+    else:
+        reason = (
+            f"platform {platform!r} is owned by the {owner!r} server; use it for "
+            f"single-device work"
+            + (f" ({rationale})" if rationale else "")
+            + ". This server answers cross-vendor normalized reads for this platform."
+        )
+    return Decision(False, owner, reason)
+
+
+def refusal_payload(device: str, platform: str | None, decision: Decision) -> dict:
+    """Refusal shaped per contracts/mcp-tools.md.
+
+    A refusal is a SUCCESSFUL call carrying a refusal result — never a protocol
+    error — so the agent can read why and route elsewhere instead of retrying
+    blindly (FR-045 / contract "Refusal semantics").
+    """
+    return {
+        "device": device,
+        "platform": platform,
+        "server": SERVER_ID,
+        "status": "refused",
+        "refused_reason": decision.reason,
+        "owning_server": decision.owning_server,
+    }

--- a/mcp-servers/multivendor-cli-mcp/server.py
+++ b/mcp-servers/multivendor-cli-mcp/server.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Multivendor CLI Driver — MCP server entry point.
+
+Spec 076 (roadmap R1). Contract:
+specs/076-multivendor-cli-driver/contracts/mcp-tools.md
+
+Gives NetClaw a general "connect to this device and ask it something" capability.
+Before this server, all four device-facing servers were platform-bound — pyATS
+(Cisco), junos-mcp (Juniper), gnmi-mcp (telemetry only), radkit-mcp
+(cloud-relayed) — leaving ~90 platform families unreachable: MikroTik, VyOS,
+SONiC, Nokia SR Linux, Extreme, Huawei, Dell, Ubiquiti EdgeOS.
+
+ROUTING — this server is NOT a replacement for pyATS or junos-mcp:
+
+  Cisco IOS/XE/NXOS/XR ......... pyATS       (far richer, ~2000 Genie parsers)
+  Juniper Junos ................ junos-mcp   (PyEZ/NETCONF)
+  Streaming telemetry .......... gnmi-mcp
+  No direct reachability ....... radkit-mcp
+  Everything else .............. THIS SERVER
+  Cross-vendor normalized reads. THIS SERVER (read-only, even on the above)
+
+Writes stay single-pathed per platform: this server REFUSES configuration change
+on platforms owned by another server (FR-010). That is what keeps Principles I
+and VIII enforceable — "verified by which tool?" must have one answer.
+
+MUST run from this server's dedicated virtualenv. `napalm`/`netmiko` resolve
+cryptography 49.x while the system interpreter carries 46.x, which NetClaw's
+NCFED federation stack uses for X.509 issuance (spec 060). Running this outside
+its venv risks the certificate stack, not this server (FR-030a, research R7).
+
+STATUS: stub. Created early per analyze finding O1 — the tool implementations
+land in later phases, but without an entry point none of them would be reachable
+over MCP, so no story phase would be independently testable as an MCP capability.
+Tools are registered here as they are implemented.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from mcp.server.fastmcp import FastMCP  # noqa: E402
+
+from policy.filter import Mode, evaluate  # noqa: E402
+from policy.platform_deny import (  # noqa: E402
+    PLATFORM_DENY,
+    READ_ONLY_PREFIXES,
+    is_modelled,
+)
+
+SERVER_NAME = "multivendor-cli"          # the `server` field in every result (FR-011)
+SERVER_VERSION = "0.1.0"
+
+mcp = FastMCP("multivendor-cli-mcp")
+
+
+def write_enabled() -> bool:
+    """Whether write tools are exposed at all (FR-022).
+
+    Default is read-only. Write tools are ABSENT from tools/list rather than
+    present-and-refusing, so an agent cannot even attempt a change unless an
+    operator has deliberately opted in.
+    """
+    return os.environ.get("MULTIVENDOR_WRITE_ENABLED", "").lower() in ("1", "true", "yes")
+
+
+def current_mode() -> Mode:
+    return Mode.WRITE_ENABLED if write_enabled() else Mode.READ_ONLY
+
+
+@mcp.tool()
+def server_info() -> dict:
+    """Report this server's identity, mode, and platform-policy coverage.
+
+    Deliberately the first tool implemented: it lets an operator confirm the
+    safety posture (read-only vs write-enabled) and see which platforms have
+    explicit destructive-syntax modelling, before trusting it with a device.
+    """
+    return {
+        "server": SERVER_NAME,
+        "version": SERVER_VERSION,
+        "mode": current_mode().value,
+        "write_enabled": write_enabled(),
+        "modelled_platforms": sorted(PLATFORM_DENY),
+        "read_only_prefixes": sorted(READ_ONLY_PREFIXES),
+        "routing": {
+            "owned_elsewhere": {
+                "cisco_ios": "pyats", "cisco_xe": "pyats",
+                "cisco_nxos": "pyats", "cisco_xr": "pyats",
+                "juniper_junos": "junos-mcp",
+            },
+            "note": (
+                "Reads may overlap with the owning server; writes may not. "
+                "Cross-vendor normalized reads are permitted everywhere, read-only."
+            ),
+        },
+        "status": "stub — tool surface lands in spec 076 Phases 3-6",
+    }
+
+
+@mcp.tool()
+def check_command_policy(command: str, platform: str | None = None) -> dict:
+    """Evaluate a command against policy WITHOUT contacting any device.
+
+    Lets an operator (or the agent) find out whether a command would be permitted
+    before anything is attempted, and see which rule would reject it. Enforcement
+    itself is server-side and unavoidable (FR-029); this only makes it inspectable.
+    """
+    verdict = evaluate(command, platform, current_mode())
+    return {
+        "server": SERVER_NAME,
+        "command": command,
+        "platform": platform,
+        "mode": current_mode().value,
+        "allowed": verdict.allowed,
+        "rule": verdict.rule.value if verdict.rule else None,
+        "denied_reason": verdict.denied_reason,
+        "platform_modelled": is_modelled(platform),
+        "note": (
+            None if is_modelled(platform)
+            else "platform has no explicit destructive-syntax model; "
+                 "universal denylist still applies"
+        ),
+    }
+
+
+def main() -> None:
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp-servers/multivendor-cli-mcp/server.py
+++ b/mcp-servers/multivendor-cli-mcp/server.py
@@ -44,6 +44,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from mcp.server.fastmcp import FastMCP  # noqa: E402
 
+import routing  # noqa: E402
+from credentials import CredentialError, resolve as resolve_credential  # noqa: E402
+from inventory import sources as inv  # noqa: E402
 from policy.filter import Mode, evaluate  # noqa: E402
 from policy.platform_deny import (  # noqa: E402
     PLATFORM_DENY,
@@ -124,6 +127,77 @@ def check_command_policy(command: str, platform: str | None = None) -> dict:
             else "platform has no explicit destructive-syntax model; "
                  "universal denylist still applies"
         ),
+    }
+
+
+@mcp.tool()
+def list_devices(group: str | None = None, platform: str | None = None) -> dict:
+    """List devices from the configured inventory, with source attribution.
+
+    Reports which of the three inventory sources answered, and why it was not the
+    preferred one when it was not (FR-017c) — so a stale cache is never mistaken
+    for live data. Never returns credential values.
+    """
+    try:
+        res = inv.resolve()
+    except inv.InventoryError as exc:
+        return {"server": SERVER_NAME, "status": "error", "error": str(exc)}
+
+    devices = res.devices
+    if group:
+        devices = [d for d in devices if group in d.groups]
+    if platform:
+        devices = [d for d in devices if d.platform == platform]
+
+    return {
+        "server": SERVER_NAME,
+        "source_used": res.source.value,
+        "fallback_reason": res.fallback_reason,
+        "count": len(devices),
+        "devices": [d.public() for d in devices],
+    }
+
+
+@mcp.tool()
+def check_device_readiness(device: str) -> dict:
+    """Check whether a device could be acted on, WITHOUT contacting it.
+
+    Resolves the device from inventory, resolves its credential reference, and
+    applies the routing rule — reporting which server owns the platform and
+    whether this one may read or write it. Deliberately contacts nothing: it
+    answers "is this wired up correctly" before any session is opened.
+    """
+    try:
+        res = inv.resolve()
+        dev = inv.find(res.devices, device)
+    except inv.InventoryError as exc:
+        return {"server": SERVER_NAME, "device": device, "status": "not_found",
+                "error": str(exc)}
+
+    cred_posture, cred_error = None, None
+    try:
+        cred_posture = resolve_credential(dev.credential_ref).posture()
+    except CredentialError as exc:
+        cred_error = str(exc)
+
+    read = routing.route(dev.platform, routing.Operation.NORMALIZED_READ)
+    raw = routing.route(dev.platform, routing.Operation.RAW_READ)
+    write = routing.route(dev.platform, routing.Operation.WRITE)
+
+    return {
+        "server": SERVER_NAME,
+        "device": dev.public(),
+        "source_used": res.source.value,
+        "credentials": cred_posture,
+        "credential_error": cred_error,
+        "routing": {
+            "owning_server": read.owning_server,
+            "normalized_read_permitted": read.permitted,
+            "raw_read_permitted": raw.permitted,
+            "write_permitted": write.permitted,
+            "write_refused_reason": write.reason,
+        },
+        "ready": cred_error is None,
     }
 
 

--- a/scripts/lib/catalog.sh
+++ b/scripts/lib/catalog.sh
@@ -13,6 +13,7 @@ CATALOG=(
     "aruba-cx|Device Automation|Aruba CX|Switch management — 16 tools (11 read, 5 write)"
     "gnmi|Device Automation|gNMI Telemetry|Streaming telemetry — Get/Set/Subscribe, YANG (bundled)"
     "radkit|Device Automation|Cisco RADKit|Cloud-relayed remote CLI, SNMP, inventory (5 tools)"
+    "multivendor-cli|Device Automation|Multivendor CLI Driver|Nornir/NAPALM/Netmiko — ~90 platform families Cisco/Juniper servers cannot reach (read-only)"
 
     "netbox|Source of Truth|NetBox|DCIM/IPAM source of truth (read-write)"
     "nautobot|Source of Truth|Nautobot|IPAM — IPs, prefixes, VRF/tenant/site (5 tools)"

--- a/scripts/lib/install-steps.sh
+++ b/scripts/lib/install-steps.sh
@@ -3729,3 +3729,59 @@ log_info "Domain-verified identity (optional): scripts/patch-claw-certs.sh --dom
 log_info "Existing claws upgrade in one command: scripts/patch-claw-certs.sh"
 echo ""
 }
+
+component_install_multivendor_cli() {
+log_step "Installing Multivendor CLI Driver (Nornir/NAPALM/Netmiko)..."
+echo "  Reaches ~90 platform families no other NetClaw server can: MikroTik, VyOS,"
+echo "  SONiC, Nokia SR Linux, Extreme, Huawei, Dell, Ubiquiti EdgeOS."
+echo "  Read-only by default. Cisco/Juniper stay with pyATS/junos-mcp."
+
+MV_DIR="$NETCLAW_DIR/mcp-servers/multivendor-cli-mcp"
+MV_VENV="$MV_DIR/.venv"
+
+# DEDICATED virtualenv, not the shared environment (spec 076 FR-030a).
+# napalm/netmiko resolve cryptography 49.x while the system carries 46.x, which
+# NCFED uses for X.509 issuance (spec 060). Installing these shared would move
+# cryptography three major versions under the certificate stack.
+#
+# `virtualenv`, not `python3 -m venv`: Python 3.14 has no ensurepip on Ubuntu
+# unless python3.14-venv is installed, and that needs root (spec 076 research R12).
+if ! command -v virtualenv &> /dev/null; then
+    log_warn "virtualenv not found — required because Python 3.14 lacks ensurepip here."
+    log_warn "Install it with: python3 -m pip install --user virtualenv"
+    log_warn "Skipping Multivendor CLI Driver."
+    return 0
+fi
+
+CRYPTO_BEFORE=$(/usr/bin/python3 -c 'import importlib.metadata as m; print(m.version("cryptography"))' 2>/dev/null || echo "none")
+
+log_info "Creating dedicated virtualenv at $MV_VENV"
+virtualenv -q -p /usr/bin/python3 "$MV_VENV" || {
+    log_warn "virtualenv creation failed — skipping Multivendor CLI Driver."
+    return 0
+}
+
+# The venv's OWN pip. Never bare pip3: on some hosts pip3 targets a different
+# interpreter's site-packages than python3 (spec 076 research R7).
+log_info "Installing dependencies (~21 packages) into the virtualenv..."
+"$MV_VENV/bin/python" -m pip install -q -r "$MV_DIR/requirements.txt" || {
+    log_warn "dependency install failed — skipping Multivendor CLI Driver."
+    return 0
+}
+
+# FR-030c: the system cryptography must be untouched, or NCFED certificate
+# handling breaks rather than this server.
+CRYPTO_AFTER=$(/usr/bin/python3 -c 'import importlib.metadata as m; print(m.version("cryptography"))' 2>/dev/null || echo "none")
+if [ "$CRYPTO_BEFORE" != "$CRYPTO_AFTER" ]; then
+    log_warn "System cryptography changed ($CRYPTO_BEFORE -> $CRYPTO_AFTER)!"
+    log_warn "NCFED X.509 issuance depends on it. Investigate before using the federation."
+else
+    log_info "System cryptography unchanged ($CRYPTO_AFTER) — NCFED stack safe"
+fi
+
+if "$MV_VENV/bin/python" -c "import nornir, napalm, netmiko, jdiff" 2>/dev/null; then
+    log_info "Multivendor CLI Driver ready (read-only; set MULTIVENDOR_WRITE_ENABLED=true to allow writes)"
+else
+    log_warn "Multivendor CLI Driver installed but imports failed — check $MV_VENV"
+fi
+}

--- a/scripts/verify-catalog-coverage.py
+++ b/scripts/verify-catalog-coverage.py
@@ -124,12 +124,6 @@ VENDORED_STATE_REASONS = {
     "checkpoint-mcp-servers": "single source backing all fifteen registered chkp-* entries",
     "clab-mcp-server": "external — EXTERNAL_INTEGRATIONS 'ContainerLab', catalog id 'containerlab' (dir name abbreviates it)",
     "mcp-cvp-fun": "backs the registered 'arista-cvp-mcp' entry (EXTERNAL_INTEGRATIONS 'Arista CVP')",
-    # IN DEVELOPMENT under spec 076 (roadmap R1). Registration, catalog entry and
-    # install function land in that spec's Phase 7 (T057-T059); until then the
-    # directory legitimately exists with no config entry. Temporary and dated --
-    # NOT a suppression -- and spec 076 T067 removes this line by registering the
-    # server properly.
-    "multivendor-cli-mcp": "in development, spec 076 Phase 7 registers it (T057-T059)",
     # OPEN FINDING, spec 075 -- recorded here so it is tracked, NOT suppressed.
     # EVE-NG is vendored and has five skills (eve-lab-topology-*, eve-ng-*), but
     # it appears in neither EXTERNAL_INTEGRATIONS nor scripts/lib/catalog.sh.

--- a/scripts/verify-catalog-coverage.py
+++ b/scripts/verify-catalog-coverage.py
@@ -124,6 +124,12 @@ VENDORED_STATE_REASONS = {
     "checkpoint-mcp-servers": "single source backing all fifteen registered chkp-* entries",
     "clab-mcp-server": "external — EXTERNAL_INTEGRATIONS 'ContainerLab', catalog id 'containerlab' (dir name abbreviates it)",
     "mcp-cvp-fun": "backs the registered 'arista-cvp-mcp' entry (EXTERNAL_INTEGRATIONS 'Arista CVP')",
+    # IN DEVELOPMENT under spec 076 (roadmap R1). Registration, catalog entry and
+    # install function land in that spec's Phase 7 (T057-T059); until then the
+    # directory legitimately exists with no config entry. Temporary and dated --
+    # NOT a suppression -- and spec 076 T067 removes this line by registering the
+    # server properly.
+    "multivendor-cli-mcp": "in development, spec 076 Phase 7 registers it (T057-T059)",
     # OPEN FINDING, spec 075 -- recorded here so it is tracked, NOT suppressed.
     # EVE-NG is vendored and has five skills (eve-lab-topology-*, eve-ng-*), but
     # it appears in neither EXTERNAL_INTEGRATIONS nor scripts/lib/catalog.sh.

--- a/specs/076-multivendor-cli-driver/checklists/requirements.md
+++ b/specs/076-multivendor-cli-driver/checklists/requirements.md
@@ -1,0 +1,101 @@
+# Specification Quality Checklist: Generic Multivendor CLI Driver
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain — the one genuine ambiguity (which library layer owns
+      which job, and how this server relates to `pyATS`) was resolved with the maintainer before the
+      spec was written and is recorded as a ratified decision
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+**Status: PASS — ready for `/speckit.plan`.**
+
+## Validation Notes
+
+### The central ambiguity was resolved before writing, not deferred
+
+"Nornir vs NAPALM vs Netmiko vs pyATS" reads as a four-way tool choice. It is not — they are four
+distinct layers (transport / normalization / orchestration / parse-and-test), and Nornir *drives*
+Netmiko rather than competing with it. Writing the spec without settling this would have produced
+requirements that silently assumed one of two incompatible architectures.
+
+The genuine trade-off is NAPALM (normalized, ~10 platforms) versus Genie (rich, Cisco-deep, ~2000
+parsers). Two coherent answers existed:
+
+- **Platform-first** (chosen): dedicated servers own their platforms; this server covers everything
+  else, plus cross-vendor normalized reads as an explicit exception.
+- **NAPALM-first** (rejected): one uniform shape everywhere, `pyATS` reserved for deep Cisco work.
+  Conceptually cleaner but discards most of Genie's parser coverage on NetClaw's most common platform.
+
+Recorded in the spec so it is not re-litigated in planning.
+
+### The exception is the part that needed writing down
+
+NAPALM supports IOS and Junos too, so "use the dedicated server for Cisco" is not a complete rule —
+it leaves cross-vendor questions unassigned, and two servers answering the same question in different
+shapes is worse than a gap. FR-008 through FR-012 exist to close this precisely: normalized
+cross-vendor reads are allowed everywhere, **writes stay single-pathed per platform** (FR-010), and
+results say which server answered (FR-011).
+
+The write constraint is a Constitution requirement, not a preference: Principle I requires device
+state be verified rather than assumed, and Principle VIII requires post-change verification. Both
+become unenforceable if "verified by which tool?" has two answers for one platform.
+
+### Read-only first is deliberately reflected in the priorities
+
+US5 (configuration change) is P3 while three read capabilities are P1/P2. This is not
+under-prioritisation — it is the point. Read-only across ~90 platforms is the valuable, safe
+increment; writes are the only part that can cause an outage. The spec ships usefulness long before
+it ships risk, satisfying the Constitution's "read-only MCP servers are preferred" standard while
+still specifying gated writes properly rather than pretending they will never be wanted.
+
+### Evidence gathered before writing
+
+| Claim in spec | How verified |
+|---|---|
+| 4 platform-bound servers today | `config/openclaw.json` + skill inventory |
+| 18 pyATS skills, 1 Junos skill | `ls workspace/skills/` counts |
+| `napalm`/`netmiko`/`nornir`/`scrapli` all absent | `importlib.util.find_spec` on each |
+| No generic-driver catalog id exists | grep of `scripts/lib/catalog.sh` |
+| Lab platforms available for SC-001 | containerlab / GNS3 / EVE-NG already integrated |
+
+The dependency-absence finding matters for planning: this feature pulls a substantial transitive tree
+where R0 pulled nothing, so Principle XV (dependency isolation, no conflicts) needs real attention
+rather than a nod.
+
+### Scope boundary held
+
+FR-009 and FR-032 exist to stop this feature quietly becoming "rewrite device access." It adds reach
+for platforms with none and one cross-vendor read capability. It does not touch `pyATS` or
+`junos-mcp`, and their skills must still work unchanged.
+
+## Notes
+
+- Ready for `/speckit.plan`. Phase 0 research owns candidate selection (adopt one, adopt both, or
+  fork), the transitive-dependency assessment, and how per-device credentials map onto the existing
+  secret store.
+- Constitution Principle XVI satisfied: spec ratified before implementation.
+- This branch is stacked on unmerged R0. If R0 changes in review, rebase before planning proceeds far.

--- a/specs/076-multivendor-cli-driver/contracts/mcp-tools.md
+++ b/specs/076-multivendor-cli-driver/contracts/mcp-tools.md
@@ -1,0 +1,202 @@
+# Contract: MCP Tool Surface
+
+**Feature**: 076-multivendor-cli-driver | **Date**: 2026-07-30
+**Transport**: stdio (declared per Constitution Principle V)
+**Server id**: `multivendor-cli-mcp`
+
+The external interface is the MCP tool surface. This is its contract: tools, arguments, return shapes,
+and — most importantly — refusal and failure semantics.
+
+---
+
+## Design rules binding every tool
+
+1. **Read-only by default.** Write-capable tools are absent from `tools/list` unless write mode is
+   explicitly enabled (FR-022).
+2. **Every result names its provenance** — the inventory source for the device, and the server that
+   answered (FR-011, FR-017c).
+3. **Failures are typed, not stringly.** `unreachable`, `auth_failed`, `platform_mismatch`, `denied`,
+   `timeout` stay distinct (FR-005).
+4. **A refusal is a successful call with a refusal result**, not a protocol error. The agent must be
+   able to read *why* and route elsewhere (FR-010).
+5. **No secret in any return value**, ever — credential `ref` and `path` only (FR-019).
+6. **Never fabricate.** An unavailable getter, an unreachable device and a filtered command are all
+   reported explicitly; none is silently omitted (FR-004, FR-007, FR-014).
+
+---
+
+## `list_devices`
+
+Resolve the inventory and report what is reachable in principle.
+
+```
+list_devices(group?: string, platform?: string, source?: "live_sot"|"generated"|"operator")
+  -> { devices: [ { name, hostname, platform, groups, source, owning_server } ],
+       source_used: "live_sot"|"generated"|"operator",
+       fallback_reason?: string }
+```
+
+- `source_used` is required (FR-017c). When it is not `live_sot`, `fallback_reason` MUST explain why —
+  a stale-cache answer must never look like a live one.
+- `owning_server` tells the agent which server owns each device (FR-009).
+- Never returns `credential_ref` values. Presence of credentials is not reported as data.
+
+---
+
+## `get_facts`
+
+Normalized, cross-vendor operational facts (FR-006).
+
+```
+get_facts(device: string, getters: string[])
+  -> { device, source, server: "multivendor-cli",
+       facts: [ { getter, available, data?, gap_reason?, provenance } ] }
+```
+
+- `available: false` with a `gap_reason` where the platform's NAPALM driver lacks the getter (FR-007).
+- `provenance` is `napalm` or `ttp_template`. A `ttp_template` result MUST NOT be presented as
+  equivalent to a `napalm` one (R9).
+- **Permitted for Cisco and Junos devices**, read-only, because cross-vendor normalized comparison is
+  the one case where this server is correct for those platforms (FR-008).
+
+---
+
+## `run_command`
+
+Raw command execution for platforms with no normalized getter (FR-002).
+
+```
+run_command(device: string, command: string)
+  -> { device, source, server, command,
+       status: "ok"|"unreachable"|"auth_failed"|"platform_mismatch"|"denied"|"timeout",
+       output?: string, denied_reason?: string }
+```
+
+- Filtering is applied **server-side before connecting** (FR-029). A denied command MUST NOT open a
+  session.
+- `denied_reason` states which rule fired — chaining, denylisted token, or non-allowlisted verb in
+  read-only mode — so the operator can tell a policy refusal from a device error.
+- `timeout` after the configured per-device bound, default 30s (R11, FR-016).
+
+### Filter evaluation order (normative)
+
+```
+1. reject if the command contains any chaining character  ; && || > < ` $(
+2. reject if the first token is denylisted (universal or platform-specific)
+3. in read-only mode, reject unless the first token matches an allow prefix
+4. otherwise permit
+```
+
+Order is contractual. `show version; write erase` passes an allowlist check on its first token and is
+catastrophic, so chaining rejection MUST come first.
+
+---
+
+## `run_fleet`
+
+One query, many devices (FR-013).
+
+```
+run_fleet(target: string, command?: string, getters?: string[],
+          max_workers?: int = 10, timeout_s?: int = 30)
+  -> { target, requested: int, max_workers, timeout_s,
+       results: [ <run_command or get_facts result> ],
+       summary: { ok: int, unreachable: int, auth_failed: int, denied: int, timeout: int } }
+```
+
+- `len(results) == requested`, always. Every targeted device appears, including failures — a silently
+  absent device reads as success (FR-014).
+- One device's failure never aborts the others (FR-014).
+- Concurrency bounded by `max_workers` (FR-015).
+- Exactly one of `command` or `getters` must be supplied.
+
+---
+
+## `check_reachability`
+
+Diagnostic separation of the failure modes (FR-005).
+
+```
+check_reachability(device: string)
+  -> { device, source, tcp: bool, auth: bool,
+       platform_expected: string, platform_detected?: string,
+       status: "ok"|"unreachable"|"auth_failed"|"platform_mismatch" }
+```
+
+- `platform_detected` differing from `platform_expected` yields `platform_mismatch` — the source of
+  truth is wrong, and connecting with the wrong driver would produce confusing output rather than an
+  error (FR-005).
+
+---
+
+## `apply_config` *(absent unless write mode is enabled — FR-022)*
+
+```
+apply_config(device: string, config: string, expected_state?: object)
+  -> { device, status: "refused"|"awaiting_approval"|"verified"|"verification_failed"
+                       |"rolled_back"|"rollback_failed",
+       refused_reason?: string, owning_server?: string,
+       baseline_ref?: string, approval_ref?: string, diff?: object }
+```
+
+- **`refused`** when the platform is owned by another server, with `owning_server` naming it (FR-010).
+  This is the single most important refusal in the surface: it is what keeps one write path per platform,
+  and therefore what keeps Principles I and VIII enforceable.
+- A baseline is captured before anything is modified (FR-024) — `baseline_ref` present from
+  `awaiting_approval` onward.
+- No transition past `awaiting_approval` without an approval (FR-025).
+- `verified` / `verification_failed` come from a structured `jdiff` comparison of actual against
+  expected state, never from command exit status (FR-026, R9).
+- `verification_failed` triggers rollback; `rollback_failed` halts and alerts (FR-027).
+
+---
+
+## Refusal semantics — worked example
+
+A Cisco IOS-XE device, write requested:
+
+```json
+{ "device": "core-sw-01", "status": "refused",
+  "refused_reason": "platform iosxe is owned by the pyats server; this server is read-only for it",
+  "owning_server": "pyats" }
+```
+
+Read requested on the same device:
+
+```json
+{ "device": "core-sw-01", "source": "live_sot", "server": "multivendor-cli",
+  "facts": [ { "getter": "get_bgp_neighbors", "available": true, "provenance": "napalm", "data": {} } ] }
+```
+
+Same device, two different answers, both correct: reads may overlap between servers, writes may not.
+
+---
+
+## Environment contract
+
+| Variable | Purpose | Required |
+|---|---|---|
+| `MULTIVENDOR_INVENTORY_SOURCE` | `live_sot` \| `generated` \| `operator` \| `auto` (default `auto`) | No |
+| `MULTIVENDOR_INVENTORY_PATH` | Operator-authored inventory path | Only for `operator` |
+| `MULTIVENDOR_GENERATED_PATH` | Generated cache location | No |
+| `MULTIVENDOR_WRITE_ENABLED` | Enables write tools; default off | No (FR-022) |
+| `MULTIVENDOR_MAX_WORKERS` | Concurrency bound, default 10 | No |
+| `MULTIVENDOR_TIMEOUT_S` | Per-device timeout, default 30 | No |
+| `VAULT_ADDR` / `VAULT_NAMESPACE` | Preferred credential path | No (FR-018) |
+| `MULTIVENDOR_USERNAME` / `MULTIVENDOR_PASSWORD` | Environment fallback credentials | No (FR-018) |
+
+All documented in `.env.example` with descriptions and no values (Principle XIII). Vault is **not** a
+prerequisite — an operator with neither a source of truth nor Vault must be able to use the server
+(SC-007a).
+
+---
+
+## Install-time contract
+
+| Requirement | Rule |
+|---|---|
+| Dependency isolation | Dedicated virtualenv; never the shared environment (FR-030a) |
+| venv creation | `/usr/bin/python3 -m venv`, populated via `<venv>/bin/python -m pip` — **never bare `pip3`**, which on a split-toolchain host targets an environment the server cannot import from (R7) |
+| Registration | Interpreter path resolved at install time, never hardcoded (FR-030b) |
+| Post-install assertion | System `cryptography` version unchanged, checked against `/usr/bin/python3` (FR-030c) |
+| Gate | `scripts/reconcile-mcp.py` exits 0 with the server registered (SC-012) |

--- a/specs/076-multivendor-cli-driver/data-model.md
+++ b/specs/076-multivendor-cli-driver/data-model.md
@@ -1,0 +1,206 @@
+# Phase 1 Data Model: Generic Multivendor CLI Driver
+
+**Feature**: 076-multivendor-cli-driver | **Date**: 2026-07-30
+
+No database. These are the runtime entities, their validation rules, and the state transitions that
+matter. Field names are indicative; the constraints are the contract.
+
+---
+
+## Entity: Device
+
+The unit of connection.
+
+| Field | Type | Rules |
+|---|---|---|
+| `name` | string | Unique within a resolution. The operator-facing handle |
+| `hostname` | string | Address or resolvable name |
+| `platform` | PlatformId | Drives driver selection. Mismatch is detectable (FR-005) |
+| `credential_ref` | string | **A reference, never a secret** (FR-017d) |
+| `groups` | list[string] | Site / role / tag membership; targets for fleet queries |
+| `source` | InventorySource | Which of the three supplied this device (FR-017c) |
+| `owning_server` | string | Which MCP server owns this platform (FR-009–011) |
+
+**Validation**
+- `credential_ref` MUST NOT contain a password, key, or token. Rejecting a device whose inventory
+  record carries credential-shaped fields is required, not optional (FR-017d, Principle XIII).
+- `platform` absent → the device is unusable; report rather than guess a default driver.
+- `source` MUST always be populated, so a stale-cache answer is never mistaken for a live one.
+
+---
+
+## Entity: InventorySource
+
+Exactly three, with different authority and different write rules. **The distinction between the two
+file-based sources is the part that matters**: conflating them destroys operator work.
+
+| Source | Authority | Server may overwrite | Staleness |
+|---|---|---|---|
+| `live_sot` | Preferred | n/a | None — queried per call |
+| `generated` | Cache / offline fallback | **Yes** — by design | Since last refresh |
+| `operator` | Operator's own | **Never** | Operator's responsibility |
+
+**Rules**
+- Resolution order: `live_sot` → `generated` → `operator`, falling back on unreachability (FR-017b).
+- `generated` files MUST carry a machine-readable marker identifying them as generated, so a refresh
+  can never overwrite an `operator` file (FR-017b).
+- `generated` MUST be reproducible from its source. One that cannot be regenerated is a defect (FR-017a).
+- pyATS `testbed.yaml` is **not** a source (FR-017e).
+- No source may contain credential material (FR-017d).
+
+---
+
+## Entity: PlatformId
+
+The OS family determining driver, command syntax, and destructive-command vocabulary.
+
+| Field | Type | Notes |
+|---|---|---|
+| `family` | enum | e.g. `mikrotik_routeros`, `vyos`, `sonic`, `nokia_srlinux`, `extreme_exos`, `huawei_vrp`, `dell_os10`, `ubiquiti_edge` |
+| `netmiko_driver` | string | Raw-CLI transport driver |
+| `napalm_driver` | string \| null | Null where NAPALM has no driver — normalized facts unavailable |
+| `owning_server` | string | `pyats` \| `junos-mcp` \| `multivendor-cli` |
+| `deny_tokens` | list[string] | Destructive first tokens **for this platform** (R6) |
+
+**Why `deny_tokens` is per-platform**: the Constitution names `write erase`, `reload`, `format flash:` —
+all Cisco syntax. Equivalents differ: VyOS `delete`, MikroTik `/system reset-configuration`, SR Linux
+`tools system configuration`, SONiC `config erase`. A Cisco-shaped denylist is insufficient (FR-023).
+
+---
+
+## Entity: CommandPolicy
+
+Server-side enforcement (FR-029) — never advisory skill prose.
+
+| Field | Type | Notes |
+|---|---|---|
+| `allow_prefixes` | list[string] | `show`, `display`, `get`, … — read-only verbs |
+| `deny_tokens` | list[string] | Universal plus per-platform |
+| `chain_chars` | list[string] | `;`, `&&`, `\|\|`, `>`, `<`, backtick, `$(` |
+| `mode` | enum | `read_only` (default) \| `write_enabled` (FR-022) |
+
+**Evaluation order** — order is itself a requirement, because a permissive check running first would
+defeat the others:
+
+```
+1. reject if any chain_chars present        ← first: chaining defeats every later check
+2. reject if first token in deny_tokens (universal or platform)
+3. in read_only mode, reject unless first token matches allow_prefixes
+4. otherwise permit
+```
+
+**Rule**: chaining rejection MUST precede allowlist evaluation. `show version; write erase` passes an
+allowlist check on its first token and is catastrophic.
+
+---
+
+## Entity: NormalizedFact
+
+A datum whose shape is identical across platforms — the unit of cross-vendor comparison.
+
+| Field | Type | Notes |
+|---|---|---|
+| `getter` | string | NAPALM getter name |
+| `available` | bool | False where the platform's driver lacks it |
+| `data` | object \| null | Null when unavailable |
+| `gap_reason` | string \| null | Why unavailable, when it is (FR-007) |
+| `provenance` | enum | `napalm` \| `ttp_template` |
+
+**Rules**
+- Unavailability MUST be reported explicitly, never silently omitted from results (FR-007).
+- `provenance = ttp_template` MUST NOT be presented as equivalent to `napalm`. Emulating a missing
+  getter by scraping CLI output and labelling it normalized is the exact failure FR-007 prevents (R9).
+
+---
+
+## Entity: RawCommandResult
+
+| Field | Type |
+|---|---|
+| `device` | string |
+| `command` | string |
+| `output` | string \| null |
+| `status` | enum: `ok` \| `unreachable` \| `auth_failed` \| `platform_mismatch` \| `denied` \| `timeout` |
+| `denied_reason` | string \| null |
+
+**Rule**: the five failure statuses MUST remain distinct (FR-005). "Unreachable" and "auth failed"
+have entirely different remediations, and collapsing them wastes an operator's time.
+
+---
+
+## Entity: FleetQuery / FleetResult
+
+| Field | Type | Notes |
+|---|---|---|
+| `target` | string | Group, tag, or explicit device list |
+| `max_workers` | int | Default 10, operator-overridable (R11) |
+| `timeout_s` | int | Default 30 per device (R11) |
+| `results` | list[RawCommandResult \| NormalizedFact] | One per device |
+
+**Rules**
+- One device's failure MUST NOT abort the others (FR-014).
+- Every targeted device MUST appear in `results`, including failures — a silently missing device reads
+  as "fine" (FR-014).
+- Devices contacted concurrently, bounded by `max_workers` (FR-015).
+
+---
+
+## Entity: ChangeTransaction (US5, P3)
+
+| Field | Type | Notes |
+|---|---|---|
+| `device` | string | |
+| `baseline` | string | Captured **before** any modification (FR-024) |
+| `baseline_path` | path | Inside the sandbox root only |
+| `approval` | ApprovalRef | Required; absent means no application (FR-025) |
+| `expected_state` | object | For post-change comparison |
+| `actual_state` | object | Read back after application |
+| `verification` | enum | `pass` \| `fail` — via `jdiff` structured diff (FR-026, R9) |
+| `rollback` | enum \| null | `not_needed` \| `succeeded` \| `failed` (FR-027) |
+
+**State transitions** — each arrow is a gate, not a step:
+
+```
+requested
+   → refused                      if platform is owned by another server (FR-010)
+   → baseline_captured            (FR-024, Principle II)
+   → awaiting_approval            (FR-025, Principle I)
+   → applied                      only after approval
+   → verified | verification_failed   via jdiff (FR-026, Principle VIII)
+   → rolled_back | rollback_failed    on verification failure (FR-027)
+```
+
+**Rules**
+- No transition to `applied` without both `baseline_captured` and an approval (FR-024, FR-025).
+- Verification MUST compare state, not command exit status (FR-026, Principle VIII).
+- `rollback_failed` MUST halt and alert rather than continue (Principle VIII).
+- Every transition GAIT-logged (FR-028, Principle IV).
+- Cisco/Junos devices terminate at `refused` (FR-010).
+
+---
+
+## Entity: CredentialResolution
+
+| Field | Type | Notes |
+|---|---|---|
+| `ref` | string | From the Device record |
+| `path` | enum | `vault` \| `environment` (FR-018) |
+| `resolved` | bool | |
+
+**Rules**
+- Vault preferred; environment is a documented fallback. Vault MUST NOT be a hard prerequisite (FR-018).
+- `path` MUST be reported so a deployment's posture is inspectable (FR-018a).
+- A credential MUST NEVER be read from an inventory file, whichever source (FR-019).
+- The secret value MUST NOT appear in any result, log, or audit record — only `ref` and `path`.
+
+---
+
+## Cross-cutting invariants
+
+1. **No secret on disk** outside a gitignored `.env` (FR-019, Principle XIII).
+2. **Attribution everywhere** — every device answer names its inventory source, and every result names
+   the server that produced it (FR-017c, FR-011).
+3. **One write path per platform** (FR-010). Reads may overlap; writes may not.
+4. **Explicit gaps over silent omission** — an unavailable getter, an unreachable device and a denied
+   command are all reported, never dropped (FR-004, FR-007, FR-014).
+5. **Filtering is server-side** (FR-029). Skill documentation describes policy; it never enforces it.

--- a/specs/076-multivendor-cli-driver/plan.md
+++ b/specs/076-multivendor-cli-driver/plan.md
@@ -1,0 +1,104 @@
+# Implementation Plan: [FEATURE]
+
+**Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
+**Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+[Extract from feature spec: primary requirement + technical approach from research]
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]  
+**Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]  
+**Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]  
+**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]  
+**Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
+**Project Type**: [e.g., library/cli/web-service/mobile-app/compiler/desktop-app or NEEDS CLARIFICATION]  
+**Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]  
+**Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]  
+**Scale/Scope**: [domain-specific, e.g., 10k users, 1M LOC, 50 screens or NEEDS CLARIFICATION]
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+[Gates determined based on constitution file]
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+# [REMOVE IF UNUSED] Option 1: Single project (DEFAULT)
+src/
+├── models/
+├── services/
+├── cli/
+└── lib/
+
+tests/
+├── contract/
+├── integration/
+└── unit/
+
+# [REMOVE IF UNUSED] Option 2: Web application (when "frontend" + "backend" detected)
+backend/
+├── src/
+│   ├── models/
+│   ├── services/
+│   └── api/
+└── tests/
+
+frontend/
+├── src/
+│   ├── components/
+│   ├── pages/
+│   └── services/
+└── tests/
+
+# [REMOVE IF UNUSED] Option 3: Mobile + API (when "iOS/Android" detected)
+api/
+└── [same as backend above]
+
+ios/ or android/
+└── [platform-specific structure: feature modules, UI flows, platform tests]
+```
+
+**Structure Decision**: [Document the selected structure and reference the real
+directories captured above]
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/076-multivendor-cli-driver/plan.md
+++ b/specs/076-multivendor-cli-driver/plan.md
@@ -54,7 +54,7 @@ Default 10 concurrent workers and a 30s per-device timeout, both operator-overri
 (FR-019). Must not perturb the system `cryptography` used by the NCFED X.509 stack (FR-030c). Must not
 regress the 18 pyATS skills or the Junos skill (FR-032).
 
-**Scale/Scope**: ~90 platform families reachable, 3 inventory sources, 41 FRs, 15 SCs, 6 user stories.
+**Scale/Scope**: ~90 platform families reachable, 3 inventory sources, 41 FRs, 15 SCs, 5 user stories.
 
 ## Constitution Check
 

--- a/specs/076-multivendor-cli-driver/plan.md
+++ b/specs/076-multivendor-cli-driver/plan.md
@@ -54,7 +54,7 @@ Default 10 concurrent workers and a 30s per-device timeout, both operator-overri
 (FR-019). Must not perturb the system `cryptography` used by the NCFED X.509 stack (FR-030c). Must not
 regress the 18 pyATS skills or the Junos skill (FR-032).
 
-**Scale/Scope**: ~90 platform families reachable, 3 inventory sources, 41 FRs, 15 SCs, 5 user stories.
+**Scale/Scope**: ≥90 platform families driver-supported (≥5 live-verified), 3 inventory sources, 44 FRs, 17 SCs, 5 user stories.
 
 ## Constitution Check
 
@@ -64,7 +64,7 @@ regress the 18 pyATS skills or the Junos skill (FR-032).
 |---|---|---|
 | **I — Safety-First (NON-NEGOTIABLE)** | **Yes — central** | Read-only default (FR-022); server-side command filtering (FR-029); unreachable devices halt rather than return assumed state (FR-004); writes require approval (FR-025). This is the principle the entire safety design serves |
 | **II — Read-Before-Write** | **Yes** | FR-024 requires a captured baseline before any modification |
-| III — ITSM-Gated Changes | Partially | Production changes need a CR; lab mode exempt. Inherited from the existing approval path rather than reimplemented |
+| **III — ITSM-Gated Changes** | **Yes** | **Corrected after `/speckit.analyze`**, which found this had zero task coverage. It had been marked "Partially — inherited", but that was an assertion rather than an implementation: FR-025's human approval and a ServiceNow Change Request are distinct gates. Now FR-025a/b/c and T070a–T070d, via the existing `servicenow-mcp` and `servicenow-change-workflow`. Unclassified devices are treated as production |
 | **IV — Immutable Audit Trail** | **Yes** | FR-028: every device interaction GAIT-logged |
 | **V — MCP-Native** | **Yes** | Delivered as an MCP server with proper JSON-RPC lifecycle; stdio transport declared |
 | **VI — Multi-Vendor Neutrality** | **Yes — this feature *is* the principle** | Vendor-neutral where the operation is generic (NAPALM getters); vendor-specific logic stays in vendor servers. FR-009/FR-010 keep the boundary explicit |
@@ -80,8 +80,9 @@ regress the 18 pyATS skills or the Junos skill (FR-032).
 | XVI — Spec-Driven Development | Yes | Spec ratified, 4 clarifications resolved, this plan precedes implementation |
 | XVII — Milestone Documentation | Yes | Blog post at completion |
 
-**Gate result: PASS.** No violations requiring justification. Two tracked high-risk areas (Principles I
-and XV), both with stated mitigations reflected in the task ordering below.
+**Gate result: PASS** — after correction. `/speckit.analyze` found Principle III (a MUST) with zero task
+coverage, which would have been a CRITICAL violation at implementation time. Now covered. Two tracked
+high-risk areas remain (Principles I and XV), both with mitigations reflected in the task ordering.
 
 **Note on Principle VI**: this is the first feature where multi-vendor neutrality is the deliverable
 rather than a constraint. The routing rule (FR-009–FR-012) is what stops "neutral" degrading into

--- a/specs/076-multivendor-cli-driver/plan.md
+++ b/specs/076-multivendor-cli-driver/plan.md
@@ -1,104 +1,216 @@
-# Implementation Plan: [FEATURE]
+# Implementation Plan: Generic Multivendor CLI Driver
 
-**Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
-**Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
-
-**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+**Branch**: `076-multivendor-cli-driver` | **Date**: 2026-07-30 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/076-multivendor-cli-driver/spec.md`
+**Research**: [research.md](./research.md) — **read R7 first**; it invalidates an earlier conclusion
+**Stacked on**: R0 / spec 075 (unmerged). Inherits `docs/ADDING-AN-MCP.md` and `scripts/reconcile-mcp.py`
 
 ## Summary
 
-[Extract from feature spec: primary requirement + technical approach from research]
+Give NetClaw a general "connect to this device and ask it something" capability. Today all four
+device-facing servers are platform-bound (`pyATS` Cisco, `junos-mcp` Juniper, `gnmi-mcp` telemetry
+only, `radkit-mcp` cloud-relayed), so roughly ninety platforms — MikroTik, VyOS, SONiC, SR Linux,
+Extreme, Huawei, Dell, EdgeOS — are unreachable.
+
+Build a new MCP server on `nornir` + `napalm` + `netmiko`, deliberately porting the safety model from
+the archived `sydasif/nornir-mcp-server` (prefix allowlist, destructive-first-token denylist, chaining
+prevention, Pydantic validation, path sandboxing) while replacing its inventory and credential layers
+with NetClaw-native ones.
+
+**Read-only first.** US1–US4 (reach, normalization, fleet fan-out, inventory/credentials) are P1/P2;
+gated configuration change is P3, so the capability is useful long before it is dangerous.
 
 ## Technical Context
 
-<!--
-  ACTION REQUIRED: Replace the content in this section with the technical details
-  for the project. The structure here is presented in advisory capacity to guide
-  the iteration process.
--->
+**Language/Version**: Python — **interpreter choice is a live decision, not a default** (see R7).
+Target `/usr/bin/python3` (3.14.4) as the venv base, since that is what NetClaw's servers actually run
+under. `nornir-netmiko` declares `Requires-Python >=3.8,<4.0`, so 3.14 is nominally in range, but wheel
+availability on 3.14 must be confirmed at implementation rather than assumed.
 
-**Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]  
-**Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]  
-**Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]  
-**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]  
-**Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
-**Project Type**: [e.g., library/cli/web-service/mobile-app/compiler/desktop-app or NEEDS CLARIFICATION]  
-**Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]  
-**Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]  
-**Scale/Scope**: [domain-specific, e.g., 10k users, 1M LOC, 50 screens or NEEDS CLARIFICATION]
+**Primary Dependencies**: `nornir` 3.5.0, `napalm` 5.2.0, `netmiko` (>=4,<5 per `nornir-netmiko`),
+`nornir-netmiko` 1.0.1, `nornir_napalm` 0.5.0, `nornir-netbox` 0.3.0, `nornir-nautobot` 4.3.0,
+`pynautobot` 3.1.1, `jdiff` 1.0.2 (change verification, R9), plus the scrapli family pulled
+transitively by NAPALM 5.x (R8). ~21 packages. **All into a dedicated virtualenv** (FR-030a).
+
+**Storage**: No database. A generated inventory cache on disk (regenerable, credential-free); an
+operator-authored inventory file (never written by the server); change baselines under a path-sandboxed
+directory.
+
+**Testing**: Contract tests for command-filter and inventory-source logic, runnable with no device
+(pure functions over inputs). Integration tests against containerlab-hosted SR Linux / SONiC / VyOS
+(R4). Harness style follows spec 075's `tests/reconcile/run-tests.sh` — bash + stdlib, no new test
+framework in the shared environment.
+
+**Target Platform**: Linux. Must install on a host with the split toolchain described in R7 without
+silently landing packages where the server cannot import them.
+
+**Project Type**: New MCP server (`mcp-servers/`) + skills (`workspace/skills/`) + installer catalog
+entry. First NetClaw feature to require a dedicated venv by specification.
+
+**Performance Goals**: A fleet query of N devices materially faster than N sequential queries (SC-005).
+Default 10 concurrent workers and a 30s per-device timeout, both operator-overridable (R11).
+
+**Constraints**: Read-only by default (FR-022). No credential on disk outside a gitignored `.env`
+(FR-019). Must not perturb the system `cryptography` used by the NCFED X.509 stack (FR-030c). Must not
+regress the 18 pyATS skills or the Junos skill (FR-032).
+
+**Scale/Scope**: ~90 platform families reachable, 3 inventory sources, 41 FRs, 15 SCs, 6 user stories.
 
 ## Constitution Check
 
-*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
 
-[Gates determined based on constitution file]
+| Principle | Applies | Assessment |
+|---|---|---|
+| **I — Safety-First (NON-NEGOTIABLE)** | **Yes — central** | Read-only default (FR-022); server-side command filtering (FR-029); unreachable devices halt rather than return assumed state (FR-004); writes require approval (FR-025). This is the principle the entire safety design serves |
+| **II — Read-Before-Write** | **Yes** | FR-024 requires a captured baseline before any modification |
+| III — ITSM-Gated Changes | Partially | Production changes need a CR; lab mode exempt. Inherited from the existing approval path rather than reimplemented |
+| **IV — Immutable Audit Trail** | **Yes** | FR-028: every device interaction GAIT-logged |
+| **V — MCP-Native** | **Yes** | Delivered as an MCP server with proper JSON-RPC lifecycle; stdio transport declared |
+| **VI — Multi-Vendor Neutrality** | **Yes — this feature *is* the principle** | Vendor-neutral where the operation is generic (NAPALM getters); vendor-specific logic stays in vendor servers. FR-009/FR-010 keep the boundary explicit |
+| **VII — Skill Modularity** | Yes | Three focused skills (FR-031): normalized facts, safe raw command, fleet fan-out. Must not duplicate pyATS skills |
+| **VIII — Verify After Every Change** | **Yes** | FR-026 compares actual against expected state; `jdiff` adopted for this (R9) rather than hand-rolled |
+| **IX — Security by Default** | **Yes** | Least privilege; read-only preferred per MCP Server Standards; no elevated permissions requested |
+| X — Observability | Partially | Per-device results and per-source attribution (FR-017c, FR-018a). HUD node required by XI |
+| **XI — Artifact Coherence (NON-NEGOTIABLE)** | **Yes — every touchpoint** | Genuinely adds capability, so unlike R0 all artifacts apply: README, `catalog.sh`, `install-steps.sh`, HUD, `SOUL.md`, 3× `SKILL.md`, `.env.example`, `TOOLS.md`, `config/openclaw.json`, server README. Enforced by R0's gate |
+| XII — Documentation-as-Code | Yes | Server README (tools, env vars, transport, install) plus 3 SKILL.md, same PR |
+| **XIII — Credential Safety** | **Yes — clarified** | Vault preferred, env fallback, never in any inventory source (FR-018/019, FR-017d) |
+| XIV — Human-in-the-Loop | Yes | Writes gated (FR-025); no external communications otherwise |
+| **XV — Backwards Compatibility** | **Yes — highest risk** | 21 new packages. R7 found a split toolchain carrying two `cryptography` versions. Dedicated venv (FR-030a) is the mitigation; FR-030c asserts no perturbation |
+| XVI — Spec-Driven Development | Yes | Spec ratified, 4 clarifications resolved, this plan precedes implementation |
+| XVII — Milestone Documentation | Yes | Blog post at completion |
+
+**Gate result: PASS.** No violations requiring justification. Two tracked high-risk areas (Principles I
+and XV), both with stated mitigations reflected in the task ordering below.
+
+**Note on Principle VI**: this is the first feature where multi-vendor neutrality is the deliverable
+rather than a constraint. The routing rule (FR-009–FR-012) is what stops "neutral" degrading into
+"ambiguous".
 
 ## Project Structure
 
 ### Documentation (this feature)
 
 ```text
-specs/[###-feature]/
-├── plan.md              # This file (/speckit.plan command output)
-├── research.md          # Phase 0 output (/speckit.plan command)
-├── data-model.md        # Phase 1 output (/speckit.plan command)
-├── quickstart.md        # Phase 1 output (/speckit.plan command)
-├── contracts/           # Phase 1 output (/speckit.plan command)
-└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+specs/076-multivendor-cli-driver/
+├── spec.md              # Ratified, 4 clarifications resolved
+├── plan.md              # This file
+├── research.md          # Phase 0 — R7 is critical, read first
+├── data-model.md        # Phase 1
+├── quickstart.md        # Phase 1 — operator onboarding for all 3 inventory sources
+├── contracts/
+│   └── mcp-tools.md     # Phase 1 — tool surface and error semantics
+├── checklists/
+│   └── requirements.md  # Spec quality (PASS)
+└── tasks.md             # Phase 2 — /speckit.tasks
 ```
 
 ### Source Code (repository root)
-<!--
-  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
-  for this feature. Delete unused options and expand the chosen structure with
-  real paths (e.g., apps/admin, packages/something). The delivered plan must
-  not include Option labels.
--->
 
 ```text
-# [REMOVE IF UNUSED] Option 1: Single project (DEFAULT)
-src/
-├── models/
-├── services/
-├── cli/
-└── lib/
+mcp-servers/multivendor-cli-mcp/
+├── server.py                  # MCP entry point (FastMCP, stdio)
+├── inventory/
+│   ├── sources.py             # 3-source resolution + attribution (FR-017, FR-017c)
+│   ├── live_sot.py            # nornir-netbox / nornir-nautobot / Infrahub
+│   ├── generated.py           # render + refresh cache; never touches operator files
+│   └── operator.py            # read-only consumer of operator-authored YAML
+├── credentials.py             # Vault preferred, env fallback, path reported (FR-018/018a)
+├── policy/
+│   ├── filter.py              # allowlist / denylist / chaining prevention (FR-023, FR-029)
+│   └── platform_deny.py       # per-platform destructive syntax (R6)
+├── tools/
+│   ├── facts.py               # NAPALM getters + explicit gap reporting (FR-006/007)
+│   ├── raw.py                 # netmiko raw command execution (FR-002)
+│   ├── fleet.py               # concurrent fan-out, per-device results (FR-013–016)
+│   └── change.py              # baseline → approve → apply → verify → rollback (P3)
+├── routing.py                 # platform-first rule; refuses Cisco/Junos writes (FR-009–011)
+├── requirements.txt           # pinned
+└── README.md
 
-tests/
-├── contract/
-├── integration/
-└── unit/
+workspace/skills/
+├── multivendor-device-query/  # normalized facts + the routing rule (FR-012, FR-031)
+├── multivendor-raw-cli/       # safe raw command execution
+└── multivendor-fleet-ops/     # fan-out across a group
 
-# [REMOVE IF UNUSED] Option 2: Web application (when "frontend" + "backend" detected)
-backend/
-├── src/
-│   ├── models/
-│   ├── services/
-│   └── api/
-└── tests/
-
-frontend/
-├── src/
-│   ├── components/
-│   ├── pages/
-│   └── services/
-└── tests/
-
-# [REMOVE IF UNUSED] Option 3: Mobile + API (when "iOS/Android" detected)
-api/
-└── [same as backend above]
-
-ios/ or android/
-└── [platform-specific structure: feature modules, UI flows, platform tests]
+scripts/lib/catalog.sh         # + one entry (no generic-driver id exists today)
+scripts/lib/install-steps.sh   # + component_install_multivendor_cli() — creates the venv
+config/openclaw.json           # + registration, interpreter resolved at install (FR-030b)
+tests/multivendor/             # filter + inventory contract tests; containerlab integration
 ```
 
-**Structure Decision**: [Document the selected structure and reference the real
-directories captured above]
+**Structure Decision**: a new vendored server under `mcp-servers/`, matching every existing NetClaw
+server. Internal packages split along the axes the spec's requirement groups already imply — inventory,
+credentials, policy, tools, routing — so each requirement group maps to one module and the command
+filter is independently testable without a device.
+
+## Implementation ordering
+
+**Safety and isolation before reach; reach before writes.**
+
+```
+Stage 1  Dedicated venv + dependency install + cryptography assertion    (FR-030a/b/c, R7)
+Stage 2  Command filter + per-platform denylist, unit-tested no-device    (FR-022/023/029, R6)
+Stage 3  Inventory: 3 sources + attribution; credentials Vault/env        (FR-017*, FR-018*, FR-019)
+Stage 4  Raw command execution — first real device reach                  (US1: FR-001–005)
+Stage 5  NAPALM normalized facts + explicit gap reporting                 (US2: FR-006–008)
+Stage 6  Routing rule + refusals                                         (FR-009–012)
+Stage 7  Fleet fan-out, concurrency bound, timeouts                       (US3: FR-013–016)
+Stage 8  Registration, catalog, install fn, skills, XI artifacts          (FR-030–032)
+Stage 9  Gated change: baseline → approve → apply → jdiff verify → rollback (US5, P3)
+```
+
+**Stage 2 before Stage 4 is deliberate.** The filter must exist and be tested before anything can
+execute a command against a real device. Building reach first and adding safety later would create a
+window in which the server can run arbitrary commands — precisely what Principle I forbids.
+
+**Stage 1 first** because R7 showed the host toolchain is split; nothing else can be trusted until the
+venv is proven to contain what the server will actually import.
+
+**Stage 9 last** and independently deferrable — if it slips, Stages 1–8 still deliver ~90 platforms of
+read-only reach.
+
+## Key design decisions
+
+**Build, don't adopt** (R1). Candidate A is archived and reloads `config.yaml` per call; candidate B has
+no filtering at all. Port A's safety model under MIT; treat B's concurrency surface as design reference
+only.
+
+**Netmiko *and* scrapli, not either/or** (R8). NAPALM 5.x is scrapli-based, so scrapli arrives
+regardless. Netmiko stays for raw-CLI platform reach; scrapli serves NAPALM's getters. The earlier
+"reject scrapli" framing was wrong.
+
+**Dedicated venv, explicit interpreter** (R7). Create with `/usr/bin/python3 -m venv`, install with
+`<venv>/bin/python -m pip` — never bare `pip3`, which on this host targets a stranded 3.13 environment
+the server cannot import from.
+
+**`jdiff` for change verification** (R9), not hand-rolled comparison. FR-026 needs structured
+actual-versus-expected diffing, and `jdiff` arrives in the tree anyway.
+
+**TTP output is second-class.** Available for platforms lacking a NAPALM getter, but must be labelled
+template-parsed and never presented as a normalized fact — FR-007 requires reporting the gap, not
+papering over it.
+
+**Generated and operator-authored inventories are different artifacts.** Generated files are caches and
+are overwritten; operator files are never touched. Conflating them destroys operator work.
 
 ## Complexity Tracking
 
-> **Fill ONLY if Constitution Check has violations that must be justified**
+> No Constitution Check violations require justification.
 
-| Violation | Why Needed | Simpler Alternative Rejected Because |
-|-----------|------------|-------------------------------------|
-| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
-| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |
+| Item | Note |
+|---|---|
+| Dedicated venv (first spec to mandate one) | Required by Principle XV given R7's split toolchain and two `cryptography` versions. Precedent exists (`mcp-servers/mcp-nvd/.venv`, R10) |
+| Three inventory sources rather than one | Ratified clarification. Each serves a real operator configuration; collapsing to one excludes either no-SoT or air-gapped operators |
+| Both netmiko and scrapli present | Not a choice — NAPALM 5.x pulls scrapli (R8). Documented so it is not mistaken for redundancy |
+| Server refuses work it is technically capable of (FR-010) | Deliberate. A single write path per platform is what keeps Principles I and VIII enforceable |
+
+## Phase 2 preview
+
+`/speckit.tasks` will generate the dependency-ordered task list. Expected shape: Stage 1 blocks
+everything; Stage 2 blocks Stages 4, 5, 7 and 9; Stage 3 blocks Stage 4 onward; Stage 6 depends on 4
+and 5; Stage 8 can proceed in parallel from Stage 4 onward; Stage 9 depends on 2, 3, 4 and 8.
+
+Open item to resolve as a task rather than an assumption: **confirm wheel availability for the full tree
+on Python 3.14.4.** `nornir-netmiko` allows `<4.0`, but 3.14 is recent and a missing wheel would force
+the venv onto an older interpreter — changing FR-030a's base, though not the decision.

--- a/specs/076-multivendor-cli-driver/quickstart.md
+++ b/specs/076-multivendor-cli-driver/quickstart.md
@@ -1,0 +1,198 @@
+# Quickstart: Multivendor CLI Driver
+
+**Feature**: 076-multivendor-cli-driver | **Date**: 2026-07-30
+
+Onboarding for the server that reaches the ~90 platforms NetClaw's other device servers cannot.
+
+---
+
+## Which server should answer? Read this first
+
+This server is **not** a replacement for `pyATS` or `junos-mcp`. Platform-first routing:
+
+| Your device | Use |
+|---|---|
+| Cisco IOS / IOS-XE / NX-OS / IOS-XR | **`pyATS`** — far richer, ~2000 Genie parsers |
+| Juniper Junos | **`junos-mcp`** — PyEZ/NETCONF |
+| Streaming telemetry, any vendor | **`gnmi-mcp`** |
+| No direct reachability | **`radkit-mcp`** |
+| MikroTik, VyOS, SONiC, SR Linux, Extreme, Huawei, Dell, EdgeOS, … | **this server** |
+| "Compare BGP neighbours across Cisco *and* Arista *and* Nokia" | **this server** (read-only) |
+
+The last row is the exception worth understanding: NAPALM normalizes output across vendors, so this
+server is the right tool when a question *spans* vendors even if a dedicated server exists for some of
+them. It answers those **read-only**.
+
+**It will refuse configuration writes on Cisco and Juniper**, naming the correct server. That is
+deliberate — one write path per platform is what makes "verify the change" mean something.
+
+---
+
+## Step 1 — Install
+
+```bash
+./scripts/install.sh          # select "Multivendor CLI Driver"
+```
+
+The install creates a **dedicated virtualenv** for this server. That is not incidental: `napalm` and
+`netmiko` pull `cryptography`, which NetClaw's federation stack uses for X.509 certificate issuance. A
+version conflict would break certificate handling rather than this server, so the dependencies stay
+isolated.
+
+If you install manually, note that on some hosts `pip3` and `python3` are **different interpreters**
+pointing at different site-packages. Always use the venv's own pip:
+
+```bash
+/usr/bin/python3 -m venv mcp-servers/multivendor-cli-mcp/.venv
+mcp-servers/multivendor-cli-mcp/.venv/bin/python -m pip install -r \
+    mcp-servers/multivendor-cli-mcp/requirements.txt
+```
+
+Verify nothing shared moved:
+
+```bash
+/usr/bin/python3 -c "import importlib.metadata as m; print(m.version('cryptography'))"
+```
+
+Same version before and after, or stop and investigate.
+
+---
+
+## Step 2 — Choose an inventory source
+
+Three supported. Pick the one matching what you already run.
+
+### Option A — Live source of truth (preferred)
+
+You run NetBox, Nautobot, or Infrahub. Devices are read at call time, so inventory **cannot drift**.
+
+```bash
+MULTIVENDOR_INVENTORY_SOURCE=live_sot
+NETBOX_URL=https://netbox.example.com
+NETBOX_TOKEN=...            # in .env, never committed
+```
+
+### Option B — Generated from a source of truth
+
+You have a source of truth but need offline or air-gapped operation. An inventory file is rendered from
+it at install and on refresh.
+
+```bash
+MULTIVENDOR_INVENTORY_SOURCE=generated
+MULTIVENDOR_GENERATED_PATH=~/.openclaw/multivendor/inventory.generated.yaml
+```
+
+> **This file is a cache.** It carries a generated marker and **will be overwritten** on refresh. Do not
+> hand-edit it — your edits will be lost. If you want a file you control, use Option C.
+
+### Option C — Operator-authored
+
+No source of truth. You write and maintain the inventory yourself, the same way you maintain a pyATS
+`testbed.yaml`.
+
+```bash
+MULTIVENDOR_INVENTORY_SOURCE=operator
+MULTIVENDOR_INVENTORY_PATH=~/.openclaw/multivendor/inventory.yaml
+```
+
+```yaml
+# inventory.yaml — hostnames and platforms only. NO credentials.
+edge-mt-01:
+  hostname: 10.0.0.1
+  platform: mikrotik_routeros
+  groups: [edge, site-hq]
+  credential_ref: default        # a REFERENCE, resolved at runtime
+fw-vyos-01:
+  hostname: 10.0.0.2
+  platform: vyos
+  groups: [edge, site-hq]
+  credential_ref: default
+```
+
+**The server never writes to this file.** A generated-inventory refresh cannot touch it.
+
+`auto` (the default) tries live, then generated, then operator — and every result tells you which one
+answered, so a stale cache never masquerades as live.
+
+**Your pyATS `testbed.yaml` is not an inventory source.** It assumes Cisco, and its platforms
+(`iosxe`, `nxos`, `iosxr`) are exactly the ones routed to `pyATS` instead.
+
+---
+
+## Step 3 — Credentials
+
+**Never in the inventory file.** Two supported paths:
+
+```bash
+# Preferred: Vault
+VAULT_ADDR=https://vault.example.com
+VAULT_NAMESPACE=netclaw
+
+# Fallback: environment variables in .env (gitignored)
+MULTIVENDOR_USERNAME=netops
+MULTIVENDOR_PASSWORD=...
+```
+
+Vault is **not required.** If you have no Vault — likely if you chose Option C — environment variables
+are fully supported. Both keep secrets off disk in any inventory file, which is the actual requirement.
+
+Every result reports which path supplied the credential, so you can audit a deployment's posture.
+
+---
+
+## Step 4 — Verify
+
+```bash
+python3 scripts/reconcile-mcp.py          # must exit 0
+```
+
+Then, from NetClaw:
+
+```
+"list my multivendor devices"
+"check reachability of edge-mt-01"
+"get interfaces and facts for fw-vyos-01"
+"show me BGP neighbours across the edge group"
+```
+
+`check_reachability` is the right first call on a new device — it separates *unreachable* from
+*authentication failed* from *the platform in your inventory is wrong*, which need three different fixes.
+
+---
+
+## Step 5 — Understand the safety model before enabling writes
+
+Read-only is the default and write tools are **not exposed at all** until you opt in:
+
+```bash
+MULTIVENDOR_WRITE_ENABLED=true
+```
+
+Filtering is enforced **server-side**, in this order:
+
+1. Reject any command containing `;` `&&` `||` `>` `<` `` ` `` `$(`
+2. Reject a denylisted first token — per platform, because destructive syntax differs (VyOS `delete`,
+   MikroTik `/system reset-configuration`, SR Linux `tools system configuration`, SONiC `config erase`)
+3. In read-only mode, reject anything not starting with `show` / `display` / `get`
+
+Chaining is rejected **first** and that ordering is deliberate: `show version; write erase` would pass
+an allowlist check on its first token.
+
+With writes enabled, every change is: capture baseline → require approval → apply → **verify actual
+state against expected via structured diff** → roll back on failure. Verification compares state, not
+whether the command returned successfully.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `status: denied`, `denied_reason` mentions chaining | Command contained `;` or `&&` | Send commands separately |
+| `status: denied` in read-only mode | Verb not in the allowlist | Use a `show`-class command, or enable write mode deliberately |
+| `status: platform_mismatch` | Inventory platform ≠ what the device reports | Fix the source of truth; wrong driver gives confusing output |
+| `status: auth_failed` | Credentials resolved but rejected | Check Vault path or env vars — note this is *not* unreachable |
+| `apply_config` returns `refused` | Cisco/Junos device | Use `pyATS` or `junos-mcp`; this server is read-only there by design |
+| `available: false` on a getter | Platform's NAPALM driver lacks it | Use `run_command` for the raw equivalent — the gap is reported, not hidden |
+| My generated inventory edits vanished | It is a cache | Move to Option C, an operator-authored file the server never writes |
+| `source_used` is `generated`, not `live_sot` | Source of truth was unreachable | Check `fallback_reason`; results may be stale |

--- a/specs/076-multivendor-cli-driver/research.md
+++ b/specs/076-multivendor-cli-driver/research.md
@@ -301,3 +301,65 @@ novel, which lowers the review burden.
   devices; 30s bounds a hung device without prematurely failing legitimate slow commands.
 
 Both are defaults with overrides, so neither becomes a hidden constraint.
+
+---
+
+## R12 — Python 3.14 has no `ensurepip` on this host; `python3 -m venv` fails
+
+Discovered executing T005/T008. `/usr/bin/python3 -m venv` fails with:
+
+```
+The virtual environment was not created successfully because ensurepip is not
+available. On Debian/Ubuntu systems, you need to install the python3-venv
+package: apt install python3.14-venv
+```
+
+Installed venv packages are `python3.10-venv`, `python3.11-venv`, `python3.12-venv` — **not**
+`python3.14-venv`, while the system interpreter is 3.14.4. More residue from the same messy upgrade
+that produced R7's split toolchain.
+
+**Decision**: create the venv with **`virtualenv -p /usr/bin/python3`**, which bundles pip and does not
+need `ensurepip`. Verified: Python 3.14.4, pip 25.1.1, isolated `site-packages`.
+
+**Rationale**: `virtualenv` is already installed and needs no root. `apt install python3.14-venv`
+requires sudo and cannot be assumed on an operator's machine. `uv` is also present and would work, but
+`virtualenv` preserves the plan's exact contract of `<venv>/bin/python -m pip`.
+
+**Consequence**: the install function (T058) must use `virtualenv`, not `python3 -m venv`, with a clear
+error if `virtualenv` is absent. Recorded in `requirements.txt` and `tests/multivendor/run-tests.sh`.
+
+---
+
+## R13 — T005 confirmed the dependency conflict FR-030c was written for
+
+The tree resolves cleanly on Python 3.14.4 — 68 packages — but wants **`cryptography 49.0.0`** while
+the system interpreter carries **46.0.5**.
+
+| Environment | cryptography |
+|---|---|
+| System `/usr/bin/python3` (NCFED X.509, spec 060) | **46.0.5** — unchanged after install |
+| Server venv | **49.0.0** |
+
+Had these been installed into the shared environment, `cryptography` would have moved three major
+versions underneath NetClaw's certificate stack. Isolation is therefore not hygiene here; it is the
+thing preventing a real regression. Verified post-install: system still 46.0.5, and `nornir`, `napalm`,
+`netmiko`, `jdiff` are all absent from the system interpreter.
+
+Also pulled: `netmiko 4.7.0`, `paramiko 4.0.0`, `scrapli 2026.2.20` (transitively via NAPALM 5.x, per
+R8), `jdiff 1.0.1`.
+
+---
+
+## R14 — `mcp 2.0.0` removes `mcp.server.fastmcp`; ten NetClaw servers are exposed
+
+An unbounded `mcp>=1.2.0` resolved **2.0.0**, in which `mcp.server.fastmcp` no longer exists (FastMCP
+moved to the separate `fastmcp` distribution). That is the import used by
+`from mcp.server.fastmcp import FastMCP` — the convention in `suzieq-mcp`, `gnmi-mcp` and others.
+
+**Decision**: pin `mcp>=1.2.0,<2` for this server. Verified working at `mcp 1.29.0`.
+
+**Repo-wide finding, out of scope here but must not be lost**: ten existing servers declare an
+unbounded `mcp>=1.0.0`, two declare `mcp>=1.2.0`, one `mcp>=1.13`. **Every one of them resolves mcp 2.x
+on a fresh install today and breaks on import.** This is the same shape as R7's `pip3` hazard: existing
+servers that work only because their environments predate the breaking change. Should be raised
+alongside T083 as its own roadmap item.

--- a/specs/076-multivendor-cli-driver/research.md
+++ b/specs/076-multivendor-cli-driver/research.md
@@ -1,0 +1,181 @@
+# Phase 0 Research: Generic Multivendor CLI Driver
+
+**Feature**: 076-multivendor-cli-driver
+**Date**: 2026-07-30
+**Purpose**: Resolve unknowns before design. The headline finding overturns a spec assumption.
+
+---
+
+## R1 — Neither candidate is adoptable as-is. The spec's "adopt, don't build" assumption fails
+
+The spec assumed "a community server will be adopted rather than written from scratch." Both
+candidates were assessed against the spec's own hard requirements. **Both fail, and for overlapping
+reasons.**
+
+### Candidate A — `sydasif/nornir-mcp-server`
+
+| Property | Finding | Verdict |
+|---|---|---|
+| License | MIT | OK |
+| Stars / activity | 2 stars, **archived (read-only) 4 June 2026** | **Unmaintained** |
+| Python | 3.12+ | Constraint to note |
+| Tools | 5: `list_devices`, `fetch_data` (NAPALM getters), `show_commands`, `apply_config`, `backup_configs` | Thin but well-chosen |
+| Command filtering | Allowlist (`show`, `display`, `get`), denylist on destructive first tokens, **blocks chaining via `;`, `&&`, `>`, `<`** | **Excellent** |
+| Input validation | Pydantic throughout | **Good** |
+| Path sandboxing | Backups restricted to a root directory, traversal prevented | **Good** |
+| Inventory | Nornir `SimpleInventory`: local `hosts.yaml`, `groups.yaml`, `defaults.yaml`; reloads `config.yaml` from cwd per call | **Violates FR-017** |
+| Credentials | Stored in group definitions in YAML | **Violates FR-019** |
+
+### Candidate B — `ntunes/netmiko-mcp-server`
+
+| Property | Finding | Verdict |
+|---|---|---|
+| License | MIT | OK |
+| Stars / activity | 3 stars, **5 total commits** | **Immature** |
+| Tools | 12, incl. `send_command_parallel`, `send_config_parallel`, `list_groups`, `get_pool_status`, `test_connection` | Good concurrency surface |
+| Command filtering | **Not present** | **Violates FR-023, FR-029** |
+| Read-only mode | **Not present** | **Violates FR-022** |
+| Credentials | Env vars plus YAML credential profiles | Partially violates FR-019 |
+| Inventory | `config/devices.yaml` with groups and tags | **Violates FR-017** |
+
+### The shared, disqualifying pattern
+
+Both are built around a **local YAML inventory with credentials in it**. That is the standard Nornir
+idiom, and it is precisely what FR-017 through FR-021 forbid: NetClaw resolves devices from
+NetBox/Nautobot/Infrahub and secrets from Vault, specifically so a second inventory cannot drift and
+no credential lands on disk. This is not a small integration detail — it is the layer both projects
+are organised around.
+
+Candidate B additionally has **no command filtering of any kind**, which is the single hardest thing
+to get right and the thing FR-023/FR-029 and Constitution Principle I most depend on.
+
+### Decision: build on the libraries directly, using Candidate A as the safety reference
+
+**Not** "adopt", **not** "write blind". Specifically:
+
+1. Build directly on `nornir` + `napalm` + `netmiko` — the libraries, not either wrapper.
+2. **Port Candidate A's safety model deliberately**, because it is genuinely good and is the part
+   most easily got wrong: prefix allowlist, destructive-first-token denylist, **chaining prevention
+   (`;`, `&&`, `>`, `<`)**, Pydantic validation, path sandboxing. MIT licence permits this; archived
+   status means there is no upstream to track or contribute back to.
+3. Replace the inventory layer with a Nornir inventory backed by NetClaw's existing sources of truth,
+   and the credential layer with Vault lookups.
+4. Take Candidate B's concurrency surface as a design reference (`*_parallel`, `get_pool_status`,
+   `test_connection`) without taking its code.
+
+**Rationale**: the two candidates offer, between them, roughly the safety model plus a concurrency
+shape — perhaps 300 lines of genuinely valuable design thinking. Everything else they provide is the
+inventory/credential layer that must be discarded. Adopting either would mean carrying an
+unmaintained dependency *and* rewriting its core abstraction; forking an archived 2-star repository is
+functionally the same as building, minus the freedom to structure it for NetClaw's needs.
+
+**Alternatives rejected**:
+- *Adopt Candidate A and swap the inventory* — a plugin swap sounds cheap, but every tool reloads
+  `config.yaml` from cwd, so the inventory assumption is threaded through the request path. Also
+  inherits an archived Python-3.12+ dependency.
+- *Adopt Candidate B and add filtering* — writing the safety layer is the hard part; B contributes
+  nothing to it, so this is building with extra steps plus a foreign inventory model.
+- *Scrapli instead of Netmiko* — faster and cleaner, but materially narrower platform coverage.
+  Reach is the entire point of R1 (FR-001), so Netmiko's ~100 platforms wins.
+
+**Consequence for the spec**: the "adopt a community server" assumption is void. Effort increases
+from integration to implementation. This is a **material scope change and needs the maintainer's
+acknowledgement before implementation proceeds.**
+
+---
+
+## R2 — Dependency footprint is the real Principle XV risk
+
+None of `napalm`, `netmiko`, `nornir`, `scrapli` is currently installed. Unlike R0, which added zero
+dependencies, this feature pulls a substantial transitive tree — `paramiko`/`cryptography` (SSH),
+`ncclient`/`lxml` (NAPALM's NETCONF drivers), `ruamel.yaml`, `pydantic`, and per-vendor driver
+packages.
+
+**Risk**: `cryptography` and `paramiko` are shared with NetClaw's existing federation/TLS stack (spec
+060 uses `cryptography` for X.509 issuance). A version conflict here would not break this feature — it
+would break NCFED certificate handling. Constitution Principle XV requires new dependencies not
+conflict with existing ones.
+
+**Decision**: isolate this server's dependencies rather than installing into the shared system
+environment, and pin explicitly. Verify the installed `cryptography` version is unchanged after
+install, since the federation stack depends on it.
+
+**Open item for Phase 1**: confirm whether NetClaw's other MCP servers use per-server virtualenvs or
+a shared environment, and match the prevailing pattern. (Note: the repo has a `.venv`, and R0 found
+three registrations that had hardcoded a `.venv` interpreter — so the pattern is not currently
+consistent and this needs deciding rather than assuming.)
+
+---
+
+## R3 — Platform coverage claim, verified
+
+Netmiko's supported-platforms list confirms the spec's reach claim. Platforms NetClaw cannot touch
+today that Netmiko drives: MikroTik RouterOS and SwitchOS, VyOS, Nokia SR Linux and SR OS, Dell SONiC
+(and Dell OS6/OS9/OS10), Extreme (EXOS/VSP/SLX), Huawei (VRP/SmartAX), Ubiquiti EdgeOS/Unifi,
+Alcatel, Arista EOS, Check Point GAiA, F5 TMSH, Fortinet, Palo Alto PAN-OS, and more.
+
+**Note worth flagging**: Netmiko also drives Fortinet, Palo Alto and Check Point — all of which are
+separate roadmap items (R3, R4, and an existing Check Point integration). This server therefore
+provides a *CLI-level* fallback for those vendors even before their dedicated API-level servers land.
+That is a genuine bonus, but it must not be mistaken for completing R3/R4: CLI access is not
+equivalent to FortiManager's policy-package API or Panorama's device-group model.
+
+**Decision**: document this explicitly in the routing skill so the agent does not treat CLI reach as
+"Fortinet support" and skip R3.
+
+---
+
+## R4 — SC-001 is testable without hardware, but not for every platform
+
+NetClaw already integrates containerlab, GNS3 and EVE-NG. Containerlab natively runs Nokia SR Linux,
+SONiC, VyOS, Arista cEOS and FRR as containers — comfortably satisfying SC-001's "five platform
+families NetClaw cannot reach today" with no hardware and no licences.
+
+MikroTik RouterOS, Extreme and Huawei need VM images (GNS3/EVE-NG) with licensing NetClaw's lab
+tooling cannot assume.
+
+**Decision**: target containerlab-hosted platforms for acceptance testing — SR Linux, SONiC, VyOS —
+plus any two more available. Do not gate SC-001 on platforms requiring licensed images.
+
+---
+
+## R5 — The normalized-fact set is bounded by NAPALM, not by ambition
+
+FR-006 requires normalized facts in one shape across platforms. In practice this is exactly NAPALM's
+getter set (`get_facts`, `get_interfaces`, `get_interfaces_ip`, `get_bgp_neighbors`, `get_lldp_neighbors`,
+`get_arp_table`, `get_environment`, …), and getter support is **uneven across drivers** — a driver may
+implement `get_facts` but not `get_bgp_neighbors`.
+
+**Decision**: enumerate supported getters per platform at runtime and report unavailability
+explicitly, which is precisely what FR-007 demands. Do not emulate a missing getter by scraping CLI
+output — that would silently produce a normalized-looking answer of lower reliability, the exact
+failure mode FR-007 exists to prevent.
+
+---
+
+## R6 — Command filtering must be per-platform, and this is the subtle part
+
+The Constitution forbids `write erase`, `reload`, `format flash:` — all **Cisco** syntax. The
+equivalents differ: VyOS `delete`/`commit`, MikroTik `/system reset-configuration`, SR Linux
+`tools system configuration`, Junos `request system zeroize`, SONiC `config erase`.
+
+A Cisco-shaped denylist is therefore not sufficient (FR-023 says so explicitly). Candidate A's design
+insight — deny on **destructive first tokens** plus block **chaining metacharacters** — generalises
+far better than pattern-matching full command strings, because chaining is how a denylist gets
+bypassed regardless of vendor.
+
+**Decision**: implement per-platform denylists keyed by platform family, layered on top of a
+universal chaining prohibition and a universal read-only prefix allowlist. Enforce server-side
+(FR-029), never in skill prose.
+
+---
+
+## Summary: what changed versus the spec
+
+| Spec assumption | Research finding | Impact |
+|---|---|---|
+| A community server will be adopted | Both candidates fail FR-017/019; A is archived, B has no filtering | **Build on libraries, port A's safety model. Scope increases.** |
+| Dependency isolation "needs attention" | `cryptography`/`paramiko` are shared with the NCFED TLS stack | Isolation is a hard requirement, not a nicety |
+| Reach claim ~90 platforms | Confirmed, and includes Fortinet/PAN-OS/Check Point | Bonus reach — must not be mistaken for R3/R4 completion |
+| Lab platforms available | True for SR Linux/SONiC/VyOS; MikroTik/Extreme/Huawei need licensed images | SC-001 targets containerlab platforms |
+| Normalized facts across platforms | Bounded by uneven NAPALM getter support | FR-007's explicit-gap reporting is essential, not optional |

--- a/specs/076-multivendor-cli-driver/research.md
+++ b/specs/076-multivendor-cli-driver/research.md
@@ -60,9 +60,6 @@ directory on every tool call, threading the inventory assumption through the req
 has **no command filtering whatsoever**, which is the hardest part to get right and the part
 Principle I most depends on.
 
-Candidate B additionally has **no command filtering of any kind**, which is the single hardest thing
-to get right and the thing FR-023/FR-029 and Constitution Principle I most depend on.
-
 ### Decision: build on the libraries directly, using Candidate A as the safety reference
 
 **Not** "adopt", **not** "write blind". Specifically:
@@ -89,8 +86,9 @@ functionally the same as building, minus the freedom to structure it for NetClaw
   inherits an archived Python-3.12+ dependency.
 - *Adopt Candidate B and add filtering* — writing the safety layer is the hard part; B contributes
   nothing to it, so this is building with extra steps plus a foreign inventory model.
-- *Scrapli instead of Netmiko* — faster and cleaner, but materially narrower platform coverage.
-  Reach is the entire point of R1 (FR-001), so Netmiko's ~100 platforms wins.
+- *Scrapli instead of Netmiko* — **this framing was superseded by R8.** NAPALM 5.x is scrapli-based, so
+  scrapli arrives regardless; the decision is not either/or. Netmiko is retained for raw-CLI platform
+  reach (FR-001), scrapli comes in under NAPALM's getters.
 
 **Consequence for the spec**: the "adopt a community server" assumption is void. Effort increases
 from integration to implementation. This is a **material scope change and needs the maintainer's
@@ -114,10 +112,13 @@ conflict with existing ones.
 environment, and pin explicitly. Verify the installed `cryptography` version is unchanged after
 install, since the federation stack depends on it.
 
-**Open item for Phase 1**: confirm whether NetClaw's other MCP servers use per-server virtualenvs or
-a shared environment, and match the prevailing pattern. (Note: the repo has a `.venv`, and R0 found
-three registrations that had hardcoded a `.venv` interpreter — so the pattern is not currently
-consistent and this needs deciding rather than assuming.)
+**Open item — RESOLVED by R10**: `mcp-servers/mcp-nvd/.venv` establishes the per-server venv
+precedent, so FR-030a follows existing practice.
+
+**Superseded in part by R7**: this item's risk assessment was later measured, and the measurement
+initially *understated* the problem. The host has a split toolchain (`pip3` → Python 3.13,
+`python3` → 3.14.4) carrying two different `cryptography` versions. Read R7 before acting on this
+section.
 
 ---
 
@@ -193,3 +194,110 @@ universal chaining prohibition and a universal read-only prefix allowlist. Enfor
 | Reach claim ~90 platforms | Confirmed, and includes Fortinet/PAN-OS/Check Point | Bonus reach — must not be mistaken for R3/R4 completion |
 | Lab platforms available | True for SR Linux/SONiC/VyOS; MikroTik/Extreme/Huawei need licensed images | SC-001 targets containerlab platforms |
 | Normalized facts across platforms | Bounded by uneven NAPALM getter support | FR-007's explicit-gap reporting is essential, not optional |
+
+---
+
+## R7 — CRITICAL: the host toolchain is split, and it invalidated an earlier finding
+
+Measured 2026-07-30:
+
+```
+python3  -> /usr/bin/python3              Python 3.14.4   cryptography 46.0.5   netmiko absent
+pip3     -> ~/.local/bin/pip3  (py 3.13)                  cryptography 45.0.2   netmiko 4.6.0
+```
+
+`pip3` installs into a **stranded Python 3.13 `site-packages`** that `/usr/bin/python3` (3.14.4)
+cannot import. Two different `cryptography` versions are present, in two environments.
+
+**This invalidated a conclusion drawn earlier in this research.** A `pip install --dry-run` of the R1
+tree reported that `cryptography`, `paramiko` and `netmiko` were "not pulled", which was read as
+evidence that the NCFED conflict risk was low. That reading was unsound: pip was resolving against
+the 3.13 environment, where those packages are *already installed*, so they were omitted as
+already-satisfied. **The conflict question is unmeasured, not resolved.**
+
+Corroborating detail: `nornir-netmiko 1.0.1` declares `netmiko (>=4.0.0,<5.0.0)`, so netmiko is
+unambiguously a real dependency — it only appeared absent because of the environment mismatch.
+
+### Consequences
+
+1. **FR-030a (dedicated virtualenv) is vindicated and now load-bearing.** With a split toolchain, any
+   install that relies on bare `pip3` lands in an environment the server will not run under.
+2. **The venv MUST be created from an explicitly chosen interpreter** and populated with that
+   interpreter's own `-m pip`, never bare `pip3`. `python3 -m venv` + `<venv>/bin/python -m pip` is the
+   only form that is self-consistent here.
+3. **The FR-030c check must compare the right environment.** Asserting "system `cryptography` unchanged"
+   is only meaningful against the interpreter NetClaw's servers actually run under (`/usr/bin/python3`,
+   3.14.4), not whatever `pip3` points at.
+4. **This is a repo-wide hazard, not an R1 one.** `scripts/lib/install-steps.sh` contains 186
+   `pip install` invocations. If any run as bare `pip3` on a host with this split, they install where
+   the servers cannot see them. Out of scope for R1, but it should be raised as its own finding — it is
+   the same class of defect spec 075 found in hardcoded interpreter paths.
+
+**Decision**: create the venv with `/usr/bin/python3 -m venv`, install with `<venv>/bin/python -m pip`,
+record the resolved interpreter path at install time (FR-030b), and run the FR-030c `cryptography`
+assertion against `/usr/bin/python3`.
+
+---
+
+## R8 — NAPALM 5.2.0 is scrapli-based, which changes the transport calculus
+
+The resolved tree for `nornir napalm netmiko nornir-netbox nornir-nautobot nornir-utils` is 21
+packages and includes:
+
+```
+napalm 5.2.0    nornir 3.5.0        nornir-netmiko 1.0.1   nornir_napalm 0.5.0
+scrapli 2026.2.20    scrapli_cfg    scrapli_community      scrapli_netconf
+nornir_scrapli  pyeapi 1.0.4   pynautobot 3.1.1   nornir-netbox 0.3.0
+jdiff 1.0.2     deepdiff 8.6.2      ttp / ttp_templates    httpx 0.27.0
+```
+
+Research R1 rejected scrapli on the grounds of narrower platform coverage. That framing was wrong:
+**scrapli arrives regardless**, because NAPALM 5.x uses it. The real position is that both transports
+are present — scrapli underneath NAPALM's normalized getters, netmiko for broad-platform raw CLI.
+
+**Decision**: keep netmiko as the raw-CLI transport for platform reach (FR-001 depends on its ~100
+platforms) and let NAPALM use scrapli internally for normalized getters. Do not attempt to force NAPALM
+onto netmiko, and do not drop netmiko in favour of scrapli.
+
+**Rationale**: this is the layering the spec already ratified — NAPALM for normalized cross-vendor
+facts, netmiko for reach. The dependency tree happens to match it.
+
+---
+
+## R9 — Two unplanned-for packages are directly useful
+
+- **`jdiff 1.0.2`** — structured diffing of network state. Lands squarely on FR-026 (compare actual
+  post-change state against expected, not merely that the command succeeded). Worth using rather than
+  hand-rolling comparison logic.
+- **`ttp` / `ttp_templates`** — template-based parsing for platforms with no NAPALM getter. Relevant to
+  FR-007, but must be used carefully: FR-007 requires reporting a normalization *gap* explicitly rather
+  than emulating a getter by scraping CLI output. TTP output must therefore be labelled as
+  template-parsed, never presented as a normalized fact.
+
+**Decision**: adopt `jdiff` for change verification. Treat `ttp` as available but explicitly
+second-class, and never let its output masquerade as a NAPALM normalized fact.
+
+---
+
+## R10 — Per-server virtualenv already has precedent
+
+R2 left open whether NetClaw uses per-server venvs or a shared environment. Answer: **both, and
+inconsistently.** `mcp-servers/mcp-nvd/.venv` exists, so the pattern is established; most other
+servers pip-install into the shared environment.
+
+**Decision**: follow the `mcp-nvd` precedent. FR-030a is consistent with existing practice rather than
+novel, which lowers the review burden.
+
+---
+
+## R11 — Deferred non-functional values, now resolved
+
+- **Concurrency bound (FR-015)**: default to **10** concurrent workers, operator-overridable. Nornir's
+  own default `num_workers` is 20; 10 is chosen because each worker holds an SSH session and network
+  devices commonly cap concurrent management sessions (frequently 5–15). Starting conservative and
+  documenting the override is safer than discovering a device's session limit under load.
+- **Per-device timeout (FR-016)**: default **30 seconds** for connect-and-execute, operator-overridable.
+  Netmiko's default read timeout is 10s, which is too aggressive for slow `show` output on loaded
+  devices; 30s bounds a hung device without prematurely failing legitimate slow commands.
+
+Both are defaults with overrides, so neither becomes a hidden constraint.

--- a/specs/076-multivendor-cli-driver/research.md
+++ b/specs/076-multivendor-cli-driver/research.md
@@ -38,13 +38,27 @@ reasons.**
 | Credentials | Env vars plus YAML credential profiles | Partially violates FR-019 |
 | Inventory | `config/devices.yaml` with groups and tags | **Violates FR-017** |
 
-### The shared, disqualifying pattern
+### The shared pattern — and a correction to how this was first assessed
 
-Both are built around a **local YAML inventory with credentials in it**. That is the standard Nornir
-idiom, and it is precisely what FR-017 through FR-021 forbid: NetClaw resolves devices from
-NetBox/Nautobot/Infrahub and secrets from Vault, specifically so a second inventory cannot drift and
-no credential lands on disk. This is not a small integration detail — it is the layer both projects
-are organised around.
+> **Corrected 2026-07-30 after clarification.** This section originally called "a local YAML inventory
+> with credentials in it" a single disqualifying pattern. That conflated two separable things and
+> overstated the case. The spec's Clarifications section is authoritative; this is kept for the record.
+
+Both projects are built around a local YAML inventory that also holds credentials. Split properly:
+
+- **The YAML inventory is not disqualifying.** It is NetClaw's established pattern — `pyATS` ships
+  `PYATS_TESTBED_PATH` for an operator-built `testbed.yaml`. Hostnames, addresses and platform
+  identifiers are not secret. The clarified spec accepts three inventory sources, two of which are
+  files (FR-017).
+- **Credentials in the YAML are disqualifying**, and that is what both candidates actually do wrong —
+  candidate A in Nornir group definitions, candidate B in YAML credential profiles. Forbidden by
+  FR-019 and Principle XIII regardless of which inventory source is in use.
+
+The build-rather-than-adopt conclusion is unchanged, but rests on narrower and more defensible
+grounds: candidate A is **archived and unmaintained** and reloads `config.yaml` from the working
+directory on every tool call, threading the inventory assumption through the request path; candidate B
+has **no command filtering whatsoever**, which is the hardest part to get right and the part
+Principle I most depends on.
 
 Candidate B additionally has **no command filtering of any kind**, which is the single hardest thing
 to get right and the thing FR-023/FR-029 and Constitution Principle I most depend on.
@@ -174,7 +188,7 @@ universal chaining prohibition and a universal read-only prefix allowlist. Enfor
 
 | Spec assumption | Research finding | Impact |
 |---|---|---|
-| A community server will be adopted | Both candidates fail FR-017/019; A is archived, B has no filtering | **Build on libraries, port A's safety model. Scope increases.** |
+| A community server will be adopted | A is **archived** and threads its inventory assumption through the request path; B has **no command filtering at all**. Both store credentials in YAML (FR-019). Their *YAML inventory* is fine — see the correction in R1 | **Build on libraries, port A's safety model. Scope increases.** |
 | Dependency isolation "needs attention" | `cryptography`/`paramiko` are shared with the NCFED TLS stack | Isolation is a hard requirement, not a nicety |
 | Reach claim ~90 platforms | Confirmed, and includes Fortinet/PAN-OS/Check Point | Bonus reach — must not be mistaken for R3/R4 completion |
 | Lab platforms available | True for SR Linux/SONiC/VyOS; MikroTik/Extreme/Huawei need licensed images | SC-001 targets containerlab platforms |

--- a/specs/076-multivendor-cli-driver/spec.md
+++ b/specs/076-multivendor-cli-driver/spec.md
@@ -64,6 +64,54 @@ platform. Recorded here so it is not re-litigated.
 
 ---
 
+## Clarifications
+
+### Session 2026-07-30
+
+- Q: How is the device inventory sourced — live dynamic plugin, generated YAML, or both? → A: **Both tiers, live preferred, generated YAML as fallback/cache.**
+- Q: Should the existing pyATS `testbed.yaml` be reused as an inventory source? → A: **No.** pyATS assumes Cisco. Operators needing inventory for other tools either **maintain their own YAML** or **use the existing source of truth**.
+- Q: How are this server's Python dependencies isolated, given `napalm`/`netmiko` pull `cryptography` which the NCFED stack also uses? → A: **Dedicated virtualenv for this server**, created by its install function, interpreter path resolved at install time and never hardcoded.
+- Q: Is Vault mandatory for credentials? → A: **No — Vault preferred, environment variables as a documented fallback.** Both keep secrets off disk; a credential in an inventory file remains forbidden.
+
+**Why the fallback is not a weakening.** Principle XIII requires secrets live in `.env` and never be
+hardcoded in source or configuration — it does not require Vault specifically, and the existing
+`pyATS` server already supports env-var credentials alongside `VAULT_ADDR`. Requiring Vault would make
+this server stricter than every existing NetClaw server while excluding exactly the no-source-of-truth
+operators the inventory decision above just made first-class.
+
+**Three accepted inventory sources, and the distinction between two of them matters.** The second
+answer above adds an operator-authored file, which the first answer's "never hand-authored" wording
+did not allow. Resolved as follows — a generated file and an operator-authored file are *different
+artifacts with different rules*, and conflating them is what produces "the refresh wiped my edits":
+
+| Source | Authority | Hand-editable? |
+|---|---|---|
+| Live source of truth (NetBox / Nautobot / Infrahub) | Preferred | N/A |
+| Inventory generated *from* a source of truth | Cache / offline fallback | **No** — regenerable, edits are lost by design |
+| Operator-authored inventory file | Operator's own responsibility | **Yes** — it is theirs to maintain |
+
+`pyATS`'s `testbed.yaml` is explicitly **not** a source. Its `os:` values (`iosxe`, `nxos`, `iosxr`)
+describe exactly the platforms FR-009 routes *away* from this server, so deriving inventory from it
+would mostly yield devices this server should decline to act on.
+
+The credential prohibition applies identically to all three sources.
+
+**Correction this clarification forces on Phase 0 research.** Research R1 called candidate A's YAML
+inventory a violation of FR-017. That conflated two separable things and was wrong:
+
+- **Device inventory in YAML is not a violation.** It is NetClaw's established pattern — `pyATS` ships
+  `PYATS_TESTBED_PATH`, where the operator builds `testbed.yaml` at install, and
+  `netbox-reconcile`/`pyats-topology` already reference generating it from a source of truth. Hostnames,
+  addresses and platform identifiers are not secret.
+- **Credentials in YAML *is* a violation**, and it is what candidate A actually does wrong by storing
+  them in Nornir group definitions. This is independent of where inventory lives.
+
+The build-rather-than-adopt decision stands, but on the narrower and more honest grounds that
+candidate A is archived and unmaintained, and reloads `config.yaml` from the working directory on
+every tool call — threading the inventory assumption through the request path. Not "YAML is wrong."
+
+---
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Reach a platform NetClaw cannot touch today (Priority: P1)
@@ -266,10 +314,34 @@ without approval, that a baseline was captured first, and that it can be reverte
 
 **Inventory and credentials**
 
-- **FR-017**: Device inventory MUST be resolved from NetClaw's existing sources of truth rather than a
-  new hand-maintained inventory file.
-- **FR-018**: Credentials MUST come from NetClaw's existing secret store.
-- **FR-019**: No credential may be written to any file on disk, in any form (Principle XIII).
+- **FR-017**: Device inventory MUST come from one of exactly three sources, and the server MUST
+  support all three:
+  - **Live source of truth** (preferred): query NetBox / Nautobot / Infrahub at call time, so
+    inventory cannot drift.
+  - **Generated from a source of truth**: an inventory file rendered from those same sources at
+    install and on refresh, for offline, air-gapped, or SoT-unavailable operation.
+  - **Operator-authored**: an inventory file the operator writes and maintains themselves, for
+    operators with no source of truth.
+- **FR-017a**: A **generated** inventory file MUST be regenerable from its source and MUST be treated
+  as a cache — the server MUST warn that hand edits will be lost on refresh. One that cannot be
+  regenerated is a defect.
+- **FR-017b**: An **operator-authored** inventory file MUST never be overwritten or regenerated by the
+  server. The two file kinds MUST be distinguishable so a refresh cannot destroy operator work.
+- **FR-017c**: The server MUST report which of the three sources supplied a device, so results are
+  attributable and a stale-cache answer is never mistaken for a live one.
+- **FR-017d**: **No inventory source may contain credential material in any form** — only hostnames,
+  addresses, platform identifiers, grouping metadata, and credential *references*. This applies
+  identically to all three sources (Principle XIII).
+- **FR-017e**: The pyATS `testbed.yaml` MUST NOT be used as an inventory source. It assumes Cisco, and
+  its platforms are precisely those FR-009 routes away from this server.
+- **FR-018**: Credentials MUST come from Vault where available, with environment variables as a
+  documented fallback. Vault MUST NOT be a hard prerequisite for using the server — an operator with
+  an operator-authored inventory and no source of truth typically has no Vault either.
+- **FR-018a**: The server MUST report which path supplied a credential (Vault or environment), so the
+  security posture of a given deployment is inspectable.
+- **FR-019**: No credential may be written to, or read from, any file on disk in any form other than a
+  gitignored `.env` (Principle XIII). Reading a credential from an inventory file is forbidden
+  regardless of which of the three inventory sources it came from.
 - **FR-020**: Per-device, per-site or per-platform credential differences MUST be supported; a single
   global credential is not sufficient.
 - **FR-021**: A device absent from every source of truth MUST be reported as absent rather than
@@ -297,6 +369,16 @@ without approval, that a baseline was captured first, and that it can be reverte
 - **FR-030**: The server MUST be registered and installable per `docs/ADDING-AN-MCP.md`, and
   `scripts/reconcile-mcp.py` MUST pass — including a catalog entry and install function, since no
   generic-driver catalog id exists today.
+- **FR-030a**: The server's Python dependencies MUST be installed into a **dedicated virtualenv**, not
+  the shared system environment. `napalm`/`netmiko` transitively require `cryptography` and `paramiko`,
+  and `cryptography` is used by the NCFED federation stack for X.509 issuance (spec 060) — a version
+  conflict would break certificate handling rather than this server (Principle XV).
+- **FR-030b**: The registration MUST resolve that virtualenv's interpreter path **at install time** and
+  MUST NOT hardcode an absolute path. Spec 075 found three registrations hardcoded to
+  `/home/ubuntu/netclaw/.venv/bin/python3` and broken for every installer; `scripts/reconcile-mcp.py`
+  now fails on exactly that defect.
+- **FR-030c**: Installation MUST verify the system `cryptography` version is unchanged afterwards, so a
+  regression in the federation stack is caught at install rather than at certificate-renewal time.
 - **FR-031**: Accompanying skills MUST cover, at minimum: normalized fact retrieval, safe raw command
   execution, and fleet-wide fan-out.
 - **FR-032**: Existing device-facing capability MUST NOT regress; all 18 pyATS skills and the Junos
@@ -305,7 +387,10 @@ without approval, that a baseline was captured first, and that it can be reverte
 ### Key Entities
 
 - **Device**: A reachable network element. Has a name, an address, a platform identifier, and a
-  credential reference. Resolved from a source of truth, never defined locally.
+  credential *reference* — never a credential. Supplied by one of three inventory sources.
+- **Inventory source**: One of live source-of-truth, generated-from-source-of-truth, or
+  operator-authored. Each device carries which source supplied it (FR-017c). Generated files are
+  caches and are overwritten on refresh; operator-authored files are never touched by the server.
 - **Platform**: The OS family determining which driver and command syntax apply. Mismatch between the
   recorded and actual platform is a detectable error condition.
 - **Device group**: A named set of devices — by site, role, platform, or tag — that one query can
@@ -330,9 +415,14 @@ without approval, that a baseline was captured first, and that it can be reverte
 - **SC-004**: A fleet query against a mixed group including at least one unreachable device returns
   results for every reachable device and isolates the failure.
 - **SC-005**: A fleet query of N devices completes substantially faster than N sequential queries.
-- **SC-006**: Zero credentials appear in any file on disk, verified by inspection.
-- **SC-007**: Zero devices are defined in a local inventory file; every device resolves from a source
-  of truth.
+- **SC-006**: Zero credentials appear in any file on disk other than a gitignored `.env`, verified by
+  inspection of all three inventory sources.
+- **SC-007**: Every device reports which of the three inventory sources supplied it, and a refresh of a
+  generated inventory leaves any operator-authored inventory untouched.
+- **SC-007a**: The server is usable by an operator with neither a source of truth nor Vault — verified
+  by onboarding one device using an operator-authored inventory and env-var credentials.
+- **SC-007b**: Installing this server leaves the system `cryptography` version unchanged, verified
+  before and after.
 - **SC-008**: Every Constitution-forbidden operation is blocked on every supported platform, verified
   per platform rather than assumed from one.
 - **SC-009**: No configuration change can be applied without a captured baseline and explicit

--- a/specs/076-multivendor-cli-driver/spec.md
+++ b/specs/076-multivendor-cli-driver/spec.md
@@ -485,9 +485,25 @@ without approval, that a baseline was captured first, and that it can be reverte
   concurrency. Candidate selection, and whether to adopt one, both, or fork, is a Phase 0 research
   decision, not a spec decision.
 - **Read-only first is not negotiable.** US5 is P3 specifically so the safe increment ships first.
-- **Lab platforms are available for testing.** NetClaw already integrates containerlab, GNS3 and
+- **Lab platforms are available for testing.** ~~NetClaw already integrates containerlab, GNS3 and
   EVE-NG, which between them host SR Linux, VyOS, SONiC and MikroTik — so SC-001 is testable without
-  buying hardware.
+  buying hardware.~~
+
+  **BLOCKED, confirmed 2026-07-31.** The available lab is **CML with four Cisco devices and nothing
+  else**. Those are IOS/IOS-XE — precisely the platforms FR-009 routes *away* from this server. So the
+  feature's headline criterion, SC-001 ("live state from ≥5 platform families NetClaw cannot reach
+  today"), **cannot be verified in this environment at all**, because the environment contains zero
+  such platforms.
+
+  What the CML devices *can* verify, and it is not trivial:
+  - **FR-010 / SC-010** — a configuration write to a Cisco device is refused and names `pyats`. This is
+    the safety-critical routing behaviour and the most consequential thing to get right.
+  - **FR-008** — read-only NAPALM getters against Cisco, the cross-vendor normalized-read exception.
+  - **FR-017 / FR-018** — inventory and credential resolution against real reachable devices.
+
+  Unblocking SC-001 needs containerlab hosting SR Linux, SONiC and VyOS (all container images, no
+  licences required — research R4). Until then Phase 4's acceptance is provably incomplete, and saying
+  otherwise would be a false claim of verification.
 - **None of the underlying libraries is currently installed** (`napalm`, `netmiko`, `nornir`,
   `scrapli` all absent), so dependency isolation per Principle XV needs real attention — these pull a
   substantial transitive tree.

--- a/specs/076-multivendor-cli-driver/spec.md
+++ b/specs/076-multivendor-cli-driver/spec.md
@@ -1,0 +1,381 @@
+# Feature Specification: Generic Multivendor CLI Driver
+
+**Feature Branch**: `076-multivendor-cli-driver`
+**Created**: 2026-07-30
+**Status**: Draft
+**Roadmap item**: R1 in `docs/COVERAGE-ROADMAP.md` — highest coverage-per-line item on the roadmap
+**Depends on**: R0 / spec 075 (this branch is stacked on it — R1 must follow `docs/ADDING-AN-MCP.md` and pass `scripts/reconcile-mcp.py`)
+**Input**: User description: "Generic multivendor network CLI driver via Nornir, NAPALM and Netmiko. Roadmap item R1 — the largest coverage-per-line item on the roadmap. NetClaw's device reach today is pyATS (Cisco), junos-mcp (Juniper), gnmi-mcp (streaming telemetry) and radkit-mcp (cloud-relayed) — there is no general 'SSH to any platform' capability. One server adds MikroTik RouterOS, VyOS, SONiC, Nokia SR Linux, Extreme, Huawei, Dell, Ubiquiti EdgeOS and roughly ninety more platforms NetClaw cannot reach at all. […] Must be read-only first with writes explicitly gated. Must follow docs/ADDING-AN-MCP.md and pass scripts/reconcile-mcp.py, both established by spec 075."
+
+---
+
+## The problem
+
+NetClaw can reach a network device four ways today, and every one of them is platform-bound:
+
+| Existing server | Reaches | Skills |
+|---|---|---|
+| `pyATS` | Cisco IOS / IOS-XE / NX-OS / IOS-XR | 18 |
+| `junos-mcp` | Juniper Junos (PyEZ/NETCONF) | 1 |
+| `gnmi-mcp` | Any platform, but streaming telemetry only — not CLI |
+| `radkit-mcp` | Cloud-relayed access, Cisco-oriented |
+
+There is **no general "connect to this device and ask it something" capability.** A NetClaw operator with a MikroTik edge router, a VyOS lab firewall, a SONiC white-box switch, a Nokia SR Linux fabric, an Extreme campus stack, a Huawei core, a Dell OS10 leaf, or a Ubiquiti EdgeOS box cannot query any of them. None of `napalm`, `netmiko`, `nornir` or `scrapli` is installed, and no installer catalog entry exists for a generic driver.
+
+This is the single largest reach gap in NetClaw, and it closes with one server.
+
+## The layering decision (ratified 2026-07-30)
+
+The four named libraries are frequently discussed as alternatives. They are not — they are four
+different layers, and recognising that resolves the design:
+
+| Layer | What it is | Platform breadth | Output shape |
+|---|---|---|---|
+| **Netmiko** | Transport: SSH sessions, prompt detection, paging quirks | ~100+ | Raw text |
+| **NAPALM** | Normalization: vendor-neutral getters over a fixed API, often using Netmiko underneath | ~10 solid | Structured, **identical across vendors** |
+| **Nornir** | Orchestration: inventory, concurrency, task composition. Talks to no device itself | inherits | inherits |
+| **pyATS / Genie** | Parse and test framework: ~2000 parsers, state snapshot/diff, test harness | **Cisco-deep**, thin elsewhere | Structured, **shape varies per command** |
+
+Nornir does not compete with Netmiko — it drives it. The genuine trade-off is **NAPALM
+(normalized but narrow) versus Genie (rich but Cisco-centric)**.
+
+### Ratified routing rule: platform-first, with one deliberate exception
+
+| Situation | Server |
+|---|---|
+| Cisco IOS / IOS-XE / NX-OS / IOS-XR | `pyATS` (existing) |
+| Juniper Junos | `junos-mcp` (existing) |
+| Streaming telemetry, any vendor | `gnmi-mcp` (existing) |
+| No direct reachability / cloud-relayed | `radkit-mcp` (existing) |
+| **Any platform with no dedicated server** | **this server** |
+| **Cross-vendor normalized comparison, even where a dedicated server exists** | **this server, via NAPALM getters (read-only)** |
+
+The last row is the exception and the reason this rule must be written down: NAPALM also supports
+IOS and Junos, so without an explicit rule two servers answer the same question in different shapes.
+
+**Writes stay single-pathed per platform.** On Cisco and Juniper this server is read-only; the
+dedicated servers own all configuration change. This is what keeps Constitution Principles I
+("device state MUST be verified, not assumed") and VIII (verify after every change) enforceable —
+"verified by which tool?" must have exactly one answer per platform.
+
+The rejected alternative was **NAPALM-first for everything read-only**: conceptually cleaner, one
+output shape everywhere, but it discards most of Genie's ~2000 parsers on NetClaw's most common
+platform. Recorded here so it is not re-litigated.
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Reach a platform NetClaw cannot touch today (Priority: P1)
+
+An operator runs a mixed network. They ask NetClaw about interface state on a MikroTik edge router,
+a VyOS firewall, or a SONiC switch — platforms with no dedicated server — and get a real answer read
+from the live device.
+
+**Why this priority**: This is the entire point of R1. Today the answer is "NetClaw cannot reach that
+device." One server changes that for roughly ninety platforms.
+
+**Independent Test**: Point the server at a lab device of a platform no existing server supports
+(containerlab can host SR Linux, VyOS and SONiC; GNS3/EVE-NG can host MikroTik) and retrieve
+interface and version state. Delivers value with nothing else in this spec implemented.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reachable device of a platform no existing NetClaw server supports, **When** the
+   operator asks for its interface state, **Then** the live state is returned.
+2. **Given** the same device, **When** the operator asks for a platform-specific `show` command,
+   **Then** the raw output is returned without the server needing a parser for it.
+3. **Given** an unreachable device, **When** a query is attempted, **Then** the operation halts and
+   reports the failure rather than returning stale or assumed state (Principle I).
+4. **Given** a platform the underlying driver does not support, **When** a connection is attempted,
+   **Then** the unsupported platform is reported clearly rather than failing obscurely.
+
+---
+
+### User Story 2 - One question, one shape, across vendors (Priority: P1)
+
+An operator asks a question that spans vendors — "show me BGP neighbours across the whole fabric" —
+and receives one uniformly-shaped answer, rather than three differently-shaped ones they must
+reconcile by hand.
+
+**Why this priority**: Equal to US1 because it is the capability no existing server can provide at
+all. `pyATS` and `junos-mcp` each answer well for their own platform, but their output shapes differ,
+so cross-vendor questions currently require manual reconciliation. This is also the one case where
+this server is the right tool even for Cisco and Juniper.
+
+**Independent Test**: Query the same normalized fact across at least three different vendors' devices
+and confirm the results share one shape and can be presented as a single table.
+
+**Acceptance Scenarios**:
+
+1. **Given** devices from three or more vendors, **When** a normalized fact is requested, **Then**
+   every result shares one shape regardless of platform.
+2. **Given** a device whose platform has a dedicated server, **When** a *normalized cross-vendor*
+   fact is requested, **Then** this server answers it read-only.
+3. **Given** a device whose platform has a dedicated server, **When** a *single-device deep* query is
+   requested, **Then** the operator is directed to the dedicated server rather than served a shallower
+   answer.
+4. **Given** a platform for which a requested normalized fact is unavailable, **When** it is
+   requested, **Then** the gap is reported explicitly rather than silently omitted from the results.
+
+---
+
+### User Story 3 - Ask many devices at once (Priority: P2)
+
+An operator asks a question of an entire fleet — or a site, or a role — and gets per-device results
+including per-device failures, without the whole operation collapsing because three devices were
+unreachable.
+
+**Why this priority**: P2 because US1 and US2 deliver value on single devices first. But fleet-wide
+questions are the common real-world case, and doing them one device at a time does not scale to a
+network.
+
+**Independent Test**: Run one query against a lab of mixed-platform devices including at least one
+deliberately unreachable, and confirm per-device results with the failure isolated.
+
+**Acceptance Scenarios**:
+
+1. **Given** a group of devices, **When** one query is issued to the group, **Then** results are
+   returned per device.
+2. **Given** a group in which some devices are unreachable, **When** the query runs, **Then**
+   reachable devices return results and unreachable ones are reported individually as failures.
+3. **Given** a large group, **When** the query runs, **Then** devices are contacted concurrently
+   rather than strictly one at a time.
+
+---
+
+### User Story 4 - Inventory and credentials come from what NetClaw already has (Priority: P2)
+
+Devices and credentials are not re-entered. The device list comes from NetClaw's existing sources of
+truth, and credentials come from the existing secret store — never from a plaintext inventory file.
+
+**Why this priority**: P2 because US1 can be demonstrated against a small explicit target first. But
+a second, hand-maintained inventory would immediately drift from NetBox/Nautobot/Infrahub, and a
+plaintext credential file would violate Constitution Principle XIII outright.
+
+**Independent Test**: Resolve a device from an existing source of truth and connect to it using a
+credential retrieved from the secret store, with no device or secret written into a local file.
+
+**Acceptance Scenarios**:
+
+1. **Given** a device recorded in an existing source of truth, **When** it is referenced by name,
+   **Then** its connection details are resolved from that source rather than a local inventory.
+2. **Given** a device requiring credentials, **When** a connection is made, **Then** credentials come
+   from the existing secret store.
+3. **Given** any operation, **When** the configuration is inspected, **Then** no credential appears in
+   any file on disk (Principle XIII).
+4. **Given** a device absent from every source of truth, **When** it is referenced, **Then** the
+   absence is reported rather than guessed at.
+
+---
+
+### User Story 5 - Configuration change is gated, staged and reversible (Priority: P3)
+
+An operator changes configuration on a platform only this server can reach. The change is preceded by
+a captured baseline, requires explicit human approval, and can be rolled back.
+
+**Why this priority**: P3 deliberately. Read-only across ninety platforms is the valuable, safe
+increment; writes are where this server could cause an outage. Shipping US1–US4 first means the
+capability is useful long before it is dangerous. Genuinely gated writes need the approval path and
+baseline capture working, which is why they come last rather than never.
+
+**Independent Test**: Attempt a configuration change on a lab device and confirm it cannot proceed
+without approval, that a baseline was captured first, and that it can be reverted.
+
+**Acceptance Scenarios**:
+
+1. **Given** a configuration change request, **When** it is issued, **Then** a baseline is captured
+   before anything is modified (Principle II).
+2. **Given** a configuration change request, **When** it is issued, **Then** it does not proceed
+   without explicit human approval.
+3. **Given** an applied change, **When** it completes, **Then** actual resulting state is compared
+   against expected state, not merely that the command succeeded (Principle VIII).
+4. **Given** a failed verification, **When** it is detected, **Then** rollback to the captured
+   baseline is attempted and the outcome reported.
+5. **Given** a Cisco or Juniper device, **When** a configuration change is requested through this
+   server, **Then** it is refused and the dedicated server named instead — writes stay single-pathed.
+6. **Given** any device interaction, **When** it completes, **Then** it is recorded in the audit
+   trail (Principle IV).
+
+---
+
+### Edge Cases
+
+- **A platform is supported by the transport layer but has no normalized getter.** Raw command
+  execution must still work; the absence of normalization must be stated, not silently degraded.
+- **A device is reachable but authentication fails.** Distinguishable from unreachable, because the
+  remediation is entirely different.
+- **A device's platform is misrecorded in the source of truth.** Connecting with the wrong driver
+  produces confusing output; a platform mismatch should be detected and reported rather than guessed.
+- **Two servers could answer the same question.** The routing rule decides, and the operator should be
+  told which server answered, so results are attributable.
+- **A command is destructive in a way the deny-list did not anticipate.** Constitution's forbidden
+  operations (`write erase`, `reload`, `format flash:`) must be blocked regardless of platform
+  syntax — and platform syntax varies, so a Cisco-shaped deny-list is insufficient.
+- **A single device hangs.** One unresponsive device must not stall a fleet-wide query indefinitely.
+- **Credentials differ per device, site, or platform.** A single global credential is not a realistic
+  assumption for a mixed network.
+- **The same device is queried through two servers and the answers disagree.** Should be surfaceable,
+  since silent disagreement about device state is worse than a reported conflict.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Reach**
+
+- **FR-001**: The server MUST connect to network devices over SSH across a broad set of platforms,
+  including at minimum MikroTik RouterOS, VyOS, SONiC, Nokia SR Linux, Extreme, Huawei, Dell and
+  Ubiquiti EdgeOS — none of which NetClaw can reach today.
+- **FR-002**: The server MUST execute an arbitrary read-only command on a device and return its
+  output, without requiring a parser for that specific command.
+- **FR-003**: The server MUST report an unsupported platform explicitly rather than failing obscurely.
+- **FR-004**: The server MUST halt and report when a device is unreachable, never returning assumed or
+  cached state as if live (Principle I).
+- **FR-005**: The server MUST distinguish "unreachable" from "authentication failed" from "platform
+  mismatch", since each has a different remediation.
+
+**Normalization**
+
+- **FR-006**: The server MUST return a set of common operational facts in one shape that is identical
+  across platforms.
+- **FR-007**: Where a normalized fact is unavailable for a platform, the server MUST report that gap
+  explicitly rather than omitting it silently.
+- **FR-008**: Normalized cross-vendor reads MUST be available even for platforms that have a
+  dedicated server, and MUST be read-only there.
+
+**Routing and boundaries**
+
+- **FR-009**: The server MUST NOT be the route for single-device Cisco or Juniper work; `pyATS` and
+  `junos-mcp` remain authoritative for their platforms.
+- **FR-010**: The server MUST refuse configuration changes on platforms owned by a dedicated server,
+  naming the correct server, so every platform has exactly one write path.
+- **FR-011**: Results MUST identify which server produced them, so answers are attributable when more
+  than one server could have answered.
+- **FR-012**: The routing rule MUST be documented in the accompanying skills so an operator and the
+  agent select consistently.
+
+**Fleet operations**
+
+- **FR-013**: The server MUST execute one query against a group of devices and return per-device
+  results.
+- **FR-014**: A failure on one device MUST NOT abort the operation for others; per-device failures
+  MUST be reported individually.
+- **FR-015**: Devices MUST be contacted concurrently, with a bound on concurrency.
+- **FR-016**: An unresponsive device MUST time out rather than stalling the operation indefinitely.
+
+**Inventory and credentials**
+
+- **FR-017**: Device inventory MUST be resolved from NetClaw's existing sources of truth rather than a
+  new hand-maintained inventory file.
+- **FR-018**: Credentials MUST come from NetClaw's existing secret store.
+- **FR-019**: No credential may be written to any file on disk, in any form (Principle XIII).
+- **FR-020**: Per-device, per-site or per-platform credential differences MUST be supported; a single
+  global credential is not sufficient.
+- **FR-021**: A device absent from every source of truth MUST be reported as absent rather than
+  guessed at.
+
+**Safety**
+
+- **FR-022**: The server MUST default to read-only. Any write capability MUST be explicitly enabled
+  rather than available by default.
+- **FR-023**: The Constitution's forbidden operations MUST be blocked on every platform, accounting
+  for the fact that destructive command syntax differs per vendor.
+- **FR-024**: Configuration changes MUST capture a baseline before modifying anything (Principle II).
+- **FR-025**: Configuration changes MUST require explicit human approval through NetClaw's existing
+  approval path (Principle I).
+- **FR-026**: After a change, actual state MUST be compared against expected state — not merely that
+  the command returned successfully (Principle VIII).
+- **FR-027**: On failed verification, rollback to the captured baseline MUST be attempted and the
+  outcome reported.
+- **FR-028**: Every device interaction MUST be recorded in the audit trail (Principle IV).
+- **FR-029**: Command filtering MUST be enforced server-side, not merely advertised in skill
+  documentation, so it cannot be bypassed by phrasing a request differently.
+
+**Integration**
+
+- **FR-030**: The server MUST be registered and installable per `docs/ADDING-AN-MCP.md`, and
+  `scripts/reconcile-mcp.py` MUST pass — including a catalog entry and install function, since no
+  generic-driver catalog id exists today.
+- **FR-031**: Accompanying skills MUST cover, at minimum: normalized fact retrieval, safe raw command
+  execution, and fleet-wide fan-out.
+- **FR-032**: Existing device-facing capability MUST NOT regress; all 18 pyATS skills and the Junos
+  skill MUST continue to work unchanged.
+
+### Key Entities
+
+- **Device**: A reachable network element. Has a name, an address, a platform identifier, and a
+  credential reference. Resolved from a source of truth, never defined locally.
+- **Platform**: The OS family determining which driver and command syntax apply. Mismatch between the
+  recorded and actual platform is a detectable error condition.
+- **Device group**: A named set of devices — by site, role, platform, or tag — that one query can
+  target.
+- **Normalized fact**: An operational datum whose shape is identical across platforms. The unit of
+  cross-vendor comparison.
+- **Raw command result**: Unparsed device output, for anything no normalized fact covers.
+- **Command policy**: The server-side allow and deny rules, including the Constitution's forbidden
+  operations expressed per platform syntax.
+- **Change transaction**: A configuration change bundling baseline, approval, application,
+  verification and rollback.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: NetClaw can retrieve live state from at least **five platform families it cannot reach
+  today**, demonstrated against real devices or lab instances.
+- **SC-002**: Total reachable platform families increase from **4 to 90+**.
+- **SC-003**: A normalized fact requested across at least three vendors returns one shape, presentable
+  as a single table without per-vendor special-casing.
+- **SC-004**: A fleet query against a mixed group including at least one unreachable device returns
+  results for every reachable device and isolates the failure.
+- **SC-005**: A fleet query of N devices completes substantially faster than N sequential queries.
+- **SC-006**: Zero credentials appear in any file on disk, verified by inspection.
+- **SC-007**: Zero devices are defined in a local inventory file; every device resolves from a source
+  of truth.
+- **SC-008**: Every Constitution-forbidden operation is blocked on every supported platform, verified
+  per platform rather than assumed from one.
+- **SC-009**: No configuration change can be applied without a captured baseline and explicit
+  approval, verified by attempting to bypass both.
+- **SC-010**: A configuration change on a Cisco or Juniper device through this server is refused and
+  names the correct server.
+- **SC-011**: All 18 pyATS skills and the Junos skill remain functional (SC verified against the
+  pre-change baseline).
+- **SC-012**: `scripts/reconcile-mcp.py` exits zero with the new server registered.
+- **SC-013**: An operator can determine which server should answer a given device question from the
+  skill documentation alone, without reading source.
+
+## Assumptions
+
+- **The layering and routing decision is settled**, per the ratified rule above: platform-first with a
+  cross-vendor read-only exception, writes single-pathed per platform. This was confirmed with the
+  maintainer on 2026-07-30 and should not be reopened during planning.
+- **A community server will be adopted rather than written from scratch.** Two candidates were
+  identified in the landscape scan — one combining normalized getters with raw CLI execution and
+  shipping command blacklisting plus input validation, the other adding connection pooling and
+  concurrency. Candidate selection, and whether to adopt one, both, or fork, is a Phase 0 research
+  decision, not a spec decision.
+- **Read-only first is not negotiable.** US5 is P3 specifically so the safe increment ships first.
+- **Lab platforms are available for testing.** NetClaw already integrates containerlab, GNS3 and
+  EVE-NG, which between them host SR Linux, VyOS, SONiC and MikroTik — so SC-001 is testable without
+  buying hardware.
+- **None of the underlying libraries is currently installed** (`napalm`, `netmiko`, `nornir`,
+  `scrapli` all absent), so dependency isolation per Principle XV needs real attention — these pull a
+  substantial transitive tree.
+- **No generic-driver catalog id exists**, so unlike R0 this feature genuinely does add a catalog
+  entry and install function.
+- **This branch is stacked on R0 (spec 075), which is not yet merged to `main`.** R1 inherits
+  `docs/ADDING-AN-MCP.md` and `scripts/reconcile-mcp.py` from it. If R0 changes during review, R1
+  rebases.
+
+## Dependencies
+
+- **Spec 075 / R0** — the add-an-MCP procedure and the reconciliation gate this feature must satisfy.
+- Existing sources of truth — NetBox, Nautobot, Infrahub — for device inventory (FR-017).
+- Existing secret store — Vault MCP — for credentials (FR-018).
+- Existing approval path — HumanRail / the established gating mechanism — for writes (FR-025).
+- GAIT — audit trail for every device interaction (FR-028).
+- `pyATS` and `junos-mcp` — not modified, but their boundaries are defined against this server.
+- Lab infrastructure — containerlab, GNS3, EVE-NG — for multi-platform testing.
+- `scripts/lib/catalog.sh` and `scripts/lib/install-steps.sh` — a new component entry and install
+  function (FR-030).

--- a/specs/076-multivendor-cli-driver/spec.md
+++ b/specs/076-multivendor-cli-driver/spec.md
@@ -5,6 +5,16 @@
 **Status**: Draft
 **Roadmap item**: R1 in `docs/COVERAGE-ROADMAP.md` — highest coverage-per-line item on the roadmap
 **Depends on**: R0 / spec 075 (this branch is stacked on it — R1 must follow `docs/ADDING-AN-MCP.md` and pass `scripts/reconcile-mcp.py`)
+**Canonical identifiers** (declared once — three related names circulate, and FR-011 requires results
+to name the answering server unambiguously):
+
+| Use | Value |
+|---|---|
+| Vendored directory | `mcp-servers/multivendor-cli-mcp/` |
+| Registered server key (`config/openclaw.json`) | `multivendor-cli-mcp` |
+| `server` field in every tool result (FR-011) | `multivendor-cli` |
+| Installer catalog id / install function | `multivendor-cli` / `component_install_multivendor_cli()` |
+
 **Input**: User description: "Generic multivendor network CLI driver via Nornir, NAPALM and Netmiko. Roadmap item R1 — the largest coverage-per-line item on the roadmap. NetClaw's device reach today is pyATS (Cisco), junos-mcp (Juniper), gnmi-mcp (streaming telemetry) and radkit-mcp (cloud-relayed) — there is no general 'SSH to any platform' capability. One server adds MikroTik RouterOS, VyOS, SONiC, Nokia SR Linux, Extreme, Huawei, Dell, Ubiquiti EdgeOS and roughly ninety more platforms NetClaw cannot reach at all. […] Must be read-only first with writes explicitly gated. Must follow docs/ADDING-AN-MCP.md and pass scripts/reconcile-mcp.py, both established by spec 075."
 
 ---
@@ -242,6 +252,15 @@ without approval, that a baseline was captured first, and that it can be reverte
    baseline is attempted and the outcome reported.
 5. **Given** a Cisco or Juniper device, **When** a configuration change is requested through this
    server, **Then** it is refused and the dedicated server named instead — writes stay single-pathed.
+6. **Given** a **production** device, **When** a change is requested without an approved ServiceNow
+   Change Request, **Then** it does not proceed — human approval alone is insufficient (Principle III).
+7. **Given** an in-flight change, **When** its Change Request is rejected or withdrawn, **Then** the
+   change halts immediately and rolls back to the captured baseline.
+8. **Given** a **lab** device, **When** a change is requested, **Then** it may proceed without a Change
+   Request but is still recorded in the audit trail.
+9. **Given** a device whose inventory does not classify it as lab or production, **When** a change is
+   requested, **Then** it is treated as production and requires a Change Request — never assumed to be
+   lab.
 6. **Given** any device interaction, **When** it completes, **Then** it is recorded in the audit
    trail (Principle IV).
 
@@ -331,7 +350,8 @@ without approval, that a baseline was captured first, and that it can be reverte
   attributable and a stale-cache answer is never mistaken for a live one.
 - **FR-017d**: **No inventory source may contain credential material in any form** — only hostnames,
   addresses, platform identifiers, grouping metadata, and credential *references*. This applies
-  identically to all three sources (Principle XIII).
+  identically to all three sources (Principle XIII). This is the inventory-scoped instance of the global
+  rule in FR-019; both are intentional and neither is redundant.
 - **FR-017e**: The pyATS `testbed.yaml` MUST NOT be used as an inventory source. It assumes Cisco, and
   its platforms are precisely those FR-009 routes away from this server.
 - **FR-018**: Credentials MUST come from Vault where available, with environment variables as a
@@ -356,6 +376,16 @@ without approval, that a baseline was captured first, and that it can be reverte
 - **FR-024**: Configuration changes MUST capture a baseline before modifying anything (Principle II).
 - **FR-025**: Configuration changes MUST require explicit human approval through NetClaw's existing
   approval path (Principle I).
+- **FR-025a**: A configuration change against a **production** device MUST additionally have an approved
+  ServiceNow Change Request before execution (Constitution Principle III). Human approval (FR-025) and
+  an ITSM Change Request are **distinct gates** — the first is a person saying yes, the second is
+  change-management authorisation with an Assess → Authorize → Implement → Review lifecycle. Satisfying
+  one does not satisfy the other.
+- **FR-025b**: If a Change Request is rejected or withdrawn mid-execution, the change MUST halt
+  immediately and roll back to the captured baseline (Principle III).
+- **FR-025c**: Lab devices MAY be changed without a Change Request, and MUST still be recorded in the
+  audit trail (Principle III). Lab-versus-production MUST be determined from device inventory metadata,
+  never inferred or assumed — an unclassified device MUST be treated as production.
 - **FR-026**: After a change, actual state MUST be compared against expected state — not merely that
   the command returned successfully (Principle VIII).
 - **FR-027**: On failed verification, rollback to the captured baseline MUST be attempted and the
@@ -409,7 +439,11 @@ without approval, that a baseline was captured first, and that it can be reverte
 
 - **SC-001**: NetClaw can retrieve live state from at least **five platform families it cannot reach
   today**, demonstrated against real devices or lab instances.
-- **SC-002**: Total reachable platform families increase from **4 to 90+**.
+- **SC-002**: Reachable platform families increase from **4** to **≥90 documented as driver-supported**,
+  of which **≥5 are verified against live devices** (SC-001). The distinction is deliberate: the 90+
+  figure comes from the underlying driver's supported-platform list, while only platforms hostable in
+  containerlab can be live-tested without licensed images (research R4). Claiming 90 verified would be
+  untestable.
 - **SC-003**: A normalized fact requested across at least three vendors returns one shape, presentable
   as a single table without per-vendor special-casing.
 - **SC-004**: A fleet query against a mixed group including at least one unreachable device returns
@@ -429,6 +463,11 @@ without approval, that a baseline was captured first, and that it can be reverte
   approval, verified by attempting to bypass both.
 - **SC-010**: A configuration change on a Cisco or Juniper device through this server is refused and
   names the correct server.
+- **SC-009a**: No change applies to a production device without an approved Change Request, verified by
+  attempting one without it; and a lab-classified device can change without one while still being
+  audit-logged.
+- **SC-009b**: An unclassified device is treated as production, verified by attempting a change
+  against a device with no lab/production metadata.
 - **SC-011**: All 18 pyATS skills and the Junos skill remain functional (SC verified against the
   pre-change baseline).
 - **SC-012**: `scripts/reconcile-mcp.py` exits zero with the new server registered.

--- a/specs/076-multivendor-cli-driver/tasks.md
+++ b/specs/076-multivendor-cli-driver/tasks.md
@@ -86,18 +86,18 @@ passing a tested server-side filter.
 **Independent test**: Resolve a device from each of the three sources in turn and confirm each reports
 its own source; confirm no credential appears in any file on disk.
 
-- [ ] T017 [US4] Implement `inventory/sources.py` with the three-source model and resolution order `live_sot` → `generated` → `operator`, plus `auto` (FR-017, FR-017b). A device absent from **every** source MUST be reported as absent, never guessed at or silently defaulted (FR-021).
+- [X] T017 [US4] Implement `inventory/sources.py` with the three-source model and resolution order `live_sot` → `generated` → `operator`, plus `auto` (FR-017, FR-017b). A device absent from **every** source MUST be reported as absent, never guessed at or silently defaulted (FR-021).
 - [ ] T018 [P] [US4] Implement `inventory/live_sot.py` using `nornir-netbox` / `nornir-nautobot`, plus Infrahub via its existing MCP surface (FR-017 live tier).
 - [ ] T019 [P] [US4] Implement `inventory/generated.py` to render an inventory file from a source of truth, writing a machine-readable **generated marker** so a refresh can never overwrite an operator file (FR-017a/b).
 - [ ] T020 [P] [US4] Implement `inventory/operator.py` as a strictly **read-only** consumer of an operator-authored file. The server MUST NOT write to it under any circumstance (FR-017b).
-- [ ] T021 [US4] Populate `source` on every resolved Device and surface it in every result, with `fallback_reason` when the source is not `live_sot` — a stale-cache answer must never look live (FR-017c).
-- [ ] T022 [US4] Reject any inventory record carrying credential-shaped fields, from any of the three sources, with a clear error naming the offending device and field (FR-017d, Principle XIII).
-- [ ] T023 [US4] Explicitly refuse `PYATS_TESTBED_PATH` as an inventory source, with an error explaining that pyATS assumes Cisco and those platforms route to `pyATS` instead (FR-017e).
-- [ ] T024 [US4] Implement `credentials.py` with Vault preferred and environment variables as a documented fallback. **Vault MUST NOT be a hard prerequisite** — an operator with an operator-authored inventory typically has no Vault either (FR-018). Support per-device, per-site and per-platform credential differences via the Device `credential_ref`; a single global credential is not a realistic assumption for a mixed network (FR-020).
-- [ ] T025 [US4] Report the credential path (`vault` or `environment`) in results so a deployment's posture is inspectable, while never emitting the secret value itself (FR-018a, FR-019).
-- [ ] T026 [US4] Implement the `list_devices` tool per contracts/mcp-tools.md, including `source_used` and `owning_server`, and never returning credential values.
-- [ ] T027 [P] [US4] Add inventory contract tests to `tests/multivendor/`: each source reports itself; a credential-bearing inventory record is rejected; a generated-file refresh leaves an operator file byte-identical; a device in no source is reported absent; two devices with different `credential_ref` values resolve independently (SC-007, FR-020, FR-021).
-- [ ] T028 [P] [US4] Document all three onboarding paths in `.env.example` with descriptions and no values (Principle XIII).
+- [X] T021 [US4] Populate `source` on every resolved Device and surface it in every result, with `fallback_reason` when the source is not `live_sot` — a stale-cache answer must never look live (FR-017c).
+- [X] T022 [US4] Reject any inventory record carrying credential-shaped fields, from any of the three sources, with a clear error naming the offending device and field (FR-017d, Principle XIII).
+- [X] T023 [US4] Explicitly refuse `PYATS_TESTBED_PATH` as an inventory source, with an error explaining that pyATS assumes Cisco and those platforms route to `pyATS` instead (FR-017e).
+- [X] T024 [US4] Implement `credentials.py` with Vault preferred and environment variables as a documented fallback. **Vault MUST NOT be a hard prerequisite** — an operator with an operator-authored inventory typically has no Vault either (FR-018). Support per-device, per-site and per-platform credential differences via the Device `credential_ref`; a single global credential is not a realistic assumption for a mixed network (FR-020).
+- [X] T025 [US4] Report the credential path (`vault` or `environment`) in results so a deployment's posture is inspectable, while never emitting the secret value itself (FR-018a, FR-019).
+- [X] T026 [US4] Implement the `list_devices` tool per contracts/mcp-tools.md, including `source_used` and `owning_server`, and never returning credential values.
+- [X] T027 [P] [US4] Add inventory contract tests to `tests/multivendor/`: each source reports itself; a credential-bearing inventory record is rejected; a generated-file refresh leaves an operator file byte-identical; a device in no source is reported absent; two devices with different `credential_ref` values resolve independently (SC-007, FR-020, FR-021).
+- [X] T028 [P] [US4] Document all three onboarding paths in `.env.example` with descriptions and no values (Principle XIII).
 
 **Checkpoint US4**: any device is resolvable and authenticable, with attribution, and no secret on disk.
 
@@ -138,11 +138,11 @@ shape, presentable as a single table with no per-vendor special-casing.
 - [ ] T040 [US2] Report an unavailable getter explicitly with a `gap_reason`, never omitting it silently from results (FR-007).
 - [ ] T041 [US2] Set `provenance` to `napalm` or `ttp_template`, and **never present a TTP-parsed result as equivalent to a NAPALM one** — emulating a missing getter by scraping CLI output is the exact failure FR-007 exists to prevent (research R9).
 - [ ] T042 [US2] Implement the `get_facts` tool per contracts/mcp-tools.md, permitted read-only on Cisco and Junos devices because cross-vendor normalized comparison is the one case where this server is correct for them (FR-008).
-- [ ] T043 [US2] Implement the platform-first routing rule in `routing.py`: dedicated servers own their platforms; this server covers the rest plus cross-vendor normalized reads (FR-009).
-- [ ] T044 [US2] Refuse configuration changes on platforms owned by another server, naming that server in `owning_server`, so every platform has exactly one write path (FR-010).
-- [ ] T045 [US2] Return a refusal as a **successful call with a refusal result**, not a protocol error, so the agent can read why and route elsewhere (contracts/mcp-tools.md).
-- [ ] T046 [US2] Stamp `server: "multivendor-cli"` on every result so answers are attributable when more than one server could have answered (FR-011).
-- [ ] T047 [P] [US2] Add routing contract tests: a Cisco write is refused and names `pyats`; a Cisco normalized read succeeds; both behaviours hold for Junos and `junos-mcp`.
+- [X] T043 [US2] Implement the platform-first routing rule in `routing.py`: dedicated servers own their platforms; this server covers the rest plus cross-vendor normalized reads (FR-009).
+- [X] T044 [US2] Refuse configuration changes on platforms owned by another server, naming that server in `owning_server`, so every platform has exactly one write path (FR-010).
+- [X] T045 [US2] Return a refusal as a **successful call with a refusal result**, not a protocol error, so the agent can read why and route elsewhere (contracts/mcp-tools.md).
+- [X] T046 [US2] Stamp `server: "multivendor-cli"` on every result so answers are attributable when more than one server could have answered (FR-011).
+- [X] T047 [P] [US2] Add routing contract tests: a Cisco write is refused and names `pyats`; a Cisco normalized read succeeds; both behaviours hold for Junos and `junos-mcp`.
 - [ ] T048 [US2] Verify SC-003: one normalized fact across three or more vendors returns one shape, and SC-010: a Cisco/Junos write through this server is refused with the correct server named.
 
 **Checkpoint US2**: cross-vendor questions answerable in one shape, with the boundary against pyATS and
@@ -174,18 +174,18 @@ confirm every reachable device returns and the failure is isolated.
 > Can proceed in parallel from the US1 checkpoint onward. Unlike spec 075, this feature genuinely adds
 > capability, so **every** Principle XI touchpoint applies.
 
-- [ ] T056 Finalise `server.py`: confirm every tool built in Phases 3–6 is registered, the read-only surface is complete, and write tools are absent unless `MULTIVENDOR_WRITE_ENABLED` is set. The stub itself was created in T016a (analyze finding O1).
-- [ ] T057 Add a catalog entry to `scripts/lib/catalog.sh` — no generic-driver catalog id exists today, so this is a genuinely new component (FR-030).
-- [ ] T058 Add `component_install_multivendor_cli()` to `scripts/lib/install-steps.sh` creating the venv per T008's method, using the venv's own pip and never bare `pip3` (FR-030a, R7).
-- [ ] T059 Register the server in `config/openclaw.json` with the venv interpreter path **resolved at install time, never hardcoded** — spec 075 found three registrations hardcoded to `/home/ubuntu/netclaw/.venv/bin/python3` and broken for every installer, and `reconcile-mcp.py` now fails on exactly that (FR-030b).
-- [ ] T060 [P] Write `mcp-servers/multivendor-cli-mcp/README.md` documenting every tool, environment variable, transport, and install step (Principle XII).
-- [ ] T061 [P] Create `workspace/skills/multivendor-device-query/SKILL.md` for normalized facts, and **state the routing rule explicitly** so operator and agent select consistently (FR-012, FR-031).
+- [X] T056 Finalise `server.py`: confirm every tool built in Phases 3–6 is registered, the read-only surface is complete, and write tools are absent unless `MULTIVENDOR_WRITE_ENABLED` is set. The stub itself was created in T016a (analyze finding O1).
+- [X] T057 Add a catalog entry to `scripts/lib/catalog.sh` — no generic-driver catalog id exists today, so this is a genuinely new component (FR-030).
+- [X] T058 Add `component_install_multivendor_cli()` to `scripts/lib/install-steps.sh` creating the venv per T008's method, using the venv's own pip and never bare `pip3` (FR-030a, R7).
+- [X] T059 Register the server in `config/openclaw.json` with the venv interpreter path **resolved at install time, never hardcoded** — spec 075 found three registrations hardcoded to `/home/ubuntu/netclaw/.venv/bin/python3` and broken for every installer, and `reconcile-mcp.py` now fails on exactly that (FR-030b).
+- [X] T060 [P] Write `mcp-servers/multivendor-cli-mcp/README.md` documenting every tool, environment variable, transport, and install step (Principle XII).
+- [X] T061 [P] Create `workspace/skills/multivendor-device-query/SKILL.md` for normalized facts, and **state the routing rule explicitly** so operator and agent select consistently (FR-012, FR-031).
 - [ ] T062 [P] Create `workspace/skills/multivendor-raw-cli/SKILL.md` for safe raw command execution, documenting the filter policy while making clear enforcement is server-side (FR-029, FR-031).
 - [ ] T063 [P] Create `workspace/skills/multivendor-fleet-ops/SKILL.md` for fleet fan-out (FR-031).
 - [ ] T064 [P] Note in the skills that netmiko also drives Fortinet, PAN-OS and Check Point, but that **CLI reach is not equivalent to their dedicated API servers** — this must not cause R3/R4 to be skipped (research R3).
 - [ ] T065 [P] Update `README.md`, `SOUL.md`, `TOOLS.md` and `ui/netclaw-visual/` per Principle XI, **including the skill and MCP counts** — the step most often forgotten, and wrong in nine places before spec 075.
 - [ ] T066 Publish `docs/ADDING-AN-MCP.md`-compliant onboarding by copying `quickstart.md` guidance into the server README, covering all three inventory sources.
-- [ ] T067 Verify `python3 scripts/reconcile-mcp.py` exits 0 with the new server registered (SC-012).
+- [X] T067 Verify `python3 scripts/reconcile-mcp.py` exits 0 with the new server registered (SC-012).
 
 ---
 

--- a/specs/076-multivendor-cli-driver/tasks.md
+++ b/specs/076-multivendor-cli-driver/tasks.md
@@ -23,6 +23,19 @@ packages. Everything in spec 075 was repository files; this is not. R7 found the
 (`pip3` → Python 3.13 stranded site-packages, `python3` → 3.14.4, two different `cryptography`
 versions), so the install must be done with the venv's own pip and verified, not assumed.
 
+**4. Post-analyze corrections applied.** `/speckit.analyze` found one CRITICAL and two HIGH issues,
+all fixed here rather than deferred:
+
+- **CRITICAL** — Constitution Principle III (ITSM-gated changes) had **zero** task coverage. The plan
+  had marked it "Partially — inherited from the existing approval path", which was an assertion, not an
+  implementation. Human approval (FR-025) and a ServiceNow Change Request are **distinct gates**. Now
+  T070a–T070d and T076a–T076b.
+- **HIGH** — the MCP entry point was sequenced *after* the stories that need it, so no story phase was
+  independently testable as an MCP capability. A stub now lands in Foundational as T016a.
+- **HIGH** — SC-002's "90+ platform families" was not verifiable; the figure comes from a driver's
+  supported-platform list, and only containerlab-hostable platforms can be live-tested. Split into
+  documented-versus-verified.
+
 ---
 
 ## Phase 1: Setup
@@ -55,6 +68,7 @@ task here is done.**
 - [ ] T013 Implement `mcp-servers/multivendor-cli-mcp/policy/platform_deny.py` with per-platform destructive first tokens (R6): VyOS `delete`, MikroTik `/system reset-configuration`, SR Linux `tools system configuration`, SONiC `config erase`, plus the Constitution's Cisco set. A Cisco-shaped denylist is explicitly insufficient (FR-023).
 - [ ] T014 Implement read-only mode as the default, with write tools absent from `tools/list` entirely unless `MULTIVENDOR_WRITE_ENABLED` is set (FR-022). Absent, not present-and-refusing.
 - [ ] T015 [P] Add Pydantic input validation across every tool argument, ported from candidate A's design (research R1).
+- [ ] T016a Implement `mcp-servers/multivendor-cli-mcp/server.py` as a **FastMCP stdio server stub** now, registering tools as they land in later phases (Principle V). **Moved into Foundational per analyze finding O1**: T029–T055 implement the tools, but without an entry point none of them is reachable over MCP, so no story phase would be independently testable as an MCP capability. The stub need only expose `initialize` / `tools/list` / `tools/call` with an empty tool set.
 - [ ] T016 [P] Add filter contract tests to `tests/multivendor/run-tests.sh` — these run with **no device**: chaining rejected first, per-platform denylist fires, read-only mode blocks non-allowlisted verbs, and `show version` alone passes. Assert exit codes directly.
 
 **Checkpoint Phase 2**: dependencies isolated and proven, and no command can reach a device without
@@ -160,7 +174,7 @@ confirm every reachable device returns and the failure is isolated.
 > Can proceed in parallel from the US1 checkpoint onward. Unlike spec 075, this feature genuinely adds
 > capability, so **every** Principle XI touchpoint applies.
 
-- [ ] T056 Implement `server.py` as a FastMCP stdio server exposing the read-only tool surface, with proper `initialize` / `tools/list` / `tools/call` lifecycle (Principle V).
+- [ ] T056 Finalise `server.py`: confirm every tool built in Phases 3–6 is registered, the read-only surface is complete, and write tools are absent unless `MULTIVENDOR_WRITE_ENABLED` is set. The stub itself was created in T016a (analyze finding O1).
 - [ ] T057 Add a catalog entry to `scripts/lib/catalog.sh` — no generic-driver catalog id exists today, so this is a genuinely new component (FR-030).
 - [ ] T058 Add `component_install_multivendor_cli()` to `scripts/lib/install-steps.sh` creating the venv per T008's method, using the venv's own pip and never bare `pip3` (FR-030a, R7).
 - [ ] T059 Register the server in `config/openclaw.json` with the venv interpreter path **resolved at install time, never hardcoded** — spec 075 found three registrations hardcoded to `/home/ubuntu/netclaw/.venv/bin/python3` and broken for every installer, and `reconcile-mcp.py` now fails on exactly that (FR-030b).
@@ -188,12 +202,18 @@ was captured first, and that it reverts on verification failure.
 - [ ] T068 [US5] Implement `tools/change.py` with the `ChangeTransaction` state machine from data-model.md, where each transition is a gate rather than a step.
 - [ ] T069 [US5] Capture a baseline **before** any modification, written inside a path-sandboxed root with traversal prevented, ported from candidate A's design (FR-024, Principle II).
 - [ ] T070 [US5] Require explicit human approval via NetClaw's existing approval path; no transition past `awaiting_approval` without it (FR-025, Principle I).
+- [ ] T070a [US5] Classify each device as **lab or production** from inventory metadata, treating an unclassified device as **production**. Never infer or assume lab status (FR-025c). **Added per analyze finding D1.**
+- [ ] T070b [US5] Require an approved ServiceNow Change Request before any change to a production device, via the existing `servicenow-mcp` integration and `servicenow-change-workflow` skill. This is a **second gate**, distinct from FR-025's human approval — a person saying yes is not change-management authorisation (FR-025a, Constitution Principle III).
+- [ ] T070c [US5] Halt immediately and roll back to the captured baseline if a Change Request is rejected or withdrawn mid-execution (FR-025b, Principle III).
+- [ ] T070d [US5] Permit lab-device changes without a Change Request while still recording them in the audit trail (FR-025c, Principle III).
 - [ ] T071 [US5] Verify post-change state by structured comparison of actual against expected using `jdiff`, **never** from command exit status (FR-026, Principle VIII, research R9).
 - [ ] T072 [US5] Attempt rollback to the captured baseline on verification failure, and **halt and alert** if rollback itself fails (FR-027, Principle VIII).
 - [ ] T073 [US5] Terminate at `refused` for Cisco and Junos devices, naming the owning server (FR-010).
 - [ ] T074 [US5] Expose `apply_config` only when `MULTIVENDOR_WRITE_ENABLED` is set — absent from `tools/list` otherwise (FR-022).
 - [ ] T075 [US5] GAIT-log every device interaction and every state transition (FR-028, Principle IV).
 - [ ] T076 [US5] Verify SC-009: no change applies without both a captured baseline and explicit approval, tested by attempting to bypass each.
+- [ ] T076a [US5] Verify SC-009a: a production-device change is refused without an approved Change Request, and a lab-classified device may change without one while still being audit-logged.
+- [ ] T076b [US5] Verify SC-009b: a device with no lab/production metadata is treated as production and requires a Change Request.
 
 ---
 
@@ -204,7 +224,7 @@ was captured first, and that it reverts on verification failure.
 - [ ] T079 Verify SC-007b / FR-030c: installing this server leaves the system `cryptography` version unchanged.
 - [ ] T080 Verify SC-006: no credential appears in any file on disk outside a gitignored `.env`, inspected across all three inventory sources.
 - [ ] T081 Verify SC-008: every Constitution-forbidden operation is blocked on **every** supported platform, tested per platform rather than inferred from one.
-- [ ] T082 Verify SC-002 and SC-013: reachable platform families increased from 4 to 90+, and an operator can tell from skill documentation alone which server should answer a given question.
+- [ ] T082 Verify SC-002 and SC-013: **≥90 platform families documented as driver-supported and ≥5 verified against live devices** — the two are separate claims and only the second is testable without licensed images (analyze finding U1, research R4). Also verify an operator can tell from skill documentation alone which server should answer a given question.
 - [ ] T083 [P] Raise the repo-wide `pip3` hazard from research R7 as its own roadmap item: `scripts/lib/install-steps.sh` contains 186 `pip install` invocations, and on a split-toolchain host any bare `pip3` lands where servers cannot import from. Out of scope here; must not be lost.
 - [ ] T084 [P] Update `docs/COVERAGE-ROADMAP.md`: mark R1 `DONE`, record that both candidate servers were rejected and why, and note the CLI-reach-is-not-R3/R4 caveat.
 - [ ] T085 Run the Constitution Principle XI Artifact Coherence Checklist and record the result.
@@ -218,7 +238,7 @@ was captured first, and that it reverts on verification failure.
 ```
 Phase 1 Setup (T001–T004)
       ↓
-Phase 2 Foundational — venv (T005–T010) then filter (T011–T016)
+Phase 2 Foundational — venv (T005–T010), filter (T011–T016), server stub (T016a)
       ↓                 ← NOTHING touches a device until this completes
 Phase 3 US4 inventory + credentials (T017–T028)
       ↓                 ← dependency prerequisite for US1, despite being P2
@@ -230,7 +250,7 @@ Phase 5 US2 (T038–T048)   Phase 6 US3 (T049–T055)   Phase 7 Integration (T05
    ↓                   ↓                     ↓
    └───────────────────┴─────────────────────┘
                        ↓
-       Phase 8 US5 gated writes (T068–T076)   ← deferrable
+       Phase 8 US5 gated writes (T068–T076b)  ← deferrable; includes ITSM CR gating
                        ↓
        Phase 9 Polish (T077–T087)
 ```
@@ -274,12 +294,12 @@ valuable; writes are the only part that can cause an outage.
 | Phase | Story | Tasks | Count |
 |---|---|---|---|
 | 1 Setup | — | T001–T004 | 4 |
-| 2 Foundational (venv + filter) | — | T005–T016 | 12 |
+| 2 Foundational (venv + filter + server stub) | — | T005–T016a | 13 |
 | 3 | US4 (P2) | T017–T028 | 12 |
 | 4 | US1 (P1) | T029–T037 | 9 |
 | 5 | US2 (P1) | T038–T048 | 11 |
 | 6 | US3 (P2) | T049–T055 | 7 |
 | 7 Integration (XI) | — | T056–T067 | 12 |
-| 8 | US5 (P3) | T068–T076 | 9 |
+| 8 | US5 (P3) | T068–T076b | 15 |
 | 9 Polish | — | T077–T087 | 11 |
-| **Total** | | | **87** |
+| **Total** | | | **94** |

--- a/specs/076-multivendor-cli-driver/tasks.md
+++ b/specs/076-multivendor-cli-driver/tasks.md
@@ -40,10 +40,10 @@ all fixed here rather than deferred:
 
 ## Phase 1: Setup
 
-- [ ] T001 Read `specs/076-multivendor-cli-driver/research.md` in full before writing any code, R7 and R8 especially — R7 invalidates an earlier conclusion about dependency safety and R8 corrects the transport decision.
-- [ ] T002 Create the server skeleton at `mcp-servers/multivendor-cli-mcp/` with the package layout from plan.md (`inventory/`, `policy/`, `tools/`, `server.py`, `routing.py`, `credentials.py`).
-- [ ] T003 Add a `.gitignore` negation entry for `mcp-servers/multivendor-cli-mcp/` so the new server directory is tracked — the repo ignores broadly and new server dirs are otherwise silently untracked.
-- [ ] T004 [P] Create the test harness skeleton at `tests/multivendor/run-tests.sh`, following spec 075's `tests/reconcile/run-tests.sh` pattern: bash + stdlib, no new framework in the shared environment. **Capture exit codes without a pipe** (`cmd >/dev/null 2>&1; echo $?`) — a `| tail` pipe reports the pipe's status and caused a misdiagnosis in spec 075.
+- [X] T001 Read `specs/076-multivendor-cli-driver/research.md` in full before writing any code, R7 and R8 especially — R7 invalidates an earlier conclusion about dependency safety and R8 corrects the transport decision.
+- [X] T002 Create the server skeleton at `mcp-servers/multivendor-cli-mcp/` with the package layout from plan.md (`inventory/`, `policy/`, `tools/`, `server.py`, `routing.py`, `credentials.py`).
+- [X] T003 Add a `.gitignore` negation entry for `mcp-servers/multivendor-cli-mcp/` so the new server directory is tracked — the repo ignores broadly and new server dirs are otherwise silently untracked.
+- [X] T004 [P] Create the test harness skeleton at `tests/multivendor/run-tests.sh`, following spec 075's `tests/reconcile/run-tests.sh` pattern: bash + stdlib, no new framework in the shared environment. **Capture exit codes without a pipe** (`cmd >/dev/null 2>&1; echo $?`) — a `| tail` pipe reports the pipe's status and caused a misdiagnosis in spec 075.
 
 ---
 
@@ -54,22 +54,22 @@ task here is done.**
 
 ### Stage 1 — dedicated virtualenv and dependency isolation (FR-030a/b/c, R7)
 
-- [ ] T005 Confirm wheel availability for the full dependency tree on `/usr/bin/python3` (3.14.4) using `--dry-run` executed by **that interpreter's own pip**. If any wheel is unavailable, select an older base interpreter and record the choice and reason in research.md — this is the plan's one open item and must be resolved by evidence, not assumption.
-- [ ] T006 Record the pre-install `cryptography` version as reported by `/usr/bin/python3` (currently 46.0.5) in `specs/076-multivendor-cli-driver/baseline-deps.txt`. This is the FR-030c comparison point and MUST be read from the interpreter NetClaw's servers run under, not from `pip3`.
-- [ ] T007 Write `mcp-servers/multivendor-cli-mcp/requirements.txt` with every dependency **explicitly pinned**: `nornir`, `napalm`, `netmiko`, `nornir-netmiko`, `nornir_napalm`, `nornir-netbox`, `nornir-nautobot`, `pynautobot`, `jdiff`. Note in a comment that the scrapli family arrives transitively via NAPALM 5.x and is expected, not accidental (R8).
-- [ ] T008 Create the virtualenv with `/usr/bin/python3 -m venv mcp-servers/multivendor-cli-mcp/.venv` and install using `<venv>/bin/python -m pip install -r requirements.txt`. **Never bare `pip3`** — on this host it targets a stranded Python 3.13 site-packages the server cannot import from (R7).
-- [ ] T009 Verify the system `cryptography` version reported by `/usr/bin/python3` is unchanged against T006's baseline (FR-030c). If it moved, stop — the NCFED X.509 stack (spec 060) depends on it and a regression here breaks certificate handling, not this server.
-- [ ] T010 Verify the venv can import `nornir`, `napalm`, `netmiko` and `jdiff`, and that the system interpreter still **cannot** — proving isolation actually holds rather than assuming it.
+- [X] T005 Confirm wheel availability for the full dependency tree on `/usr/bin/python3` (3.14.4) using `--dry-run` executed by **that interpreter's own pip**. If any wheel is unavailable, select an older base interpreter and record the choice and reason in research.md — this is the plan's one open item and must be resolved by evidence, not assumption.
+- [X] T006 Record the pre-install `cryptography` version as reported by `/usr/bin/python3` (currently 46.0.5) in `specs/076-multivendor-cli-driver/baseline-deps.txt`. This is the FR-030c comparison point and MUST be read from the interpreter NetClaw's servers run under, not from `pip3`.
+- [X] T007 Write `mcp-servers/multivendor-cli-mcp/requirements.txt` with every dependency **explicitly pinned**: `nornir`, `napalm`, `netmiko`, `nornir-netmiko`, `nornir_napalm`, `nornir-netbox`, `nornir-nautobot`, `pynautobot`, `jdiff`. Note in a comment that the scrapli family arrives transitively via NAPALM 5.x and is expected, not accidental (R8).
+- [X] T008 Create the virtualenv with `/usr/bin/python3 -m venv mcp-servers/multivendor-cli-mcp/.venv` and install using `<venv>/bin/python -m pip install -r requirements.txt`. **Never bare `pip3`** — on this host it targets a stranded Python 3.13 site-packages the server cannot import from (R7).
+- [X] T009 Verify the system `cryptography` version reported by `/usr/bin/python3` is unchanged against T006's baseline (FR-030c). If it moved, stop — the NCFED X.509 stack (spec 060) depends on it and a regression here breaks certificate handling, not this server.
+- [X] T010 Verify the venv can import `nornir`, `napalm`, `netmiko` and `jdiff`, and that the system interpreter still **cannot** — proving isolation actually holds rather than assuming it.
 
 ### Stage 2 — command filter and per-platform denylists (FR-022/023/029, R6)
 
-- [ ] T011 Implement `mcp-servers/multivendor-cli-mcp/policy/filter.py` with the four-step evaluation from contracts/mcp-tools.md. **Chaining rejection MUST be step 1** — `show version; write erase` passes an allowlist check on its first token and is catastrophic. Order is contractual, not stylistic.
-- [ ] T012 Implement chaining detection for `;`, `&&`, `||`, `>`, `<`, backtick and `$(` in `policy/filter.py` (FR-023).
-- [ ] T013 Implement `mcp-servers/multivendor-cli-mcp/policy/platform_deny.py` with per-platform destructive first tokens (R6): VyOS `delete`, MikroTik `/system reset-configuration`, SR Linux `tools system configuration`, SONiC `config erase`, plus the Constitution's Cisco set. A Cisco-shaped denylist is explicitly insufficient (FR-023).
-- [ ] T014 Implement read-only mode as the default, with write tools absent from `tools/list` entirely unless `MULTIVENDOR_WRITE_ENABLED` is set (FR-022). Absent, not present-and-refusing.
-- [ ] T015 [P] Add Pydantic input validation across every tool argument, ported from candidate A's design (research R1).
-- [ ] T016a Implement `mcp-servers/multivendor-cli-mcp/server.py` as a **FastMCP stdio server stub** now, registering tools as they land in later phases (Principle V). **Moved into Foundational per analyze finding O1**: T029–T055 implement the tools, but without an entry point none of them is reachable over MCP, so no story phase would be independently testable as an MCP capability. The stub need only expose `initialize` / `tools/list` / `tools/call` with an empty tool set.
-- [ ] T016 [P] Add filter contract tests to `tests/multivendor/run-tests.sh` — these run with **no device**: chaining rejected first, per-platform denylist fires, read-only mode blocks non-allowlisted verbs, and `show version` alone passes. Assert exit codes directly.
+- [X] T011 Implement `mcp-servers/multivendor-cli-mcp/policy/filter.py` with the four-step evaluation from contracts/mcp-tools.md. **Chaining rejection MUST be step 1** — `show version; write erase` passes an allowlist check on its first token and is catastrophic. Order is contractual, not stylistic.
+- [X] T012 Implement chaining detection for `;`, `&&`, `||`, `>`, `<`, backtick and `$(` in `policy/filter.py` (FR-023).
+- [X] T013 Implement `mcp-servers/multivendor-cli-mcp/policy/platform_deny.py` with per-platform destructive first tokens (R6): VyOS `delete`, MikroTik `/system reset-configuration`, SR Linux `tools system configuration`, SONiC `config erase`, plus the Constitution's Cisco set. A Cisco-shaped denylist is explicitly insufficient (FR-023).
+- [X] T014 Implement read-only mode as the default, with write tools absent from `tools/list` entirely unless `MULTIVENDOR_WRITE_ENABLED` is set (FR-022). Absent, not present-and-refusing.
+- [X] T015 [P] Add Pydantic input validation across every tool argument, ported from candidate A's design (research R1).
+- [X] T016a Implement `mcp-servers/multivendor-cli-mcp/server.py` as a **FastMCP stdio server stub** now, registering tools as they land in later phases (Principle V). **Moved into Foundational per analyze finding O1**: T029–T055 implement the tools, but without an entry point none of them is reachable over MCP, so no story phase would be independently testable as an MCP capability. The stub need only expose `initialize` / `tools/list` / `tools/call` with an empty tool set.
+- [X] T016 [P] Add filter contract tests to `tests/multivendor/run-tests.sh` — these run with **no device**: chaining rejected first, per-platform denylist fires, read-only mode blocks non-allowlisted verbs, and `show version` alone passes. Assert exit codes directly.
 
 **Checkpoint Phase 2**: dependencies isolated and proven, and no command can reach a device without
 passing a tested server-side filter.

--- a/specs/076-multivendor-cli-driver/tasks.md
+++ b/specs/076-multivendor-cli-driver/tasks.md
@@ -1,0 +1,285 @@
+# Tasks: Generic Multivendor CLI Driver
+
+**Feature**: 076-multivendor-cli-driver | **Date**: 2026-07-30
+**Input**: [spec.md](./spec.md) · [plan.md](./plan.md) · [research.md](./research.md) · [data-model.md](./data-model.md) · [contracts/mcp-tools.md](./contracts/mcp-tools.md) · [quickstart.md](./quickstart.md)
+**Tech**: Python (interpreter chosen deliberately — see R7), `nornir`/`napalm`/`netmiko`/`jdiff` in a **dedicated virtualenv**
+**Stacked on**: R0 / spec 075 (unmerged). Must pass `scripts/reconcile-mcp.py`
+
+---
+
+## Three things that shape this task list
+
+**1. Execution order inverts priority for US4.** US4 (inventory and credentials) is P2, but you cannot
+connect to a device without it — so it executes *before* US1 (P1, reach). Priority describes user value;
+this ordering describes dependency. Same shape as spec 075, where enforcement was P1 but had to run last.
+
+**2. The command filter is Foundational, not part of a story.** It blocks every device interaction and
+belongs to no single story, so it sits in Phase 2 alongside the venv. Building reach first and adding
+safety later would create a window in which arbitrary commands execute — precisely what Principle I
+forbids. **Phase 2 must be complete before any task touches a real device.**
+
+**3. Stage 1 is the first task in this whole roadmap that changes system state.** It installs ~21
+packages. Everything in spec 075 was repository files; this is not. R7 found the host toolchain split
+(`pip3` → Python 3.13 stranded site-packages, `python3` → 3.14.4, two different `cryptography`
+versions), so the install must be done with the venv's own pip and verified, not assumed.
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Read `specs/076-multivendor-cli-driver/research.md` in full before writing any code, R7 and R8 especially — R7 invalidates an earlier conclusion about dependency safety and R8 corrects the transport decision.
+- [ ] T002 Create the server skeleton at `mcp-servers/multivendor-cli-mcp/` with the package layout from plan.md (`inventory/`, `policy/`, `tools/`, `server.py`, `routing.py`, `credentials.py`).
+- [ ] T003 Add a `.gitignore` negation entry for `mcp-servers/multivendor-cli-mcp/` so the new server directory is tracked — the repo ignores broadly and new server dirs are otherwise silently untracked.
+- [ ] T004 [P] Create the test harness skeleton at `tests/multivendor/run-tests.sh`, following spec 075's `tests/reconcile/run-tests.sh` pattern: bash + stdlib, no new framework in the shared environment. **Capture exit codes without a pipe** (`cmd >/dev/null 2>&1; echo $?`) — a `| tail` pipe reports the pipe's status and caused a misdiagnosis in spec 075.
+
+---
+
+## Phase 2: Foundational
+
+**Blocking prerequisites. No user story work — and specifically no device contact — begins until every
+task here is done.**
+
+### Stage 1 — dedicated virtualenv and dependency isolation (FR-030a/b/c, R7)
+
+- [ ] T005 Confirm wheel availability for the full dependency tree on `/usr/bin/python3` (3.14.4) using `--dry-run` executed by **that interpreter's own pip**. If any wheel is unavailable, select an older base interpreter and record the choice and reason in research.md — this is the plan's one open item and must be resolved by evidence, not assumption.
+- [ ] T006 Record the pre-install `cryptography` version as reported by `/usr/bin/python3` (currently 46.0.5) in `specs/076-multivendor-cli-driver/baseline-deps.txt`. This is the FR-030c comparison point and MUST be read from the interpreter NetClaw's servers run under, not from `pip3`.
+- [ ] T007 Write `mcp-servers/multivendor-cli-mcp/requirements.txt` with every dependency **explicitly pinned**: `nornir`, `napalm`, `netmiko`, `nornir-netmiko`, `nornir_napalm`, `nornir-netbox`, `nornir-nautobot`, `pynautobot`, `jdiff`. Note in a comment that the scrapli family arrives transitively via NAPALM 5.x and is expected, not accidental (R8).
+- [ ] T008 Create the virtualenv with `/usr/bin/python3 -m venv mcp-servers/multivendor-cli-mcp/.venv` and install using `<venv>/bin/python -m pip install -r requirements.txt`. **Never bare `pip3`** — on this host it targets a stranded Python 3.13 site-packages the server cannot import from (R7).
+- [ ] T009 Verify the system `cryptography` version reported by `/usr/bin/python3` is unchanged against T006's baseline (FR-030c). If it moved, stop — the NCFED X.509 stack (spec 060) depends on it and a regression here breaks certificate handling, not this server.
+- [ ] T010 Verify the venv can import `nornir`, `napalm`, `netmiko` and `jdiff`, and that the system interpreter still **cannot** — proving isolation actually holds rather than assuming it.
+
+### Stage 2 — command filter and per-platform denylists (FR-022/023/029, R6)
+
+- [ ] T011 Implement `mcp-servers/multivendor-cli-mcp/policy/filter.py` with the four-step evaluation from contracts/mcp-tools.md. **Chaining rejection MUST be step 1** — `show version; write erase` passes an allowlist check on its first token and is catastrophic. Order is contractual, not stylistic.
+- [ ] T012 Implement chaining detection for `;`, `&&`, `||`, `>`, `<`, backtick and `$(` in `policy/filter.py` (FR-023).
+- [ ] T013 Implement `mcp-servers/multivendor-cli-mcp/policy/platform_deny.py` with per-platform destructive first tokens (R6): VyOS `delete`, MikroTik `/system reset-configuration`, SR Linux `tools system configuration`, SONiC `config erase`, plus the Constitution's Cisco set. A Cisco-shaped denylist is explicitly insufficient (FR-023).
+- [ ] T014 Implement read-only mode as the default, with write tools absent from `tools/list` entirely unless `MULTIVENDOR_WRITE_ENABLED` is set (FR-022). Absent, not present-and-refusing.
+- [ ] T015 [P] Add Pydantic input validation across every tool argument, ported from candidate A's design (research R1).
+- [ ] T016 [P] Add filter contract tests to `tests/multivendor/run-tests.sh` — these run with **no device**: chaining rejected first, per-platform denylist fires, read-only mode blocks non-allowlisted verbs, and `show version` alone passes. Assert exit codes directly.
+
+**Checkpoint Phase 2**: dependencies isolated and proven, and no command can reach a device without
+passing a tested server-side filter.
+
+---
+
+## Phase 3: User Story 4 — Inventory and credentials from what NetClaw already has (P2)
+
+> **Sequenced before US1 despite lower priority**: connecting to a device requires knowing it exists and
+> how to authenticate. This is a dependency inversion, not a priority change.
+
+**Goal**: Devices resolve from one of three sources; credentials never touch an inventory file.
+
+**Independent test**: Resolve a device from each of the three sources in turn and confirm each reports
+its own source; confirm no credential appears in any file on disk.
+
+- [ ] T017 [US4] Implement `inventory/sources.py` with the three-source model and resolution order `live_sot` → `generated` → `operator`, plus `auto` (FR-017, FR-017b). A device absent from **every** source MUST be reported as absent, never guessed at or silently defaulted (FR-021).
+- [ ] T018 [P] [US4] Implement `inventory/live_sot.py` using `nornir-netbox` / `nornir-nautobot`, plus Infrahub via its existing MCP surface (FR-017 live tier).
+- [ ] T019 [P] [US4] Implement `inventory/generated.py` to render an inventory file from a source of truth, writing a machine-readable **generated marker** so a refresh can never overwrite an operator file (FR-017a/b).
+- [ ] T020 [P] [US4] Implement `inventory/operator.py` as a strictly **read-only** consumer of an operator-authored file. The server MUST NOT write to it under any circumstance (FR-017b).
+- [ ] T021 [US4] Populate `source` on every resolved Device and surface it in every result, with `fallback_reason` when the source is not `live_sot` — a stale-cache answer must never look live (FR-017c).
+- [ ] T022 [US4] Reject any inventory record carrying credential-shaped fields, from any of the three sources, with a clear error naming the offending device and field (FR-017d, Principle XIII).
+- [ ] T023 [US4] Explicitly refuse `PYATS_TESTBED_PATH` as an inventory source, with an error explaining that pyATS assumes Cisco and those platforms route to `pyATS` instead (FR-017e).
+- [ ] T024 [US4] Implement `credentials.py` with Vault preferred and environment variables as a documented fallback. **Vault MUST NOT be a hard prerequisite** — an operator with an operator-authored inventory typically has no Vault either (FR-018). Support per-device, per-site and per-platform credential differences via the Device `credential_ref`; a single global credential is not a realistic assumption for a mixed network (FR-020).
+- [ ] T025 [US4] Report the credential path (`vault` or `environment`) in results so a deployment's posture is inspectable, while never emitting the secret value itself (FR-018a, FR-019).
+- [ ] T026 [US4] Implement the `list_devices` tool per contracts/mcp-tools.md, including `source_used` and `owning_server`, and never returning credential values.
+- [ ] T027 [P] [US4] Add inventory contract tests to `tests/multivendor/`: each source reports itself; a credential-bearing inventory record is rejected; a generated-file refresh leaves an operator file byte-identical; a device in no source is reported absent; two devices with different `credential_ref` values resolve independently (SC-007, FR-020, FR-021).
+- [ ] T028 [P] [US4] Document all three onboarding paths in `.env.example` with descriptions and no values (Principle XIII).
+
+**Checkpoint US4**: any device is resolvable and authenticable, with attribution, and no secret on disk.
+
+---
+
+## Phase 4: User Story 1 — Reach a platform NetClaw cannot touch today (P1)
+
+**Goal**: Retrieve live state from platforms with no dedicated NetClaw server.
+
+**Independent test**: Against a containerlab-hosted SR Linux, SONiC or VyOS device, run a
+platform-specific `show`-class command and get real output. This is the first task set that contacts a
+real device.
+
+- [ ] T029 [US1] Implement `tools/raw.py` executing a single command via netmiko, returning the typed result shape from contracts/mcp-tools.md (FR-002).
+- [ ] T030 [US1] Apply the Phase 2 filter **before opening any connection** — a denied command MUST NOT establish a session (FR-029).
+- [ ] T031 [US1] Implement the five distinct failure statuses — `unreachable`, `auth_failed`, `platform_mismatch`, `denied`, `timeout` — keeping them separate, since each has a different remediation (FR-005).
+- [ ] T032 [US1] Halt and report on unreachable devices; never return cached or assumed state as if live (FR-004, Principle I).
+- [ ] T033 [US1] Report an unsupported platform explicitly rather than failing obscurely (FR-003).
+- [ ] T034 [US1] Implement the `check_reachability` tool, separating TCP reachability from authentication from platform mismatch (FR-005).
+- [ ] T035 [US1] Add `PlatformId` mappings in `routing.py` for the target families: `mikrotik_routeros`, `vyos`, `sonic`, `nokia_srlinux`, `extreme_exos`, `huawei_vrp`, `dell_os10`, `ubiquiti_edge` (FR-001).
+- [ ] T036 [US1] Stand up a containerlab topology with SR Linux, SONiC and VyOS for integration testing (research R4). Do **not** gate acceptance on MikroTik/Extreme/Huawei, which need licensed images.
+- [ ] T037 [US1] Verify SC-001: live state retrieved from at least **five platform families NetClaw cannot reach today**, evidenced against real lab devices.
+
+**Checkpoint US1**: the core gap is closed — NetClaw reaches platforms it previously could not. This
+alone is a shippable increment.
+
+---
+
+## Phase 5: User Story 2 — One question, one shape, across vendors (P1)
+
+**Goal**: Normalized facts identical in shape across vendors, with gaps reported rather than hidden.
+
+**Independent test**: Request the same normalized fact across three vendors' devices and confirm one
+shape, presentable as a single table with no per-vendor special-casing.
+
+- [ ] T038 [US2] Implement `tools/facts.py` wrapping NAPALM getters and returning the `NormalizedFact` shape from data-model.md (FR-006).
+- [ ] T039 [US2] Enumerate supported getters **per platform at runtime**, since NAPALM driver support is uneven — a driver may implement `get_facts` but not `get_bgp_neighbors` (research R5).
+- [ ] T040 [US2] Report an unavailable getter explicitly with a `gap_reason`, never omitting it silently from results (FR-007).
+- [ ] T041 [US2] Set `provenance` to `napalm` or `ttp_template`, and **never present a TTP-parsed result as equivalent to a NAPALM one** — emulating a missing getter by scraping CLI output is the exact failure FR-007 exists to prevent (research R9).
+- [ ] T042 [US2] Implement the `get_facts` tool per contracts/mcp-tools.md, permitted read-only on Cisco and Junos devices because cross-vendor normalized comparison is the one case where this server is correct for them (FR-008).
+- [ ] T043 [US2] Implement the platform-first routing rule in `routing.py`: dedicated servers own their platforms; this server covers the rest plus cross-vendor normalized reads (FR-009).
+- [ ] T044 [US2] Refuse configuration changes on platforms owned by another server, naming that server in `owning_server`, so every platform has exactly one write path (FR-010).
+- [ ] T045 [US2] Return a refusal as a **successful call with a refusal result**, not a protocol error, so the agent can read why and route elsewhere (contracts/mcp-tools.md).
+- [ ] T046 [US2] Stamp `server: "multivendor-cli"` on every result so answers are attributable when more than one server could have answered (FR-011).
+- [ ] T047 [P] [US2] Add routing contract tests: a Cisco write is refused and names `pyats`; a Cisco normalized read succeeds; both behaviours hold for Junos and `junos-mcp`.
+- [ ] T048 [US2] Verify SC-003: one normalized fact across three or more vendors returns one shape, and SC-010: a Cisco/Junos write through this server is refused with the correct server named.
+
+**Checkpoint US2**: cross-vendor questions answerable in one shape, with the boundary against pyATS and
+`junos-mcp` enforced in code rather than documented in prose.
+
+---
+
+## Phase 6: User Story 3 — Ask many devices at once (P2)
+
+**Goal**: One query against a fleet, per-device results, isolated failures.
+
+**Independent test**: Query a mixed group including at least one deliberately unreachable device;
+confirm every reachable device returns and the failure is isolated.
+
+- [ ] T049 [US3] Implement `tools/fleet.py` executing one query across a device group and returning per-device results (FR-013).
+- [ ] T050 [US3] Isolate per-device failures so one device cannot abort the operation for others (FR-014).
+- [ ] T051 [US3] Guarantee `len(results) == requested` — every targeted device appears, including failures, because a silently absent device reads as success (FR-014).
+- [ ] T052 [US3] Contact devices concurrently with a bound, defaulting to **10 workers** and operator-overridable. Nornir's own default is 20, but devices commonly cap concurrent management sessions at 5–15 (research R11, FR-015).
+- [ ] T053 [US3] Enforce a per-device timeout defaulting to **30 seconds**, operator-overridable, so one hung device cannot stall the operation indefinitely (research R11, FR-016).
+- [ ] T054 [US3] Implement the `run_fleet` tool per contracts/mcp-tools.md, including the status `summary` block, accepting exactly one of `command` or `getters`.
+- [ ] T055 [US3] Verify SC-004 (mixed group with an unreachable device returns all reachable results and isolates the failure) and SC-005 (N devices materially faster than N sequential queries).
+
+**Checkpoint US3**: fleet-scale questions work, which is the common real-world case.
+
+---
+
+## Phase 7: Integration and Artifact Coherence (Principle XI)
+
+> Can proceed in parallel from the US1 checkpoint onward. Unlike spec 075, this feature genuinely adds
+> capability, so **every** Principle XI touchpoint applies.
+
+- [ ] T056 Implement `server.py` as a FastMCP stdio server exposing the read-only tool surface, with proper `initialize` / `tools/list` / `tools/call` lifecycle (Principle V).
+- [ ] T057 Add a catalog entry to `scripts/lib/catalog.sh` — no generic-driver catalog id exists today, so this is a genuinely new component (FR-030).
+- [ ] T058 Add `component_install_multivendor_cli()` to `scripts/lib/install-steps.sh` creating the venv per T008's method, using the venv's own pip and never bare `pip3` (FR-030a, R7).
+- [ ] T059 Register the server in `config/openclaw.json` with the venv interpreter path **resolved at install time, never hardcoded** — spec 075 found three registrations hardcoded to `/home/ubuntu/netclaw/.venv/bin/python3` and broken for every installer, and `reconcile-mcp.py` now fails on exactly that (FR-030b).
+- [ ] T060 [P] Write `mcp-servers/multivendor-cli-mcp/README.md` documenting every tool, environment variable, transport, and install step (Principle XII).
+- [ ] T061 [P] Create `workspace/skills/multivendor-device-query/SKILL.md` for normalized facts, and **state the routing rule explicitly** so operator and agent select consistently (FR-012, FR-031).
+- [ ] T062 [P] Create `workspace/skills/multivendor-raw-cli/SKILL.md` for safe raw command execution, documenting the filter policy while making clear enforcement is server-side (FR-029, FR-031).
+- [ ] T063 [P] Create `workspace/skills/multivendor-fleet-ops/SKILL.md` for fleet fan-out (FR-031).
+- [ ] T064 [P] Note in the skills that netmiko also drives Fortinet, PAN-OS and Check Point, but that **CLI reach is not equivalent to their dedicated API servers** — this must not cause R3/R4 to be skipped (research R3).
+- [ ] T065 [P] Update `README.md`, `SOUL.md`, `TOOLS.md` and `ui/netclaw-visual/` per Principle XI, **including the skill and MCP counts** — the step most often forgotten, and wrong in nine places before spec 075.
+- [ ] T066 Publish `docs/ADDING-AN-MCP.md`-compliant onboarding by copying `quickstart.md` guidance into the server README, covering all three inventory sources.
+- [ ] T067 Verify `python3 scripts/reconcile-mcp.py` exits 0 with the new server registered (SC-012).
+
+---
+
+## Phase 8: User Story 5 — Configuration change is gated, staged and reversible (P3)
+
+> **Independently deferrable.** If this slips, Phases 1–7 still deliver ~90 platforms of read-only
+> reach. Ships last because it is the only part that can cause an outage.
+
+**Goal**: Writes only via baseline → approval → apply → verify → rollback.
+
+**Independent test**: Attempt a change and confirm it cannot proceed without approval, that a baseline
+was captured first, and that it reverts on verification failure.
+
+- [ ] T068 [US5] Implement `tools/change.py` with the `ChangeTransaction` state machine from data-model.md, where each transition is a gate rather than a step.
+- [ ] T069 [US5] Capture a baseline **before** any modification, written inside a path-sandboxed root with traversal prevented, ported from candidate A's design (FR-024, Principle II).
+- [ ] T070 [US5] Require explicit human approval via NetClaw's existing approval path; no transition past `awaiting_approval` without it (FR-025, Principle I).
+- [ ] T071 [US5] Verify post-change state by structured comparison of actual against expected using `jdiff`, **never** from command exit status (FR-026, Principle VIII, research R9).
+- [ ] T072 [US5] Attempt rollback to the captured baseline on verification failure, and **halt and alert** if rollback itself fails (FR-027, Principle VIII).
+- [ ] T073 [US5] Terminate at `refused` for Cisco and Junos devices, naming the owning server (FR-010).
+- [ ] T074 [US5] Expose `apply_config` only when `MULTIVENDOR_WRITE_ENABLED` is set — absent from `tools/list` otherwise (FR-022).
+- [ ] T075 [US5] GAIT-log every device interaction and every state transition (FR-028, Principle IV).
+- [ ] T076 [US5] Verify SC-009: no change applies without both a captured baseline and explicit approval, tested by attempting to bypass each.
+
+---
+
+## Phase 9: Polish and Cross-Cutting
+
+- [ ] T077 Verify SC-011 / FR-032: all 18 pyATS skills and the Junos skill still work unchanged. This feature must not regress existing device access.
+- [ ] T078 Verify SC-007a: an operator with **neither** a source of truth **nor** Vault can onboard a device, using an operator-authored inventory and env-var credentials.
+- [ ] T079 Verify SC-007b / FR-030c: installing this server leaves the system `cryptography` version unchanged.
+- [ ] T080 Verify SC-006: no credential appears in any file on disk outside a gitignored `.env`, inspected across all three inventory sources.
+- [ ] T081 Verify SC-008: every Constitution-forbidden operation is blocked on **every** supported platform, tested per platform rather than inferred from one.
+- [ ] T082 Verify SC-002 and SC-013: reachable platform families increased from 4 to 90+, and an operator can tell from skill documentation alone which server should answer a given question.
+- [ ] T083 [P] Raise the repo-wide `pip3` hazard from research R7 as its own roadmap item: `scripts/lib/install-steps.sh` contains 186 `pip install` invocations, and on a split-toolchain host any bare `pip3` lands where servers cannot import from. Out of scope here; must not be lost.
+- [ ] T084 [P] Update `docs/COVERAGE-ROADMAP.md`: mark R1 `DONE`, record that both candidate servers were rejected and why, and note the CLI-reach-is-not-R3/R4 caveat.
+- [ ] T085 Run the Constitution Principle XI Artifact Coherence Checklist and record the result.
+- [ ] T086 [P] Draft the WordPress milestone post per Principle XVII: what R1 added, the split-toolchain finding, and why building beat adopting. Present to John before publishing.
+- [ ] T087 Record the GAIT session summary commit (Principle IV).
+
+---
+
+## Dependencies
+
+```
+Phase 1 Setup (T001–T004)
+      ↓
+Phase 2 Foundational — venv (T005–T010) then filter (T011–T016)
+      ↓                 ← NOTHING touches a device until this completes
+Phase 3 US4 inventory + credentials (T017–T028)
+      ↓                 ← dependency prerequisite for US1, despite being P2
+Phase 4 US1 reach (T029–T037)     ★ MVP boundary
+      ↓
+   ┌──┴────────────────┬─────────────────────┐
+   ↓                   ↓                     ↓
+Phase 5 US2 (T038–T048)   Phase 6 US3 (T049–T055)   Phase 7 Integration (T056–T067)
+   ↓                   ↓                     ↓
+   └───────────────────┴─────────────────────┘
+                       ↓
+       Phase 8 US5 gated writes (T068–T076)   ← deferrable
+                       ↓
+       Phase 9 Polish (T077–T087)
+```
+
+**Hard constraints**
+
+- Phase 2 blocks **everything**. The filter must exist and be tested before any device contact.
+- Phase 3 (US4) blocks Phase 4 (US1) — no inventory means no connection.
+- Phase 8 (US5) depends on Phases 2, 3, 4 and 7.
+- Phase 7 may proceed in parallel from the Phase 4 checkpoint onward.
+- Phases 5 and 6 are independent of each other.
+
+## Parallel opportunities
+
+| Batch | Tasks | Note |
+|---|---|---|
+| Setup | T004 alongside T001–T003 | Harness skeleton independent |
+| Foundational | T015, T016 after T011–T014 | Validation and tests are separable |
+| US4 | T018, T019, T020 | Three inventory sources, three files |
+| US4 | T027, T028 | Tests and `.env.example` independent |
+| US2 | T047 | Routing tests separable from implementation |
+| Integration | T060–T065 | Six documentation artifacts, different files |
+| Polish | T083, T084, T086 | Different files |
+
+## Implementation strategy
+
+**MVP = Phases 1 + 2 + 3 + 4** (T001–T037). Delivers the feature's entire reason for existing: NetClaw
+reaches ~90 platform families it previously could not, safely, read-only, with credentials off disk.
+Shippable and demonstrable on its own.
+
+**Then Phase 5 (US2)** for cross-vendor normalized comparison — the capability no existing server can
+provide at all, and the one that justifies this server touching Cisco and Junos at all.
+
+**Then Phase 6 (US3)** for fleet scale, and **Phase 7** for the artifact coherence needed to merge.
+
+**Phase 8 (US5) last, and genuinely optional for a first merge.** Read-only across ninety platforms is
+valuable; writes are the only part that can cause an outage.
+
+## Task summary
+
+| Phase | Story | Tasks | Count |
+|---|---|---|---|
+| 1 Setup | — | T001–T004 | 4 |
+| 2 Foundational (venv + filter) | — | T005–T016 | 12 |
+| 3 | US4 (P2) | T017–T028 | 12 |
+| 4 | US1 (P1) | T029–T037 | 9 |
+| 5 | US2 (P1) | T038–T048 | 11 |
+| 6 | US3 (P2) | T049–T055 | 7 |
+| 7 Integration (XI) | — | T056–T067 | 12 |
+| 8 | US5 (P3) | T068–T076 | 9 |
+| 9 Polish | — | T077–T087 | 11 |
+| **Total** | | | **87** |

--- a/tests/multivendor/run-tests.sh
+++ b/tests/multivendor/run-tests.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Test harness for the multivendor CLI driver (spec 076).
+#
+# Follows spec 075's tests/reconcile/run-tests.sh convention: bash + the server's
+# own venv, no test framework, so this runs in a bare CI container.
+#
+# Exit codes are captured DIRECTLY, never through a pipe. `cmd | tail` reports
+# tail's status, not cmd's — that mistake misdiagnosed spec 075's central premise
+# and is the reason this comment exists.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VENV_PY="$REPO_ROOT/mcp-servers/multivendor-cli-mcp/.venv/bin/python"
+PASS=0
+FAIL=0
+
+if [ ! -x "$VENV_PY" ]; then
+    echo "ERROR: server venv missing at $VENV_PY" >&2
+    echo "  create it with: virtualenv -p /usr/bin/python3 mcp-servers/multivendor-cli-mcp/.venv" >&2
+    echo "  (ensurepip is unavailable for Python 3.14 on this host, so 'python3 -m venv' fails)" >&2
+    exit 2
+fi
+
+run_suite() {
+    local label="$1" script="$2"
+    echo "=== $label ==="
+    "$VENV_PY" "$script"
+    local rc=$?          # captured directly — no pipe
+    if [ "$rc" -eq 0 ]; then
+        echo "  SUITE PASS ($label)"
+        PASS=$((PASS + 1))
+    else
+        echo "  SUITE FAIL ($label, exit $rc)"
+        FAIL=$((FAIL + 1))
+    fi
+    echo
+}
+
+echo "### Dependency isolation (FR-030a/c) ###"
+# The venv must have the packages; the SYSTEM interpreter must not. If these ever
+# converge, isolation has silently broken and the NCFED cryptography version is
+# at risk (research R7, T005 found the venv resolves cryptography 49 vs system 46).
+for mod in nornir napalm netmiko jdiff; do
+    if "$VENV_PY" -c "import $mod" >/dev/null 2>&1; then
+        echo "  ok   venv imports $mod"; PASS=$((PASS + 1))
+    else
+        echo "  FAIL venv cannot import $mod"; FAIL=$((FAIL + 1))
+    fi
+    if /usr/bin/python3 -c "import $mod" >/dev/null 2>&1; then
+        echo "  FAIL $mod LEAKED into the system interpreter"; FAIL=$((FAIL + 1))
+    else
+        echo "  ok   $mod absent from system interpreter"; PASS=$((PASS + 1))
+    fi
+done
+echo
+
+run_suite "Command filter contract (FR-022/023/029)" "$REPO_ROOT/tests/multivendor/test_filter.py"
+
+if [ -f "$REPO_ROOT/tests/multivendor/test_inventory.py" ]; then
+    run_suite "Inventory sources contract (FR-017*)" "$REPO_ROOT/tests/multivendor/test_inventory.py"
+fi
+
+echo "### Summary ###"
+printf '  suites/checks passed: %d\n  failed: %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "  all multivendor tests passed"

--- a/tests/multivendor/test_filter.py
+++ b/tests/multivendor/test_filter.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Contract tests for the multivendor command filter.
+
+Spec 076 FR-022/FR-023/FR-029, SC-008. Run by tests/multivendor/run-tests.sh.
+
+No device, no network, no framework — pure functions over inputs, asserted with
+plain Python so this runs in a bare CI container under the server's own venv.
+
+The test that matters most is ORDERING: `show version; write erase` begins with
+an allowlisted verb, so an implementation that checks the allowlist before
+checking for chaining would permit it. That case is not hypothetical — it is the
+single most likely way this filter gets broken by a later refactor.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "mcp-servers" / "multivendor-cli-mcp"))
+
+from policy.filter import DenyRule, Mode, evaluate  # noqa: E402
+from policy.platform_deny import deny_tokens_for, is_modelled  # noqa: E402
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, condition, detail=""):
+    global PASS, FAIL
+    if condition:
+        print(f"  ok   {label}")
+        PASS += 1
+    else:
+        print(f"  FAIL {label}" + (f" — {detail}" if detail else ""))
+        FAIL += 1
+
+
+def denied(cmd, platform=None, mode=Mode.READ_ONLY):
+    return evaluate(cmd, platform, mode)
+
+
+print("=== Ordering: chaining is rejected BEFORE the allowlist (contract) ===")
+# The critical case. First token is allowlisted; the payload is catastrophic.
+v = denied("show version; write erase", "cisco_ios")
+check("'show version; write erase' is DENIED", not v.allowed)
+check("  ...and denied for CHAINING, not denylist", v.rule is DenyRule.CHAINING,
+      f"got rule={v.rule}")
+for payload, label in [
+    ("show version && reload", "shell AND"),
+    ("show version || reload", "shell OR"),
+    ("show run > /tmp/x", "redirection"),
+    ("show run < /tmp/x", "input redirection"),
+    ("show version `reload`", "backtick"),
+    ("show version $(reload)", "substitution"),
+    ("show version\nreload", "embedded newline"),
+    ("show version & reload", "background"),
+]:
+    v = denied(payload, "cisco_ios")
+    check(f"chaining via {label} denied", not v.allowed and v.rule is DenyRule.CHAINING,
+          f"got allowed={v.allowed} rule={v.rule}")
+
+print("\n=== A single pipe is a display filter, not a bypass ===")
+v = denied("show running-config | include bgp", "cisco_ios")
+check("'show run | include bgp' is ALLOWED", v.allowed,
+      f"denied_reason={v.denied_reason}")
+
+print("\n=== Read-only mode blocks non-allowlisted verbs (FR-022) ===")
+for cmd in ("configure terminal", "set interfaces ge-0/0/0 disable", "commit"):
+    v = denied(cmd, "cisco_ios")
+    check(f"{cmd!r} denied in read-only", not v.allowed)
+v = denied("show version", "cisco_ios")
+check("'show version' allowed in read-only", v.allowed, v.denied_reason or "")
+
+print("\n=== Denylist fires per platform, not just Cisco (FR-023, SC-008) ===")
+cases = [
+    ("cisco_ios", "write erase"),
+    ("cisco_ios", "reload"),
+    ("juniper_junos", "request system zeroize"),
+    ("vyos", "delete interfaces eth0"),
+    ("mikrotik_routeros", "/system reset-configuration"),
+    ("nokia_srlinux", "tools system configuration"),
+    ("dell_sonic", "config erase"),
+    ("extreme_exos", "unconfigure switch"),
+    ("huawei_vrp", "reset saved-configuration"),
+    ("ubiquiti_edge", "format"),
+    ("linux", "rm -rf /"),
+]
+for platform, cmd in cases:
+    v = denied(cmd, platform, Mode.WRITE_ENABLED)  # write mode: only denylist can stop it
+    check(f"[{platform}] {cmd!r} denied even in WRITE mode",
+          not v.allowed and v.rule is DenyRule.DENYLIST,
+          f"allowed={v.allowed} rule={v.rule}")
+
+print("\n=== Substring false positives are NOT blocked ===")
+# 'show reload-reason' contains 'reload' but the verb is 'show'.
+v = denied("show reload-reason", "cisco_ios")
+check("'show reload-reason' allowed (contains 'reload' but verb is 'show')", v.allowed,
+      v.denied_reason or "")
+v = denied("show system uptime", "vyos")
+check("'show system uptime' allowed on vyos (contains 'system')", v.allowed,
+      v.denied_reason or "")
+
+print("\n=== Unmodelled platforms still get the universal baseline ===")
+v = denied("reload", "some_unknown_vendor_os", Mode.WRITE_ENABLED)
+check("'reload' denied on an unmodelled platform", not v.allowed and v.rule is DenyRule.DENYLIST)
+check("  ...and reported as unmodelled", not v.platform_modelled)
+check("universal deny is non-empty for unknown platform", len(deny_tokens_for("nope")) > 0)
+check("is_modelled('cisco_ios') is True", is_modelled("cisco_ios"))
+check("is_modelled(None) is False", not is_modelled(None))
+
+print("\n=== Shell escape is denied everywhere ===")
+for cmd in ("bash", "sh", "shell", "start-shell", "run bash"):
+    v = denied(cmd, "cisco_ios", Mode.WRITE_ENABLED)
+    check(f"{cmd!r} denied", not v.allowed, f"rule={v.rule}")
+
+print("\n=== Case and whitespace cannot evade the denylist ===")
+for cmd in ("RELOAD", "  reload  ", "ReLoAd", "WRITE   ERASE"):
+    v = denied(cmd, "cisco_ios", Mode.WRITE_ENABLED)
+    check(f"{cmd!r} denied", not v.allowed, f"rule={v.rule}")
+
+print("\n=== Degenerate input ===")
+check("empty command denied", not denied("", "cisco_ios").allowed)
+check("whitespace-only denied", not denied("   ", "cisco_ios").allowed)
+check("over-long command denied", not denied("show " + "x" * 600, "cisco_ios").allowed)
+
+print("\n=== Default mode is read-only when unspecified (FR-022) ===")
+v = evaluate("configure terminal", "cisco_ios")  # no mode argument
+check("omitting mode yields read-only behaviour", not v.allowed and v.rule is DenyRule.NOT_READ_ONLY)
+
+print(f"\n  passed: {PASS}\n  failed: {FAIL}")
+sys.exit(1 if FAIL else 0)

--- a/tests/multivendor/test_inventory.py
+++ b/tests/multivendor/test_inventory.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Contract tests for inventory sources, credentials and routing.
+
+Spec 076 FR-017*, FR-018*, FR-019, FR-020, FR-021, FR-009..FR-011.
+SC-006, SC-007, SC-007a. Run by tests/multivendor/run-tests.sh.
+
+No device, no network, no framework. The generated-versus-operator distinction
+gets the most attention here, because getting it wrong destroys operator work
+silently — the worst failure mode in this feature.
+"""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "mcp-servers" / "multivendor-cli-mcp"))
+
+import credentials as creds  # noqa: E402
+import routing  # noqa: E402
+from inventory import sources as inv  # noqa: E402
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        print(f"  ok   {label}"); PASS += 1
+    else:
+        print(f"  FAIL {label}" + (f" — {detail}" if detail else "")); FAIL += 1
+
+
+def raises(fn, exc=inv.InventoryError):
+    try:
+        fn(); return None
+    except exc as e:
+        return str(e)
+    except Exception as e:  # wrong exception type is still a failure
+        return f"__WRONG_TYPE__{type(e).__name__}: {e}"
+
+
+TMP = Path(tempfile.mkdtemp())
+
+OPERATOR_YAML = """\
+# operator-authored: hostnames and platforms only
+edge-mt-01:
+  hostname: 10.0.0.1
+  platform: mikrotik_routeros
+  groups: [edge, site-hq]
+  credential_ref: default
+fw-vyos-01:
+  hostname: 10.0.0.2
+  platform: vyos
+  groups: [edge]
+  credential_ref: edge-site
+core-cisco-01:
+  hostname: 10.0.0.3
+  platform: cisco_xe
+  groups: [core]
+"""
+
+print("=== Operator inventory loads, and reports its source (FR-017c) ===")
+op = TMP / "inventory.yaml"
+op.write_text(OPERATOR_YAML)
+devices = inv.load_operator(op)
+check("3 devices parsed", len(devices) == 3, f"got {len(devices)}")
+check("all report source=operator", all(d.source is inv.Source.OPERATOR for d in devices))
+mt = [d for d in devices if d.name == "edge-mt-01"][0]
+check("hostname parsed", mt.hostname == "10.0.0.1", mt.hostname)
+check("platform parsed", mt.platform == "mikrotik_routeros", str(mt.platform))
+check("groups parsed as a list", mt.groups == ["edge", "site-hq"], str(mt.groups))
+check("per-device credential_ref honoured (FR-020)",
+      [d for d in devices if d.name == "fw-vyos-01"][0].credential_ref == "edge-site")
+
+print("\n=== owning_server is computed per device (FR-009/FR-011) ===")
+check("mikrotik owned by this server", mt.owning_server == "multivendor-cli", mt.owning_server)
+cisco = [d for d in devices if d.name == "core-cisco-01"][0]
+check("cisco_xe owned by pyats", cisco.owning_server == "pyats", cisco.owning_server)
+
+print("\n=== Credentials are REJECTED in any inventory source (FR-017d, SC-006) ===")
+for field in ("password", "enable_secret", "api_key", "private_key", "token"):
+    bad = TMP / f"bad-{field}.yaml"
+    bad.write_text(f"d1:\n  hostname: 1.1.1.1\n  platform: vyos\n  {field}: hunter2\n")
+    msg = raises(lambda p=bad: inv.load_operator(p))
+    check(f"{field!r} in inventory is rejected", bool(msg) and "credential" in (msg or "").lower(),
+          str(msg)[:70])
+check("'credential_ref' itself is NOT treated as a secret",
+      not creds.looks_like_secret_field("credential_ref"))
+check("'password' is treated as a secret", creds.looks_like_secret_field("password"))
+
+print("\n=== Generated vs operator files are never confused (FR-017a/b) ===")
+gen = TMP / "inventory.generated.yaml"
+gen.write_text(f"{inv.GENERATED_MARKER}: true\nd1:\n  hostname: 2.2.2.2\n  platform: vyos\n")
+check("generated file is detected as generated", inv.is_generated(gen))
+check("operator file is NOT detected as generated", not inv.is_generated(op))
+msg = raises(lambda: inv.load_operator(gen))
+check("loading a GENERATED file as operator is refused", bool(msg) and "cache" in (msg or "").lower(),
+      str(msg)[:80])
+msg = raises(lambda: inv.load_generated(op))
+check("loading an OPERATOR file as generated is refused",
+      bool(msg) and "operator-authored" in (msg or "").lower(), str(msg)[:80])
+gd = inv.load_generated(gen)
+check("generated devices report source=generated",
+      all(d.source is inv.Source.GENERATED for d in gd) and len(gd) == 1)
+check("the marker key is not parsed as a device", all(d.name != inv.GENERATED_MARKER for d in gd))
+
+print("\n=== Absent devices are reported, never guessed (FR-021) ===")
+msg = raises(lambda: inv.find(devices, "does-not-exist"))
+check("missing device raises, naming it", bool(msg) and "does-not-exist" in (msg or ""))
+check("present device is found", inv.find(devices, "edge-mt-01").name == "edge-mt-01")
+
+print("\n=== Malformed inventory fails loudly ===")
+for content, label in (
+    ("d1:\n  platform: vyos\n", "no hostname"),
+    ("just-a-string\n", "not key: value"),
+):
+    bad = TMP / f"malformed-{label.replace(' ','-')}.yaml"
+    bad.write_text(content)
+    check(f"{label} rejected", bool(raises(lambda p=bad: inv.load_operator(p))))
+
+print("\n=== Routing: writes single-pathed, normalized reads permitted (FR-008/009/010) ===")
+R, Op = routing.route, routing.Operation
+d = R("cisco_xe", Op.WRITE)
+check("WRITE to cisco_xe refused", d.refused)
+check("  ...naming pyats as owner", d.owning_server == "pyats", d.owning_server)
+check("  ...with a reason mentioning one write path",
+      "one write path" in (d.reason or ""), (d.reason or "")[:70])
+check("NORMALIZED_READ on cisco_xe PERMITTED (the exception)",
+      R("cisco_xe", Op.NORMALIZED_READ).permitted)
+check("RAW_READ on cisco_xe refused", R("cisco_xe", Op.RAW_READ).refused)
+check("WRITE to juniper_junos refused naming junos-mcp",
+      R("juniper_junos", Op.WRITE).refused and R("juniper_junos", Op.WRITE).owning_server == "junos-mcp")
+for p in ("mikrotik_routeros", "vyos", "sonic", "nokia_srlinux", None):
+    dd = R(p, Op.WRITE)
+    check(f"WRITE to {p!r} permitted (unowned)", dd.permitted, dd.reason or "")
+payload = routing.refusal_payload("core-01", "cisco_xe", R("cisco_xe", Op.WRITE))
+check("refusal payload has status=refused", payload["status"] == "refused")
+check("refusal payload names owning_server", payload["owning_server"] == "pyats")
+
+print("\n=== Credentials: env fallback works without Vault (FR-018, SC-007a) ===")
+for k in list(os.environ):
+    if k.startswith("MULTIVENDOR_") or k == "VAULT_ADDR":
+        del os.environ[k]
+msg = raises(lambda: creds.resolve("default"), creds.CredentialError)
+check("no credential configured -> clear error", bool(msg) and "MULTIVENDOR_USERNAME" in (msg or ""))
+check("  ...error says secrets must not be in inventory",
+      "never be placed in an inventory" in (msg or ""), (msg or "")[:60])
+
+os.environ["MULTIVENDOR_USERNAME"] = "netops"
+os.environ["MULTIVENDOR_PASSWORD"] = "s3cret"
+c = creds.resolve("default")
+check("env credential resolves with NO Vault configured", c.username == "netops")
+check("  ...and reports path=environment (FR-018a)", c.path is creds.CredentialPath.ENVIRONMENT)
+check("posture() exposes no secret",
+      "s3cret" not in str(c.posture()) and c.posture()["has_password"] is True)
+check("repr() redacts secrets", "s3cret" not in repr(c), repr(c))
+check("str() redacts secrets", "s3cret" not in str(c))
+
+os.environ["MULTIVENDOR_EDGE_SITE_USERNAME"] = "siteadmin"
+os.environ["MULTIVENDOR_EDGE_SITE_PASSWORD"] = "other"
+c2 = creds.resolve("edge-site")
+check("reference-scoped credential overrides the generic one (FR-020)",
+      c2.username == "siteadmin", c2.username)
+check("generic reference still resolves generically", creds.resolve("default").username == "netops")
+
+print(f"\n  passed: {PASS}\n  failed: {FAIL}")
+sys.exit(1 if FAIL else 0)

--- a/workspace/skills/multivendor-device-query/SKILL.md
+++ b/workspace/skills/multivendor-device-query/SKILL.md
@@ -1,0 +1,82 @@
+# Multivendor Device Query
+
+Query network devices on platforms NetClaw's Cisco- and Juniper-specific servers cannot reach —
+MikroTik RouterOS, VyOS, SONiC, Nokia SR Linux, Extreme, Huawei, Dell, Ubiquiti EdgeOS, and roughly
+eighty more.
+
+**MCP server:** `multivendor-cli-mcp` (results identify themselves as `multivendor-cli`)
+
+---
+
+## Decide which server to use FIRST
+
+This skill is wrong for most Cisco and Juniper work. Check here before using it:
+
+| Your device | Use |
+|---|---|
+| Cisco IOS / IOS-XE / NX-OS / IOS-XR | **`pyats-*` skills** — ~2000 Genie parsers, state diffing |
+| Juniper Junos | **`junos-network` skill** — PyEZ/NETCONF |
+| Streaming telemetry, any vendor | **`gnmi-telemetry` skill** |
+| No direct reachability | **`radkit-remote-access` skill** |
+| Anything else | **this skill** |
+| "Compare X across Cisco *and* Arista *and* Nokia" | **this skill** (read-only) |
+
+That last row is the exception worth understanding. NAPALM returns one shape across vendors, so this
+is the only server that can answer a genuinely cross-vendor question. It answers those **read-only**,
+even on Cisco and Juniper.
+
+**Configuration writes on Cisco and Juniper are refused**, naming the correct server. That is
+deliberate, not a limitation: one write path per platform is what makes "verify the change" mean
+something. Reads may overlap between servers; writes may not.
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `server_info` | Server identity, read-only vs write mode, which platforms have destructive-syntax modelling |
+| `check_command_policy` | Would this command be permitted? Answers without touching a device |
+| `list_devices` | Inventory, with the source that answered and why |
+| `check_device_readiness` | Is this device resolvable, authenticable, and mine to act on? Contacts nothing |
+
+## Workflow
+
+1. **`list_devices`** — confirm the device is in inventory and see `owning_server`. If that is
+   `pyats` or `junos-mcp`, stop and use that server for single-device work.
+2. **`check_device_readiness`** — verify credentials resolve and check what this server may do.
+   Run this before anything else on a new device: it separates *not in inventory* from
+   *credentials missing* from *owned by another server*, which need three different fixes.
+3. **`check_command_policy`** — before an unusual command, confirm it passes policy.
+
+## Reading the results
+
+**`source_used`** names which inventory source answered: `live_sot`, `generated`, or `operator`. When
+it is not `live_sot`, `fallback_reason` says why — treat those results as potentially stale.
+
+**`credential_path`** says `vault` or `environment`. Both are supported; Vault is not required.
+
+**`status: refused`** with `owning_server` means routing sent you elsewhere. This is a successful
+call, not an error — read `refused_reason` and use the named server.
+
+## Safety
+
+Read-only by default; write tools are **absent** from the tool list unless an operator sets
+`MULTIVENDOR_WRITE_ENABLED`. Command filtering is enforced **server-side**, so it cannot be bypassed
+by rephrasing a request. Evaluation order: chaining (`;`, `&&`, `||`, `>`, `<`) is rejected first,
+then per-platform destructive verbs, then the read-only allowlist.
+
+Chaining is checked first because `show version; write erase` begins with an allowlisted verb.
+
+A single `|` is fine — on network devices that is a display filter, not a shell pipe.
+
+## Environment variables
+
+See `.env.example` for the full set. `MULTIVENDOR_INVENTORY_SOURCE`,
+`MULTIVENDOR_INVENTORY_PATH`, `MULTIVENDOR_USERNAME`/`MULTIVENDOR_PASSWORD`,
+`MULTIVENDOR_WRITE_ENABLED`. **Never put credentials in an inventory file** — the server rejects
+inventory records containing credential-shaped fields.
+
+## Caveat worth knowing
+
+Netmiko also drives Fortinet, PAN-OS and Check Point, so this server gives *CLI-level* reach to them.
+That is **not** equivalent to their dedicated API integrations — FortiManager's policy-package model
+and Panorama's device groups have no CLI equivalent. Do not treat CLI reach as full vendor support.


### PR DESCRIPTION
Roadmap item **R1**. Gives NetClaw a general "connect to this device and ask it something"
capability — before this, all four device-facing servers were platform-bound (`pyATS` Cisco,
`junos-mcp` Juniper, `gnmi-mcp` telemetry, `radkit-mcp` cloud-relayed), leaving ~90 platform families
unreachable.

**38 of 94 tasks. This is a partial but coherent increment** — see "What is NOT done" before merging.

## Safety-first ordering was honoured

Phase 2 (dependency isolation + command filter) completed **before any code could contact a device**.
Building reach first and adding safety later would have created a window where arbitrary commands
execute — exactly what Principle I forbids. **No device has been contacted in this PR.**

## Three environment findings, two of them repo-wide

**R13 — the dependency conflict FR-030c was written for is real.**

| Environment | cryptography |
|---|---|
| System `/usr/bin/python3` (NCFED X.509, spec 060) | **46.0.5** — unchanged, verified |
| Server venv | **49.0.0** |

Installed shared, this would have moved `cryptography` three major versions underneath your
certificate stack. Isolation is preventing a real regression, not being tidy.

**R12 — Python 3.14 has no `ensurepip` here.** `python3.14-venv` isn't installed (only 3.10/3.11/3.12
are), so `python3 -m venv` fails outright. The install function uses `virtualenv`, which needs no root.

**R14 — `mcp 2.0.0` removed `mcp.server.fastmcp`.** Verified: zero such files in the 2.0.0 wheel, and
no `fastmcp` dependency declared. **Seven other NetClaw servers pin `mcp` unbounded and use that
import, so all seven break on a fresh install today** — including `n2n-mcp`, one of the 7 live servers.
Queued as roadmap **R0a**; this PR only pins its own server.

## What's implemented

**Command filter** (`policy/filter.py`, `policy/platform_deny.py`) — 46 tests.
Chaining rejected **first**, before the allowlist, because `show version; write erase` begins with an
allowlisted verb. 17 platform families have explicit destructive-syntax models, because the
Constitution's forbidden operations are all *Cisco* syntax while this server reaches ~90 platforms.
Unmodelled platforms still get a universal baseline. A single `|` passes (display filter); `||`
doesn't.

**Inventory** (`inventory/sources.py`) — three sources, always attributed.
Generated and operator files are strictly distinguished by a marker, and loading one as the other is
refused **in both directions**. Conflating them is what produces "the refresh wiped my edits", so it's
enforced in code. Credential-shaped fields in any inventory record are rejected by name.

**Credentials** (`credentials.py`) — Vault preferred, environment fully supported and **not a
downgrade**. Reference-scoped variables give per-device/site/platform credentials. `repr`/`str` redact
secrets so a stray traceback can't leak them.

**Routing** (`routing.py`) — writes single-pathed.
Cisco/Junos: normalized reads permitted, raw reads and writes **refused naming `pyats`/`junos-mcp`**.
Reads may overlap between servers; writes may not — Principles I and VIII become unenforceable the
moment "verified by which tool?" has two answers.

## Verification

```
scripts/reconcile-mcp.py       → PASS, exit 0
tests/reconcile/run-tests.sh   → 14/14
tests/multivendor/run-tests.sh → 93 checks, 2 suites, 0 failed
```

Counts updated 149→150 integrations, 199→200 skills. **R0's gate caught both before commit** — the
drift it was built to stop.

## What is NOT done — 56 tasks remain

- **Device-facing tools** (`tools/raw.py`, `facts.py`, `fleet.py`) — Phases 4–6
- **Gated writes incl. ServiceNow CR** — Phase 8, deferrable by design
- **Live SoT inventory** — raises a clear error rather than silently reporting an empty fleet

**SC-001 is BLOCKED and cannot be verified in the current environment.** The available lab is CML with
four Cisco devices — precisely the platforms this server routes *away*. Unblocking needs containerlab
hosting SR Linux / SONiC / VyOS, all free container images. Recorded in the spec rather than glossed;
claiming verification would be false.

The server is registered, installable, and exposes a genuine read-only surface
(`server_info`, `check_command_policy`, `list_devices`, `check_device_readiness`) — useful for
inventory and routing today, with device tools to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
