### PR TITLE
Fix/checkpoint mcp env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -433,10 +433,28 @@ NETCLAW_ENABLE_PASSWORD=changeme
 # CHKP_TE_API_KEY=your-threat-emulation-key             # Threat Emulation API key
 
 # Spark Management — MSP-oriented distributed firewall management
-# CHKP_SPARK_API_KEY=your-spark-api-key                 # Spark Management API key
+# Authenticates via Infinity Portal (client_id / secret_key), NOT a bare API key.
+# CHKP_SPARK_CLIENT_ID=your-spark-client-id             # Infinity Portal client ID (required)
+# CHKP_SPARK_SECRET_KEY=your-spark-secret-key           # Infinity Portal secret key (required)
+# CHKP_SPARK_INFINITY_PORTAL_URL=https://cloudinfra-gw.portal.checkpoint.com  # Portal URL (required)
+# CHKP_SPARK_REGION=                                    # Portal region (optional)
+
+# Documentation Tool — Check Point Documentation Tool API
+# Authenticates via Infinity Portal (client_id / secret_key + auth URL).
+# CHKP_DOCS_CLIENT_ID=your-docs-client-id               # Infinity Portal client ID (required)
+# CHKP_DOCS_SECRET_KEY=your-docs-secret-key             # Infinity Portal secret key (required)
+# CHKP_DOCS_AUTH_URL=https://cloudinfra-gw.portal.checkpoint.com/auth/external  # Auth URL (required)
+# CHKP_DOCS_REGION=                                     # Portal region (optional)
 
 # Argos ERM — exposure and risk management platform
-# CHKP_ARGOS_API_KEY=your-argos-api-key                 # Argos ERM API key
+# Authenticates via its own server URL + integration token, NOT a bare API key.
+# CHKP_ARGOS_SERVER_URL=https://your-argos-server       # Argos server URL (required)
+# CHKP_ARGOS_INTEGRATION_TOKEN=your-argos-token         # Argos integration token (required)
+# CHKP_ARGOS_CUSTOMER_ID=                               # Argos customer ID (optional)
+
+# Gaia OS — networking/routing on a gateway; uses interactive dialog auth (prompts
+# for gateway IP/user/password per call, cached ~15 min). No credential env vars.
+# CHKP_GAIA_VERBOSE=false                               # Verbose logging (optional)
 
 # Global Settings
 # CHKP_TELEMETRY_DISABLED=true                          # Disable Check Point telemetry

