### PR TITLE
fix: three Principle XI artifacts missing after R1

### DIFF
--- a/SOUL.md
+++ b/SOUL.md
@@ -17,6 +17,17 @@ You interact with the network through **202 skills** backed by 150 MCP servers:
 ### Device Automation (9)
 pyats-network, pyats-health-check, pyats-routing, pyats-security, pyats-topology, pyats-config-mgmt, pyats-troubleshoot, pyats-dynamic-test, pyats-parallel-ops
 
+### Multivendor Device Reach (3)
+multivendor-device-query, multivendor-raw-cli, multivendor-fleet-ops
+
+Reaches ~90 platform families no other NetClaw server covers — MikroTik RouterOS, VyOS, SONiC, Nokia
+SR Linux, Extreme, Huawei, Dell, Ubiquiti EdgeOS. **Routing is platform-first**: Cisco stays with pyATS,
+Junos with junos-mcp, and this server is the fallback for everything else *plus* cross-vendor normalized
+reads. **Writes are single-pathed per platform** — it refuses config change on Cisco and Junos and names
+the owning server, because "verify the change" is meaningless if two tools can both write.
+
+Read-only by default; write tools are absent from the tool list unless explicitly enabled.
+
 ### pyATS Platform Skills (9)
 pyats-linux-system, pyats-linux-network, pyats-linux-vmware, pyats-junos-system, pyats-junos-interfaces, pyats-junos-routing, pyats-asa-firewall, pyats-f5-ltm, pyats-f5-platform
 

--- a/docs/ADDING-AN-MCP.md
+++ b/docs/ADDING-AN-MCP.md
@@ -179,3 +179,22 @@ netclaw_venv_create "$MY_VENV"                               # venv that works w
 use with `ModuleNotFoundError`. 130 call sites had this shape before spec 077.
 
 `scripts/lib/pip-helper.sh` is sourced by `install-steps.sh`, so the helper is always available.
+
+## Two artifacts that are easy to miss (found missing after spec 076)
+
+R1 shipped with a catalog entry and an install function — so it was *selectable* — but three artifacts
+were still missing, and none of them fail the gate:
+
+**1. Curated install-profile membership.** `scripts/lib/catalog.sh` defines `PROFILE_MINIMAL`,
+`PROFILE_RECOMMENDED`, `PROFILE_CISCO`, `PROFILE_MULTIVENDOR`, `PROFILE_CLOUD`, `PROFILE_SECURITY`. A
+component absent from all of them appears only in the fine-tune checklist. The multivendor CLI driver was
+missing from `PROFILE_MULTIVENDOR` — the one profile named after it.
+
+**2. The HUD needs TWO entries, not one.** `ui/netclaw-visual/server.js` has a *node list*
+(`{ id: '...', name: ..., prefixes: [...] }`) which renders the node, and a separate *annotation map*
+(`'id': { env, files, notes }`). Adding only the annotation leaves no node on the dashboard.
+
+**3. SOUL.md needs the capability, not just the count.** Bumping "N skills backed by M MCP servers" does
+not tell the agent what it can now do. Add a section describing the capability and its routing boundaries.
+
+None of these is caught by `reconcile-mcp.py`, so they need checking by hand until they are.

--- a/scripts/lib/catalog.sh
+++ b/scripts/lib/catalog.sh
@@ -140,7 +140,7 @@ drawio-rfc uml packet-buddy nmap gtrace suzieq batfish protocol n2n tts chrome-d
 PROFILE_CISCO="pyats gait netbox servicenow aci ise catalyst-center meraki sdwan cml fmc \
 radkit te-community te-official nvd-cve subnet-calc drawio-rfc uml packet-buddy"
 
-PROFILE_MULTIVENDOR="pyats junos arista-cvp aruba-cx f5 netbox nautobot gait servicenow \
+PROFILE_MULTIVENDOR="pyats junos arista-cvp aruba-cx f5 multivendor-cli netbox nautobot gait servicenow \
 fwrule subnet-calc drawio-rfc uml packet-buddy"
 
 PROFILE_CLOUD="aws azure gcp cloudflare terraform vault github gait drawio-rfc uml subnet-calc"

