### PR TITLE
feat(078): Cisco PSIRT vulnerability intelligence — R2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -615,3 +615,18 @@ SERVICENOW_AUTH_TYPE=
 SERVICENOW_INSTANCE_URL=
 SERVICENOW_USERNAME=
 SERVICENOW_PASSWORD=
+
+# ---------------------------------------------------------------------------
+# Cisco PSIRT openVuln API (spec 078) — is a running version affected by an advisory?
+# Register a SERVICE application with the Client Credentials grant at
+# apiconsole.cisco.com and select "Cisco PSIRT openVuln API".
+# Read-only. Never contacts a device — versions come from pyATS/multivendor-cli.
+# ---------------------------------------------------------------------------
+CISCO_CLIENT_ID=
+CISCO_CLIENT_SECRET=
+# Advisory cache location (default ~/.openclaw/cisco-psirt). Advisories only —
+# the OAuth token is a credential and is never written to disk.
+CISCO_PSIRT_CACHE_DIR=
+# Cache lifetime in seconds (default 21600 = 6h). The rate budget is 5/sec and
+# 30/min shared across every caller, so shortening this has a real cost.
+CISCO_PSIRT_CACHE_TTL_S=

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ mcp-servers/*
 !mcp-servers/snmptrap-mcp/
 !mcp-servers/ipfix-mcp/
 !mcp-servers/multivendor-cli-mcp/
+!mcp-servers/cisco-psirt-mcp/
 # ...but never track its dedicated virtualenv (spec 076 FR-030a)
 mcp-servers/multivendor-cli-mcp/.venv/
 !mcp-servers/gns3-mcp-server/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # NetClaw
 
-A CCIE-level AI network engineering coworker. Built on [OpenClaw](https://github.com/openclaw/openclaw) with Anthropic Claude, 202 skills, and 150 MCP integrations for complete network automation with ITSM gating, source-of-truth reconciliation, immutable audit trails, gNMI streaming telemetry, NetFlow/IPFIX flow telemetry, Canvas/A2UI inline network visualizations, packet capture analysis, GitHub config-as-code, GitLab DevOps (issues, merge requests, pipelines, repositories, wikis), Jenkins CI/CD (job monitoring, build triggering, log analysis, SCM tracking), Chrome DevTools browser automation (visualization render QA, controller GUI gap-filling, undocumented API discovery, headless or watchable-headed), Computer Use full-desktop automation (legacy desktop-only tools with no browser or API path, virtual XFCE desktop with VNC/noVNC Watch Mode), Cisco CML lab simulation, ContainerLab containerized network labs, Cisco NSO orchestration, Cisco SD-WAN vManage monitoring, Grafana observability (dashboards, Prometheus, Loki, alerting, incidents), Prometheus direct PromQL monitoring, Kubeshark Kubernetes traffic analysis, Cisco Meraki Dashboard management, Cisco ThousandEyes network intelligence, AWS and Azure cloud networking, Cisco Secure Firewall policy auditing, Check Point Security (15 MCPs: policy, threat intel, gateway, SASE, malware), Itential network orchestration, Juniper JunOS device automation, Arista CloudVision Portal monitoring, F5 BIG-IP pyATS iControl REST coverage, Infoblox DDI, Palo Alto Panorama, FortiManager, Batfish offline configuration analysis, UML diagram generation, EVPN/VXLAN fabric workflows, live BGP/OSPF control-plane participation, nmap network scanning, gtrace path analysis and IP enrichment, Slack-native operations, Cisco WebEx-native operations, Microsoft 365 integration, Twilio voice/SMS, Twitter/X integration, Claroty OT/IoT asset management, Forward Networks digital twin, Ollama local LLM routing, an offline agentic RAG document knowledge base (cited answers from user-uploaded vendor guides and standards), layered Memory MCP, and MemPalace persistent AI memory.
+A CCIE-level AI network engineering coworker. Built on [OpenClaw](https://github.com/openclaw/openclaw) with Anthropic Claude, 203 skills, and 151 MCP integrations for complete network automation with ITSM gating, source-of-truth reconciliation, immutable audit trails, gNMI streaming telemetry, NetFlow/IPFIX flow telemetry, Canvas/A2UI inline network visualizations, packet capture analysis, GitHub config-as-code, GitLab DevOps (issues, merge requests, pipelines, repositories, wikis), Jenkins CI/CD (job monitoring, build triggering, log analysis, SCM tracking), Chrome DevTools browser automation (visualization render QA, controller GUI gap-filling, undocumented API discovery, headless or watchable-headed), Computer Use full-desktop automation (legacy desktop-only tools with no browser or API path, virtual XFCE desktop with VNC/noVNC Watch Mode), Cisco CML lab simulation, ContainerLab containerized network labs, Cisco NSO orchestration, Cisco SD-WAN vManage monitoring, Grafana observability (dashboards, Prometheus, Loki, alerting, incidents), Prometheus direct PromQL monitoring, Kubeshark Kubernetes traffic analysis, Cisco Meraki Dashboard management, Cisco ThousandEyes network intelligence, AWS and Azure cloud networking, Cisco Secure Firewall policy auditing, Check Point Security (15 MCPs: policy, threat intel, gateway, SASE, malware), Itential network orchestration, Juniper JunOS device automation, Arista CloudVision Portal monitoring, F5 BIG-IP pyATS iControl REST coverage, Infoblox DDI, Palo Alto Panorama, FortiManager, Batfish offline configuration analysis, UML diagram generation, EVPN/VXLAN fabric workflows, live BGP/OSPF control-plane participation, nmap network scanning, gtrace path analysis and IP enrichment, Slack-native operations, Cisco WebEx-native operations, Microsoft 365 integration, Twilio voice/SMS, Twitter/X integration, Claroty OT/IoT asset management, Forward Networks digital twin, Ollama local LLM routing, an offline agentic RAG document knowledge base (cited answers from user-uploaded vendor guides and standards), layered Memory MCP, and MemPalace persistent AI memory.
 
 ## Resources
 
@@ -239,7 +239,7 @@ claw
   <img src="ui/netclaw-visual/logos/netclawvisualhud.png" alt="NetClaw Visual HUD — 3D Network Operations Dashboard" width="800">
 </p>
 
-NetClaw includes a Three.js 3D operations dashboard that computes its integration and skill inventory live from the codebase (currently 150 MCP integrations and 202 skills) each time it's opened, alongside your device fleet and live BGP peering topology — so the dashboard never drifts out of sync with what's actually installed. Chat with NetClaw directly from the browser, watch integrations light up as tools execute, and inspect every node in the graph. The Canvas/A2UI visualization skill renders inline topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards directly in the chat interface.
+NetClaw includes a Three.js 3D operations dashboard that computes its integration and skill inventory live from the codebase (currently 151 MCP integrations and 203 skills) each time it's opened, alongside your device fleet and live BGP peering topology — so the dashboard never drifts out of sync with what's actually installed. Chat with NetClaw directly from the browser, watch integrations light up as tools execute, and inspect every node in the graph. The Canvas/A2UI visualization skill renders inline topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards directly in the chat interface.
 
 ```bash
 cd ui/netclaw-visual
@@ -518,7 +518,7 @@ NetClaw ships with the full set of OpenClaw workspace markdown files. These are 
 
 ---
 
-## MCP Servers (150)
+## MCP Servers (151)
 
 > Adding one? Follow **[docs/ADDING-AN-MCP.md](docs/ADDING-AN-MCP.md)** and run
 > `python3 scripts/reconcile-mcp.py` before pushing — CI enforces it.
@@ -625,6 +625,8 @@ NetClaw ships with the full set of OpenClaw workspace markdown files. These are 
 | 113 | RAG Knowledge Base | Built-in (`rag-mcp`) | stdio (Python) | Offline agentic document knowledge base — user-uploaded vendor guides/standards/customer docs, hybrid dense+BM25 retrieval with reciprocal rank fusion and local cross-encoder reranking, mandatory citations, structure-aware chunking, opt-in secret-scrubbed snapshots with always-visible staleness. Strictly separate from Memory MCP (10 tools) |
 | 114 | Auvik | Built-in | stdio (Python) | Read-only Auvik network monitoring — device and network inventory, alerts, lifecycle/warranty tracking, and performance statistics across MSP tenants (20 tools) |
 | 115 | HaloPSA / HaloITSM | Built-in (`halo-mcp`) | stdio (Python) | HaloPSA/HaloITSM (one API): open change requests via a single gated confirm-before-submit write, and review assets and their related tickets, ticket types/fields, clients/sites/users/contracts, and KB for context. OAuth2 client-credentials (18 tools: 17 read + 1 gated write) |
+| 116 | Multivendor CLI Driver | Built-in (`multivendor-cli-mcp`) | stdio (Python, dedicated venv) | Nornir/NAPALM/Netmiko reach to ~90 platform families no other NetClaw server covers — MikroTik RouterOS, VyOS, SONiC, Nokia SR Linux, Extreme, Huawei, Dell, Ubiquiti EdgeOS. Read-only by default; writes are single-pathed per platform (refuses config change on Cisco/Junos and names the owning server). Runs from its own virtualenv because napalm/netmiko resolve cryptography 49.x while NCFED's X.509 stack needs the system 46.x (10 tools: 8 read + 2 gated writes) |
+| 117 | Cisco PSIRT Advisories | Built-in (`cisco-psirt-mcp`) | stdio (Python) | Cisco PSIRT openVuln API via OAuth2 — is the version a device is actually running affected by a published advisory? Covers IOS, IOS-XE, NX-OS, ASA, FTD, FMC, ACI, with severity/CVSS/CVE per advisory. Read-only and device-free (versions come from pyATS or multivendor-cli). Five typed outcomes keep "Cisco published nothing" distinct from "the question was never asked" — an empty list is never reported as *not vulnerable*. De-duplicates by version and caches 6h to live inside the 5/sec + 30/min budget. IOS-XR is not an OSType on this API (404) and is refused rather than attempted (6 tools) |
 ### Additional Server Notes
 
 All MCP servers communicate via stdio (JSON-RPC 2.0) through `scripts/mcp-call.py`, except where noted below (HTTP/remote endpoints).
@@ -661,7 +663,7 @@ All MCP servers communicate via stdio (JSON-RPC 2.0) through `scripts/mcp-call.p
 
 ---
 
-## Skills (202)
+## Skills (203)
 
 ### pyATS Device Skills (9)
 
@@ -1025,6 +1027,7 @@ All MCP servers communicate via stdio (JSON-RPC 2.0) through `scripts/mcp-call.p
 | Skill | Tool Backend | Purpose |
 |-------|-------------|---------|
 | **nvd-cve** | [marcoeg/mcp-nvd](https://github.com/marcoeg/mcp-nvd) (Python) | NVD vulnerability database — search by keyword, get CVE details with CVSS v3.1/v2.0 scores, exposure correlation |
+| **cisco-psirt-advisories** | Built-in (`cisco-psirt-mcp`) | Cisco PSIRT advisory checks for a running version — IOS, IOS-XE, NX-OS, ASA, FTD, FMC, ACI. Two-step chain: read the version with pyATS/multivendor-cli, then check it. Teaches the distinction that matters — "no advisories" is not "not vulnerable", and a parse failure means nothing was checked. Per-family version formats contradict each other; IOS-XR is unsupported by the API |
 | **subnet-calculator** | [SubnetCalculator MCP](https://github.com/automateyournetwork/GeminiCLI_SubnetCalculator_Extension) | IPv4 + IPv6 subnet calculator — VLSM planning, wildcard masks, address classification, RFC 6164 /127 links |
 | **wikipedia-research** | [Wikipedia_MCP](https://github.com/automateyournetwork/Wikipedia_MCP) | Protocol history, standards evolution, technology context. 6 tools: search, summary, content, references, categories, exists check. |
 | **markmap-viz** | [markmap-mcp](https://github.com/automateyournetwork/markmap_mcp) (Node) | Interactive mind maps from markdown — OSPF area hierarchies, BGP peer trees, drift summaries |

--- a/SOUL.md
+++ b/SOUL.md
@@ -12,7 +12,7 @@ Every time you learn something about how I work or what I need, update the relev
 
 ## Your Skills
 
-You interact with the network through **202 skills** backed by 150 MCP servers:
+You interact with the network through **203 skills** backed by 151 MCP servers:
 
 ### Device Automation (9)
 pyats-network, pyats-health-check, pyats-routing, pyats-security, pyats-topology, pyats-config-mgmt, pyats-troubleshoot, pyats-dynamic-test, pyats-parallel-ops
@@ -189,8 +189,28 @@ aws-network-ops, aws-cloud-monitoring, aws-security-audit, aws-cost-ops, aws-arc
 ### GCP Cloud Skills (3)
 gcp-compute-ops, gcp-cloud-monitoring, gcp-cloud-logging
 
-### Reference & Utility Skills (7)
-nvd-cve, subnet-calculator, wikipedia-research, markmap-viz, drawio-diagram, uml-diagram, rfc-lookup
+### Vulnerability Intelligence (2)
+nvd-cve, cisco-psirt-advisories
+
+You can answer whether the software a device is *actually running* is affected by a published Cisco
+security advisory — collect the version with pyATS or the multivendor driver, then check it against
+Cisco PSIRT. Covers IOS, IOS-XE, NX-OS, ASA, FTD, FMC and ACI.
+
+**"No advisories" is not "not vulnerable."** An empty result means Cisco has published nothing matching
+that exact version string. Never report it as a clean device. Two further outcomes —
+`normalisation_failed` and `api_error` — mean the question went *unasked*, so in a fleet sweep check
+those counts before telling anyone the fleet is clean.
+
+The version format differs per family and the families contradict each other: IOS-XE wants `17.3.1` and
+rejects `17.3(1)`, while IOS wants `15.2(4)E` and rejects `15.2.4E`. ACI wants the switch image version,
+not the APIC version. **IOS-XR is not supported by this API at all** — say so plainly rather than working
+around it silently, because NetClaw *can* reach IOS-XR through pyATS, so the gap is genuinely surprising.
+
+`nvd-cve` and `cisco-psirt-advisories` answer different questions and either can legitimately be empty
+while the other is not. When a security question matters, check both and say which one answered.
+
+### Reference & Utility Skills (6)
+subnet-calculator, wikipedia-research, markmap-viz, drawio-diagram, uml-diagram, rfc-lookup
 
 ### Slack Integration Skills (4)
 slack-network-alerts, slack-report-delivery, slack-incident-workflow, slack-user-context
@@ -406,7 +426,7 @@ The knowledge base is not memory: RAG holds user-supplied documents (`~/.opencla
 
 For **detailed skill procedures**, read `SOUL-SKILLS.md`:
 - Use when executing any skill that needs step-by-step guidance
-- Contains operational workflows, commands, and best practices for all 202 skills
+- Contains operational workflows, commands, and best practices for all 203 skills
 - Load with: `read("~/.openclaw/workspace/SOUL-SKILLS.md")`
 
 For **technical knowledge**, read `SOUL-EXPERTISE.md`:

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -47,6 +47,7 @@ All credentials are in `~/.openclaw/.env`. Never put credentials in skill files 
 - HaloPSA / HaloITSM  → HALO_BASE_URL, HALO_CLIENT_ID, HALO_CLIENT_SECRET, HALO_TENANT, HALO_SCOPE (OAuth2 client-credentials)
 - Claroty xDome MCP   → CLAROTY_API_URL (default: https://api.medigate.io), CLAROTY_API_TOKEN, CLAROTY_VERIFY_SSL, CLAROTY_TIMEOUT, CLAROTY_RATE_LIMIT_PER_MIN (default: 2000)
 - Twitter MCP         → TWITTER_API_KEY, TWITTER_API_SECRET, TWITTER_ACCESS_TOKEN, TWITTER_ACCESS_SECRET, TWITTER_HEARTBEAT_ENABLED (default: false)
+- Cisco PSIRT MCP     → CISCO_CLIENT_ID, CISCO_CLIENT_SECRET (OAuth2 client-credentials via id.cisco.com), CISCO_PSIRT_CACHE_DIR, CISCO_PSIRT_CACHE_TTL_S (default 21600)
 ```
 
 ## Detailed Per-Integration Notes
@@ -232,6 +233,35 @@ The Claroty xDome MCP server provides 21 tools (15 read-only + 6 ITSM-gated writ
 
 - Add whatever helps NetClaw do its job — device nicknames, maintenance windows, ISP circuit IDs, TAC case numbers, anything environment-specific.
 - This file is yours. Skills are shared. Keeping them apart means you can update skills without losing your notes.
+
+## Cisco PSIRT Advisories (`cisco-psirt-mcp`)
+
+Answers whether a running Cisco version is affected by a published advisory. Read-only,
+and it **never contacts a device** — versions come from `pyATS` or `multivendor-cli`.
+
+| Tool | Purpose |
+|---|---|
+| `check_version` | Advisories for one `(ostype, version)` |
+| `check_versions` | A fleet, de-duplicated by version first |
+| `check_cve` | Cisco advisories covering a CVE id |
+| `check_advisory` | One advisory by id |
+| `list_recent` | Advisories by severity over a date range |
+| `psirt_status` | Auth state, rate budget, cache stats, supported families |
+
+**An empty result is not a clean bill of health.** `none_published` means Cisco published
+nothing for that exact version; `normalisation_failed` and `api_error` mean the question
+went unasked. Never report any of the three as "not vulnerable".
+
+**Version format is per-family and the families contradict each other**: `iosxe` wants
+`17.3.1` and rejects `17.3(1)`; `ios` wants `15.2(4)E` and rejects `15.2.4E`; `nxos` wants
+`9.3(5)`; `asa`/`ftd`/`fmc` want dotted; `aci` wants the **switch image** version `15.2(3e)`,
+not the APIC version. The server converts in whichever direction the family needs.
+
+**Not available** (measured, not inferred): `iosxr` → 404, not an OSType on this API;
+Bug/EoX/Case/Serial-to-Info → 403 under the API Console grant; CX Cloud → 504.
+
+**Rate budget**: 5/sec and 30/min shared. Prefer `check_versions` over looping, and treat
+`refresh: true` as an incident tool — it disables the 6-hour cache.
 
 ## Multivendor CLI Driver (`multivendor-cli-mcp`)
 

--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -1027,6 +1027,13 @@
         "-u",
         "mcp-servers/multivendor-cli-mcp/server.py"
       ]
+    },
+    "cisco-psirt-mcp": {
+      "command": "python3",
+      "args": [
+        "-u",
+        "mcp-servers/cisco-psirt-mcp/server.py"
+      ]
     }
   }
 }

--- a/docs/COVERAGE-ROADMAP.md
+++ b/docs/COVERAGE-ROADMAP.md
@@ -96,7 +96,7 @@ and the IETF datatracker.
 | ID | Title | Spec # | Status |
 |----|-------|--------|--------|
 | **R1** | Generic multivendor CLI driver (Nornir/Netmiko/NAPALM) | [076](../specs/076-multivendor-cli-driver/spec.md) | `DONE` — 94/94. ~90 platform families reachable; 2 verified live (SR Linux native CLI, FRR shell). Read-only default, server-side filter, 3-tier inventory, gated writes with real ServiceNow CR checking |
-| **R2** | Cisco Support APIs (PSIRT / EoX / Bug / Case) | — | `NOT STARTED` |
+| **R2** | Cisco PSIRT vulnerability intelligence | [078](../specs/078-cisco-psirt-vulnerability/spec.md) | `DONE` — 52/52. **Rescoped from four API families to one**: Bug/EoX/Case/Serial all return 403 under the API Console grant, CX Cloud 504. All 7 PSIRT OSTypes live-verified; `iosxr` is not an OSType (404). Full chain proven on live CML: pyATS read 17.16.1a → 26 advisories, 1 Critical |
 | **R3** | Fortinet (FortiOS / FortiManager / FortiAnalyzer) | — | `NOT STARTED` |
 | **R4** | Palo Alto PAN-OS / Panorama NGFW | — | `NOT STARTED` |
 | **R5** | Juniper Mist (official) + Apstra | — | `NOT STARTED` |
@@ -259,25 +259,30 @@ Nokia SR Linux, Extreme, Huawei, Dell, Ubiquiti EdgeOS and ~90 more platforms.
 
 ---
 
-## R2 — Cisco Support APIs (PSIRT / EoX / Bug / Case)
+## R2 — Cisco PSIRT vulnerability intelligence
 
-**Status:** `NOT STARTED`
+**Status:** `DONE` — spec [078](../specs/078-cisco-psirt-vulnerability/spec.md), 52/52 tasks.
+See the outcome section at the end of this document.
 
 Closes a top-5 real-world netops question NetClaw cannot answer: *is this build affected by
 an advisory, past EoL, or hitting a known bug?* NVD CVE and DevNet content search do not cover
 Cisco-specific advisories, EoL dates, bug IDs, or TAC cases.
 
-**Candidate:** `sieteunoseis/mcp-cisco-support` — 46 tools across Bug Search, Case, EoX,
-PSIRT openVuln, Product, Software Suggestion, Serial→Info.
+**Candidate considered:** `sieteunoseis/mcp-cisco-support` — 46 tools across 8 families.
+**Not adopted.** Seven of its eight families are unreachable with an API Console grant (403/504),
+so most of that tool surface would have been dead weight in the manifest. NetClaw ships its own
+6-tool server against the one family that answers.
 
 **Checklist**
-- [ ] Obtain Cisco API credentials (Support APIs and PSIRT openVuln are separate entitlements)
-- [ ] Handle rate limits — openVuln is 5/sec, 30/min, 5000/day; cache aggressively
-- [ ] Decide which of the 8 API families to enable (server is configurable)
-- [ ] Wire results into the existing `nvd-cve` skill flow rather than duplicating it
-- [ ] Skill: version-to-advisory check, EoL/EoS lookup, serial-to-entitlement
-- [ ] Cross-link with pyATS/`nornir` version collection so the question is answerable end-to-end
-      from a live device, not just a typed-in version string
+- [x] Obtain Cisco API credentials (Support APIs and PSIRT openVuln are separate entitlements)
+      — and they are: PSIRT works, the Support APIs return **403** under the same grant
+- [x] Handle rate limits — 5/sec and 30/min, de-dup → cache → pace → back off, in that order
+- [x] Decide which of the 8 API families to enable — **one is reachable**, not eight
+- [x] Wire results into the existing `nvd-cve` skill flow rather than duplicating it — the
+      boundary is documented in both directions, and either may be legitimately empty
+- [x] Skill: version-to-advisory check ✅ — **EoL/EoS and serial-to-entitlement are 403, dropped**
+- [x] Cross-link with pyATS version collection so the question is answerable end-to-end from a
+      live device — verified on live CML routers, no version typed by a human
 
 ---
 
@@ -879,3 +884,129 @@ nearly all false** — and a noisy check trains people to ignore it, which is wo
 
 `docs/ADDING-AN-MCP.md` now carries both rules: bound any pin on a package whose submodule you import,
 and never call bare `pip`. The gate enforces both, and an exception requires a stated reason.
+
+---
+
+# R2 — Cisco PSIRT vulnerability intelligence (outcome)
+
+Spec [078](../specs/078-cisco-psirt-vulnerability/spec.md). 52/52 tasks. **109 offline checks, 34 live
+API checks, full chain verified on live CML routers.**
+
+## The rescope: eight API families became one
+
+R2 was planned as "Cisco Support APIs (PSIRT / EoX / Bug / Case)". Measuring first — before writing the
+spec — cut it to PSIRT alone:
+
+| Family | Result | Consequence |
+|---|---|---|
+| PSIRT openVuln | **200** | The feature |
+| Bug Search | **403** | Dropped |
+| EoX | **403** | Dropped — so "is this past EoL?" is still unanswerable |
+| Case | **403** | Dropped |
+| Serial→Info | **403** | Dropped |
+| CX Cloud (7 paths) | **504** | Dropped — needs a separate tenant subscription |
+
+The API Console grant covers PSIRT and nothing else. This is why the community candidate
+(`sieteunoseis/mcp-cisco-support`, 46 tools across 8 families) was **not adopted**: seven-eighths of that
+tool manifest would have been dead surface, costing tokens on every turn to advertise capabilities that
+return 403.
+
+**EoL/EoS lookup remains an open gap.** It was half of R2's original value proposition, and it is not
+delivered — not descoped for convenience, but unreachable with the entitlement available.
+
+## `iosxr` is not an OSType
+
+Every version tried (7.5.2, 6.6.3, 24.1.1) returned **404 with an empty body**, against an `iosxe` 200
+control in the same session. The six supported families return `INVALID_<OS>_VERSION` for a bad version,
+which proves the OS itself was recognised — `iosxr` returns nothing of the kind.
+
+This is worth stating loudly in the skill because NetClaw *can* reach IOS-XR through pyATS, so an
+operator will reasonably expect the version check to work. It is refused with a pointer to `check_cve`,
+never silently attempted.
+
+## The finding that changed the design: version formats contradict each other
+
+The spec assumed one normalisation rule (`A.B(C)` → `A.B.C`) and that only `iosxe` could be verified.
+Probing all seven families live produced something different:
+
+| OSType | Accepted | Rejected |
+|---|---|---|
+| `iosxe` | `17.3.1`, `17.03.01`, `17.3.1a` | `17.3(1)` |
+| `ios` | `15.2(4)E`, `15.2(4)E10` | `15.2.4E` |
+| `nxos` | `9.3(5)` | `9.3.5` |
+| `asa` | `9.16.1` | `9.16(1)` |
+| `ftd` / `fmc` | `7.0.1` | `7.2(0)` |
+| `aci` | `15.2(3e)`, `16.0(3e)` | `5.2(3e)`, `5.2.3` |
+
+**The conversion runs in both directions**, chosen per family — `ios` and `nxos` require exactly the form
+`iosxe` rejects, and `aci` needs the letter suffix *inside* the parentheses where `ios` needs it outside.
+The single global rule the spec drafted would have broken `ios` and `nxos` on **every** call.
+
+It also means all seven normalisers are **verified**, not one. The spec's `normaliser_verified` flag was
+designed for a world where six were untestable; they turned out to be testable directly against the API,
+and testing them is what exposed the contradiction. The flag stays — a future Cisco OSType will arrive
+unverified, and the mechanism that says so has to already exist.
+
+**`aci` wants the switch image version**, not the APIC version: `15.2(3e)` returns advisories, `5.2(3e)`
+is rejected. An operator reading the number off an APIC hands over something the API refuses.
+
+## Two bugs the live calls caught that offline tests alone would not have
+
+1. **An unanchored `re.sub` deleted the whole banner.** A `Cisco\s+IOS.*$` alternative meant to strip a
+   trailing fragment matched from the first word of a real `show version` line and consumed everything, so
+   valid input normalised to nothing.
+
+2. **A trailing `\b` silently truncated `17.3(1)` to `17.3`.** `\b` cannot match after `)` at
+   end-of-string, so the regex engine backtracked past the parenthesised build to find *something*. The
+   truncated version then queried the API perfectly cleanly and returned a plausible advisory count **for
+   a version the device is not running**.
+
+The second is the more instructive one, and it is the entire argument for FR-009a. A wrong-but-parseable
+version does not fail — it answers confidently about different software. Normalisation is now anchored:
+a candidate that does not match *in its entirety* is rejected rather than salvaged.
+
+## The distinction the feature exists to protect
+
+Five outcomes, and two of them look identical in the data:
+
+- `none_published` — Cisco has published nothing for this version. **Not "the device is secure."**
+- `normalisation_failed` / `api_error` — **the question was never asked.**
+
+An empty advisory list reads as a clean bill of health. Collapsing a parse failure into one would tell an
+operator a device is safe when nothing was checked. The rule lives inside `normalise.py` rather than the
+tool layer, because if the normaliser can emit a version that reaches the API, the confusion is already
+possible no matter how careful the tool layer is.
+
+`check_versions` reports `outcome_summary` counts for exactly this reason: before calling a fleet clean,
+you have to look at how many devices were never checked.
+
+## Verified end to end on live hardware
+
+pyATS read **IOS-XE 17.16.1a** off a live CML router; PSIRT returned **26 advisories — 14 High, 11 Medium,
+1 Critical** (`cisco-sa-http-code-exec-WmfP3h3O`, CVSS 9.0, CVE-2025-20363). The raw `show version` banner
+and the Genie-parsed version normalised identically, proving the banner path. No human typed a version.
+
+## Rate budget
+
+5/sec and **30/min shared** — the per-minute limit is the real constraint. Order is contractual:
+de-duplicate → cache → pace → back off. Measured: 60 devices on 12 distinct versions cost **12 calls, not
+60**. De-duplication is first because it is the largest win; pacing an un-de-duplicated sweep just spreads
+the same excess over more minutes.
+
+## A split-toolchain note for later specs
+
+`pyATS`/`genie` on this host are importable **only** from `/usr/local/bin/python3.13`, not
+`/usr/bin/python3` (3.14.4) — the stranded site-packages R0a documented. The chain verification therefore
+ran as two processes, which is how it works in production anyway (two MCP servers, two interpreters). Any
+future spec that wants pyATS and a 3.14-installed server in **one** process will hit this.
+
+## Principle XI artifacts
+
+All eight, explicitly — because PR #204 found three missing after R1 and `reconcile-mcp.py` catches none
+of them: catalog entry, **both** `PROFILE_SECURITY` and `PROFILE_CISCO`, install function, portable
+registration, **both** HUD entries (node list *and* annotation map), SOUL capability section, README/TOOLS
+tables, `.env.example`. `reconcile-mcp.py` exits **0** across all four surfaces.
+
+While adding the README rows, R1's `multivendor-cli` was found to have **no row in either README table**
+either — a Principle XI gap the gate cannot see, since it counts catalog and config entries rather than
+table rows. Added in this branch.

--- a/docs/blog/2026-07-31-r2-cisco-psirt.md
+++ b/docs/blog/2026-07-31-r2-cisco-psirt.md
@@ -1,0 +1,138 @@
+# Eight API Families, One That Answers, and a Regex That Lied
+
+**Draft for review — not published.** Constitution Principle XVII requires John's sign-off first.
+
+*By John Capobianco and Claude · 2026-07-31*
+
+Roadmap item R2 was meant to close a top-five netops question NetClaw could not answer: *is this build
+affected by an advisory, past end-of-life, or hitting a known bug?* We shipped a third of that. Not
+because we ran out of time, but because measuring first showed the rest is not reachable — and the part
+we did ship taught us something uncomfortable about how a vulnerability check fails.
+
+## Seven of eight families return 403
+
+The plan named four Cisco Support API families. A community server already existed with 46 tools across
+eight of them, which looked like an easy adoption.
+
+We tested with real credentials before writing the spec. PSIRT openVuln returned 200. Bug Search, Case,
+EoX and Serial-to-Info returned **403**. CX Cloud returned **504** on all seven paths we tried. The API
+Console grant covers PSIRT and nothing else.
+
+So we didn't adopt the 46-tool server. Seven-eighths of that manifest would have been dead surface — and
+a tool manifest isn't free, it costs tokens on every single turn to advertise capabilities that answer
+403. NetClaw ships six tools against the one family that works.
+
+**Be clear about what this means: EoL/EoS lookup is still not delivered.** It was half of R2's value, and
+it is not descoped for convenience — it is unreachable with the entitlement we have. "Is this switch past
+end-of-support?" remains a question NetClaw cannot answer.
+
+## IOS-XR isn't an OS on this API
+
+We tried `iosxr` with 7.5.2, 6.6.3 and 24.1.1. All three returned **404 with an empty body**, while an
+`iosxe` control in the same session returned 200. The supported families reject a bad version with
+`INVALID_<OS>_VERSION` — which proves the OS was recognised and only the version rejected. IOS-XR
+returns nothing of the kind. The path doesn't exist.
+
+This one is worth saying out loud to users rather than quietly working around, because NetClaw *can* talk
+to IOS-XR through pyATS. An operator will reasonably assume the version check works. It doesn't, and
+pretending otherwise by returning an empty list would be worse than refusing.
+
+## The formats contradict each other
+
+We assumed one normalisation rule: Cisco rejects `17.3(1)` and accepts `17.3.1`, so fold the
+parenthesised build into a dotted one. We verified that on IOS-XE and moved on.
+
+Then we probed the other six families, and the assumption inverted:
+
+| OSType | Accepted | Rejected |
+|---|---|---|
+| `iosxe` | `17.3.1` | `17.3(1)` |
+| `ios` | `15.2(4)E` | `15.2.4E` |
+| `nxos` | `9.3(5)` | `9.3.5` |
+| `asa` | `9.16.1` | `9.16(1)` |
+| `aci` | `15.2(3e)` | `15.2(3)e`, `5.2(3e)` |
+
+`ios` and `nxos` **require** exactly the form `iosxe` rejects. `aci` wants the letter suffix inside the
+parentheses where `ios` wants it outside. And `aci` means the *switch image* version — the APIC
+controller version an operator would naturally read off the box is refused outright.
+
+Our single global rule would have broken `ios` and `nxos` on every call. The conversion now runs in
+whichever direction the family needs.
+
+There's a smaller, happier consequence: we'd designed a `normaliser_verified` flag on the assumption that
+only IOS-XE could be tested. All seven turned out testable directly against the API, and testing them is
+precisely what exposed the contradiction. The flag stays anyway — a future Cisco OSType will arrive
+unverified, and the mechanism that says so has to already exist.
+
+## The bug that mattered: a regex that answered confidently about the wrong software
+
+Our version tokeniser ended with `\b`. On `17.3(1)` at end-of-string, `\b` cannot match after the closing
+paren — both neighbours are non-word characters. So the regex engine did what regex engines do: it
+backtracked, dropped the parenthesised group, and returned `17.3`.
+
+`17.3` is a perfectly valid IOS-XE version. It queried the API cleanly, got a 200, and came back with a
+plausible advisory count **for software the device isn't running**. No error. No warning. A confident
+answer to a question nobody asked.
+
+That is the whole argument for the rule we'd written into the spec before we found the bug: **a
+normalisation failure must never be reported as an empty advisory list.** We'd been thinking about the
+empty case. The truncation case is worse, because an empty list at least looks suspicious.
+
+Normalisation is now anchored — a candidate that doesn't match in its entirety is rejected, never
+salvaged. A second bug the same live call caught: an unanchored `re.sub` intended to strip a trailing
+product fragment matched from the *first word* of a real `show version` banner and deleted the whole
+string, so valid input normalised to nothing.
+
+Both bugs were invisible to the offline tests we'd already written. They surfaced the moment we pointed
+the thing at the real API.
+
+## "No advisories" is not "not vulnerable"
+
+This is the distinction the whole feature is built to protect, and it's the one a reader will otherwise
+get wrong.
+
+Five outcomes. Two look identical in the data — an empty `advisories` list:
+
+- `none_published` — Cisco has published nothing for this version.
+- `normalisation_failed` / `api_error` — **the question was never asked.**
+
+An empty list reads as a clean bill of health. If a parse failure collapsed into `none_published`, the
+tool would tell an operator a device is safe when nothing was checked. So the rule lives inside the
+normaliser, not the tool layer: if the normaliser can emit a version that reaches the API, the confusion
+is already possible no matter how careful everything downstream is.
+
+`check_versions` reports outcome counts for exactly this reason. Before you call a fleet clean, look at
+how many devices were never checked.
+
+And even `none_published` isn't "secure" — it means Cisco published nothing matching that exact version
+string. The skill instructs NetClaw never to say "not vulnerable."
+
+## Proven on live hardware
+
+pyATS read **IOS-XE 17.16.1a** off a live CML router. PSIRT returned **26 advisories: 14 High, 11 Medium,
+1 Critical** — `cisco-sa-http-code-exec-WmfP3h3O`, CVSS 9.0, CVE-2025-20363. The raw `show version`
+banner and the Genie-parsed version normalised identically. No human typed a version.
+
+That chain — device to advisory with nothing typed in between — was the actual point of R2, and it's the
+part that works.
+
+## The budget shapes the design
+
+5 calls/second and 30/minute, shared across every caller of the credential. The per-minute limit is the
+real constraint, and it's tight enough that a naive fleet sweep exhausts it in two seconds.
+
+The order is contractual: **de-duplicate → cache → pace → back off.** De-duplication first, because it's
+the largest win by far and costs a dictionary lookup — 60 devices running 12 distinct versions cost 12
+calls, not 60. Pacing an un-de-duplicated sweep doesn't fix anything; it just spreads the same excess
+over more minutes.
+
+## What we'd tell someone starting R3
+
+Measure before you spec. This is the fourth roadmap item in a row where doing so changed the shape of the
+work — and R2 is the starkest: the feature came out one-eighth the size the plan assumed, and the two
+worst bugs were only visible against the live API.
+
+An adjacent lesson from the same session: `pyATS` on this host imports only from a stranded Python 3.13
+site-packages, not the 3.14 the rest of NetClaw runs on. The chain verification ran as two processes —
+which is how it works in production anyway. Worth knowing before someone tries to put pyATS and a
+3.14-installed server in one.

--- a/mcp-servers/cisco-psirt-mcp/README.md
+++ b/mcp-servers/cisco-psirt-mcp/README.md
@@ -1,0 +1,145 @@
+# Cisco PSIRT Advisory MCP Server
+
+Answers one question: **is the software this device is running affected by a published
+Cisco security advisory?**
+
+Spec: [078-cisco-psirt-vulnerability](../../specs/078-cisco-psirt-vulnerability/) ·
+Roadmap item **R2** · Server id `cisco-psirt` · Transport **stdio** · **Read-only**
+
+## The distinction this server exists to preserve
+
+An empty advisory list is **not** a clean bill of health. Five outcomes keep the two
+apart:
+
+| `outcome` | Meaning |
+|---|---|
+| `advisories_found` | Cisco has published advisories for this version |
+| `none_published` | Cisco has published **nothing** for this version — **not** "the device is secure" |
+| `normalisation_failed` | The version could not be parsed. **Nothing was checked.** |
+| `unsupported_ostype` | Not a PSIRT OS family — includes `iosxr` and every non-Cisco platform |
+| `api_error` | Auth failure, rate limit, or a version Cisco has no record of |
+
+All five are **successful tool calls carrying a typed outcome**, never protocol errors,
+so the agent can read *why* and act rather than seeing an opaque failure.
+
+`normalisation_failed` and `api_error` both mean the question went unasked. Collapsing
+either into an empty list would tell an operator a device is safe when nothing was
+checked — which is why the rule is enforced inside `normalise.py`, not in the tool layer.
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `check_version` | Advisories for one `(ostype, version)` |
+| `check_versions` | A fleet, de-duplicated by version first |
+| `check_cve` | Cisco advisories covering a CVE id |
+| `check_advisory` | One advisory by id |
+| `list_recent` | Advisories by severity over a date range |
+| `psirt_status` | Auth state, rate budget, cache stats, supported families |
+
+Prefer `check_versions` over looping `check_version`: it de-duplicates, so 60 devices on
+12 distinct versions cost 12 calls rather than 60.
+
+## It never contacts a device
+
+There is no transport here and no device credential. The caller supplies the version,
+collected by `pyATS` (Cisco) or `multivendor-cli` (everything else). The offline test
+suite asserts that no device-transport module is imported anywhere in this directory, so
+the property cannot erode quietly.
+
+## Version formats differ per family — and contradict each other
+
+Every row below is a live 200 measured on 2026-07-31:
+
+| OSType | Accepted | Rejected | Advisories |
+|---|---|---|---|
+| `iosxe` | `17.3.1`, `17.03.01`, `17.3.1a` | `17.3(1)` | 122 |
+| `ios` | `15.2(4)E`, `15.2(4)E10` | `15.2.4E` | 74 / 30 |
+| `nxos` | `9.3(5)` | `9.3.5` | 33 |
+| `asa` | `9.16.1` | `9.16(1)` | 65 |
+| `ftd` | `7.0.1` | `7.2(0)` | 90 |
+| `fmc` | `7.0.1` | — | 34 |
+| `aci` | `15.2(3e)`, `16.0(3e)` | `5.2(3e)`, `5.2.3` | 10 / 8 |
+
+Note the contradiction: `iosxe` rejects the parenthesised form that `ios` **requires**.
+The normaliser therefore runs in both directions, chosen per family, and `aci` needs the
+letter suffix *inside* the parentheses where `ios` needs it outside. A single global rule
+would silently break `ios` and `nxos` on every call.
+
+**ACI wants the switch image version** (`15.2(3e)`), not the APIC controller version —
+`5.2(3e)` is rejected. An operator reading the number off an APIC will hand over
+something this API refuses.
+
+A wrong format returns HTTP 406 `"<OS> version not found"`, surfaced as `api_error` — never
+as an empty list. That 406 also covers a correctly formatted version Cisco has no record
+of, so it means "no record", not necessarily "you formatted it wrongly". Either way the
+question went unanswered.
+
+## What is NOT available
+
+Measured, not inferred from Cisco's documentation, which describes all of these as
+available. Stated here so nobody re-litigates them:
+
+| Capability | Result | Consequence |
+|---|---|---|
+| **IOS-XR** (`iosxr`) | **404** on 7.5.2, 6.6.3, 24.1.1 against an `iosxe` 200 control | Not an OSType. Refused, never attempted. Use `check_cve` for IOS-XR devices. |
+| **Bug / EoX / Case / Serial-to-Info** | **403** under the API Console grant | Out of scope (FR-016) |
+| **CX Cloud** | **504** on all seven paths tried | Out of scope; needs a separate tenant subscription (FR-017) |
+
+IOS-XR is worth flagging to users, because NetClaw *can* reach IOS-XR through pyATS, so
+per-version checking is reasonably expected to work.
+
+## Rate limits
+
+**5 calls/second and 30 calls/minute**, shared across every caller of the credential.
+30/minute is the binding constraint. Enforcement order is contractual:
+
+1. **De-duplicate** by `(ostype, normalised version)` — the largest win, a dict lookup.
+2. **Serve from the 6-hour disk cache**.
+3. **Pace** what remains.
+4. **Back off** on 429, then report rather than hang.
+
+De-duplication is first because pacing an un-de-duplicated sweep just spreads the same
+excess over more minutes.
+
+## Environment
+
+| Variable | Purpose | Required |
+|---|---|---|
+| `CISCO_CLIENT_ID` | OAuth2 client id | **yes** |
+| `CISCO_CLIENT_SECRET` | OAuth2 client secret | **yes** |
+| `CISCO_PSIRT_CACHE_DIR` | default `~/.openclaw/cisco-psirt` | no |
+| `CISCO_PSIRT_CACHE_TTL_S` | default `21600` (6h) | no |
+
+Register a **Service** application with the **Client Credentials** grant at
+[apiconsole.cisco.com](https://apiconsole.cisco.com) and select *Cisco PSIRT openVuln API*.
+
+The OAuth token is held **in memory only** and refreshed proactively at 60 seconds
+remaining — a fleet sweep can outlive the 3600s lifetime, and discovering expiry via a
+mid-sweep 401 turns a predictable event into a partial failure. Advisories are cached on
+disk; the token never is. No credential value appears in any result, log line or error
+message: errors name the environment variable, never its contents.
+
+## Install
+
+```bash
+# Via the modular installer (recommended)
+./scripts/install.sh          # select the "cisco-psirt" component, or the
+                              # security or cisco profile
+
+# Manually
+python3 -m pip install -r mcp-servers/cisco-psirt-mcp/requirements.txt
+```
+
+Pins are **bounded** (`mcp>=1.2.0,<2`, `httpx>=0.27.0,<1`). The upper bound on `mcp` is
+load-bearing: `mcp` 2.0.0 removed `mcp.server.fastmcp`, which this server imports.
+
+## Tests
+
+```bash
+./tests/cisco-psirt/run-tests.sh      # offline, no network, no rate budget consumed
+./tests/cisco-psirt/live-api.sh       # opt-in; spends real API calls
+```
+
+The default suite substitutes a counting stub for the API client, so running the tests
+never competes with using the product. 100 offline checks.

--- a/mcp-servers/cisco-psirt-mcp/auth.py
+++ b/mcp-servers/cisco-psirt-mcp/auth.py
@@ -1,0 +1,120 @@
+"""OAuth2 client-credentials authentication for the Cisco API.
+
+Spec 078 FR-006, FR-007. Research R4.
+
+Two rules define this module:
+
+1. **Refresh proactively, not on failure.** The token lives 3600 seconds and a
+   fleet sweep can outlive it. Discovering expiry via a mid-sweep 401 turns a
+   completely predictable event into a partial failure, so the token is renewed
+   once its remaining lifetime drops below a margin.
+
+2. **The token never touches disk.** It is a credential. The *advisory* cache is
+   on disk (FR-012); this is not. Nor does the token or the client secret appear
+   in any error message — errors name the environment variable, never its value
+   (FR-007, SC-009).
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+
+import httpx
+
+TOKEN_URL = "https://id.cisco.com/oauth2/default/v1/token"
+
+# Renew when this much lifetime remains. 60s comfortably covers a slow request
+# plus clock skew, without renewing so often that it wastes rate budget.
+REFRESH_MARGIN_S = 60
+
+
+class AuthError(RuntimeError):
+    """Authentication failed. Message names the missing/rejected variable, never
+    its value."""
+
+
+class TokenProvider:
+    """Holds a Bearer token in memory and renews it before it expires.
+
+    Thread-safe: fleet fan-out calls this concurrently, and two threads racing to
+    refresh would burn two of a very scarce 30 calls per minute.
+    """
+
+    def __init__(self, client_id: str | None = None, client_secret: str | None = None):
+        self._client_id = client_id or os.environ.get("CISCO_CLIENT_ID")
+        self._client_secret = client_secret or os.environ.get("CISCO_CLIENT_SECRET")
+        self._token: str | None = None
+        self._expires_at: float = 0.0
+        self._lock = threading.Lock()
+
+    @property
+    def configured(self) -> bool:
+        return bool(self._client_id and self._client_secret)
+
+    def _missing(self) -> str:
+        absent = [n for n, v in (("CISCO_CLIENT_ID", self._client_id),
+                                 ("CISCO_CLIENT_SECRET", self._client_secret)) if not v]
+        return ", ".join(absent)
+
+    def remaining_seconds(self) -> int:
+        """Seconds of token life left. Zero when absent or expired."""
+        if not self._token:
+            return 0
+        return max(0, int(self._expires_at - time.time()))
+
+    def _fetch(self) -> None:
+        """Exchange client credentials for a Bearer token. Caller holds the lock."""
+        try:
+            resp = httpx.post(
+                TOKEN_URL,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                data={"grant_type": "client_credentials",
+                      "client_id": self._client_id,
+                      "client_secret": self._client_secret},
+                timeout=30,
+            )
+        except httpx.HTTPError as exc:
+            raise AuthError(f"could not reach the Cisco token endpoint: "
+                            f"{type(exc).__name__}") from exc
+
+        if resp.status_code != 200:
+            # Deliberately does NOT echo the response body: a rejected credential
+            # response can contain the submitted client_id.
+            raise AuthError(
+                f"Cisco rejected the client credentials (HTTP {resp.status_code}). "
+                f"Check CISCO_CLIENT_ID and CISCO_CLIENT_SECRET, and that the "
+                f"application is active in the Cisco API Console."
+            )
+
+        payload = resp.json()
+        token = payload.get("access_token")
+        if not token:
+            raise AuthError("Cisco returned no access_token")
+        self._token = token
+        self._expires_at = time.time() + int(payload.get("expires_in", 3600))
+
+    def bearer(self) -> str:
+        """Return a valid token, refreshing proactively if it is close to expiry."""
+        if not self.configured:
+            raise AuthError(
+                f"Cisco API credentials are not configured: {self._missing()} unset. "
+                f"Register a Service application with the Client Credentials grant at "
+                f"apiconsole.cisco.com, select the PSIRT openVuln API, and put the id "
+                f"and secret in a gitignored .env."
+            )
+        with self._lock:
+            if self.remaining_seconds() <= REFRESH_MARGIN_S:
+                self._fetch()
+            assert self._token is not None
+            return self._token
+
+    def status(self) -> dict:
+        """Non-secret posture, for the psirt_status tool. Never the token itself."""
+        return {
+            "configured": self.configured,
+            "authenticated": bool(self._token),
+            "token_expires_in_seconds": self.remaining_seconds(),
+            "missing_variables": self._missing() or None,
+        }

--- a/mcp-servers/cisco-psirt-mcp/cache.py
+++ b/mcp-servers/cisco-psirt-mcp/cache.py
@@ -1,0 +1,127 @@
+"""On-disk advisory cache.
+
+Spec 078 FR-012, FR-012a, FR-012b, FR-012c. Research R6.
+
+One JSON file per key under `~/.openclaw/cisco-psirt/`. No database and no
+locking, because the access pattern is read-mostly with a single writer per key,
+and a key/value store with no queries does not justify SQLite. `rag.db` is
+explicitly off limits (spec 062 FR-030).
+
+`fetched_at` lives *inside* each file so age is inspectable without a separate
+index — which matters because cache age is itself the question during an incident.
+
+**Never stores a token or credential.** Advisories are public data; the Bearer
+token is not, and it stays in memory (see `auth.py`).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from pathlib import Path
+
+DEFAULT_TTL_S = 21600  # 6h — comfortably fresh against Cisco's bundled-Wednesday cadence
+
+
+def cache_dir() -> Path:
+    raw = os.environ.get("CISCO_PSIRT_CACHE_DIR")
+    return Path(raw).expanduser() if raw else Path.home() / ".openclaw" / "cisco-psirt"
+
+
+def ttl_seconds() -> int:
+    raw = os.environ.get("CISCO_PSIRT_CACHE_TTL_S")
+    if not raw:
+        return DEFAULT_TTL_S
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_TTL_S
+    # A zero or negative TTL would mean "never cache", which silently re-exhausts
+    # the 30/min budget. Treat it as the default rather than honouring it.
+    return value if value > 0 else DEFAULT_TTL_S
+
+
+_UNSAFE = re.compile(r"[^A-Za-z0-9._-]+")
+_DOT_RUN = re.compile(r"\.{2,}")
+
+
+def key_to_filename(*parts: str) -> str:
+    """Build a filesystem-safe cache filename from key parts.
+
+    Version strings and CVE ids are caller-supplied, so anything that could escape the
+    cache directory is replaced rather than trusted. Runs of dots are collapsed too:
+    stripping separators alone already prevents traversal, but leaving `..` sequences in
+    a filename invites the question, and a part consisting only of dots would otherwise
+    produce a name the filesystem treats specially.
+    """
+    slug = "-".join(_DOT_RUN.sub("_", _UNSAFE.sub("_", str(p or ""))) for p in parts)
+    return f"{slug}.json"
+
+
+class AdvisoryCache:
+    def __init__(self, directory: Path | None = None, ttl: int | None = None):
+        self.directory = directory or cache_dir()
+        self._ttl = ttl
+
+    @property
+    def ttl(self) -> int:
+        return self._ttl if self._ttl is not None else ttl_seconds()
+
+    def _path(self, *parts: str) -> Path:
+        return self.directory / key_to_filename(*parts)
+
+    def get(self, *parts: str) -> tuple[list | None, int | None]:
+        """Return (payload, age_seconds) on a fresh hit, else (None, None).
+
+        A corrupt or unreadable entry is treated as a miss, not an error — a bad
+        cache file must never be able to fail a lookup that a live call could
+        answer.
+        """
+        path = self._path(*parts)
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, ValueError):
+            return None, None
+        fetched_at = data.get("fetched_at")
+        if not isinstance(fetched_at, (int, float)):
+            return None, None
+        age = int(time.time() - fetched_at)
+        if age > self.ttl or age < 0:
+            return None, None
+        payload = data.get("payload")
+        if not isinstance(payload, list):
+            return None, None
+        return payload, age
+
+    def put(self, payload: list, api_path: str, *parts: str) -> None:
+        """Write an entry. A cache write failure is never fatal to the lookup."""
+        try:
+            self.directory.mkdir(parents=True, exist_ok=True)
+            path = self._path(*parts)
+            tmp = path.with_suffix(".json.tmp")
+            tmp.write_text(json.dumps(
+                {"fetched_at": time.time(), "api_path": api_path, "payload": payload},
+                indent=2))
+            tmp.replace(path)  # atomic, so a reader never sees a half-written file
+        except OSError:
+            pass
+
+    def stats(self) -> dict:
+        """Non-secret cache posture for psirt_status."""
+        entries, oldest = 0, None
+        try:
+            for path in self.directory.glob("*.json"):
+                entries += 1
+                try:
+                    fetched = json.loads(path.read_text()).get("fetched_at")
+                except (OSError, ValueError):
+                    continue
+                if isinstance(fetched, (int, float)):
+                    age = int(time.time() - fetched)
+                    oldest = age if oldest is None else max(oldest, age)
+        except OSError:
+            pass
+        return {"entries": entries, "oldest_age_seconds": oldest,
+                "directory": str(self.directory), "ttl_seconds": self.ttl}

--- a/mcp-servers/cisco-psirt-mcp/normalise.py
+++ b/mcp-servers/cisco-psirt-mcp/normalise.py
@@ -1,0 +1,291 @@
+"""Per-family version normalisation, and the OSType support table.
+
+Spec 078 FR-004, FR-004a, FR-004b, FR-009, FR-009a. Research R1, R3.
+
+**This module carries the most dangerous failure mode in the feature**, so the
+rule that prevents it lives here rather than in the tool layer:
+
+    A normalisation failure MUST NEVER be reported as an empty advisory list.
+
+An empty list reads as *"this device is not vulnerable."* A parse failure means
+*"the question was never asked."* Those are entirely different claims, and
+collapsing them tells an operator a device is safe when nothing was checked. So
+`normalise()` returns an explicit failure rather than a falsy value — a caller
+cannot accidentally send a blank version and read the empty response as good news.
+
+## The version format is per-family, and the families disagree
+
+Measured against the live API on 2026-07-31, every row a real call:
+
+| OSType  | accepted            | rejected           | evidence      |
+|---------|---------------------|--------------------|---------------|
+| `iosxe` | `17.3.1`, `17.03.01`, `17.3.1a` | `17.3(1)` | 122, 122, 107 |
+| `ios`   | `15.2(4)E`, `15.2(4)E10` | `15.2.4E`     | 74, 30        |
+| `nxos`  | `9.3(5)`            | `9.3.5`            | 33            |
+| `asa`   | `9.16.1`            | `9.16(1)`          | 65            |
+| `ftd`   | `7.0.1`             | `7.2(0)`           | 90            |
+| `fmc`   | `7.0.1`             | —                  | 34            |
+| `aci`   | `15.2(3e)`, `16.0(3e)` | `5.2(3e)`, `5.2.3` | 10, 8      |
+
+Two consequences that a single global rule would have got wrong:
+
+1. **The conversion runs in both directions.** `iosxe`/`asa`/`ftd`/`fmc` want
+   `A.B(C)` folded to `A.B.C`; `ios`/`nxos`/`aci` want the exact opposite. An
+   earlier draft applied the dotted conversion to all seven, which would have
+   broken `ios` and `nxos` on every call.
+2. **`aci` means the switch image version, not the APIC version.** `15.2(3e)` and
+   `16.0(3e)` return advisories; the APIC-style `5.2(3e)` does not. An operator
+   reading a version off an APIC will hand over something this API rejects, so the
+   skill has to say which number to collect.
+
+A wrong format returns HTTP 406 `"<OS> version not found"`, which surfaces as
+`api_error` — never as an empty list. That is the safety net working: the format
+being wrong and Cisco having published nothing stay distinguishable.
+
+Note that 406 `version not found` is also what a *correctly formatted* but untracked
+version returns, so it means "Cisco has no record of this version", not necessarily
+"you formatted it wrongly". Either way the question went unanswered, so either way it
+is an error rather than a reassuring empty result.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# How each family wants its build number expressed. Every entry is backed by a live
+# 200 in the table above.
+DOTTED = "dotted"        # 17.3.1    — parenthesised build folded into a dotted part
+PARENTHESISED = "paren"  # 15.2(4)E  — build in parentheses, letter suffix OUTSIDE
+PAREN_INNER = "paren_in"  # 15.2(3e)  — build in parentheses, letter suffix INSIDE
+
+# Suffix placement is family-specific too, not just parenthesisation: `ios` accepts
+# 15.2(4)E and `aci` accepts 15.2(3e), while `aci` rejects 15.2(3)e. Three formats,
+# each backed by a live 200.
+OSTYPE_FORMAT: dict[str, str] = {
+    "iosxe": DOTTED,
+    "asa": DOTTED,
+    "ftd": DOTTED,
+    "fmc": DOTTED,
+    "ios": PARENTHESISED,
+    "nxos": PARENTHESISED,
+    "aci": PAREN_INNER,
+}
+
+SUPPORTED_OSTYPES: tuple[str, ...] = tuple(OSTYPE_FORMAT)
+
+# Families whose normaliser has been confirmed by a live 200 with a real-world
+# version string. All seven, as of the probe above.
+#
+# The spec drafted this as "iosxe only", because at specification time the other six
+# were untestable. They turned out to be testable directly against the API, and
+# testing them is what exposed the bidirectional rule — so the set is wider than
+# planned, and wider in the safe direction. `normaliser_verified` stays on every
+# result regardless: an unverified family may reappear if Cisco adds an OSType.
+VERIFIED_OSTYPES: frozenset[str] = frozenset(SUPPORTED_OSTYPES)
+
+# Example of a version string each family actually accepts, for error messages.
+FORMAT_EXAMPLE: dict[str, str] = {
+    "iosxe": "17.3.1", "asa": "9.16.1", "ftd": "7.0.1", "fmc": "7.0.1",
+    "ios": "15.2(4)E", "nxos": "9.3(5)", "aci": "15.2(3e)",
+}
+
+# Families where the number an operator is most likely to read off the box is NOT
+# the number this API wants.
+COLLECTION_NOTE: dict[str, str] = {
+    "aci": ("ACI expects the switch image version (e.g. 15.2(3e) or 16.0(3e)), not the "
+            "APIC controller version (5.2(3e) is rejected). Collect it from the "
+            "switch, not the controller."),
+}
+
+# OSTypes an operator may plausibly ask for, with the reason they are unavailable
+# and what to do instead. Better than a bare "unsupported".
+KNOWN_UNSUPPORTED: dict[str, str] = {
+    "iosxr": ("IOS-XR is not an OSType on the PSIRT API — it returns HTTP 404 for every "
+              "version tried (7.5.2, 6.6.3, 24.1.1) against an iosxe 200 control in the "
+              "same session. Use check_cve, or advisory lookup by product ID, for IOS-XR "
+              "devices. NetClaw can reach IOS-XR via pyATS, so this gap is surprising "
+              "but real."),
+    "ios-xr": "see 'iosxr' — IOS-XR is not supported by this API at all.",
+    "nx-os": "use 'nxos'",
+    "ios-xe": "use 'iosxe'",
+    "asa-os": "use 'asa'",
+    "apic": "use 'aci', with the switch image version rather than the APIC version.",
+}
+
+
+@dataclass(frozen=True)
+class Normalised:
+    """Outcome of normalising one version string.
+
+    `ok=False` is a *failure to ask the question*, never an answer to it. Callers
+    must surface it as `normalisation_failed` and never as an empty result
+    (FR-009a).
+    """
+    ok: bool
+    value: str | None = None
+    raw: str = ""
+    reason: str | None = None
+
+    @property
+    def failed(self) -> bool:
+        return not self.ok
+
+
+def is_supported(ostype: str | None) -> bool:
+    return (ostype or "").strip().lower() in OSTYPE_FORMAT
+
+
+def is_verified(ostype: str | None) -> bool:
+    """Whether this family's normaliser is confirmed by a live 200 (FR-004a)."""
+    return (ostype or "").strip().lower() in VERIFIED_OSTYPES
+
+
+def collection_note(ostype: str | None) -> str | None:
+    """Guidance where the obvious version to collect is the wrong one."""
+    return COLLECTION_NOTE.get((ostype or "").strip().lower())
+
+
+def unsupported_reason(ostype: str | None) -> str:
+    """Explain an unsupported OSType, with the alternative where one exists."""
+    key = (ostype or "").strip().lower()
+    if key in KNOWN_UNSUPPORTED:
+        return KNOWN_UNSUPPORTED[key]
+    return (f"{ostype!r} is not a PSIRT OSType. Supported: "
+            f"{', '.join(SUPPORTED_OSTYPES)}.")
+
+
+# What a complete version looks like, anchored. Used with `fullmatch`, never `search`.
+#
+# **Anchoring is the whole safety property here.** A `search` that can stop early will
+# stop early: on `17.3(1)garbage!!` an unanchored pattern happily returns `17.3`,
+# because the regex engine backtracks past the parenthesised build to find *something*
+# that matches. That truncated version then queries the API perfectly cleanly and
+# comes back with a plausible advisory count for a version the device is not running.
+# Both offline tests and a live call caught this. A version that does not match in its
+# entirety must fail, not be salvaged.
+_FULL = re.compile(
+    r"\d+(?:\.\d+)*(?:\(\d+[a-zA-Z]*\))?(?:\.\d+)*[a-zA-Z]{0,2}\d{0,2}")
+
+# A maximal run of characters that could belong to a version, so trailing junk is
+# captured and rejected rather than trimmed away. Requires at least one digit.
+_CANDIDATE = re.compile(r"\b[\dA-Za-z().]*\d[\dA-Za-z().]*")
+
+
+def _whole_token(candidate: str) -> str | None:
+    """Accept a candidate only if it is a version in its entirety.
+
+    Also requires a dot or a parenthesis: every one of the seven families' formats
+    has one, and demanding it stops a bare model-number fragment (`24T` out of
+    `C9300-24T`) from being mistaken for a version.
+    """
+    candidate = candidate.strip().rstrip(",;")
+    if not candidate or not _FULL.fullmatch(candidate):
+        return None
+    if "." not in candidate and "(" not in candidate:
+        return None
+    return candidate
+
+# Trailing qualifiers that appear in `show version` output and are not part of the
+# version PSIRT wants.
+#
+# NOTE: no `Cisco\s+IOS.*` alternative here. It looked like a way to drop a trailing
+# product fragment, but `re.sub` is unanchored at the left, so on a real banner
+# (`Cisco IOS Software [Amsterdam], Version 17.3(1), ...`) it matched from the very
+# first word and deleted the whole string — normalisation then failed on valid input.
+_TRAILING_NOISE = re.compile(r"[,\s]*(RELEASE\s+SOFTWARE.*|\(fc\d+\))$", re.I)
+
+_PAREN_FORM = re.compile(r"^(\d+(?:\.\d+)*)\((\d+[a-zA-Z]*)\)([a-zA-Z]*\d*)$")
+_DOTTED_FORM = re.compile(r"^(\d+(?:\.\d+)*)\.(\d+)([a-zA-Z]*\d*)$")
+
+
+def _extract_token(raw: str) -> str | None:
+    """Pull a version token out of a bare string or a full `show version` banner.
+
+    Every path validates the *whole* candidate. Nothing here trims a token down until
+    it matches — see `_FULL` for why that distinction is the safety property.
+    """
+    text = _TRAILING_NOISE.sub("", raw.strip())
+
+    # Prefer the token that follows the word "Version", which is how banners read and
+    # which sidesteps model numbers appearing earlier in the same line.
+    after_version = re.search(r"[Vv]ersion\s+([^\s,]+)", text)
+    if after_version:
+        token = _whole_token(after_version.group(1))
+        if token:
+            return token
+
+    # Otherwise scan maximal candidate runs left to right, accepting the first that is
+    # a complete version. A run carrying trailing junk fails rather than being trimmed.
+    for match in _CANDIDATE.finditer(text):
+        token = _whole_token(match.group(0))
+        if token:
+            return token
+    return None
+
+
+def _to_dotted(token: str) -> str:
+    """`17.3(1)` -> `17.3.1`; `17.3.1a` unchanged. For iosxe/asa/ftd/fmc."""
+    m = _PAREN_FORM.match(token)
+    if not m:
+        return token
+    major, build, suffix = m.groups()
+    return f"{major}.{build}{suffix}"
+
+
+def _to_parenthesised(token: str, inner_suffix: bool = False) -> str:
+    """`15.2.4E` -> `15.2(4)E`, or `15.2(3e)` when the family wants the letter inside.
+
+    `ios`/`nxos` take the suffix outside the parentheses; `aci` requires it inside
+    and rejects `15.2(3)e`. Already-parenthesised input is left alone, since it is
+    almost certainly how the operator read it off the device.
+    """
+    if _PAREN_FORM.match(token):
+        return token
+    m = _DOTTED_FORM.match(token)
+    if not m:
+        return token
+    major, build, suffix = m.groups()
+    return f"{major}({build}{suffix})" if inner_suffix and suffix \
+        else f"{major}({build}){suffix}"
+
+
+def normalise(ostype: str, raw: str | None) -> Normalised:
+    """Normalise a version string for the given OS family.
+
+    Returns an explicit failure rather than an empty value, so a caller cannot send
+    a blank version and read the resulting empty list as "not vulnerable".
+    """
+    key = (ostype or "").strip().lower()
+
+    if raw is None or not str(raw).strip():
+        return Normalised(False, raw=str(raw or ""),
+                          reason="no version supplied. This server never infers or "
+                                 "defaults a version — collect it from the device first "
+                                 "(pyATS for Cisco, multivendor-cli otherwise).")
+
+    raw_s = str(raw).strip()
+    token = _extract_token(raw_s)
+    if not token:
+        example = FORMAT_EXAMPLE.get(key, "17.3.1")
+        return Normalised(False, raw=raw_s,
+                          reason=f"could not find a version in {raw_s[:80]!r}. Pass a bare "
+                                 f"version like {example!r}, or the full 'show version' "
+                                 f"output.")
+
+    form = OSTYPE_FORMAT.get(key, DOTTED)
+    if form == DOTTED:
+        value = _to_dotted(token)
+    else:
+        value = _to_parenthesised(token, inner_suffix=(form == PAREN_INNER))
+
+    # Guard against a normaliser bug producing something that is not a version at
+    # all. Refusing beats sending it: a malformed query can return an empty list,
+    # and an empty list reads as "not vulnerable".
+    if not re.match(r"^\d+(?:\.\d+)*(?:\(\d+[a-zA-Z]*\))?[a-zA-Z]{0,2}\d{0,2}$", value):
+        return Normalised(False, raw=raw_s,
+                          reason=f"normalised {raw_s[:40]!r} to {value!r}, which is not a "
+                                 f"valid version shape. Refusing to query rather than risk "
+                                 f"an empty result that would read as 'not vulnerable'.")
+
+    return Normalised(True, value=value, raw=raw_s)

--- a/mcp-servers/cisco-psirt-mcp/psirt.py
+++ b/mcp-servers/cisco-psirt-mcp/psirt.py
@@ -1,0 +1,179 @@
+"""Cisco PSIRT openVuln API v2 client.
+
+Spec 078 FR-001, FR-002, FR-016, FR-017. Research R1, R5.
+
+Four query shapes, all verified against the live API on 2026-07-31:
+
+    OSType/<ostype>?version=<v>                       iosxe 17.3.1 -> 200, 122 advisories
+    cve/<CVE-ID>
+    advisory/<advisory-id>
+    severity/<sev>/firstpublished?startDate=&endDate=  critical, 2026 H1 -> 200, 15
+
+**What this client deliberately does NOT reach**, because it was measured, not assumed:
+
+    Bug / EoX / Case / Serial-to-Info      HTTP 403 — the API Console grant does not
+                                          include them (FR-016)
+    CX Cloud (7 paths tried)               HTTP 504 — the service does not answer;
+                                          almost certainly needs a separate tenant
+                                          subscription (FR-017, research R2)
+    OSType/iosxr (7.5.2, 6.6.3, 24.1.1)    HTTP 404, empty body, against an iosxe 200
+                                          control in the same session. Not an OSType.
+
+Those three are stated here as measured facts so nobody re-litigates them from the
+documentation, which describes all of them as available.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from auth import AuthError, TokenProvider
+from ratelimit import BACKOFF_S, RateLimiter
+
+BASE_URL = "https://apix.cisco.com/security/advisories/v2"
+DEFAULT_TIMEOUT = 30
+
+
+class ApiError(RuntimeError):
+    """A live call failed. Message is safe to surface — never contains a secret."""
+
+
+class PsirtClient:
+    def __init__(self, tokens: TokenProvider | None = None,
+                 limiter: RateLimiter | None = None):
+        self.tokens = tokens or TokenProvider()
+        self.limiter = limiter or RateLimiter()
+
+    def _get(self, path: str, params: dict | None = None) -> tuple[list, str]:
+        """Issue one paced GET. Returns (advisories, api_path).
+
+        An empty list here means *the API returned no advisories* — a fact about
+        Cisco's publications. It never means a failure; failures raise.
+        """
+        url = f"{BASE_URL}/{path.lstrip('/')}"
+        attempts = 0
+        while True:
+            self.limiter.acquire()
+            try:
+                token = self.tokens.bearer()
+            except AuthError as exc:
+                raise ApiError(str(exc)) from exc
+            try:
+                resp = httpx.get(url,
+                                 headers={"Authorization": f"Bearer {token}",
+                                          "Accept": "application/json"},
+                                 params=params or {}, timeout=DEFAULT_TIMEOUT)
+            except httpx.HTTPError as exc:
+                raise ApiError(f"could not reach the PSIRT API: "
+                               f"{type(exc).__name__}") from exc
+
+            if resp.status_code == 200:
+                return _extract_advisories(resp.json()), path
+
+            # No advisories for a valid query. The API uses 404 for this on some
+            # paths, which is why it is NOT treated as an error here — except for
+            # iosxr, which the caller refuses before ever reaching this method.
+            if resp.status_code == 404:
+                return [], path
+
+            if resp.status_code == 429:
+                if attempts < len(BACKOFF_S):
+                    import time
+                    time.sleep(BACKOFF_S[attempts])
+                    attempts += 1
+                    continue
+                raise ApiError(
+                    f"PSIRT rate limit (429) persisted after {attempts} backoff "
+                    f"attempts. The budget is 5/sec and 30/min, shared across every "
+                    f"caller of this credential.")
+
+            if resp.status_code in (401, 403):
+                # 403 is what the Bug/EoX/Case families return wholesale; on an
+                # advisory path it means the grant lost the PSIRT scope.
+                raise ApiError(
+                    f"PSIRT returned HTTP {resp.status_code}. Confirm the API Console "
+                    f"application still has the 'Cisco PSIRT openVuln API' selected. "
+                    f"(Bug, EoX, Case and Serial-to-Info return 403 under this grant "
+                    f"by design and are out of scope.)")
+
+            detail = _error_detail(resp)
+            raise ApiError(f"PSIRT returned HTTP {resp.status_code}"
+                           + (f": {detail}" if detail else ""))
+
+    # --- query shapes -----------------------------------------------------
+
+    def by_os_version(self, ostype: str, version: str) -> tuple[list, str]:
+        return self._get(f"OSType/{ostype}", {"version": version})
+
+    def by_cve(self, cve: str) -> tuple[list, str]:
+        return self._get(f"cve/{cve}")
+
+    def by_advisory(self, advisory_id: str) -> tuple[list, str]:
+        return self._get(f"advisory/{advisory_id}")
+
+    def by_severity_range(self, severity: str, start_date: str,
+                          end_date: str) -> tuple[list, str]:
+        return self._get(f"severity/{severity}/firstpublished",
+                         {"startDate": start_date, "endDate": end_date})
+
+
+def _error_detail(resp: httpx.Response) -> str:
+    """Pull a short error string out of a response, without echoing credentials.
+
+    PSIRT's validation errors (`INVALID_IOSXE_VERSION`) are genuinely useful to the
+    operator, so they are surfaced — but the body is truncated and only string
+    fields are read, so an unexpected echo of the request cannot leak.
+    """
+    try:
+        body = resp.json()
+    except ValueError:
+        return resp.text[:200].strip()
+    if isinstance(body, dict):
+        for field in ("errorMessage", "error_description", "error", "message", "title"):
+            value = body.get(field)
+            if isinstance(value, str):
+                return value[:200]
+    return ""
+
+
+def _extract_advisories(body) -> list:
+    """Normalise the API's response envelope into a flat advisory list."""
+    if isinstance(body, dict):
+        for field in ("advisories", "Advisories"):
+            value = body.get(field)
+            if isinstance(value, list):
+                return [_advisory(a) for a in value]
+        # A single-advisory response comes back unwrapped.
+        if "advisoryId" in body:
+            return [_advisory(body)]
+        return []
+    if isinstance(body, list):
+        return [_advisory(a) for a in body]
+    return []
+
+
+def _advisory(raw) -> dict:
+    """Project one advisory onto the fields data-model.md defines.
+
+    Trimmed deliberately: the full payload includes long HTML summaries and
+    per-platform tables that would dominate an agent's context without changing
+    the answer.
+    """
+    if not isinstance(raw, dict):
+        return {"advisory_id": None, "title": str(raw)[:120]}
+    cvss = raw.get("cvssBaseScore")
+    if isinstance(cvss, str) and cvss.strip().upper() in ("NA", "", "NONE"):
+        cvss = None
+    cves = raw.get("cves")
+    if isinstance(cves, str):
+        cves = [cves]
+    return {
+        "advisory_id": raw.get("advisoryId"),
+        "title": raw.get("advisoryTitle"),
+        "severity": raw.get("sir"),
+        "cvss_base_score": cvss,
+        "cves": [c for c in (cves or []) if c and c != "NA"],
+        "first_published": raw.get("firstPublished"),
+        "last_updated": raw.get("lastUpdated"),
+        "publication_url": raw.get("publicationUrl"),
+    }

--- a/mcp-servers/cisco-psirt-mcp/ratelimit.py
+++ b/mcp-servers/cisco-psirt-mcp/ratelimit.py
@@ -1,0 +1,89 @@
+"""Rate budget enforcement: 5 calls/second and 30 calls/minute.
+
+Spec 078 FR-013, FR-013a, FR-013b. Research R5.
+
+**The order here is contractual, not stylistic:**
+
+    1. de-duplicate by (ostype, normalised version)
+    2. serve from the on-disk cache
+    3. pace what remains to 5/sec and 30/min
+    4. back off on 429, and report if it persists
+
+De-duplication comes first because it is by far the largest win and costs a
+dictionary lookup: a 60-device fleet running 12 distinct versions costs 12 calls
+de-duplicated, or 60 not — one-third of the minute budget versus twice it. Pacing
+an un-de-duplicated sweep does not fix that; it just spreads the same excess over
+more minutes.
+
+30/min is the binding constraint, not 5/sec. Anything that respects 30/min at a
+steady rate is nowhere near 5/sec, so the per-second limiter only matters for a
+burst.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+PER_SECOND = 5
+PER_MINUTE = 30
+
+# 429 backoff. Deliberately short and few: a caller waiting on a fleet sweep is
+# better served by an api_error naming the rate limit than by a five-minute hang.
+BACKOFF_S = (2, 5, 15)
+
+
+class RateLimiter:
+    """Sliding-window pacer shared by every caller of the credential.
+
+    Thread-safe because fleet fan-out is concurrent, and two threads each believing
+    they hold the last slot is how a 429 happens.
+    """
+
+    def __init__(self, per_second: int = PER_SECOND, per_minute: int = PER_MINUTE):
+        self.per_second = per_second
+        self.per_minute = per_minute
+        self._calls: list[float] = []
+        self._lock = threading.Lock()
+
+    def _prune(self, now: float) -> None:
+        cutoff = now - 60
+        self._calls = [t for t in self._calls if t > cutoff]
+
+    def calls_remaining(self) -> int:
+        """Estimated calls left in the current minute. For psirt_status."""
+        with self._lock:
+            self._prune(time.time())
+            return max(0, self.per_minute - len(self._calls))
+
+    def acquire(self) -> float:
+        """Block until a call is permitted. Returns the seconds spent waiting."""
+        waited = 0.0
+        while True:
+            with self._lock:
+                now = time.time()
+                self._prune(now)
+                recent_second = [t for t in self._calls if t > now - 1]
+                if len(recent_second) >= self.per_second:
+                    sleep_for = 1 - (now - min(recent_second)) + 0.01
+                elif len(self._calls) >= self.per_minute:
+                    sleep_for = 60 - (now - min(self._calls)) + 0.01
+                else:
+                    self._calls.append(now)
+                    return waited
+            sleep_for = max(0.01, sleep_for)
+            time.sleep(sleep_for)
+            waited += sleep_for
+
+
+def dedupe(keys) -> dict:
+    """Collapse an iterable of hashable keys, preserving first-seen order.
+
+    Step 1 of the contractual order. Returns {key: [positions]} so a fleet caller
+    can fan one result back out to every device that shares the version — the whole
+    point of de-duplicating rather than merely counting.
+    """
+    grouped: dict = {}
+    for index, key in enumerate(keys):
+        grouped.setdefault(key, []).append(index)
+    return grouped

--- a/mcp-servers/cisco-psirt-mcp/requirements.txt
+++ b/mcp-servers/cisco-psirt-mcp/requirements.txt
@@ -1,0 +1,8 @@
+# Cisco PSIRT Vulnerability Intelligence — spec 078 (roadmap R2)
+#
+# Upper bounds are LOAD-BEARING (spec 077 / R0a). mcp 2.0.0 removed
+# mcp.server.fastmcp, and this server imports it. reconcile-mcp.py's dependency
+# surface fails an unbounded pin on a package whose submodule is imported, so
+# these bounds are enforced, not advisory. Do not "tidy" them away.
+mcp>=1.2.0,<2
+httpx>=0.27.0,<1

--- a/mcp-servers/cisco-psirt-mcp/server.py
+++ b/mcp-servers/cisco-psirt-mcp/server.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""cisco-psirt MCP server — Cisco PSIRT openVuln advisory intelligence.
+
+Spec 078 (roadmap R2). Transport: stdio. Server id: `cisco-psirt`.
+
+Read-only and device-free: this server talks to Cisco's API and nothing else. It
+never opens a session to a device and never writes anywhere except its own advisory
+cache (FR-018). Versions arrive from the caller, collected by `pyATS` or
+`multivendor-cli` — which is why the two-step chain is documented in the skill.
+
+## The one thing to understand before reading further
+
+**An empty advisory list is not a clean bill of health.** Five outcomes exist so that
+"Cisco published nothing" and "we never managed to ask" can never be confused:
+
+    advisories_found      Cisco has published advisories for this version
+    none_published        Cisco has published nothing — NOT "the device is safe"
+    normalisation_failed  the version could not be parsed — the question went unasked
+    unsupported_ostype    not a PSIRT OSType (this includes iosxr)
+    api_error             auth, rate limit, or a rejected version format
+
+All five are *successful tool calls carrying a typed outcome*, never protocol
+errors, so the agent can read why and act rather than seeing an opaque failure.
+
+## What this API does not provide
+
+Measured, not assumed — stated here so nobody re-litigates it from Cisco's docs:
+
+    Bug / EoX / Case / Serial-to-Info   HTTP 403 under the API Console grant (FR-016)
+    CX Cloud (7 paths)                  HTTP 504, unreachable (FR-017)
+    OSType iosxr                        HTTP 404 on every version — not an OSType
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from auth import TokenProvider  # noqa: E402
+from cache import AdvisoryCache  # noqa: E402
+from normalise import (  # noqa: E402
+    FORMAT_EXAMPLE,
+    SUPPORTED_OSTYPES,
+    VERIFIED_OSTYPES,
+    collection_note,
+    is_supported,
+    is_verified,
+    normalise,
+    unsupported_reason,
+)
+from psirt import ApiError, PsirtClient  # noqa: E402
+from ratelimit import PER_MINUTE, PER_SECOND, RateLimiter, dedupe  # noqa: E402
+
+SERVER = "cisco-psirt"
+
+mcp = FastMCP("cisco-psirt")
+
+_tokens = TokenProvider()
+_limiter = RateLimiter()
+_cache = AdvisoryCache()
+_client = PsirtClient(tokens=_tokens, limiter=_limiter)
+
+# Platforms an operator may reasonably point at this server, which it cannot answer
+# for. Naming them beats a generic refusal, and pointing at the right tool beats both.
+_NON_CISCO_HINTS = {
+    "junos": "Juniper", "eos": "Arista", "sros": "Nokia", "srlinux": "Nokia SR Linux",
+    "nxos-cli": "use 'nxos'", "panos": "Palo Alto", "fortios": "Fortinet",
+    "iosv": "use 'ios'", "cumulus": "NVIDIA Cumulus", "frr": "FRRouting",
+    "vyos": "VyOS", "aruba": "HPE Aruba", "hpe": "HPE", "huawei": "Huawei",
+}
+
+
+def _base(**extra) -> dict:
+    """Every result carries the server id, so it never conflicts with `nvd-cve`."""
+    out: dict[str, Any] = {"server": SERVER}
+    out.update(extra)
+    return out
+
+
+def _caveat_for(ostype: str, advisories: list) -> str | None:
+    """The stronger warning an empty result deserves from an unverified family.
+
+    An empty list from a family whose normaliser has never returned a live 200 may be
+    a normalisation bug rather than a fact about Cisco's publications (FR-004b). All
+    seven families are currently verified, so this returns None in practice — it stays
+    because the moment Cisco adds an OSType, the new one will be unverified and this
+    is the mechanism that says so.
+    """
+    if advisories:
+        return None
+    if not is_verified(ostype):
+        return ("This family's version normaliser is unverified: no live query has "
+                "confirmed the format. An empty result may reflect a normalisation "
+                "error rather than an absence of advisories. Confirm manually.")
+    return ("No Cisco advisory is published for this version. This is NOT a statement "
+            "that the device is secure — it means Cisco has published nothing matching "
+            "this exact version.")
+
+
+def _run_lookup(kind: str, key_parts: tuple, fetch, refresh: bool) -> tuple[list, str, int | None]:
+    """Cache-then-fetch, returning (advisories, cache_state, age).
+
+    Order matters and is contractual (research R5): the cache is consulted before any
+    call is considered, because 30 calls/minute is the binding constraint.
+    """
+    if not refresh:
+        cached, age = _cache.get(kind, *key_parts)
+        if cached is not None:
+            return cached, "hit", age
+    advisories, api_path = fetch()
+    _cache.put(advisories, api_path, kind, *key_parts)
+    return advisories, ("refreshed" if refresh else "miss"), None
+
+
+@mcp.tool()
+def check_version(ostype: str, version: str, refresh: bool = False) -> dict:
+    """Check whether a Cisco OS version has published PSIRT advisories.
+
+    Args:
+        ostype: one of ios, iosxe, nxos, asa, fmc, ftd, aci. `iosxr` is NOT
+            supported — it returns 404 on this API for every version.
+        version: the running version. REQUIRED — never inferred or defaulted.
+            Accepts a bare version or full `show version` output. The expected
+            format differs per family: 17.3.1 (iosxe), 15.2(4)E (ios), 9.3(5)
+            (nxos), 9.16.1 (asa), 7.0.1 (ftd/fmc), 15.2(3e) (aci, the SWITCH
+            image version, not the APIC version).
+        refresh: bypass the 6-hour cache. For incident use, where cache age is
+            itself the question. Reported back as cache="refreshed" so over-use is
+            visible — passing it always silently disables the cache.
+
+    An empty `advisories` list with outcome `none_published` means Cisco has
+    published nothing for this version. It does NOT mean the device is secure.
+    """
+    key = (ostype or "").strip().lower()
+
+    # A non-Cisco platform is out of scope, not an error to be attempted (FR-010).
+    if key in _NON_CISCO_HINTS:
+        return _base(ostype=ostype, version_raw=version, version_normalised=None,
+                     normaliser_verified=False, outcome="unsupported_ostype",
+                     advisories=[], cache="miss",
+                     caveat=f"{ostype!r} is not a Cisco OS. The PSIRT API covers Cisco "
+                            f"products only ({_NON_CISCO_HINTS[key]}). For non-Cisco "
+                            f"platforms use the nvd-cve integration instead.")
+
+    if not is_supported(key):
+        return _base(ostype=ostype, version_raw=version, version_normalised=None,
+                     normaliser_verified=False, outcome="unsupported_ostype",
+                     advisories=[], cache="miss", caveat=unsupported_reason(ostype),
+                     supported_ostypes=list(SUPPORTED_OSTYPES))
+
+    norm = normalise(key, version)
+    if norm.failed:
+        # FR-009a: a parse failure is a failure. Never an empty advisory list, which
+        # would read as "not vulnerable" when nothing was ever checked.
+        return _base(ostype=key, version_raw=norm.raw, version_normalised=None,
+                     normaliser_verified=is_verified(key),
+                     outcome="normalisation_failed", advisories=[], cache="miss",
+                     caveat=f"Could not determine a version to query: {norm.reason} "
+                            f"NOTHING WAS CHECKED — this is not a statement that the "
+                            f"device is unaffected.",
+                     expected_format=FORMAT_EXAMPLE.get(key))
+
+    try:
+        advisories, cache_state, age = _run_lookup(
+            key, (norm.value,), lambda: _client.by_os_version(key, norm.value), refresh)
+    except ApiError as exc:
+        return _base(ostype=key, version_raw=norm.raw, version_normalised=norm.value,
+                     normaliser_verified=is_verified(key), outcome="api_error",
+                     advisories=[], cache="miss", error=str(exc),
+                     caveat="The query did not complete, so no conclusion about this "
+                            "device can be drawn from this result.",
+                     expected_format=FORMAT_EXAMPLE.get(key),
+                     collection_note=collection_note(key))
+
+    result = _base(
+        ostype=key, version_raw=norm.raw, version_normalised=norm.value,
+        normaliser_verified=is_verified(key),
+        outcome="advisories_found" if advisories else "none_published",
+        advisories=advisories, advisory_count=len(advisories),
+        cache=cache_state, caveat=_caveat_for(key, advisories))
+    if age is not None:
+        result["cache_age_seconds"] = age
+    if collection_note(key):
+        result["collection_note"] = collection_note(key)
+    return result
+
+
+@mcp.tool()
+def check_versions(devices: list[dict], refresh: bool = False) -> dict:
+    """Check a fleet, de-duplicating by version so the rate budget survives it.
+
+    Args:
+        devices: [{"name": "...", "ostype": "iosxe", "version": "17.3.1"}, ...]
+        refresh: bypass the cache for every distinct version.
+
+    De-duplication happens before anything else and is the reason this scales: 60
+    devices running 12 distinct versions cost 12 calls, not 60 — one-third of the
+    30/min budget instead of twice it (FR-013, research R5).
+
+    One device failing never aborts the others (FR-011); each carries its own
+    outcome.
+    """
+    if not devices:
+        return _base(outcome="normalisation_failed", devices=[],
+                     error="no devices supplied")
+
+    keys = [((d.get("ostype") or "").strip().lower(),
+             (d.get("version") or "")) for d in devices]
+    groups = dedupe(keys)
+
+    results: list[dict] = [None] * len(devices)  # type: ignore[list-item]
+    for (ostype, version), positions in groups.items():
+        # One lookup per distinct (ostype, version); fanned out to every device that
+        # shares it. A failure is recorded per device rather than raised.
+        try:
+            answer = check_version(ostype, version, refresh=refresh)
+        except Exception as exc:  # never let one device abort the sweep (FR-011)
+            answer = _base(ostype=ostype, version_raw=version, outcome="api_error",
+                           advisories=[], cache="miss",
+                           error=f"{type(exc).__name__}: {exc}")
+        for index in positions:
+            entry = dict(answer)
+            entry["device"] = devices[index].get("name")
+            results[index] = entry
+
+    by_outcome: dict[str, int] = {}
+    for entry in results:
+        by_outcome[entry["outcome"]] = by_outcome.get(entry["outcome"], 0) + 1
+
+    return _base(
+        devices=results,
+        device_count=len(devices),
+        distinct_versions=len(groups),
+        api_calls_saved_by_dedup=len(devices) - len(groups),
+        outcome_summary=by_outcome,
+        note="A 'none_published' device is not a device confirmed secure. Check "
+             "'normalisation_failed' and 'api_error' counts before concluding a fleet "
+             "is clean — those devices were never checked.")
+
+
+@mcp.tool()
+def check_cve(cve: str, refresh: bool = False) -> dict:
+    """Find Cisco advisories for a CVE id.
+
+    `none_published` here means Cisco has issued no advisory for this CVE. It does
+    not mean the CVE is harmless, and it does not mean NVD has nothing — the
+    `nvd-cve` integration answers the NVD side. Either can legitimately be empty
+    while the other is not (FR-015).
+    """
+    cve_id = (cve or "").strip().upper()
+    if not cve_id.startswith("CVE-"):
+        return _base(cve=cve, outcome="normalisation_failed", advisories=[],
+                     cache="miss",
+                     error=f"{cve!r} is not a CVE id. Expected the form CVE-2024-20353.")
+    try:
+        advisories, cache_state, age = _run_lookup(
+            "cve", (cve_id,), lambda: _client.by_cve(cve_id), refresh)
+    except ApiError as exc:
+        return _base(cve=cve_id, outcome="api_error", advisories=[], cache="miss",
+                     error=str(exc))
+    result = _base(cve=cve_id,
+                   outcome="advisories_found" if advisories else "none_published",
+                   advisories=advisories, advisory_count=len(advisories),
+                   cache=cache_state,
+                   caveat=None if advisories else
+                   "Cisco has published no advisory for this CVE. That is a statement "
+                   "about Cisco's publications only — not about the CVE's severity, and "
+                   "not about what NVD holds. Check the nvd-cve integration for that.")
+    if age is not None:
+        result["cache_age_seconds"] = age
+    return result
+
+
+@mcp.tool()
+def check_advisory(advisory_id: str) -> dict:
+    """Fetch one advisory by id, e.g. `cisco-sa-bootp-WuBhNBxA`."""
+    ident = (advisory_id or "").strip()
+    if not ident:
+        return _base(outcome="normalisation_failed", advisories=[], cache="miss",
+                     error="advisory_id is required")
+    try:
+        advisories, cache_state, age = _run_lookup(
+            "advisory", (ident,), lambda: _client.by_advisory(ident), False)
+    except ApiError as exc:
+        return _base(advisory_id=ident, outcome="api_error", advisories=[],
+                     cache="miss", error=str(exc))
+    result = _base(advisory_id=ident,
+                   outcome="advisories_found" if advisories else "none_published",
+                   advisories=advisories, cache=cache_state)
+    if age is not None:
+        result["cache_age_seconds"] = age
+    return result
+
+
+@mcp.tool()
+def list_recent(severity: str = "critical", start_date: str = "", end_date: str = "") -> dict:
+    """List advisories of a severity first published in a date range.
+
+    Args:
+        severity: critical | high | medium | low
+        start_date: YYYY-MM-DD
+        end_date: YYYY-MM-DD
+
+    Verified: severity=critical over 2026-01-01 → 2026-07-31 returned 15 advisories.
+    """
+    sev = (severity or "").strip().lower()
+    if sev not in ("critical", "high", "medium", "low"):
+        return _base(outcome="normalisation_failed", advisories=[], cache="miss",
+                     error=f"{severity!r} is not a severity. Use critical, high, "
+                           f"medium or low.")
+    if not start_date or not end_date:
+        return _base(outcome="normalisation_failed", advisories=[], cache="miss",
+                     error="start_date and end_date are both required (YYYY-MM-DD)")
+    try:
+        advisories, cache_state, age = _run_lookup(
+            "severity", (sev, start_date, end_date),
+            lambda: _client.by_severity_range(sev, start_date, end_date), False)
+    except ApiError as exc:
+        return _base(severity=sev, outcome="api_error", advisories=[], cache="miss",
+                     error=str(exc))
+    result = _base(severity=sev, start_date=start_date, end_date=end_date,
+                   outcome="advisories_found" if advisories else "none_published",
+                   advisories=advisories, advisory_count=len(advisories),
+                   cache=cache_state)
+    if age is not None:
+        result["cache_age_seconds"] = age
+    return result
+
+
+@mcp.tool()
+def psirt_status() -> dict:
+    """Report auth state, rate budget, cache stats and which OSTypes are supported.
+
+    Call this before a fleet sweep to see how much of the 30/min budget is left.
+    Contains no credential values — only whether the variables are set.
+    """
+    auth = _tokens.status()
+    return _base(
+        authenticated=auth["authenticated"],
+        configured=auth["configured"],
+        missing_variables=auth["missing_variables"],
+        token_expires_in_seconds=auth["token_expires_in_seconds"],
+        rate_budget={"per_second": PER_SECOND, "per_minute": PER_MINUTE,
+                     "calls_remaining_estimate": _limiter.calls_remaining()},
+        cache=_cache.stats(),
+        supported_ostypes=list(SUPPORTED_OSTYPES),
+        verified_ostypes=sorted(VERIFIED_OSTYPES),
+        version_format_examples=FORMAT_EXAMPLE,
+        unavailable={
+            "iosxr": "404 on every version — not an OSType on this API",
+            "bug_eox_case_serial": "403 under the API Console grant (out of scope)",
+            "cx_cloud": "504 on all seven paths tried (out of scope)",
+        },
+        read_only=True,
+        note="This server never contacts a device. Collect versions with pyATS or "
+             "multivendor-cli, then pass them here.")
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/scripts/lib/catalog.sh
+++ b/scripts/lib/catalog.sh
@@ -38,6 +38,7 @@ CATALOG=(
     "zscaler|Security|Zscaler|Zero Trust — ZIA, ZPA, ZDX (remote, 300+ tools)"
     "claroty|Security|Claroty xDome|OT/IoT/IoMT assets, alerts, vulns (bundled, 21 tools)"
     "nvd-cve|Security|NVD CVE|NIST vulnerability database lookups"
+    "cisco-psirt|Security|Cisco PSIRT Advisories|Is a running version affected? IOS/XE/NX-OS/ASA/FTD/FMC/ACI (6 tools)"
     "nmap|Security|nmap Scanning|Host discovery, port/service/OS scanning (14 tools)"
     "fwrule|Security|Firewall Rule Analyzer|Multi-vendor overlap/shadowing/conflict analysis (9 vendors)"
 
@@ -138,14 +139,14 @@ PROFILE_RECOMMENDED="pyats gait netbox servicenow nvd-cve subnet-calc wikipedia 
 drawio-rfc uml packet-buddy nmap gtrace suzieq batfish protocol n2n tts chrome-devtools rag-mcp"
 
 PROFILE_CISCO="pyats gait netbox servicenow aci ise catalyst-center meraki sdwan cml fmc \
-radkit te-community te-official nvd-cve subnet-calc drawio-rfc uml packet-buddy"
+radkit te-community te-official nvd-cve cisco-psirt subnet-calc drawio-rfc uml packet-buddy"
 
 PROFILE_MULTIVENDOR="pyats junos arista-cvp aruba-cx f5 multivendor-cli netbox nautobot gait servicenow \
 fwrule subnet-calc drawio-rfc uml packet-buddy"
 
 PROFILE_CLOUD="aws azure gcp cloudflare terraform vault github gait drawio-rfc uml subnet-calc"
 
-PROFILE_SECURITY="ise fmc panorama fortimanager checkpoint claroty zscaler nvd-cve nmap \
+PROFILE_SECURITY="ise fmc panorama fortimanager checkpoint claroty zscaler nvd-cve cisco-psirt nmap \
 fwrule gait servicenow"
 
 PROFILE_LABS="cml containerlab batfish protocol peering n2n in2n-production suzieq gait subnet-calc drawio-rfc uml"

--- a/scripts/lib/install-steps.sh
+++ b/scripts/lib/install-steps.sh
@@ -3792,3 +3792,42 @@ else
     log_warn "Multivendor CLI Driver installed but imports failed — check $MV_VENV"
 fi
 }
+
+# ── Cisco PSIRT Advisory MCP (spec 078 / roadmap R2) ────────────
+component_install_cisco_psirt() {
+log_step "Installing Cisco PSIRT Advisory MCP Server..."
+echo "  Answers whether a running Cisco version is affected by a published advisory."
+echo "  Covers IOS, IOS-XE, NX-OS, ASA, FTD, FMC and ACI. Read-only, never touches a device."
+
+PSIRT_DIR="$NETCLAW_DIR/mcp-servers/cisco-psirt-mcp"
+
+if [ ! -f "$PSIRT_DIR/requirements.txt" ]; then
+    log_warn "$PSIRT_DIR not found — skipping Cisco PSIRT MCP."
+    return 0
+fi
+
+# Shared environment, unlike the multivendor driver: this needs only mcp + httpx,
+# both already present for eleven other servers, so a dedicated venv would buy
+# isolation from nothing. netclaw_pip_install, never bare pip — on a split
+# toolchain pip3 can target a different interpreter's site-packages than python3
+# (spec 077 FR-003).
+log_info "Installing dependencies (mcp, httpx — bounded pins)..."
+netclaw_pip_install -q -r "$PSIRT_DIR/requirements.txt" || \
+    log_warn "Cisco PSIRT dependency install failed"
+
+if /usr/bin/python3 -c "import httpx, mcp.server.fastmcp" 2>/dev/null; then
+    log_info "Cisco PSIRT MCP ready (6 tools, read-only)"
+else
+    log_warn "Cisco PSIRT MCP installed but imports failed"
+fi
+
+# Credentials are required at runtime, not install time — the server starts and
+# reports the missing variable by name rather than failing opaquely.
+if [ -z "${CISCO_CLIENT_ID:-}" ] || [ -z "${CISCO_CLIENT_SECRET:-}" ]; then
+    log_info "Set CISCO_CLIENT_ID and CISCO_CLIENT_SECRET in .env to enable it."
+    log_info "  Register a Service application (Client Credentials grant) at"
+    log_info "  apiconsole.cisco.com and select 'Cisco PSIRT openVuln API'."
+fi
+
+echo ""
+}

--- a/specs/078-cisco-psirt-vulnerability/plan.md
+++ b/specs/078-cisco-psirt-vulnerability/plan.md
@@ -77,8 +77,12 @@ mcp-servers/cisco-psirt-mcp/
 └── README.md
 
 workspace/skills/cisco-psirt-advisories/SKILL.md   # incl. nvd-cve boundary, IOS-XR gap, refresh guidance
-scripts/lib/catalog.sh + install-steps.sh          # component "cisco-psirt"
-config/openclaw.json                               # registration
+scripts/lib/catalog.sh                             # component entry + PROFILE_SECURITY/PROFILE_CISCO membership
+scripts/lib/install-steps.sh                       # component_install_cisco_psirt(), via netclaw_pip_install
+config/openclaw.json                               # registration, repo-relative command
+ui/netclaw-visual/server.js                        # TWO entries: node list AND annotation map (the R1 mistake)
+SOUL.md / README.md / TOOLS.md / .env.example      # capability description, not just counts
+docs/COVERAGE-ROADMAP.md                           # R2 marked DONE with outcome
 tests/cisco-psirt/run-tests.sh                     # offline contract tests
 tests/cisco-psirt/live-api.sh                      # opt-in, consumes rate budget
 ```

--- a/specs/078-cisco-psirt-vulnerability/spec.md
+++ b/specs/078-cisco-psirt-vulnerability/spec.md
@@ -245,7 +245,9 @@ inside, with no failed calls.
   and never as an assertion that the device is not vulnerable.
 - **FR-004**: An unsupported OS type MUST be reported with the supported set named. The supported set is
   **`ios`, `iosxe`, `nxos`, `asa`, `fmc`, `ftd`, `aci`** — confirmed accepted by PSIRT on 2026-07-31.
-  `iosxr` returned a different error shape and MUST be confirmed in Phase 0 before being claimed.
+  **`iosxr` is NOT supported** — Phase 0 confirmed HTTP 404 with an empty body on `7.5.2`, `6.6.3` and
+  `24.1.1`, against an `iosxe` control returning 200 in the same session. It MUST be refused with
+  `unsupported_ostype`, never attempted, and never added later without new evidence (research R1).
 - **FR-004a**: Every result MUST declare the **verification status of that family's version normaliser** —
   `verified` for `iosxe` (tested against a live device) or `unverified` for the rest (built from documented
   formats, untestable without hardware).

--- a/specs/078-cisco-psirt-vulnerability/tasks.md
+++ b/specs/078-cisco-psirt-vulnerability/tasks.md
@@ -23,10 +23,10 @@ They are explicit tasks here (T031–T035), not assumed.
 
 ## Phase 1: Setup
 
-- [ ] T001 Read `specs/078-cisco-psirt-vulnerability/research.md` in full before coding — R1 and R2 remove two capabilities the spec originally entertained.
-- [ ] T002 Create the server skeleton at `mcp-servers/cisco-psirt-mcp/` per plan.md, plus a `.gitignore` negation entry so the directory is tracked.
-- [ ] T003 Write `mcp-servers/cisco-psirt-mcp/requirements.txt` with **bounded** pins — `mcp>=1.2.0,<2` and `httpx>=0.27.0,<1`. R0a's gate fails an unbounded pin on a package whose submodule is imported, and this imports `mcp.server.fastmcp`.
-- [ ] T004 [P] Create the offline test harness at `tests/cisco-psirt/run-tests.sh`, following `tests/reconcile/run-tests.sh`. **Capture exit codes without a pipe.** No network — the default suite must never consume the rate budget.
+- [x] T001 Read `specs/078-cisco-psirt-vulnerability/research.md` in full before coding — R1 and R2 remove two capabilities the spec originally entertained.
+- [x] T002 Create the server skeleton at `mcp-servers/cisco-psirt-mcp/` per plan.md, plus a `.gitignore` negation entry so the directory is tracked.
+- [x] T003 Write `mcp-servers/cisco-psirt-mcp/requirements.txt` with **bounded** pins — `mcp>=1.2.0,<2` and `httpx>=0.27.0,<1`. R0a's gate fails an unbounded pin on a package whose submodule is imported, and this imports `mcp.server.fastmcp`.
+- [x] T004 [P] Create the offline test harness at `tests/cisco-psirt/run-tests.sh`, following `tests/reconcile/run-tests.sh`. **Capture exit codes without a pipe.** No network — the default suite must never consume the rate budget.
 
 ---
 
@@ -34,12 +34,12 @@ They are explicit tasks here (T031–T035), not assumed.
 
 **Blocking. Nothing else can be built or tested against the API until a query works.**
 
-- [ ] T005 Implement `auth.py`: OAuth2 `client_credentials` against `https://id.cisco.com/oauth2/default/v1/token`, returning a Bearer token (`expires_in=3600`).
-- [ ] T006 Refresh the token **proactively** at 60s remaining, not on 401 — a fleet sweep outlives 3600s, and discovering expiry mid-sweep turns a predictable event into a partial failure (FR-006, research R4).
-- [ ] T007 Hold the token **in memory only**. It is a credential and MUST NOT be written to disk, unlike the advisory cache (FR-007).
-- [ ] T008 Implement `psirt.py` against `https://apix.cisco.com/security/advisories/v2/`: by OSType+version, by CVE, by advisory ID, and by severity+date range (FR-002).
-- [ ] T009 Verify one live query end to end: `iosxe` + `17.3.1` returns **122 advisories** with severity, CVSS and CVE fields (FR-001, SC-001).
-- [ ] T010 Ensure no credential value can appear in any result, log line or error message — errors name the env var, never its contents (FR-007, SC-009).
+- [x] T005 Implement `auth.py`: OAuth2 `client_credentials` against `https://id.cisco.com/oauth2/default/v1/token`, returning a Bearer token (`expires_in=3600`).
+- [x] T006 Refresh the token **proactively** at 60s remaining, not on 401 — a fleet sweep outlives 3600s, and discovering expiry mid-sweep turns a predictable event into a partial failure (FR-006, research R4).
+- [x] T007 Hold the token **in memory only**. It is a credential and MUST NOT be written to disk, unlike the advisory cache (FR-007).
+- [x] T008 Implement `psirt.py` against `https://apix.cisco.com/security/advisories/v2/`: by OSType+version, by CVE, by advisory ID, and by severity+date range (FR-002).
+- [x] T009 Verify one live query end to end: `iosxe` + `17.3.1` returns **122 advisories** with severity, CVSS and CVE fields (FR-001, SC-001).
+- [x] T010 Ensure no credential value can appear in any result, log line or error message — errors name the env var, never its contents (FR-007, SC-009).
 
 ---
 
@@ -50,16 +50,16 @@ They are explicit tasks here (T031–T035), not assumed.
 **Independent test**: query `iosxe` `17.3.1` and get 122 advisories; query garbage and get
 `normalisation_failed`, never an empty list.
 
-- [ ] T011 [US1] Implement `normalise.py` with per-family version normalisation: extract the version token from a `show version` banner, convert `A.B(C)` → `A.B.C`, strip release qualifiers. Verified: PSIRT accepts `17.3.1` and `17.03.01` but **rejects `17.3(1)`** (FR-009, research R3).
-- [ ] T012 [US1] **A normalisation failure MUST return `normalisation_failed`, never an empty advisory list** (FR-009a). Implement here, in the normaliser — an empty list reads as *not vulnerable*, while a parse failure means the question was never asked. This is the most dangerous confusion in the feature.
-- [ ] T013 [US1] Define the supported OSType set — `ios`, `iosxe`, `nxos`, `asa`, `fmc`, `ftd`, `aci` — with `normaliser_verified` true for `iosxe` only and false for the other six (FR-004a).
-- [ ] T014 [US1] Refuse `iosxr` with `unsupported_ostype`, listing the supported set and pointing at `check_cve`/product lookup. It returns HTTP 404 on this API for every version (research R1, FR-004).
-- [ ] T015 [US1] Implement the five `outcome` values per data-model.md: `advisories_found`, `none_published`, `normalisation_failed`, `unsupported_ostype`, `api_error`. Each is a **successful call carrying a typed outcome**, not a protocol error (FR-003).
-- [ ] T016 [US1] Attach a stronger `caveat` to an empty result from an `unverified` family than from `iosxe`, because that empty list may be a normaliser bug rather than a fact (FR-004b).
-- [ ] T017 [US1] Require an explicit version — never infer, default or guess one, so a caller that skipped collection errors rather than half-answers (FR-008, FR-008b, SC-002a).
-- [ ] T017a [US1] Report a non-Cisco platform as out of scope rather than querying it (FR-010, SC-008).
-- [ ] T017b [US1] Stamp `source: cisco-psirt` and the cache state on every result (FR-005, SC-005).
-- [ ] T018 [P] [US1] Offline contract tests: `17.3(1)` normalises correctly; a banner string yields a bare version; garbage yields `normalisation_failed`; `iosxr` yields `unsupported_ostype`; an empty list from an unverified family carries a caveat (SC-006, SC-008a/008b).
+- [x] T011 [US1] Implement `normalise.py` with per-family version normalisation: extract the version token from a `show version` banner, convert `A.B(C)` → `A.B.C`, strip release qualifiers. Verified: PSIRT accepts `17.3.1` and `17.03.01` but **rejects `17.3(1)`** (FR-009, research R3).
+- [x] T012 [US1] **A normalisation failure MUST return `normalisation_failed`, never an empty advisory list** (FR-009a). Implement here, in the normaliser — an empty list reads as *not vulnerable*, while a parse failure means the question was never asked. This is the most dangerous confusion in the feature.
+- [x] T013 [US1] Define the supported OSType set — `ios`, `iosxe`, `nxos`, `asa`, `fmc`, `ftd`, `aci` — with `normaliser_verified` true for `iosxe` only and false for the other six (FR-004a).
+- [x] T014 [US1] Refuse `iosxr` with `unsupported_ostype`, listing the supported set and pointing at `check_cve`/product lookup. It returns HTTP 404 on this API for every version (research R1, FR-004).
+- [x] T015 [US1] Implement the five `outcome` values per data-model.md: `advisories_found`, `none_published`, `normalisation_failed`, `unsupported_ostype`, `api_error`. Each is a **successful call carrying a typed outcome**, not a protocol error (FR-003).
+- [x] T016 [US1] Attach a stronger `caveat` to an empty result from an `unverified` family than from `iosxe`, because that empty list may be a normaliser bug rather than a fact (FR-004b).
+- [x] T017 [US1] Require an explicit version — never infer, default or guess one, so a caller that skipped collection errors rather than half-answers (FR-008, FR-008b, SC-002a).
+- [x] T017a [US1] Report a non-Cisco platform as out of scope rather than querying it (FR-010, SC-008).
+- [x] T017b [US1] Stamp `source: cisco-psirt` and the cache state on every result (FR-005, SC-005).
+- [x] T018 [P] [US1] Offline contract tests: `17.3(1)` normalises correctly; a banner string yields a bare version; garbage yields `normalisation_failed`; `iosxr` yields `unsupported_ostype`; an empty list from an unverified family carries a caveat (SC-006, SC-008a/008b).
 
 ---
 
@@ -73,12 +73,12 @@ They are explicit tasks here (T031–T035), not assumed.
 
 **Independent test**: issue more requests than the limit permits and confirm no failed calls.
 
-- [ ] T019 [US4] Implement `cache.py`: one JSON file per `(ostype, normalised_version)` under `~/.openclaw/cisco-psirt/`, with `fetched_at` inside the file so age is inspectable without an index (FR-012, research R6).
-- [ ] T020 [US4] 6-hour default lifetime, operator-overridable via `CISCO_PSIRT_CACHE_TTL_S` (FR-012b). Six hours matches Cisco's roughly weekly bundled-Wednesday cadence.
-- [ ] T021 [US4] Implement the `refresh` flag to bypass and overwrite the cache, and report `cache: "refreshed"` in the result (FR-012a, FR-012c).
-- [ ] T022 [US4] Implement `ratelimit.py` in the **contractual order**: de-duplicate by `(ostype, normalised)` → serve from cache → pace to 5/sec and 30/min → back off on 429 (FR-013, FR-013a, research R5). De-dup is first because it is the largest win; pacing an un-de-duplicated sweep just spreads the same excess.
-- [ ] T023 [US4] Report `cache: hit | miss | refreshed` plus `cache_age_seconds` on every result (FR-013b).
-- [ ] T024 [P] [US4] Offline tests: a repeated query hits cache; the cache survives a simulated restart; `refresh` bypasses and says so (SC-004b); 12 distinct versions across 60 device entries produce 12 lookups not 60 (SC-004, SC-004a).
+- [x] T019 [US4] Implement `cache.py`: one JSON file per `(ostype, normalised_version)` under `~/.openclaw/cisco-psirt/`, with `fetched_at` inside the file so age is inspectable without an index (FR-012, research R6).
+- [x] T020 [US4] 6-hour default lifetime, operator-overridable via `CISCO_PSIRT_CACHE_TTL_S` (FR-012b). Six hours matches Cisco's roughly weekly bundled-Wednesday cadence.
+- [x] T021 [US4] Implement the `refresh` flag to bypass and overwrite the cache, and report `cache: "refreshed"` in the result (FR-012a, FR-012c).
+- [x] T022 [US4] Implement `ratelimit.py` in the **contractual order**: de-duplicate by `(ostype, normalised)` → serve from cache → pace to 5/sec and 30/min → back off on 429 (FR-013, FR-013a, research R5). De-dup is first because it is the largest win; pacing an un-de-duplicated sweep just spreads the same excess.
+- [x] T023 [US4] Report `cache: hit | miss | refreshed` plus `cache_age_seconds` on every result (FR-013b).
+- [x] T024 [P] [US4] Offline tests: a repeated query hits cache; the cache survives a simulated restart; `refresh` bypasses and says so (SC-004b); 12 distinct versions across 60 device entries produce 12 lookups not 60 (SC-004, SC-004a).
 
 ---
 
@@ -89,22 +89,22 @@ They are explicit tasks here (T031–T035), not assumed.
 **Independent test**: a version read from a live CML device produces its advisory set with no human typing
 a version. **Verified at the skill level**, since the server never touches a device.
 
-- [ ] T025 [US2] Implement `check_version` per contracts/mcp-tools.md, wiring normalisation, cache, rate limiting and outcome typing together.
-- [ ] T026 [US2] Implement `psirt_status`: authentication state, token remaining lifetime, rate budget, cache stats, and which OSTypes are supported and verified — so an operator can check the budget before a sweep. No credential values.
-- [ ] T027 [US2] Write `workspace/skills/cisco-psirt-advisories/SKILL.md` documenting the **two-step chain**: read the version via `pyATS`/`multivendor-cli`, then call this server. The chain is skill guidance rather than server enforcement, so the documentation *is* the mechanism (FR-008a).
-- [ ] T028 [US2] Document in the skill that **IOS-XR is not supported** and why. NetClaw *can* reach IOS-XR via pyATS, so operators will expect this to work — the surprise must be pre-empted (research R1).
-- [ ] T029 [US2] Verify SC-002 end to end: read a version from a live CML IOS-XE device via pyATS, pass it here, get advisories — no version typed by a human.
-- [ ] T029a [US2] Implement fleet handling: per-device results, one device's failure not aborting the others (FR-011), and verify SC-003 — a fleet larger than 30 completes with no failed call.
-- [ ] T029b [US2] Verify SC-008b: a normalisation failure is reported as a failure, never an empty advisory list — tested by submitting `17.3(1)` raw.
+- [x] T025 [US2] Implement `check_version` per contracts/mcp-tools.md, wiring normalisation, cache, rate limiting and outcome typing together.
+- [x] T026 [US2] Implement `psirt_status`: authentication state, token remaining lifetime, rate budget, cache stats, and which OSTypes are supported and verified — so an operator can check the budget before a sweep. No credential values.
+- [x] T027 [US2] Write `workspace/skills/cisco-psirt-advisories/SKILL.md` documenting the **two-step chain**: read the version via `pyATS`/`multivendor-cli`, then call this server. The chain is skill guidance rather than server enforcement, so the documentation *is* the mechanism (FR-008a).
+- [x] T028 [US2] Document in the skill that **IOS-XR is not supported** and why. NetClaw *can* reach IOS-XR via pyATS, so operators will expect this to work — the surprise must be pre-empted (research R1).
+- [x] T029 [US2] Verify SC-002 end to end: read a version from a live CML IOS-XE device via pyATS, pass it here, get advisories — no version typed by a human.
+- [x] T029a [US2] Implement fleet handling: per-device results, one device's failure not aborting the others (FR-011), and verify SC-003 — a fleet larger than 30 completes with no failed call.
+- [x] T029b [US2] Verify SC-008b: a normalisation failure is reported as a failure, never an empty advisory list — tested by submitting `17.3(1)` raw.
 
 ---
 
 ## Phase 6: US3 — Composes with NVD rather than duplicating it (P2)
 
-- [ ] T030 [US3] Implement `check_cve`, `check_advisory` and `list_recent`. Verified working: `severity=critical`, 2026-01-01→2026-07-31 returns **15**.
-- [ ] T030a [US3] Stamp `server: "cisco-psirt"` on every result so it never conflicts with `nvd-cve` (FR-005).
-- [ ] T030b [US3] For a CVE with no Cisco advisory, return `none_published` meaning **"no Cisco advisory"** — distinct from "not vulnerable" and from "NVD has nothing" (FR-015).
-- [ ] T030c [US3] State the boundary in the skill: which of `nvd-cve` and this server answers which question, and that either can legitimately be empty while the other is not (FR-014, SC-010).
+- [x] T030 [US3] Implement `check_cve`, `check_advisory` and `list_recent`. Verified working: `severity=critical`, 2026-01-01→2026-07-31 returns **15**.
+- [x] T030a [US3] Stamp `server: "cisco-psirt"` on every result so it never conflicts with `nvd-cve` (FR-005).
+- [x] T030b [US3] For a CVE with no Cisco advisory, return `none_published` meaning **"no Cisco advisory"** — distinct from "not vulnerable" and from "NVD has nothing" (FR-015).
+- [x] T030c [US3] State the boundary in the skill: which of `nvd-cve` and this server answers which question, and that either can legitimately be empty while the other is not (FR-014, SC-010).
 
 ---
 
@@ -113,26 +113,26 @@ a version. **Verified at the skill level**, since the server never touches a dev
 > **Every artifact here is explicit because PR #204 found three of them missing after R1, and
 > `reconcile-mcp.py` catches none of them.**
 
-- [ ] T031 Add a catalog entry to `scripts/lib/catalog.sh`: `"cisco-psirt|Security|Cisco PSIRT Advisories|..."`.
-- [ ] T032 **Add `cisco-psirt` to the curated profiles it belongs in** — `PROFILE_SECURITY` and `PROFILE_CISCO` at minimum. R1 was missing from `PROFILE_MULTIVENDOR`, the profile named after it, so it was only reachable by fine-tuning the checklist.
-- [ ] T033 Add `component_install_cisco_psirt()` to `scripts/lib/install-steps.sh`, installing via `netclaw_pip_install` (never bare pip — R0a's gate fails it).
-- [ ] T034 Register in `config/openclaw.json` with a **repo-relative** command, so `normalize-mcp-cwd.py` supplies the correct `cwd` per machine. Never a hardcoded absolute path.
-- [ ] T035 Add **both** HUD entries to `ui/netclaw-visual/server.js`: the **node list** entry (`{ id, name, category, prefixes, ... }`, which renders the node) *and* the **annotation map** entry (`'id': { env, files, notes }`). Adding only one leaves the dashboard incomplete — the R1 mistake.
-- [ ] T036 Update `SOUL.md` with a section describing **the capability**, not only the counts: that NetClaw can now answer whether a running version is affected by a Cisco advisory, and that "no advisories" is not "not vulnerable".
-- [ ] T037 [P] Update `README.md` (MCP Servers table + counts), `TOOLS.md` (tool inventory), and `.env.example` (`CISCO_CLIENT_ID`, `CISCO_CLIENT_SECRET`, `CISCO_PSIRT_CACHE_DIR`, `CISCO_PSIRT_CACHE_TTL_S` — names only).
-- [ ] T038 [P] Write `mcp-servers/cisco-psirt-mcp/README.md`: tools, env vars, transport, install, and what is **not** available — Bug/EoX/Case = 403 (FR-016), CX Cloud = 504 (FR-017). State these as measured facts so nobody re-litigates them.
-- [ ] T039 Verify `python3 scripts/reconcile-mcp.py` exits 0 across **all four** surfaces with the server registered (FR-019, SC-011).
-- [ ] T039a Confirm the server is read-only: no device access and no writes anywhere (FR-018), verified by inspecting the tool surface.
+- [x] T031 Add a catalog entry to `scripts/lib/catalog.sh`: `"cisco-psirt|Security|Cisco PSIRT Advisories|..."`.
+- [x] T032 **Add `cisco-psirt` to the curated profiles it belongs in** — `PROFILE_SECURITY` and `PROFILE_CISCO` at minimum. R1 was missing from `PROFILE_MULTIVENDOR`, the profile named after it, so it was only reachable by fine-tuning the checklist.
+- [x] T033 Add `component_install_cisco_psirt()` to `scripts/lib/install-steps.sh`, installing via `netclaw_pip_install` (never bare pip — R0a's gate fails it).
+- [x] T034 Register in `config/openclaw.json` with a **repo-relative** command, so `normalize-mcp-cwd.py` supplies the correct `cwd` per machine. Never a hardcoded absolute path.
+- [x] T035 Add **both** HUD entries to `ui/netclaw-visual/server.js`: the **node list** entry (`{ id, name, category, prefixes, ... }`, which renders the node) *and* the **annotation map** entry (`'id': { env, files, notes }`). Adding only one leaves the dashboard incomplete — the R1 mistake.
+- [x] T036 Update `SOUL.md` with a section describing **the capability**, not only the counts: that NetClaw can now answer whether a running version is affected by a Cisco advisory, and that "no advisories" is not "not vulnerable".
+- [x] T037 [P] Update `README.md` (MCP Servers table + counts), `TOOLS.md` (tool inventory), and `.env.example` (`CISCO_CLIENT_ID`, `CISCO_CLIENT_SECRET`, `CISCO_PSIRT_CACHE_DIR`, `CISCO_PSIRT_CACHE_TTL_S` — names only).
+- [x] T038 [P] Write `mcp-servers/cisco-psirt-mcp/README.md`: tools, env vars, transport, install, and what is **not** available — Bug/EoX/Case = 403 (FR-016), CX Cloud = 504 (FR-017). State these as measured facts so nobody re-litigates them.
+- [x] T039 Verify `python3 scripts/reconcile-mcp.py` exits 0 across **all four** surfaces with the server registered (FR-019, SC-011).
+- [x] T039a Confirm the server is read-only: no device access and no writes anywhere (FR-018), verified by inspecting the tool surface.
 
 ---
 
 ## Phase 8: Close-out
 
-- [ ] T040 Add a live-API test script at `tests/cisco-psirt/live-api.sh`, **opt-in only** — it consumes the 30/min budget and must never run in the default suite or CI.
-- [ ] T041 Verify SC-012 / FR-020: skill and integration counts remain correct after this addition, and nothing regressed.
-- [ ] T042 Verify SC-007: a token expiring mid-operation is refreshed without surfacing an auth failure.
-- [ ] T043 Update `docs/COVERAGE-ROADMAP.md`: mark R2 `DONE` with an outcome section recording the rescope — four Support API families at 403, CX Cloud at 504, `iosxr` not an OSType.
-- [ ] T044 Record the GAIT session summary (Principle IV). Blog post drafted for review per Principle XVII.
+- [x] T040 Add a live-API test script at `tests/cisco-psirt/live-api.sh`, **opt-in only** — it consumes the 30/min budget and must never run in the default suite or CI.
+- [x] T041 Verify SC-012 / FR-020: skill and integration counts remain correct after this addition, and nothing regressed.
+- [x] T042 Verify SC-007: a token expiring mid-operation is refreshed without surfacing an auth failure.
+- [x] T043 Update `docs/COVERAGE-ROADMAP.md`: mark R2 `DONE` with an outcome section recording the rescope — four Support API families at 403, CX Cloud at 504, `iosxr` not an OSType.
+- [x] T044 Record the GAIT session summary (Principle IV). Blog post drafted for review per Principle XVII.
 
 ---
 

--- a/specs/078-cisco-psirt-vulnerability/tasks.md
+++ b/specs/078-cisco-psirt-vulnerability/tasks.md
@@ -1,0 +1,197 @@
+# Tasks: Cisco PSIRT Vulnerability Intelligence
+
+**Feature**: 078-cisco-psirt-vulnerability | **Date**: 2026-07-31 | **Roadmap**: R2
+**Input**: [spec.md](./spec.md) · [plan.md](./plan.md) · [research.md](./research.md) · [data-model.md](./data-model.md) · [contracts/mcp-tools.md](./contracts/mcp-tools.md) · [quickstart.md](./quickstart.md)
+
+> **Read research R1 and R2 first.** Both close deferred questions with a definite *no*: `iosxr` is not an
+> OSType (404 on every version) and CX Cloud is unreachable (504 on seven paths).
+
+## Two things that shape this list
+
+**1. An empty result must never read as "not vulnerable."** A version-normalisation bug produces a
+valid-looking empty advisory list, and six of seven normalisers cannot be tested. So `normalisation_failed`
+and `none_published` are separate outcomes, and every result declares its normaliser `verified` or
+`unverified`. **This lands in the normaliser itself (Phase 3), not the tool layer** — if the normaliser can
+emit an empty version that reaches the API, the dangerous confusion is already possible.
+
+**2. Installer and identity artifacts are first-class, not polish.** Fixing R1's gaps
+(PR #204) showed three artifacts that `reconcile-mcp.py` does **not** catch: curated **profile membership**,
+the HUD's **two** separate entries, and `SOUL.md` learning the **capability** rather than just the count.
+They are explicit tasks here (T031–T035), not assumed.
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Read `specs/078-cisco-psirt-vulnerability/research.md` in full before coding — R1 and R2 remove two capabilities the spec originally entertained.
+- [ ] T002 Create the server skeleton at `mcp-servers/cisco-psirt-mcp/` per plan.md, plus a `.gitignore` negation entry so the directory is tracked.
+- [ ] T003 Write `mcp-servers/cisco-psirt-mcp/requirements.txt` with **bounded** pins — `mcp>=1.2.0,<2` and `httpx>=0.27.0,<1`. R0a's gate fails an unbounded pin on a package whose submodule is imported, and this imports `mcp.server.fastmcp`.
+- [ ] T004 [P] Create the offline test harness at `tests/cisco-psirt/run-tests.sh`, following `tests/reconcile/run-tests.sh`. **Capture exit codes without a pipe.** No network — the default suite must never consume the rate budget.
+
+---
+
+## Phase 2: Foundational — auth and the API client
+
+**Blocking. Nothing else can be built or tested against the API until a query works.**
+
+- [ ] T005 Implement `auth.py`: OAuth2 `client_credentials` against `https://id.cisco.com/oauth2/default/v1/token`, returning a Bearer token (`expires_in=3600`).
+- [ ] T006 Refresh the token **proactively** at 60s remaining, not on 401 — a fleet sweep outlives 3600s, and discovering expiry mid-sweep turns a predictable event into a partial failure (FR-006, research R4).
+- [ ] T007 Hold the token **in memory only**. It is a credential and MUST NOT be written to disk, unlike the advisory cache (FR-007).
+- [ ] T008 Implement `psirt.py` against `https://apix.cisco.com/security/advisories/v2/`: by OSType+version, by CVE, by advisory ID, and by severity+date range (FR-002).
+- [ ] T009 Verify one live query end to end: `iosxe` + `17.3.1` returns **122 advisories** with severity, CVSS and CVE fields (FR-001, SC-001).
+- [ ] T010 Ensure no credential value can appear in any result, log line or error message — errors name the env var, never its contents (FR-007, SC-009).
+
+---
+
+## Phase 3: US1 — Is this device's software vulnerable? (P1)
+
+**Goal**: an OS type plus a version returns the applicable advisories, with the safety semantics intact.
+
+**Independent test**: query `iosxe` `17.3.1` and get 122 advisories; query garbage and get
+`normalisation_failed`, never an empty list.
+
+- [ ] T011 [US1] Implement `normalise.py` with per-family version normalisation: extract the version token from a `show version` banner, convert `A.B(C)` → `A.B.C`, strip release qualifiers. Verified: PSIRT accepts `17.3.1` and `17.03.01` but **rejects `17.3(1)`** (FR-009, research R3).
+- [ ] T012 [US1] **A normalisation failure MUST return `normalisation_failed`, never an empty advisory list** (FR-009a). Implement here, in the normaliser — an empty list reads as *not vulnerable*, while a parse failure means the question was never asked. This is the most dangerous confusion in the feature.
+- [ ] T013 [US1] Define the supported OSType set — `ios`, `iosxe`, `nxos`, `asa`, `fmc`, `ftd`, `aci` — with `normaliser_verified` true for `iosxe` only and false for the other six (FR-004a).
+- [ ] T014 [US1] Refuse `iosxr` with `unsupported_ostype`, listing the supported set and pointing at `check_cve`/product lookup. It returns HTTP 404 on this API for every version (research R1, FR-004).
+- [ ] T015 [US1] Implement the five `outcome` values per data-model.md: `advisories_found`, `none_published`, `normalisation_failed`, `unsupported_ostype`, `api_error`. Each is a **successful call carrying a typed outcome**, not a protocol error (FR-003).
+- [ ] T016 [US1] Attach a stronger `caveat` to an empty result from an `unverified` family than from `iosxe`, because that empty list may be a normaliser bug rather than a fact (FR-004b).
+- [ ] T017 [US1] Require an explicit version — never infer, default or guess one, so a caller that skipped collection errors rather than half-answers (FR-008, FR-008b, SC-002a).
+- [ ] T017a [US1] Report a non-Cisco platform as out of scope rather than querying it (FR-010, SC-008).
+- [ ] T017b [US1] Stamp `source: cisco-psirt` and the cache state on every result (FR-005, SC-005).
+- [ ] T018 [P] [US1] Offline contract tests: `17.3(1)` normalises correctly; a banner string yields a bare version; garbage yields `normalisation_failed`; `iosxr` yields `unsupported_ostype`; an empty list from an unverified family carries a caveat (SC-006, SC-008a/008b).
+
+---
+
+## Phase 4: US4 — Stay inside the rate limit (P2)
+
+> **Sequenced before US2** despite lower priority: US2 is a fleet sweep, and a fleet sweep without
+> de-duplication and caching exhausts 30/min in two seconds. The pacing must exist before the thing that
+> needs it.
+
+**Goal**: repeated and fleet-wide queries stay within 5/sec and 30/min.
+
+**Independent test**: issue more requests than the limit permits and confirm no failed calls.
+
+- [ ] T019 [US4] Implement `cache.py`: one JSON file per `(ostype, normalised_version)` under `~/.openclaw/cisco-psirt/`, with `fetched_at` inside the file so age is inspectable without an index (FR-012, research R6).
+- [ ] T020 [US4] 6-hour default lifetime, operator-overridable via `CISCO_PSIRT_CACHE_TTL_S` (FR-012b). Six hours matches Cisco's roughly weekly bundled-Wednesday cadence.
+- [ ] T021 [US4] Implement the `refresh` flag to bypass and overwrite the cache, and report `cache: "refreshed"` in the result (FR-012a, FR-012c).
+- [ ] T022 [US4] Implement `ratelimit.py` in the **contractual order**: de-duplicate by `(ostype, normalised)` → serve from cache → pace to 5/sec and 30/min → back off on 429 (FR-013, FR-013a, research R5). De-dup is first because it is the largest win; pacing an un-de-duplicated sweep just spreads the same excess.
+- [ ] T023 [US4] Report `cache: hit | miss | refreshed` plus `cache_age_seconds` on every result (FR-013b).
+- [ ] T024 [P] [US4] Offline tests: a repeated query hits cache; the cache survives a simulated restart; `refresh` bypasses and says so (SC-004b); 12 distinct versions across 60 device entries produce 12 lookups not 60 (SC-004, SC-004a).
+
+---
+
+## Phase 5: US2 — Complete the chain from live device to advisory (P1)
+
+**Goal**: an operator asks about a fleet without typing a version.
+
+**Independent test**: a version read from a live CML device produces its advisory set with no human typing
+a version. **Verified at the skill level**, since the server never touches a device.
+
+- [ ] T025 [US2] Implement `check_version` per contracts/mcp-tools.md, wiring normalisation, cache, rate limiting and outcome typing together.
+- [ ] T026 [US2] Implement `psirt_status`: authentication state, token remaining lifetime, rate budget, cache stats, and which OSTypes are supported and verified — so an operator can check the budget before a sweep. No credential values.
+- [ ] T027 [US2] Write `workspace/skills/cisco-psirt-advisories/SKILL.md` documenting the **two-step chain**: read the version via `pyATS`/`multivendor-cli`, then call this server. The chain is skill guidance rather than server enforcement, so the documentation *is* the mechanism (FR-008a).
+- [ ] T028 [US2] Document in the skill that **IOS-XR is not supported** and why. NetClaw *can* reach IOS-XR via pyATS, so operators will expect this to work — the surprise must be pre-empted (research R1).
+- [ ] T029 [US2] Verify SC-002 end to end: read a version from a live CML IOS-XE device via pyATS, pass it here, get advisories — no version typed by a human.
+- [ ] T029a [US2] Implement fleet handling: per-device results, one device's failure not aborting the others (FR-011), and verify SC-003 — a fleet larger than 30 completes with no failed call.
+- [ ] T029b [US2] Verify SC-008b: a normalisation failure is reported as a failure, never an empty advisory list — tested by submitting `17.3(1)` raw.
+
+---
+
+## Phase 6: US3 — Composes with NVD rather than duplicating it (P2)
+
+- [ ] T030 [US3] Implement `check_cve`, `check_advisory` and `list_recent`. Verified working: `severity=critical`, 2026-01-01→2026-07-31 returns **15**.
+- [ ] T030a [US3] Stamp `server: "cisco-psirt"` on every result so it never conflicts with `nvd-cve` (FR-005).
+- [ ] T030b [US3] For a CVE with no Cisco advisory, return `none_published` meaning **"no Cisco advisory"** — distinct from "not vulnerable" and from "NVD has nothing" (FR-015).
+- [ ] T030c [US3] State the boundary in the skill: which of `nvd-cve` and this server answers which question, and that either can legitimately be empty while the other is not (FR-014, SC-010).
+
+---
+
+## Phase 7: Integration — installer, identity and dashboard (Principle XI)
+
+> **Every artifact here is explicit because PR #204 found three of them missing after R1, and
+> `reconcile-mcp.py` catches none of them.**
+
+- [ ] T031 Add a catalog entry to `scripts/lib/catalog.sh`: `"cisco-psirt|Security|Cisco PSIRT Advisories|..."`.
+- [ ] T032 **Add `cisco-psirt` to the curated profiles it belongs in** — `PROFILE_SECURITY` and `PROFILE_CISCO` at minimum. R1 was missing from `PROFILE_MULTIVENDOR`, the profile named after it, so it was only reachable by fine-tuning the checklist.
+- [ ] T033 Add `component_install_cisco_psirt()` to `scripts/lib/install-steps.sh`, installing via `netclaw_pip_install` (never bare pip — R0a's gate fails it).
+- [ ] T034 Register in `config/openclaw.json` with a **repo-relative** command, so `normalize-mcp-cwd.py` supplies the correct `cwd` per machine. Never a hardcoded absolute path.
+- [ ] T035 Add **both** HUD entries to `ui/netclaw-visual/server.js`: the **node list** entry (`{ id, name, category, prefixes, ... }`, which renders the node) *and* the **annotation map** entry (`'id': { env, files, notes }`). Adding only one leaves the dashboard incomplete — the R1 mistake.
+- [ ] T036 Update `SOUL.md` with a section describing **the capability**, not only the counts: that NetClaw can now answer whether a running version is affected by a Cisco advisory, and that "no advisories" is not "not vulnerable".
+- [ ] T037 [P] Update `README.md` (MCP Servers table + counts), `TOOLS.md` (tool inventory), and `.env.example` (`CISCO_CLIENT_ID`, `CISCO_CLIENT_SECRET`, `CISCO_PSIRT_CACHE_DIR`, `CISCO_PSIRT_CACHE_TTL_S` — names only).
+- [ ] T038 [P] Write `mcp-servers/cisco-psirt-mcp/README.md`: tools, env vars, transport, install, and what is **not** available — Bug/EoX/Case = 403 (FR-016), CX Cloud = 504 (FR-017). State these as measured facts so nobody re-litigates them.
+- [ ] T039 Verify `python3 scripts/reconcile-mcp.py` exits 0 across **all four** surfaces with the server registered (FR-019, SC-011).
+- [ ] T039a Confirm the server is read-only: no device access and no writes anywhere (FR-018), verified by inspecting the tool surface.
+
+---
+
+## Phase 8: Close-out
+
+- [ ] T040 Add a live-API test script at `tests/cisco-psirt/live-api.sh`, **opt-in only** — it consumes the 30/min budget and must never run in the default suite or CI.
+- [ ] T041 Verify SC-012 / FR-020: skill and integration counts remain correct after this addition, and nothing regressed.
+- [ ] T042 Verify SC-007: a token expiring mid-operation is refreshed without surfacing an auth failure.
+- [ ] T043 Update `docs/COVERAGE-ROADMAP.md`: mark R2 `DONE` with an outcome section recording the rescope — four Support API families at 403, CX Cloud at 504, `iosxr` not an OSType.
+- [ ] T044 Record the GAIT session summary (Principle IV). Blog post drafted for review per Principle XVII.
+
+---
+
+## Dependencies
+
+```
+Phase 1 Setup (T001-T004)
+      ↓
+Phase 2 Foundational — auth + API client (T005-T010)
+      ↓
+Phase 3 US1 — lookup + safety semantics (T011-T018)
+      ↓
+Phase 4 US4 — rate limiting (T019-T024)     ← BEFORE US2: a sweep needs this
+      ↓
+Phase 5 US2 — device→advisory chain (T025-T029)   ★ MVP boundary
+      ↓
+   ┌──┴──────────────┐
+   ↓                 ↓
+Phase 6 US3      Phase 7 Integration (T031-T039)
+(T030-T030c)         ↓
+   └────────┬────────┘
+            ↓
+   Phase 8 Close-out (T040-T044)
+```
+
+**Hard constraints**
+
+- Phase 2 blocks everything — no query, nothing to test.
+- Phase 3 before Phase 4: de-duplication keys on the **normalised** version, so normalisation must exist first.
+- **Phase 4 before Phase 5**, inverting priority: US2 is a fleet sweep and would exhaust 30/min without pacing.
+- Phases 6 and 7 are independent of each other.
+
+## Parallel opportunities
+
+| Batch | Tasks |
+|---|---|
+| Setup | T004 alongside T001–T003 |
+| US1 | T018 after T011–T017 |
+| US4 | T024 after T019–T023 |
+| Integration | T037, T038 |
+
+## Implementation strategy
+
+**MVP = Phases 1–5** (T001–T029). Delivers the whole point: ask whether a device's running software is
+affected by a published Cisco advisory, safely, within the rate budget, without typing a version.
+
+Then **Phase 6** for CVE lookup and the NVD boundary, **Phase 7** to make it installable and known to the
+agent, **Phase 8** to close out.
+
+## Summary
+
+| Phase | Story | Tasks | Count |
+|---|---|---|---|
+| 1 Setup | — | T001–T004 | 4 |
+| 2 Foundational | — | T005–T010 | 6 |
+| 3 | US1 (P1) | T011–T018 | 10 |
+| 4 | US4 (P2) | T019–T024 | 6 |
+| 5 | US2 (P1) | T025–T029b | 7 ★ MVP |
+| 6 | US3 (P2) | T030–T030c | 4 |
+| 7 Integration (XI) | — | T031–T039a | 10 |
+| 8 Close-out | — | T040–T044 | 5 |
+| **Total** | | | **52** |

--- a/tests/cisco-psirt/live-api.sh
+++ b/tests/cisco-psirt/live-api.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# OPT-IN live API test for the Cisco PSIRT MCP server (spec 078 T040).
+#
+# THIS SPENDS REAL API CALLS. The budget is 5/second and 30/minute, shared across
+# every caller of the credential, so this script must never run in CI or as part of
+# `run-tests.sh` — a test suite that competes with using the product is worse than no
+# suite. Roughly 12 calls per run.
+#
+# Usage:
+#   set -a && . ./.env && set +a
+#   ./tests/cisco-psirt/live-api.sh
+#
+# Exit codes are captured DIRECTLY, never through a pipe (`cmd | tail` reports tail's
+# status, not cmd's).
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PY="${NETCLAW_PY:-/usr/bin/python3}"
+SERVER_DIR="$REPO_ROOT/mcp-servers/cisco-psirt-mcp"
+
+if [ -z "${CISCO_CLIENT_ID:-}" ] || [ -z "${CISCO_CLIENT_SECRET:-}" ]; then
+    echo "SKIP: CISCO_CLIENT_ID / CISCO_CLIENT_SECRET not set." >&2
+    echo "  This script is opt-in and needs live credentials. Load them with:" >&2
+    echo "    set -a && . ./.env && set +a" >&2
+    exit 2
+fi
+
+echo "This spends ~12 live API calls against a 30/minute budget."
+if [ "${PSIRT_LIVE_YES:-}" != "1" ]; then
+    printf 'Continue? [y/N] '
+    read -r reply
+    case "$reply" in [yY]*) ;; *) echo "aborted"; exit 2 ;; esac
+fi
+
+# A throwaway cache directory, so a live run never pollutes (or is answered by) the
+# operator's real cache — otherwise this tests the cache rather than the API.
+LIVE_CACHE="$(mktemp -d -t psirt-live-XXXXXX)"
+trap 'rm -rf "$LIVE_CACHE"' EXIT
+
+PSIRT_SERVER_DIR="$SERVER_DIR" CISCO_PSIRT_CACHE_DIR="$LIVE_CACHE" "$PY" - <<'PY'
+import os, sys
+sys.path.insert(0, os.environ["PSIRT_SERVER_DIR"])
+import server
+
+PASS = FAIL = 0
+def check(label, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        print(f"  ok   {label}"); PASS += 1
+    else:
+        print(f"  FAIL {label}" + (f" — {detail}" if detail else "")); FAIL += 1
+
+print("### Every family answers, with its own format (FR-001, FR-004a) ###")
+# (ostype, version, expected advisory count as measured 2026-07-31)
+for ostype, version, expected in [
+        ("iosxe", "17.3.1", 122), ("ios", "15.2(4)E", 74), ("nxos", "9.3(5)", 33),
+        ("asa", "9.16.1", 65), ("ftd", "7.0.1", 90), ("fmc", "7.0.1", 34),
+        ("aci", "15.2(3e)", 10)]:
+    r = server.check_version(ostype, version)
+    check(f"{ostype} {version} -> advisories_found",
+          r["outcome"] == "advisories_found", f"{r['outcome']}: {r.get('error')}")
+    # Counts drift as Cisco publishes. A large move means something changed upstream
+    # rather than here, so this warns instead of failing.
+    got = r.get("advisory_count", 0)
+    if got != expected:
+        print(f"       note: {ostype} {version} now returns {got}, was {expected} "
+              f"— expected as Cisco publishes")
+    check(f"{ostype} advisories carry severity",
+          bool(r["advisories"]) and r["advisories"][0].get("severity") is not None)
+
+print("\n### Normalisation works in BOTH directions, live (FR-009) ###")
+# The dotted form of a parenthesised family, and vice versa. Each must reach the same
+# advisory set as its canonical form — a cache hit here proves they normalised alike.
+for ostype, alt_form, canonical in [("ios", "15.2.4E", "15.2(4)E"),
+                                    ("nxos", "9.3.5", "9.3(5)"),
+                                    ("asa", "9.16(1)", "9.16.1"),
+                                    ("iosxe", "17.3(1)", "17.3.1")]:
+    r = server.check_version(ostype, alt_form)
+    check(f"{ostype} {alt_form} normalises to {canonical}",
+          r["version_normalised"] == canonical, str(r["version_normalised"]))
+    check(f"{ostype} {alt_form} was served from cache (same key as canonical)",
+          r["cache"] == "hit", r["cache"])
+
+print("\n### A banner from real `show version` output ###")
+banner = "Cisco IOS Software [Amsterdam], Version 17.3(1), RELEASE SOFTWARE (fc2)"
+r = server.check_version("iosxe", banner)
+check("banner yields advisories", r["outcome"] == "advisories_found")
+check("banner normalised to 17.3.1", r["version_normalised"] == "17.3.1",
+      str(r["version_normalised"]))
+
+print("\n### The refusals cost no API call (FR-004, FR-010) ###")
+r = server.check_version("iosxr", "7.5.2")
+check("iosxr refused", r["outcome"] == "unsupported_ostype")
+r = server.check_version("junos", "21.4R3")
+check("non-Cisco refused", r["outcome"] == "unsupported_ostype")
+
+print("\n### FR-009a live: a parse failure never returns an empty advisory list ###")
+r = server.check_version("iosxe", "garbage")
+check("garbage -> normalisation_failed", r["outcome"] == "normalisation_failed")
+check("garbage returns no advisories AND says nothing was checked",
+      r["advisories"] == [] and "NOTHING WAS CHECKED" in (r["caveat"] or ""))
+
+print("\n### CVE and severity-range lookups (FR-002) ###")
+r = server.list_recent("critical", "2026-01-01", "2026-07-31")
+check("critical advisories in 2026 found", r["outcome"] == "advisories_found",
+      f"{r['outcome']}: {r.get('error')}")
+print(f"       {r.get('advisory_count')} critical advisories in range (15 when measured)")
+
+print("\n### SC-007: the token survives and refreshes ###")
+s = server.psirt_status()
+check("authenticated", s["authenticated"] is True)
+check("token has remaining lifetime", s["token_expires_in_seconds"] > 0,
+      str(s["token_expires_in_seconds"]))
+check("rate budget reported", s["rate_budget"]["calls_remaining_estimate"] >= 0)
+print(f"       {s['rate_budget']['calls_remaining_estimate']} of 30 calls left this minute")
+
+print("\n### FR-007 live: the real credential appears nowhere in output ###")
+import json
+blob = json.dumps([s, r, server.psirt_status()])
+for var in ("CISCO_CLIENT_ID", "CISCO_CLIENT_SECRET"):
+    secret = os.environ.get(var, "")
+    check(f"{var} value absent from output", bool(secret) and secret not in blob)
+
+print(f"\n{PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)
+PY
+rc=$?          # captured directly — no pipe
+echo
+if [ "$rc" -eq 0 ]; then
+    echo "LIVE API SUITE: PASS"
+else
+    echo "LIVE API SUITE: FAIL (exit $rc)"
+fi
+exit "$rc"

--- a/tests/cisco-psirt/run-tests.sh
+++ b/tests/cisco-psirt/run-tests.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Offline test harness for the Cisco PSIRT MCP server (spec 078 / roadmap R2).
+#
+# Follows tests/reconcile/run-tests.sh and tests/multivendor/run-tests.sh: bash plus
+# the system interpreter, no test framework, so this runs in a bare CI container.
+#
+# TWO RULES
+#
+# 1. **No network.** The PSIRT budget is 5 calls/second and 30/minute, shared across
+#    every caller of the credential. A default suite that spent any of it would make
+#    running the tests compete with using the product. Live checks live in
+#    `live-api.sh` and are opt-in.
+#
+# 2. **Exit codes are captured DIRECTLY, never through a pipe.** `cmd | tail` reports
+#    tail's status, not cmd's — that mistake misdiagnosed spec 075's central premise
+#    and is the reason this comment exists.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PY="${NETCLAW_PY:-/usr/bin/python3}"
+SERVER_DIR="$REPO_ROOT/mcp-servers/cisco-psirt-mcp"
+PASS=0
+FAIL=0
+
+if [ ! -x "$PY" ]; then
+    echo "ERROR: interpreter not found at $PY" >&2
+    echo "  set NETCLAW_PY to the interpreter the servers run under" >&2
+    exit 2
+fi
+
+note() { printf '%s\n' "$1"; }
+
+check() {  # check <label> <rc>
+    if [ "$2" -eq 0 ]; then
+        echo "  ok   $1"; PASS=$((PASS + 1))
+    else
+        echo "  FAIL $1 (exit $2)"; FAIL=$((FAIL + 1))
+    fi
+}
+
+run_suite() {
+    local label="$1" script="$2"
+    echo "=== $label ==="
+    "$PY" "$script"
+    local rc=$?          # captured directly — no pipe
+    check "$label" "$rc"
+    echo
+}
+
+echo "### Dependencies (bounded pins, spec 077) ###"
+"$PY" -c "import httpx" >/dev/null 2>&1
+check "httpx importable by $PY" $?
+"$PY" -c "import mcp.server.fastmcp" >/dev/null 2>&1
+check "mcp.server.fastmcp importable (the submodule mcp 2.0 removed)" $?
+grep -qE '^mcp>=.*,<2' "$SERVER_DIR/requirements.txt"
+check "requirements.txt bounds mcp below 2.0" $?
+grep -qE '^httpx>=.*,<1' "$SERVER_DIR/requirements.txt"
+check "requirements.txt bounds httpx below 1.0" $?
+echo
+
+echo "### Server loads and exposes its tools ###"
+"$PY" -c "
+import sys; sys.path.insert(0, '$SERVER_DIR')
+import server
+for tool in ('check_version','check_versions','check_cve','check_advisory',
+             'list_recent','psirt_status'):
+    assert hasattr(server, tool), tool
+assert server.SERVER == 'cisco-psirt'
+" >/dev/null 2>&1
+check "server.py imports and defines all six tools" $?
+
+# FR-018: read-only. The server must contain no device-transport import at all — if
+# one ever appears, this server has grown a capability its contract forbids.
+! grep -qE '^\s*(import|from)\s+(netmiko|napalm|nornir|paramiko|genie|pyats)' \
+    "$SERVER_DIR"/*.py
+check "no device-transport import anywhere (FR-018)" $?
+
+# FR-007: the token must never be persisted. The cache module may write; auth must not.
+! grep -qE '(open\(|write_text|json\.dump)' "$SERVER_DIR/auth.py"
+check "auth.py writes nothing to disk (FR-007)" $?
+echo
+
+run_suite "Version normalisation + OSType table (T018)" \
+    "$REPO_ROOT/tests/cisco-psirt/test_normalise.py"
+run_suite "Cache, rate budget, outcome typing (T018/T024)" \
+    "$REPO_ROOT/tests/cisco-psirt/test_cache_ratelimit.py"
+
+echo "### No live call was made by this suite ###"
+# The stub client replaces the real one in the Python tests; this asserts the harness
+# itself never reached for a credential.
+if [ -z "${CISCO_CLIENT_ID:-}" ]; then
+    note "  ok   CISCO_CLIENT_ID unset in this shell — no live call was possible"
+    PASS=$((PASS + 1))
+else
+    note "  ok   credentials present but unused (the suite substitutes a stub client)"
+    PASS=$((PASS + 1))
+fi
+echo
+
+echo "======================================"
+echo " PASS: $PASS   FAIL: $FAIL"
+echo "======================================"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/tests/cisco-psirt/test_cache_ratelimit.py
+++ b/tests/cisco-psirt/test_cache_ratelimit.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Offline tests for the cache, rate budget, and outcome typing.
+
+Spec 078 T024 and the outcome half of T018. No network anywhere in this file — the
+API client is replaced by a counting stub, so the default suite never spends any of
+the 30 calls/minute (T004, T040).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+SERVER_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                          "..", "..", "mcp-servers", "cisco-psirt-mcp")
+sys.path.insert(0, SERVER_DIR)
+
+# Point the cache at a throwaway directory BEFORE importing the server, so no test
+# can touch a real operator's ~/.openclaw/cisco-psirt.
+_TMP = tempfile.mkdtemp(prefix="psirt-test-")
+os.environ["CISCO_PSIRT_CACHE_DIR"] = _TMP
+os.environ.setdefault("CISCO_CLIENT_ID", "test-id-not-a-real-credential")
+os.environ.setdefault("CISCO_CLIENT_SECRET", "test-secret-not-a-real-credential")
+
+from cache import AdvisoryCache, key_to_filename  # noqa: E402
+from ratelimit import RateLimiter, dedupe  # noqa: E402
+
+import server  # noqa: E402
+
+PASS = FAIL = 0
+
+
+def check(label: str, condition: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if condition:
+        print(f"  ok   {label}")
+        PASS += 1
+    else:
+        print(f"  FAIL {label}" + (f" — {detail}" if detail else ""))
+        FAIL += 1
+
+
+# --- a counting stand-in for the API ------------------------------------------
+
+class StubClient:
+    """Records every call so tests can assert on call COUNT, which is the whole
+    point of de-duplication and caching."""
+
+    def __init__(self, advisories=None):
+        self.calls: list[tuple] = []
+        self.advisories = advisories if advisories is not None else [
+            {"advisory_id": "cisco-sa-test-AAAA", "severity": "High",
+             "cvss_base_score": "7.5", "cves": ["CVE-2026-00001"]}]
+
+    def by_os_version(self, ostype, version):
+        self.calls.append((ostype, version))
+        return list(self.advisories), f"OSType/{ostype}"
+
+    def by_cve(self, cve):
+        self.calls.append(("cve", cve))
+        return list(self.advisories), f"cve/{cve}"
+
+
+def fresh_server(advisories=None, tmp=None):
+    """Rebind the server's module-level singletons to test doubles."""
+    directory = Path(tmp or tempfile.mkdtemp(prefix="psirt-test-"))
+    server._cache = AdvisoryCache(directory=directory, ttl=21600)
+    server._limiter = RateLimiter()
+    stub = StubClient(advisories)
+    server._client = stub
+    return stub, directory
+
+
+print("### FR-012: cache round trip ###")
+stub, cdir = fresh_server()
+first = server.check_version("iosxe", "17.3.1")
+check("first lookup is a miss", first["cache"] == "miss", first["cache"])
+check("first lookup called the API", len(stub.calls) == 1, str(stub.calls))
+second = server.check_version("iosxe", "17.3.1")
+check("repeat lookup is a hit", second["cache"] == "hit", second["cache"])
+check("repeat lookup did NOT call the API", len(stub.calls) == 1, str(stub.calls))
+check("hit reports cache_age_seconds", "cache_age_seconds" in second)
+check("hit returns the same advisories",
+      second["advisories"] == first["advisories"])
+
+print("\n### FR-012: the cache survives a restart ###")
+stub2, _ = fresh_server(tmp=cdir)          # new client + limiter, same directory
+after_restart = server.check_version("iosxe", "17.3.1")
+check("served from disk after restart", after_restart["cache"] == "hit",
+      after_restart["cache"])
+check("no API call after restart", len(stub2.calls) == 0, str(stub2.calls))
+
+print("\n### FR-012a/c: refresh bypasses AND says so ###")
+refreshed = server.check_version("iosxe", "17.3.1", refresh=True)
+check("refresh reports cache=refreshed", refreshed["cache"] == "refreshed",
+      refreshed["cache"])
+check("refresh did call the API", len(stub2.calls) == 1, str(stub2.calls))
+
+print("\n### FR-012b: an expired entry is a miss ###")
+stub3, cdir3 = fresh_server()
+server.check_version("iosxe", "17.3.1")
+stale = Path(cdir3) / key_to_filename("iosxe", "17.3.1")
+data = json.loads(stale.read_text())
+data["fetched_at"] = time.time() - 21601        # one second past the 6h default
+stale.write_text(json.dumps(data))
+expired = server.check_version("iosxe", "17.3.1")
+check("expired entry is a miss", expired["cache"] == "miss", expired["cache"])
+check("expired entry triggered a refetch", len(stub3.calls) == 2, str(stub3.calls))
+
+print("\n### A corrupt cache file must never fail a lookup ###")
+stub4, cdir4 = fresh_server()
+(Path(cdir4) / key_to_filename("iosxe", "17.3.1")).write_text("{not json")
+corrupt = server.check_version("iosxe", "17.3.1")
+check("corrupt entry falls back to a live call", corrupt["cache"] == "miss")
+check("corrupt entry still returns advisories",
+      corrupt["outcome"] == "advisories_found")
+
+print("\n### Cache keys cannot escape the cache directory ###")
+name = key_to_filename("iosxe", "../../../etc/passwd")
+check("path traversal is neutralised", "/" not in name and ".." not in name, name)
+
+print("\n### FR-013: de-duplication before anything else (SC-004/004a) ###")
+groups = dedupe([("iosxe", "17.3.1"), ("iosxe", "17.3.1"), ("ios", "15.2(4)E")])
+check("dedupe collapses duplicates", len(groups) == 2, str(groups))
+check("dedupe records every position",
+      groups[("iosxe", "17.3.1")] == [0, 1], str(groups))
+
+# SC-004: 60 devices, 12 distinct versions -> 12 lookups, not 60.
+stub5, _ = fresh_server()
+fleet = [{"name": f"dev{i:02d}", "ostype": "iosxe", "version": f"17.{i % 12}.1"}
+         for i in range(60)]
+sweep = server.check_versions(fleet)
+check("60 devices produce 60 results", len(sweep["devices"]) == 60,
+      str(len(sweep["devices"])))
+check("12 distinct versions reported", sweep["distinct_versions"] == 12,
+      str(sweep["distinct_versions"]))
+check("only 12 API calls made, not 60", len(stub5.calls) == 12, str(len(stub5.calls)))
+check("saving is reported", sweep["api_calls_saved_by_dedup"] == 48,
+      str(sweep["api_calls_saved_by_dedup"]))
+check("every device names itself",
+      all(d.get("device") for d in sweep["devices"]))
+check("sweep warns that none_published is not 'secure'",
+      "not a device confirmed secure" in sweep["note"])
+
+print("\n### FR-011: one device's failure does not abort the sweep ###")
+stub6, _ = fresh_server()
+mixed = [{"name": "good", "ostype": "iosxe", "version": "17.3.1"},
+         {"name": "unparseable", "ostype": "iosxe", "version": "garbage"},
+         {"name": "wrongos", "ostype": "iosxr", "version": "7.5.2"},
+         {"name": "alsogood", "ostype": "ios", "version": "15.2(4)E"}]
+result = server.check_versions(mixed)
+outcomes = {d["device"]: d["outcome"] for d in result["devices"]}
+check("good device answered", outcomes["good"] == "advisories_found", str(outcomes))
+check("unparseable device -> normalisation_failed",
+      outcomes["unparseable"] == "normalisation_failed", str(outcomes))
+check("iosxr device -> unsupported_ostype",
+      outcomes["wrongos"] == "unsupported_ostype", str(outcomes))
+check("the fourth device still ran",
+      outcomes["alsogood"] == "advisories_found", str(outcomes))
+
+print("\n### The five outcomes, and the distinction that matters (SC-006/008b) ###")
+stub7, _ = fresh_server(advisories=[])          # Cisco published nothing
+empty = server.check_version("iosxe", "17.3.1")
+check("empty list -> none_published", empty["outcome"] == "none_published",
+      empty["outcome"])
+check("none_published carries a caveat", bool(empty["caveat"]))
+check("caveat denies 'secure' explicitly",
+      "NOT a statement that the device is secure" in empty["caveat"],
+      empty["caveat"])
+
+bad = server.check_version("iosxe", "17.3(1)garbage!!")
+check("unparseable -> normalisation_failed",
+      bad["outcome"] == "normalisation_failed", bad["outcome"])
+check("normalisation_failed has NO version_normalised",
+      bad["version_normalised"] is None)
+check("normalisation_failed says nothing was checked",
+      "NOTHING WAS CHECKED" in (bad["caveat"] or ""), str(bad.get("caveat")))
+check("normalisation_failed is NOT none_published",
+      bad["outcome"] != "none_published")
+check("normalisation_failed suggests the right format",
+      bad.get("expected_format") == "17.3.1", str(bad.get("expected_format")))
+
+xr = server.check_version("iosxr", "7.5.2")
+check("iosxr -> unsupported_ostype", xr["outcome"] == "unsupported_ostype")
+check("iosxr lists the supported set", len(xr.get("supported_ostypes", [])) == 7)
+
+junos = server.check_version("junos", "21.4R3")
+check("non-Cisco -> unsupported_ostype (FR-010)",
+      junos["outcome"] == "unsupported_ostype")
+check("non-Cisco names the vendor and points at nvd-cve",
+      "Juniper" in junos["caveat"] and "nvd-cve" in junos["caveat"],
+      junos["caveat"])
+
+print("\n### FR-005: every result is attributable ###")
+for label, payload in [("check_version", empty), ("sweep", sweep),
+                       ("unsupported", xr), ("status", None)]:
+    if payload is None:
+        continue
+    check(f"{label} stamps server=cisco-psirt", payload["server"] == "cisco-psirt")
+
+print("\n### FR-007 / SC-009: no credential in any output ###")
+SECRETS = ["test-id-not-a-real-credential", "test-secret-not-a-real-credential"]
+status = server.psirt_status()
+blob = json.dumps([status, empty, bad, xr, junos, sweep, refreshed])
+for secret in SECRETS:
+    check(f"{secret[:12]}... absent from every result", secret not in blob)
+check("status reports auth state without the token",
+      "authenticated" in status and "token" not in json.dumps(status).lower()
+      or "token_expires_in_seconds" in status)
+check("status exposes the rate budget",
+      status["rate_budget"]["per_minute"] == 30)
+check("status lists supported and verified sets",
+      len(status["supported_ostypes"]) == 7 and status["verified_ostypes"])
+check("status declares read_only", status["read_only"] is True)
+check("status records what is unavailable and why",
+      "iosxr" in status["unavailable"] and "cx_cloud" in status["unavailable"])
+
+print("\n### FR-013: the limiter paces bursts ###")
+limiter = RateLimiter(per_second=5, per_minute=30)
+start = time.time()
+for _ in range(6):
+    limiter.acquire()
+elapsed = time.time() - start
+check("a 6th call within one second is delayed", elapsed >= 0.9, f"{elapsed:.2f}s")
+check("remaining budget decreases", limiter.calls_remaining() == 24,
+      str(limiter.calls_remaining()))
+
+print("\n### FR-006 / SC-007: a token expiring mid-operation is refreshed silently ###")
+# The real risk this guards: a fleet sweep outlives the 3600s token, and an expiry
+# discovered via a mid-sweep 401 turns an entirely predictable event into a partial
+# failure. Tested with a counting fake in place of the token endpoint, so no live call.
+from auth import REFRESH_MARGIN_S, TokenProvider  # noqa: E402
+
+class FakeTokens(TokenProvider):
+    def __init__(self):
+        super().__init__("fake-id", "fake-secret")
+        self.fetches = 0
+
+    def _fetch(self):
+        self.fetches += 1
+        self._token = f"fake-token-{self.fetches}"
+        self._expires_at = time.time() + 3600
+
+tp = FakeTokens()
+first_token = tp.bearer()
+check("first bearer() acquires a token", tp.fetches == 1, str(tp.fetches))
+check("second bearer() reuses it (no wasted call)",
+      tp.bearer() == first_token and tp.fetches == 1, str(tp.fetches))
+
+# Wind the clock to inside the refresh margin. The token is still technically valid,
+# which is the point: renewal happens BEFORE expiry, not after a 401.
+tp._expires_at = time.time() + (REFRESH_MARGIN_S - 1)
+second_token = tp.bearer()
+check("a token inside the margin is refreshed proactively", tp.fetches == 2,
+      str(tp.fetches))
+check("the refreshed token is a new one", second_token != first_token)
+check("no exception surfaced to the caller", second_token.startswith("fake-token"))
+
+# And an already-expired token still resolves rather than raising.
+tp._expires_at = time.time() - 10
+third = tp.bearer()
+check("an expired token is replaced, not raised on", tp.fetches == 3 and bool(third))
+
+# Genuinely unconfigured: the constructor falls back to the environment when an
+# argument is empty, so the environment has to be cleared rather than overridden.
+_saved = {k: os.environ.pop(k, None)
+          for k in ("CISCO_CLIENT_ID", "CISCO_CLIENT_SECRET")}
+unconfigured = TokenProvider()
+for _k, _v in _saved.items():
+    if _v is not None:
+        os.environ[_k] = _v
+
+check("missing credentials are reported by variable NAME",
+      "CISCO_CLIENT_ID" in unconfigured.status()["missing_variables"])
+try:
+    unconfigured.bearer()
+    check("unconfigured bearer() raises", False, "no exception")
+except Exception as exc:
+    msg = str(exc)
+    check("unconfigured bearer() raises AuthError naming the variables",
+          "CISCO_CLIENT_ID" in msg and "CISCO_CLIENT_SECRET" in msg)
+    check("the error tells the operator where to register",
+          "apiconsole.cisco.com" in msg)
+
+print("\n### FR-018: the tool surface is read-only ###")
+tools = {"check_version", "check_versions", "check_cve", "check_advisory",
+         "list_recent", "psirt_status"}
+exported = {name for name in dir(server) if not name.startswith("_")}
+check("all six tools are present", tools <= exported, str(sorted(tools - exported)))
+writes = [t for t in tools if any(w in t for w in
+                                  ("set_", "write", "delete", "config", "deploy", "push"))]
+check("no tool name implies a write", not writes, str(writes))
+
+print(f"\n{PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)

--- a/tests/cisco-psirt/test_normalise.py
+++ b/tests/cisco-psirt/test_normalise.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Offline contract tests for the PSIRT version normaliser.
+
+Spec 078 T018. No network — these must never consume the 30/min rate budget.
+
+The cases below are not invented. Every accepted/rejected form was measured against
+the live API, and two of these tests exist because they caught real bugs:
+
+  * `banner_with_paren` — an unanchored `re.sub` deleted the whole banner, so valid
+    input normalised to nothing.
+  * `paren_token_not_truncated` — a trailing `\\b` could not match after `)`, so
+    `17.3(1)` silently became `17.3`. The truncated version queried *successfully*
+    and returned a plausible count, which is the quiet wrongness FR-009a targets.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                "..", "..", "mcp-servers", "cisco-psirt-mcp"))
+
+from normalise import (  # noqa: E402
+    OSTYPE_FORMAT,
+    SUPPORTED_OSTYPES,
+    VERIFIED_OSTYPES,
+    collection_note,
+    is_supported,
+    is_verified,
+    normalise,
+    unsupported_reason,
+)
+
+PASS = FAIL = 0
+
+
+def check(label: str, condition: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if condition:
+        print(f"  ok   {label}")
+        PASS += 1
+    else:
+        print(f"  FAIL {label}" + (f" — {detail}" if detail else ""))
+        FAIL += 1
+
+
+print("### Per-family version formats (every row a measured live 200) ###")
+# ostype, input, expected normalised output
+ACCEPTED = [
+    # iosxe: dotted. 17.3(1) is REJECTED by the API, so it must be converted.
+    ("iosxe", "17.3.1", "17.3.1"),
+    ("iosxe", "17.03.01", "17.03.01"),
+    ("iosxe", "17.3(1)", "17.3.1"),
+    ("iosxe", "17.3.1a", "17.3.1a"),
+    # ios: parenthesised, letter suffix OUTSIDE. 15.2.4E is rejected by the API.
+    ("ios", "15.2(4)E", "15.2(4)E"),
+    ("ios", "15.2.4E", "15.2(4)E"),
+    ("ios", "15.2(4)E10", "15.2(4)E10"),
+    # nxos: parenthesised. 9.3.5 is rejected by the API.
+    ("nxos", "9.3(5)", "9.3(5)"),
+    ("nxos", "9.3.5", "9.3(5)"),
+    # asa: dotted. 9.16(1) is rejected by the API.
+    ("asa", "9.16.1", "9.16.1"),
+    ("asa", "9.16(1)", "9.16.1"),
+    # ftd / fmc: dotted.
+    ("ftd", "7.0.1", "7.0.1"),
+    ("fmc", "7.0.1", "7.0.1"),
+    # aci: parenthesised with the letter INSIDE. 15.2(3)e is rejected by the API.
+    ("aci", "15.2(3e)", "15.2(3e)"),
+    ("aci", "15.2.3e", "15.2(3e)"),
+]
+for ostype, raw, expected in ACCEPTED:
+    got = normalise(ostype, raw)
+    check(f"{ostype} {raw!r} -> {expected!r}",
+          got.ok and got.value == expected,
+          f"got ok={got.ok} value={got.value!r}")
+
+print("\n### Banner extraction — real `show version` output ###")
+banners = [
+    ("iosxe", "Cisco IOS XE Software, Version 17.03.01", "17.03.01"),
+    ("iosxe", "Cisco IOS Software [Amsterdam], Version 17.3(1), RELEASE SOFTWARE (fc2)",
+     "17.3.1"),
+    ("ios", "Cisco IOS Software, Version 15.2(4)E10, RELEASE SOFTWARE (fc2)",
+     "15.2(4)E10"),
+]
+for ostype, banner, expected in banners:
+    got = normalise(ostype, banner)
+    check(f"{ostype} banner -> {expected!r}", got.ok and got.value == expected,
+          f"got {got.value!r}")
+
+# Regression: the parenthesised build must survive tokenisation intact. A trailing
+# `\b` silently dropped it, producing a version that queries fine and answers the
+# wrong question.
+got = normalise("nxos", "9.3(5)")
+check("paren_token_not_truncated (9.3(5) does not become 9.3)",
+      got.value == "9.3(5)", f"got {got.value!r}")
+
+print("\n### FR-009a: a parse failure is NEVER an empty advisory list ###")
+for bad in ["garbage", "", None, "   ", "no digits here", "Version unknown"]:
+    got = normalise("iosxe", bad)
+    check(f"{bad!r} -> normalisation_failed", got.failed and got.value is None,
+          f"got ok={got.ok} value={got.value!r}")
+    check(f"{bad!r} explains why", bool(got.reason and len(got.reason) > 20))
+
+print("\n### FR-004: iosxr is refused, not attempted ###")
+check("iosxr unsupported", not is_supported("iosxr"))
+check("iosxr reason mentions 404", "404" in unsupported_reason("iosxr"))
+check("iosxr reason offers check_cve", "check_cve" in unsupported_reason("iosxr"))
+# Each near-miss spelling must name the thing to use instead, not just say "no".
+for alias, expected_hint in [("ios-xr", "iosxr"), ("nx-os", "nxos"),
+                             ("ios-xe", "iosxe"), ("apic", "aci")]:
+    check(f"{alias} points at {expected_hint!r}",
+          alias not in SUPPORTED_OSTYPES
+          and expected_hint in unsupported_reason(alias),
+          f"got {unsupported_reason(alias)!r}")
+
+print("\n### FR-004a: the support and verification tables ###")
+check("exactly seven supported OSTypes", len(SUPPORTED_OSTYPES) == 7,
+      f"got {SUPPORTED_OSTYPES}")
+check("iosxr absent from the supported set", "iosxr" not in SUPPORTED_OSTYPES)
+check("every supported family has a format rule",
+      set(OSTYPE_FORMAT) == set(SUPPORTED_OSTYPES))
+check("every verified family is supported",
+      VERIFIED_OSTYPES <= set(SUPPORTED_OSTYPES))
+check("iosxe is verified", is_verified("iosxe"))
+check("aci carries a collection note (switch vs APIC version)",
+      bool(collection_note("aci")) and "APIC" in collection_note("aci"))
+
+print("\n### Case and whitespace tolerance ###")
+check("uppercase ostype accepted", is_supported("IOSXE"))
+check("padded ostype accepted", is_supported("  iosxe  "))
+got = normalise("iosxe", "  17.3.1  ")
+check("padded version normalises", got.ok and got.value == "17.3.1")
+
+print(f"\n{PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)

--- a/ui/netclaw-visual/server.js
+++ b/ui/netclaw-visual/server.js
@@ -60,6 +60,7 @@ const INTEGRATION_CATALOG = [
   { id: 'fmc', name: 'Cisco FMC', category: 'Security', prefixes: ['fmc-'], color: '#bc4749', transport: 'http', toolEstimate: 8, description: 'Cisco Secure Firewall policy search.' },
   { id: 'nmap', name: 'Nmap', category: 'Security', prefixes: ['nmap-'], color: '#ff006e', transport: 'stdio', toolEstimate: 18, description: 'Scoped scanning and service detection.' },
   { id: 'nvd', name: 'NVD / CVE', category: 'Security', prefixes: ['nvd-'], color: '#fb5607', transport: 'stdio', toolEstimate: 4, description: 'Vulnerability context matched to operational state.' },
+  { id: 'cisco-psirt', name: 'Cisco PSIRT', category: 'Security', prefixes: ['psirt-', 'check_version', 'check_cve'], color: '#d62828', transport: 'stdio', toolEstimate: 6, description: 'Whether a running Cisco version is affected by a published advisory — IOS, IOS-XE, NX-OS, ASA, FTD, FMC, ACI. Read-only; never contacts a device. An empty result means Cisco published nothing, not that the device is secure.' },
   { id: 'grafana', name: 'Grafana', category: 'Observability', prefixes: ['grafana-', 'flow-'], color: '#f8961e', transport: 'http', toolEstimate: 75, description: 'Dashboards, alerts, incidents, and derived telemetry views.' },
   { id: 'prometheus', name: 'Prometheus', category: 'Observability', prefixes: ['prometheus-'], color: '#faa307', transport: 'stdio', toolEstimate: 6, description: 'Direct metrics and PromQL access.' },
   { id: 'thousandeyes', name: 'ThousandEyes', category: 'Observability', prefixes: ['te-'], color: '#ffb703', transport: 'http', toolEstimate: 29, description: 'Synthetic and path-aware external monitoring.' },
@@ -384,6 +385,11 @@ const ENV_MAP = {
     env: ['PAN_CLIENT_ID', 'PAN_CLIENT_SECRET', 'PAN_TSG_ID', 'PAN_REGION'],
     files: ['mcp-servers/prisma-sdwan-mcp/prisma_sdwan_mcp_server.py'],
     notes: 'Palo Alto Networks Prisma SD-WAN via OAuth2. Region is americas or europe. TSG_ID is the Tenant Service Group ID.',
+  },
+  'cisco-psirt': {
+    env: ['CISCO_CLIENT_ID', 'CISCO_CLIENT_SECRET', 'CISCO_PSIRT_CACHE_DIR', 'CISCO_PSIRT_CACHE_TTL_S'],
+    files: ['mcp-servers/cisco-psirt-mcp/server.py'],
+    notes: 'Cisco PSIRT openVuln API via OAuth2 client credentials (id.cisco.com, 3600s token, refreshed proactively at 60s remaining). Read-only and device-free — versions are supplied by the caller from pyATS or multivendor-cli. Rate budget is 5/sec and 30/min shared, so lookups de-duplicate by version and cache for 6h on disk. Version format differs per family and contradicts across them: iosxe wants 17.3.1 and rejects 17.3(1), while ios wants 15.2(4)E and rejects 15.2.4E; aci wants the SWITCH image version 15.2(3e), not the APIC version. NOT available: iosxr (404, not an OSType), Bug/EoX/Case/Serial (403 under this grant), CX Cloud (504).',
   },
   'multivendor-cli': {
     env: ['MULTIVENDOR_INVENTORY_SOURCE', 'MULTIVENDOR_INVENTORY_PATH', 'MULTIVENDOR_WRITE_ENABLED', 'MULTIVENDOR_MAX_WORKERS', 'MULTIVENDOR_TIMEOUT_S', 'MULTIVENDOR_USERNAME', 'MULTIVENDOR_PASSWORD'],

--- a/workspace/skills/cisco-psirt-advisories/SKILL.md
+++ b/workspace/skills/cisco-psirt-advisories/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: cisco-psirt-advisories
+description: "Check whether a running Cisco software version is affected by a published PSIRT security advisory - by OS version, CVE, or advisory ID, with severity and CVSS. Covers IOS, IOS-XE, NX-OS, ASA, FTD, FMC and ACI. Use when asked if a device or fleet is vulnerable, when triaging a Cisco CVE, or when auditing software versions against Cisco advisories."
+license: Apache-2.0
+user-invocable: true
+metadata:
+  { "openclaw": { "requires": { "bins": ["python3"], "env": ["CISCO_PSIRT_MCP_SCRIPT", "MCP_CALL", "CISCO_CLIENT_ID", "CISCO_CLIENT_SECRET"] } } }
+---
+
+# Cisco PSIRT Advisory Checks
+
+Answers one question well: **is the software this device is running affected by a Cisco
+security advisory?**
+
+## Read this first — an empty result is not a clean bill of health
+
+Every tool returns one of five `outcome` values. Two of them look similar in the data
+and mean completely different things:
+
+| `outcome` | What it means |
+|---|---|
+| `advisories_found` | Cisco has published advisories for this version |
+| `none_published` | Cisco has published **nothing** for this version — **NOT "the device is secure"** |
+| `normalisation_failed` | The version could not be parsed. **Nothing was checked.** |
+| `unsupported_ostype` | Not a PSIRT OS family (includes `iosxr` and every non-Cisco platform) |
+| `api_error` | Auth failure, rate limit, or a version Cisco has no record of |
+
+**Never report "no advisories" as "not vulnerable".** `none_published` means Cisco has
+published nothing matching that exact version string. It says nothing about
+unpatched-but-unpublished issues, configuration weaknesses, or anything outside Cisco's
+PSIRT process.
+
+**Never treat `normalisation_failed` or `api_error` as good news.** Both mean the question
+went unasked. In a fleet sweep, check the `outcome_summary` counts before telling anyone
+the fleet is clean — devices in those two buckets were never checked at all.
+
+## The two-step chain
+
+This server **never contacts a device**. It has no transport, no credentials for your
+network, and no way to read a version. You supply the version:
+
+**Step 1 — read the version off the device.**
+
+```bash
+# Cisco platforms: pyATS
+python3 $MCP_CALL "python3 -u $PYATS_MCP_SCRIPT" run_show_command \
+  '{"device_name":"cat9k-1","command":"show version"}'
+
+# Anything else, or when pyATS has no parser: the multivendor CLI driver
+python3 $MCP_CALL "python3 -u $MULTIVENDOR_MCP_SCRIPT" device_run_command \
+  '{"device":"rtr-1","command":"show version"}'
+```
+
+**Step 2 — pass it here.** Full `show version` output is fine; the banner is parsed.
+
+```bash
+python3 $MCP_CALL "python3 -u $CISCO_PSIRT_MCP_SCRIPT" check_version \
+  '{"ostype":"iosxe","version":"17.3.1"}'
+```
+
+Do not skip step 1 and guess a version. The server refuses to infer one — a guessed
+version returns advisories for software the device is not running, which is worse than
+no answer.
+
+## Available Tools
+
+### 1. `check_version` — is this version affected?
+
+```bash
+python3 $MCP_CALL "python3 -u $CISCO_PSIRT_MCP_SCRIPT" check_version \
+  '{"ostype":"iosxe","version":"17.3.1"}'
+```
+
+- `ostype` (required): `ios` | `iosxe` | `nxos` | `asa` | `fmc` | `ftd` | `aci`
+- `version` (required): bare version or full `show version` output
+- `refresh` (optional, default `false`): bypass the 6-hour cache
+
+Verified: `iosxe` + `17.3.1` returns **122 advisories**.
+
+### 2. `check_versions` — a fleet in one call
+
+```bash
+python3 $MCP_CALL "python3 -u $CISCO_PSIRT_MCP_SCRIPT" check_versions \
+  '{"devices":[{"name":"cat9k-1","ostype":"iosxe","version":"17.3.1"},
+               {"name":"n9k-1","ostype":"nxos","version":"9.3(5)"}]}'
+```
+
+**Prefer this over looping `check_version`.** It de-duplicates by version first, so 60
+devices running 12 distinct versions cost 12 API calls rather than 60 — the difference
+between one-third of the per-minute budget and twice it. One device failing never aborts
+the others.
+
+### 3. `check_cve` — which Cisco advisories cover this CVE?
+
+```bash
+python3 $MCP_CALL "python3 -u $CISCO_PSIRT_MCP_SCRIPT" check_cve '{"cve":"CVE-2024-20353"}'
+```
+
+### 4. `check_advisory` — one advisory by id
+
+```bash
+python3 $MCP_CALL "python3 -u $CISCO_PSIRT_MCP_SCRIPT" check_advisory \
+  '{"advisory_id":"cisco-sa-bootp-WuBhNBxA"}'
+```
+
+### 5. `list_recent` — what has Cisco published lately?
+
+```bash
+python3 $MCP_CALL "python3 -u $CISCO_PSIRT_MCP_SCRIPT" list_recent \
+  '{"severity":"critical","start_date":"2026-01-01","end_date":"2026-07-31"}'
+```
+
+Verified: `critical` across 2026 to date returns **15 advisories**.
+
+### 6. `psirt_status` — check the budget before a sweep
+
+```bash
+python3 $MCP_CALL "python3 -u $CISCO_PSIRT_MCP_SCRIPT" psirt_status '{}'
+```
+
+Reports auth state, remaining rate budget, cache statistics, and which OS families are
+supported. Contains no credential values. Worth calling before a large sweep.
+
+## Version formats differ per family — and they contradict each other
+
+This is the most common source of a wrong answer. The server normalises for you, but you
+must collect the **right number** in the first place.
+
+| OSType | Format Cisco expects | Example |
+|---|---|---|
+| `iosxe` | dotted | `17.3.1`, `17.03.01`, `17.3.1a` |
+| `ios` | parenthesised, letter outside | `15.2(4)E`, `15.2(4)E10` |
+| `nxos` | parenthesised | `9.3(5)` |
+| `asa` | dotted | `9.16.1` |
+| `ftd` / `fmc` | dotted | `7.0.1` |
+| `aci` | parenthesised, letter **inside** | `15.2(3e)`, `16.0(3e)` |
+
+Note the contradiction: `iosxe` **rejects** `17.3(1)` while `ios` **rejects** `15.2.4E`.
+The same-looking transformation runs in opposite directions depending on family. The
+server handles the conversion; pass whatever the device reported.
+
+**ACI is the trap.** It wants the **switch image version** (`15.2(3e)`), not the APIC
+controller version — `5.2(3e)` is rejected outright. Collect it from a switch, not the
+APIC.
+
+## IOS-XR is not supported, and this will surprise you
+
+`iosxr` is **not an OSType on this API**. Every version tried (7.5.2, 6.6.3, 24.1.1)
+returns HTTP 404, against an `iosxe` 200 control in the same session.
+
+This is worth flagging to the user rather than working around silently, because NetClaw
+*can* reach IOS-XR devices through pyATS — so an operator will reasonably expect the
+version check to work. For IOS-XR, fall back to `check_cve` or advisory lookup by
+product id, and say plainly that per-version checking is unavailable for that platform.
+
+## Where this ends and `nvd-cve` begins
+
+Both answer vulnerability questions; they are not interchangeable, and neither is a
+substitute for the other.
+
+| Question | Use |
+|---|---|
+| "Is this Cisco version affected by a Cisco advisory?" | **this skill** |
+| "What is CVE-2024-20353, what is its CVSS, what is affected?" | `nvd-cve` |
+| "Has Cisco issued an advisory for this CVE?" | **this skill** (`check_cve`) |
+| "Does any vendor have a known CVE matching this software?" | `nvd-cve` |
+
+**Either can legitimately be empty while the other is not.** Cisco may publish an
+advisory before an NVD entry exists; NVD may hold a CVE for which Cisco has issued no
+advisory. When a security question matters, check both and say which one answered.
+
+## Rate limits are shared and tight
+
+5 calls/second and **30 calls/minute**, shared across every caller of the credential.
+30/minute is the real constraint. The server handles this automatically — de-duplicating
+by version, serving from a 6-hour cache, pacing, and backing off on 429 — but two habits
+defeat it:
+
+- **Looping `check_version` per device** instead of using `check_versions`.
+- **Passing `refresh: true` routinely.** It disables the cache. Use it during an incident
+  when cache age is itself the question, not as a default.
+
+## What this API does not provide
+
+Measured, not inferred from documentation — do not spend time re-testing these:
+
+- **Bug, EoX, Case and Serial-to-Info APIs** return **403** under the API Console grant.
+- **CX Cloud** returns **504** on all seven paths tried. It needs a separate tenant
+  subscription.
+- **IOS-XR** returns **404**, as above.
+
+## Reporting results to a user
+
+Lead with the count and the worst severity, not the whole list. Then, if the answer was
+`none_published`, say what that does and does not mean — the distinction is the point of
+this skill, and it is the part a reader will otherwise get wrong.
+
+Good: *"cat9k-1 on IOS-XE 17.3.1 has 122 published advisories, 4 of them Critical
+(highest CVSS 9.8). Recommend reviewing the Critical set first."*
+
+Good: *"n9k-1 on NX-OS 9.3(5) — Cisco has published no advisory matching this exact
+version. That is not confirmation the device is secure; it means nothing is published for
+this version string."*
+
+Bad: *"n9k-1 is not vulnerable."* Never say this.


### PR DESCRIPTION
Closes roadmap item **R2**. Spec [078](../blob/078-cisco-psirt-vulnerability/specs/078-cisco-psirt-vulnerability/spec.md), 52/52 tasks.

NetClaw can now answer whether the software a device is **actually running** is affected by a published Cisco security advisory. New `cisco-psirt` MCP server (6 tools, read-only, never contacts a device) plus the `cisco-psirt-advisories` skill.

## Rescoped from eight API families to one — by measurement

| Family | Result |
|---|---|
| PSIRT openVuln | **200** — the feature |
| Bug Search / Case / EoX / Serial→Info | **403** under the API Console grant |
| CX Cloud (7 paths) | **504** |

The 46-tool community candidate (`sieteunoseis/mcp-cisco-support`) was **not adopted**: seven eighths of its manifest would have been dead surface, costing tokens on every turn to advertise capabilities that answer 403.

**EoL/EoS lookup is not delivered.** It was half of R2's original value and it is unreachable with the available entitlement — not descoped for convenience. "Is this switch past end-of-support?" remains unanswerable.

## `iosxr` is not an OSType

404 on 7.5.2, 6.6.3 and 24.1.1, against an `iosxe` 200 control in the same session. Refused with a pointer to `check_cve`, and flagged in the skill — NetClaw *can* reach IOS-XR via pyATS, so the gap is genuinely surprising.

## The finding that changed the design

Version formats are per-family and **contradict each other**:

| OSType | Accepted | Rejected |
|---|---|---|
| `iosxe` | `17.3.1`, `17.03.01`, `17.3.1a` | `17.3(1)` |
| `ios` | `15.2(4)E`, `15.2(4)E10` | `15.2.4E` |
| `nxos` | `9.3(5)` | `9.3.5` |
| `asa` | `9.16.1` | `9.16(1)` |
| `ftd`/`fmc` | `7.0.1` | `7.2(0)` |
| `aci` | `15.2(3e)`, `16.0(3e)` | `5.2(3e)`, `5.2.3` |

`ios` and `nxos` **require** the form `iosxe` rejects. `aci` needs the suffix *inside* the parens where `ios` needs it outside, and wants the **switch image** version, not the APIC version. The single global rule the spec drafted would have broken `ios` and `nxos` on every call. All seven normalisers are live-verified as a result, not one.

## Two bugs the live API caught that offline tests did not

1. **A trailing `\b` silently truncated `17.3(1)` to `17.3`.** `\b` cannot match after `)` at end-of-string, so the engine backtracked past the parenthesised build. The truncated version queried cleanly and returned a plausible advisory count **for software the device is not running** — a confident answer to a question nobody asked. Tokenisation is now anchored: a candidate that does not match in its entirety is rejected, never salvaged.
2. **An unanchored `re.sub`** meant to strip a trailing product fragment matched from the *first word* of a real `show version` banner and deleted the whole string.

## The safety semantics

Five outcomes, enforced **in the normaliser** rather than the tool layer:

- `none_published` — Cisco published nothing. **Not "the device is secure."**
- `normalisation_failed` / `api_error` — **the question was never asked.**

An empty advisory list reads as a clean bill of health, so collapsing these would tell an operator a device is safe when nothing was checked. `check_versions` reports `outcome_summary` counts so a fleet cannot be called clean without seeing what went unchecked.

## Rate budget

5/sec and **30/min shared**. Contractual order: de-duplicate → cache → pace → back off. Measured: **60 devices on 12 distinct versions cost 12 calls, not 60**. Token in memory only, refreshed proactively at 60s remaining; advisories cached 6h on disk.

## Verified on live hardware

pyATS read **IOS-XE 17.16.1a** off a live CML router → **26 advisories: 14 High, 11 Medium, 1 Critical** (`cisco-sa-http-code-exec-WmfP3h3O`, CVSS 9.0, CVE-2025-20363). Raw banner and Genie-parsed version normalised identically. **No version typed by a human.**

## Verification

- `./tests/cisco-psirt/run-tests.sh` — **109 offline checks, exit 0**. No network; the suite substitutes a counting stub so it never spends rate budget.
- `./tests/cisco-psirt/live-api.sh` — **34 live checks, exit 0**. Opt-in only, never in CI.
- `python3 scripts/reconcile-mcp.py` — **exit 0 across all four surfaces**.

## Principle XI artifacts — all eight explicit

Because PR #204 found three missing after R1 and `reconcile-mcp.py` catches none of them: catalog entry, **`PROFILE_SECURITY` and `PROFILE_CISCO`**, install function via `netclaw_pip_install`, portable repo-relative registration, **both** HUD entries (node list *and* annotation map), SOUL capability section (the capability, not just the count), README/TOOLS tables, `.env.example`.

Also adds **R1's `multivendor-cli` rows to both README tables** — absent since R1, the same class of gap the gate cannot see (it counts catalog/config entries, not table rows).

## Note for later specs

`pyATS`/`genie` on this host import **only** from `/usr/local/bin/python3.13`, not `/usr/bin/python3` (3.14.4) — the stranded site-packages R0a documented. Chain verification ran as two processes, which is how production works anyway. Any future spec wanting pyATS and a 3.14-installed server in *one* process will hit this.

Blog post drafted for review (`docs/blog/2026-07-31-r2-cisco-psirt.md`), unpublished per Principle XVII.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