--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -359,7 +359,9 @@
       ],
       "env": {
         "MANAGEMENT_HOST": "${CHKP_MGMT_HOST}",
-        "PORT": "${CHKP_MGMT_PORT:-443}",
+        "MANAGEMENT_PORT": "${CHKP_MGMT_PORT:-443}",
+        "S1C_URL": "${CHKP_S1C_URL}",
+        "CLOUD_INFRA_TOKEN": "${CHKP_S1C_API_KEY}",
         "API_KEY": "${CHKP_MGMT_API_KEY}",
         "USERNAME": "${CHKP_MGMT_USERNAME}",
         "PASSWORD": "${CHKP_MGMT_PASSWORD}",
@@ -374,7 +376,9 @@
       ],
       "env": {
         "MANAGEMENT_HOST": "${CHKP_MGMT_HOST}",
-        "PORT": "${CHKP_MGMT_PORT:-443}",
+        "MANAGEMENT_PORT": "${CHKP_MGMT_PORT:-443}",
+        "S1C_URL": "${CHKP_S1C_URL}",
+        "CLOUD_INFRA_TOKEN": "${CHKP_S1C_API_KEY}",
         "API_KEY": "${CHKP_MGMT_API_KEY}",
         "USERNAME": "${CHKP_MGMT_USERNAME}",
         "PASSWORD": "${CHKP_MGMT_PASSWORD}",
@@ -389,7 +393,9 @@
       ],
       "env": {
         "MANAGEMENT_HOST": "${CHKP_MGMT_HOST}",
-        "PORT": "${CHKP_MGMT_PORT:-443}",
+        "MANAGEMENT_PORT": "${CHKP_MGMT_PORT:-443}",
+        "S1C_URL": "${CHKP_S1C_URL}",
+        "CLOUD_INFRA_TOKEN": "${CHKP_S1C_API_KEY}",
         "API_KEY": "${CHKP_MGMT_API_KEY}",
         "USERNAME": "${CHKP_MGMT_USERNAME}",
         "PASSWORD": "${CHKP_MGMT_PASSWORD}",
@@ -404,7 +410,9 @@
       ],
       "env": {
         "MANAGEMENT_HOST": "${CHKP_MGMT_HOST}",
-        "PORT": "${CHKP_MGMT_PORT:-443}",
+        "MANAGEMENT_PORT": "${CHKP_MGMT_PORT:-443}",
+        "S1C_URL": "${CHKP_S1C_URL}",
+        "CLOUD_INFRA_TOKEN": "${CHKP_S1C_API_KEY}",
         "API_KEY": "${CHKP_MGMT_API_KEY}",
         "USERNAME": "${CHKP_MGMT_USERNAME}",
         "PASSWORD": "${CHKP_MGMT_PASSWORD}",
@@ -441,7 +449,9 @@
       ],
       "env": {
         "MANAGEMENT_HOST": "${CHKP_MGMT_HOST}",
-        "PORT": "${CHKP_MGMT_PORT:-443}",
+        "MANAGEMENT_PORT": "${CHKP_MGMT_PORT:-443}",
+        "S1C_URL": "${CHKP_S1C_URL}",
+        "CLOUD_INFRA_TOKEN": "${CHKP_S1C_API_KEY}",
         "API_KEY": "${CHKP_MGMT_API_KEY}",
         "USERNAME": "${CHKP_MGMT_USERNAME}",
         "PASSWORD": "${CHKP_MGMT_PASSWORD}",
@@ -456,7 +466,9 @@
       ],
       "env": {
         "MANAGEMENT_HOST": "${CHKP_MGMT_HOST}",
-        "PORT": "${CHKP_MGMT_PORT:-443}",
+        "MANAGEMENT_PORT": "${CHKP_MGMT_PORT:-443}",
+        "S1C_URL": "${CHKP_S1C_URL}",
+        "CLOUD_INFRA_TOKEN": "${CHKP_S1C_API_KEY}",
         "API_KEY": "${CHKP_MGMT_API_KEY}",
         "USERNAME": "${CHKP_MGMT_USERNAME}",
         "PASSWORD": "${CHKP_MGMT_PASSWORD}",
@@ -480,12 +492,7 @@
         "mcp-servers/checkpoint-mcp-servers/packages/gaia/dist/index.js"
       ],
       "env": {
-        "MANAGEMENT_HOST": "${CHKP_MGMT_HOST}",
-        "PORT": "${CHKP_MGMT_PORT:-443}",
-        "API_KEY": "${CHKP_MGMT_API_KEY}",
-        "USERNAME": "${CHKP_MGMT_USERNAME}",
-        "PASSWORD": "${CHKP_MGMT_PASSWORD}",
-        "DOMAIN": "${CHKP_MGMT_DOMAIN}",
+        "VERBOSE": "${CHKP_GAIA_VERBOSE:-false}",
         "TELEMETRY_DISABLED": "${CHKP_TELEMETRY_DISABLED:-true}"
       }
     },
@@ -495,6 +502,10 @@
         "mcp-servers/checkpoint-mcp-servers/packages/documentation-tool/dist/index.js"
       ],
       "env": {
+        "CLIENT_ID": "${CHKP_DOCS_CLIENT_ID}",
+        "SECRET_KEY": "${CHKP_DOCS_SECRET_KEY}",
+        "AUTH_URL": "${CHKP_DOCS_AUTH_URL}",
+        "REGION": "${CHKP_DOCS_REGION}",
         "TELEMETRY_DISABLED": "${CHKP_TELEMETRY_DISABLED:-true}"
       }
     },
@@ -504,7 +515,10 @@
         "mcp-servers/checkpoint-mcp-servers/packages/spark-management/dist/index.js"
       ],
       "env": {
-        "API_KEY": "${CHKP_SPARK_API_KEY}",
+        "CLIENT_ID": "${CHKP_SPARK_CLIENT_ID}",
+        "SECRET_KEY": "${CHKP_SPARK_SECRET_KEY}",
+        "INFINITY_PORTAL_URL": "${CHKP_SPARK_INFINITY_PORTAL_URL}",
+        "REGION": "${CHKP_SPARK_REGION}",
         "TELEMETRY_DISABLED": "${CHKP_TELEMETRY_DISABLED:-true}"
       }
     },