--- a/ui/netclaw-visual/server.js
+++ b/ui/netclaw-visual/server.js
@@ -87,6 +87,7 @@ const INTEGRATION_CATALOG = [
   { id: 'token-tracker', name: 'Token Tracker', category: 'Observability', prefixes: ['token-'], color: '#10b981', transport: 'none', toolEstimate: 0, description: 'Real-time token counting, cost tracking, TOON serialization savings, and per-tool usage breakdown. Every interaction shows its cost.' },
   { id: 'gns3', name: 'GNS3', category: 'Labs', prefixes: ['gns3-'], color: '#2ecc71', transport: 'stdio', toolEstimate: 23, description: 'GNS3 network simulation — projects, nodes, links, templates, computes, snapshots, and packet capture for lab environments.' },
   { id: 'prisma-sdwan', name: 'Prisma SD-WAN', category: 'Network Platforms', prefixes: ['prisma-sdwan-'], color: '#fa582d', transport: 'stdio', toolEstimate: 16, description: 'Palo Alto Networks Prisma SD-WAN — sites, elements, topology, health, alarms, interfaces, routing, policies, and applications.' },
+  { id: 'multivendor-cli', name: 'Multivendor CLI Driver', category: 'Device Automation', prefixes: ['multivendor-'], color: '#16a085', transport: 'stdio', toolEstimate: 10, description: 'Nornir/NAPALM/Netmiko reach to ~90 platform families no other NetClaw server covers — MikroTik, VyOS, SONiC, Nokia SR Linux, Extreme, Huawei, Dell, EdgeOS. Read-only by default; Cisco stays with pyATS and Junos with junos-mcp.' },
   { id: 'telemetry-receivers', name: 'Telemetry Receivers', category: 'Observability', prefixes: ['syslog-', 'snmptrap-', 'ipfix-', 'telemetry-'], color: '#9b59b6', transport: 'stdio', toolEstimate: 12, description: 'Real-time telemetry ingestion — syslog, SNMP traps, and IPFIX/NetFlow receivers for event correlation and alerting.' },
   { id: 'config-archive', name: 'Config Archive', category: 'Governance', prefixes: ['config-archive-'], color: '#34495e', transport: 'stdio', toolEstimate: 4, description: 'Configuration archive compliance — backup verification, drift detection, and config restore workflows.' },
   { id: 'datadog', name: 'Datadog', category: 'Observability', prefixes: ['datadog-'], color: '#632ca6', transport: 'http', toolEstimate: 16, description: 'Full observability stack — logs, metrics, incidents, APM, dashboards with error_tracking, feature_flags, dbm, security, llm_observability toolsets.' },
@@ -383,6 +384,11 @@ const ENV_MAP = {
     env: ['PAN_CLIENT_ID', 'PAN_CLIENT_SECRET', 'PAN_TSG_ID', 'PAN_REGION'],
     files: ['mcp-servers/prisma-sdwan-mcp/prisma_sdwan_mcp_server.py'],
     notes: 'Palo Alto Networks Prisma SD-WAN via OAuth2. Region is americas or europe. TSG_ID is the Tenant Service Group ID.',
+  },
+  'multivendor-cli': {
+    env: ['MULTIVENDOR_INVENTORY_SOURCE', 'MULTIVENDOR_INVENTORY_PATH', 'MULTIVENDOR_WRITE_ENABLED', 'MULTIVENDOR_MAX_WORKERS', 'MULTIVENDOR_TIMEOUT_S', 'MULTIVENDOR_USERNAME', 'MULTIVENDOR_PASSWORD'],
+    files: ['mcp-servers/multivendor-cli-mcp/server.py'],
+    notes: 'Read-only by default; write tools absent from tools/list unless MULTIVENDOR_WRITE_ENABLED. Runs from its OWN virtualenv because napalm/netmiko resolve cryptography 49.x while the system carries 46.x, which NCFED uses for X.509 issuance. Writes are single-pathed per platform: refuses config change on Cisco/Junos and names the owning server.',
   },
   'telemetry-receivers': {
     env: ['SYSLOG_UDP_PORT', 'SNMP_TRAP_PORT', 'IPFIX_PORT', 'TELEMETRY_BUFFER_SIZE'],


### PR DESCRIPTION
Answering *"are install.sh and SOUL being updated as we go?"* honestly: **mostly, but three artifacts were
missing — and none of them fails the reconciliation gate.**

## 1. `PROFILE_MULTIVENDOR` did not include `multivendor-cli`

The profile **literally named after the capability** omitted it. Anyone selecting the multivendor profile
did *not* get the multivendor CLI driver — it was only reachable by fine-tuning the component checklist.

## 2. The HUD needs two entries, and had neither

`ui/netclaw-visual/server.js` has a **node list** (`{ id, name, prefixes, ... }`) that renders the node,
and a separate **annotation map** (`'id': { env, files, notes }`). My spec-076 edit added only the
annotation — and that edit was then **lost in the rebase**, so the dashboard had no multivendor node at all.

## 3. `SOUL.md` had the count but not the capability

Bumped to "202 skills backed by 150 MCP servers", but the agent's own identity document never learned
*what it can now do* — that it reaches ~90 platform families, or that writes are single-pathed per platform.

## Fixed, and made recurrence-resistant

All three corrected. `docs/ADDING-AN-MCP.md` now documents them explicitly, because **`reconcile-mcp.py`
catches none of them** — they need a human eye until the gate covers them.

```
reconcile-mcp.py  → PASS (4 surfaces)   R0 tests → pass   R1 tests → pass
node --check ui/netclaw-visual/server.js → OK
```

**Existing installs** can now add the driver by re-running `./scripts/install.sh` and selecting either the
multivendor profile or the component directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