@@ -523,7 +537,9 @@
         "mcp-servers/checkpoint-mcp-servers/packages/argos-erm/dist/index.js"
       ],
       "env": {
-        "API_KEY": "${CHKP_ARGOS_API_KEY}",
+        "ARGOS_SERVER_URL": "${CHKP_ARGOS_SERVER_URL}",
+        "ARGOS_INTEGRATION_TOKEN": "${CHKP_ARGOS_INTEGRATION_TOKEN}",
+        "ARGOS_CUSTOMER_ID": "${CHKP_ARGOS_CUSTOMER_ID}",
         "TELEMETRY_DISABLED": "${CHKP_TELEMETRY_DISABLED:-true}"
       }
     },
@@ -534,7 +550,9 @@
       ],
       "env": {
         "MANAGEMENT_HOST": "${CHKP_MGMT_HOST}",
-        "PORT": "${CHKP_MGMT_PORT:-443}",
+        "MANAGEMENT_PORT": "${CHKP_MGMT_PORT:-443}",
+        "S1C_URL": "${CHKP_S1C_URL}",
+        "CLOUD_INFRA_TOKEN": "${CHKP_S1C_API_KEY}",
         "API_KEY": "${CHKP_MGMT_API_KEY}",
         "USERNAME": "${CHKP_MGMT_USERNAME}",
         "PASSWORD": "${CHKP_MGMT_PASSWORD}",

--- a/scripts/checkpoint-enable.sh
+++ b/scripts/checkpoint-enable.sh
@@ -198,6 +198,110 @@ fi
 echo ""
 
 # ═══════════════════════════════════════════
+# Step 4b: Prune unresolved credential placeholders
+# ═══════════════════════════════════════════
+# OpenClaw substitutes ${VAR} in an MCP server's env block only when VAR is set
+# to a NON-EMPTY value; an unset/empty VAR is handed to the server as the LITERAL
+# string "${VAR}" (and ${VAR:-default} is NOT defaulted). The management-family
+# servers accept EITHER the Smart-1 Cloud path (S1C_URL) OR the on-prem path
+# (MANAGEMENT_HOST); a leaked literal for the path you are NOT using makes the
+# server pick the wrong one and fail (e.g. "Invalid URL"). So, using the creds
+# just written to $OPENCLAW_ENV, drop chkp-* env keys whose ${VAR} is unset and
+# bake in any ${VAR:-default} defaults. Operates only on the deployed runtime
+# config (never the committed repo config). See codereview-verification.md B3.
+
+log_step "4b/5 Pruning unresolved credential placeholders in OpenClaw config..."
+
+OPENCLAW_CONFIG="${OPENCLAW_CONFIG_PATH:-$OPENCLAW_DIR/openclaw.json}"
+if [ ! -f "$OPENCLAW_CONFIG" ]; then
+    log_warn "OpenClaw config not found at $OPENCLAW_CONFIG — skipping prune."
+    log_warn "Run the base installer (scripts/install.sh) first, or set OPENCLAW_CONFIG_PATH, then re-run this script."
+elif ! command -v python3 &> /dev/null; then
+    log_warn "python3 not found — skipping prune. chkp-* servers may receive literal \${VAR} values for unset creds."
+else
+    CHKP_PRUNE_ENV="$OPENCLAW_ENV" python3 - "$OPENCLAW_CONFIG" <<'PY'
+import json, os, re, sys
+
+cfg_path = sys.argv[1]
+env_path = os.environ["CHKP_PRUNE_ENV"]
+
+# Vars set to a non-empty value in the runtime .env (what OpenClaw can resolve).
+set_vars = set()
+try:
+    with open(env_path) as fh:
+        for line in fh:
+            s = line.strip()
+            if not s or s.startswith("#") or "=" not in s:
+                continue
+            k, v = s.split("=", 1)
+            if v.strip() != "":
+                set_vars.add(k)
+except FileNotFoundError:
+    pass
+
+# Guard: if no real Check Point credential is set yet, do NOT prune (that would
+# strip every placeholder, including S1C_URL/API_KEY, from an unconfigured
+# install). Telemetry/log-level toggles don't count as credentials.
+_noncred = {"CHKP_TELEMETRY_DISABLED", "CHKP_LOG_LEVEL"}
+if not any(k.startswith("CHKP_") and k not in _noncred for k in set_vars):
+    print("  no Check Point credentials set in %s yet — skipping prune" % env_path)
+    print("  (configure creds, then re-run scripts/checkpoint-enable.sh to prune)")
+    sys.exit(0)
+
+with open(cfg_path) as fh:
+    raw = fh.read()
+cfg = json.loads(raw)
+
+# OpenClaw reads the legacy top-level "mcpServers" and the canonical "mcp"."servers".
+servers = cfg.get("mcpServers")
+if servers is None:
+    servers = cfg.get("mcp", {}).get("servers", {})
+
+pat = re.compile(r"^\$\{([A-Z0-9_]+)(?::-([^}]*))?\}$")
+dropped, baked = [], []
+for name, srv in (servers or {}).items():
+    if not name.startswith("chkp-") or not isinstance(srv.get("env"), dict):
+        continue
+    env = srv["env"]
+    for key in list(env.keys()):
+        val = env[key]
+        if not isinstance(val, str):
+            continue
+        m = pat.match(val)
+        if not m:
+            continue
+        var, default = m.group(1), m.group(2)
+        if var in set_vars:
+            continue  # OpenClaw will substitute it correctly
+        if default is not None:
+            env[key] = default            # bake the ${VAR:-default} default
+            baked.append("%s.%s=%s" % (name, key, default))
+        else:
+            del env[key]                  # drop the unresolvable bare ${VAR}
+            dropped.append("%s.%s" % (name, key))
+
+if dropped or baked:
+    with open(cfg_path + ".bak", "w") as fh:
+        fh.write(raw)                     # back up the pre-prune config
+    with open(cfg_path, "w") as fh:
+        json.dump(cfg, fh, indent=2)
+        fh.write("\n")
+    print("  pruned %d unresolved placeholder(s); baked %d default(s) in %s"
+          % (len(dropped), len(baked), cfg_path))
+    for d in dropped:
+        print("    dropped %s" % d)
+    for b in baked:
+        print("    baked   %s" % b)
+    print("  backup: %s.bak" % cfg_path)
+else:
+    print("  no unresolved chkp-* placeholders — nothing to prune")
+PY
+    [ $? -eq 0 ] && log_info "Placeholder prune complete." || log_warn "Placeholder prune reported an error."
+fi
+
+echo ""
+
+# ═══════════════════════════════════════════
 # Step 5: Verify Installation
 # ═══════════════════════════════════════════
 


### PR DESCRIPTION
This corrects the Check Point MCP integration so the servers actually authenticate, and fixes a config-substitution issue that broke the Smart-1 Cloud path.

## 1. Env-var wiring corrected to match the server contracts

Several servers were sent env vars that don't match what the packages actually read (checked against each package's `src/server-config.json` in CheckPointSW/mcp-servers):

- **Management family (7 servers):** `PORT` → `MANAGEMENT_PORT`. The old name was silently ignored, so any non-443 Web API port was dropped.
- **Smart-1 Cloud path wired in:** add `S1C_URL` + `CLOUD_INFRA_TOKEN` to the management-family servers. Previously only the on-prem `MANAGEMENT_HOST` path was reachable, so an S1C tenant could not be targeted at all.
- **spark-management:** `API_KEY` → Infinity-Portal auth (`CLIENT_ID`, `SECRET_KEY`, `INFINITY_PORTAL_URL`, `REGION`).
- **documentation-tool:** add the required Infinity-Portal auth (`CLIENT_ID`, `SECRET_KEY`, `AUTH_URL`, `REGION`) — it is not credential-free.
- **argos-erm:** `API_KEY` → `ARGOS_SERVER_URL`, `ARGOS_INTEGRATION_TOKEN`, `ARGOS_CUSTOMER_ID`.
- **gaia:** drop the no-op credential block (Gaia uses interactive dialog auth); keep only `VERBOSE`.
`.env.example` updated to document the corrected variables for each server.

## 2. Prune unresolved `${VAR}` placeholders from the deployed config

OpenClaw substitutes `${VAR}` in an MCP server's env block only when the var is set to a non-empty value; an unset/empty var is handed to the server as the **literal** string `"${VAR}"`, and `${VAR:-default}` is not defaulted. Because the management-family blocks now wire both the Smart-1 Cloud path (`S1C_URL` / `CLOUD_INFRA_TOKEN`) and the on-prem path (`MANAGEMENT_HOST`), an S1C-only user's server received a garbage non-empty `MANAGEMENT_HOST`, took the wrong auth branch, and failed with `Invalid URL`.

After writing credentials, `checkpoint-enable.sh` now prunes each `chkp-*` env block in the **deployed runtime config** (`$OPENCLAW_DIR/openclaw.json`, overridable via `OPENCLAW_CONFIG_PATH`): it drops keys whose `${VAR}` is unset
and bakes in any `${VAR:-default}` defaults, leaving only resolvable vars. It guards against pruning an unconfigured install, backs up the config first, and never touches the committed repo config.

Validated end-to-end against a live Smart-1 Cloud management tenant.