### PR TITLE
feat(081): BGP & registry intelligence — RPKI / RDAP / PeeringDB / RIPEstat (R9)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -667,3 +667,23 @@ FORTINET_VERIFY_SSL=
 # it only makes the two gates reachable. Every write additionally requires
 # human approval AND an approved ServiceNow change record.
 FORTINET_ALLOW_WRITES=
+
+# ─────────────────────────────────────────────────────────────────────
+# BGP & Registry Intelligence — spec 081 (roadmap R9)
+# Server: mcp-servers/bgp-intel-mcp
+#
+# NO CREDENTIALS REQUIRED. All five sources (RPKI validator, RDAP, RIPEstat,
+# PeeringDB, RIPE Atlas) are public unauthenticated APIs. There is nothing here
+# to leak, rotate or scope — the only variables are optional tuning.
+# ─────────────────────────────────────────────────────────────────────
+# Command the bgp-registry-intel skill invokes
+BGP_INTEL_MCP_CMD=
+# Contact string sent to public APIs. These are volunteer-funded community
+# services and identifying yourself is the courtesy they ask of automated
+# consumers. Defaults to a NetClaw string with the project URL.
+BGP_INTEL_USER_AGENT=
+# Requests per second per source. Default 4, enforced as a true sliding window.
+# May be LOWERED to be more polite; values above 4 are clamped, not honoured.
+BGP_INTEL_MAX_RPS=
+# GAIT audit trail path. Defaults under ~/.openclaw/gait/
+BGP_INTEL_AUDIT_LOG=

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ mcp-servers/multivendor-cli-mcp/.venv/
 !mcp-servers/tts-mcp/
 !mcp-servers/halo-mcp/
 !mcp-servers/fortinet-mcp/
+!mcp-servers/bgp-intel-mcp/
 
 # Traces
 trace.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # netclaw Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-08-01
+Auto-generated from all feature plans. Last updated: 2026-08-03
 
 ## Active Technologies
 - N/A (stateless server; subscription state held in-memory during runtime) (003-gnmi-mcp-server)
@@ -108,6 +108,8 @@ Auto-generated from all feature plans. Last updated: 2026-08-01
 - on-disk cache, one JSON file per `(ostype, version)` under `~/.openclaw/cisco-psirt/`. No (078-cisco-psirt-vulnerability)
 - Python 3.10+, system interpreter. Unlike spec 076 this needs **no dedicated venv** — + `mcp>=1.2.0,<2` and `httpx>=0.27.0,<1`. Two packages, identical to spec 078's (080-fortinet-coverage)
 - None. Stateless proxy to three appliance APIs. Change baselines (US3) write under a (080-fortinet-coverage)
+- Python 3.10+, system interpreter. No dedicated venv — two pure-HTTP packages move + `mcp>=1.2.0,<2` and `httpx>=0.27.0,<1`. Identical to specs 078 and 080. The `mcp` (081-bgp-registry-intel)
+- **None on disk.** Per-source in-memory TTL cache only (clarification Q3): RPKI 5 min, routing (081-bgp-registry-intel)
 
 - Python 3.10+ + FastMCP (MCP framework), grpcio + grpcio-tools (gRPC transport), pygnmi (gNMI client library), protobuf, cryptography (TLS handling) (003-gnmi-mcp-server)
 
@@ -127,9 +129,9 @@ cd src [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLO
 Python 3.10+: Follow standard conventions
 
 ## Recent Changes
+- 081-bgp-registry-intel: Added Python 3.10+, system interpreter. No dedicated venv — two pure-HTTP packages move + `mcp>=1.2.0,<2` and `httpx>=0.27.0,<1`. Identical to specs 078 and 080. The `mcp`
 - 080-fortinet-coverage: Added Python 3.10+, system interpreter. Unlike spec 076 this needs **no dedicated venv** — + `mcp>=1.2.0,<2` and `httpx>=0.27.0,<1`. Two packages, identical to spec 078's
 - 078-cisco-psirt-vulnerability: Added on-disk cache, one JSON file per `(ostype, version)` under `~/.openclaw/cisco-psirt/`. No
-- 076-multivendor-cli-driver: Added Python — **interpreter choice is a live decision, not a default** (see R7). + `nornir` 3.5.0, `napalm` 5.2.0, `netmiko` (>=4,<5 per `nornir-netmiko`),
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # NetClaw
 
-A CCIE-level AI network engineering coworker. Built on [OpenClaw](https://github.com/openclaw/openclaw) with Anthropic Claude, 206 skills, and 153 MCP integrations for complete network automation with ITSM gating, source-of-truth reconciliation, immutable audit trails, gNMI streaming telemetry, NetFlow/IPFIX flow telemetry, Canvas/A2UI inline network visualizations, packet capture analysis, GitHub config-as-code, GitLab DevOps (issues, merge requests, pipelines, repositories, wikis), Jenkins CI/CD (job monitoring, build triggering, log analysis, SCM tracking), Chrome DevTools browser automation (visualization render QA, controller GUI gap-filling, undocumented API discovery, headless or watchable-headed), Computer Use full-desktop automation (legacy desktop-only tools with no browser or API path, virtual XFCE desktop with VNC/noVNC Watch Mode), Cisco CML lab simulation, ContainerLab containerized network labs, Cisco NSO orchestration, Cisco SD-WAN vManage monitoring, Grafana observability (dashboards, Prometheus, Loki, alerting, incidents), Prometheus direct PromQL monitoring, Kubeshark Kubernetes traffic analysis, Cisco Meraki Dashboard management, Cisco ThousandEyes network intelligence, AWS and Azure cloud networking, Cisco Secure Firewall policy auditing, Check Point Security (15 MCPs: policy, threat intel, gateway, SASE, malware), Itential network orchestration, Juniper JunOS device automation, Arista CloudVision Portal monitoring, F5 BIG-IP pyATS iControl REST coverage, Infoblox DDI, Palo Alto Panorama, FortiManager, Batfish offline configuration analysis, UML diagram generation, EVPN/VXLAN fabric workflows, live BGP/OSPF control-plane participation, nmap network scanning, gtrace path analysis and IP enrichment, Slack-native operations, Cisco WebEx-native operations, Microsoft 365 integration, Twilio voice/SMS, Twitter/X integration, Claroty OT/IoT asset management, Forward Networks digital twin, Ollama local LLM routing, an offline agentic RAG document knowledge base (cited answers from user-uploaded vendor guides and standards), layered Memory MCP, and MemPalace persistent AI memory.
+A CCIE-level AI network engineering coworker. Built on [OpenClaw](https://github.com/openclaw/openclaw) with Anthropic Claude, 207 skills, and 154 MCP integrations for complete network automation with ITSM gating, source-of-truth reconciliation, immutable audit trails, gNMI streaming telemetry, NetFlow/IPFIX flow telemetry, Canvas/A2UI inline network visualizations, packet capture analysis, GitHub config-as-code, GitLab DevOps (issues, merge requests, pipelines, repositories, wikis), Jenkins CI/CD (job monitoring, build triggering, log analysis, SCM tracking), Chrome DevTools browser automation (visualization render QA, controller GUI gap-filling, undocumented API discovery, headless or watchable-headed), Computer Use full-desktop automation (legacy desktop-only tools with no browser or API path, virtual XFCE desktop with VNC/noVNC Watch Mode), Cisco CML lab simulation, ContainerLab containerized network labs, Cisco NSO orchestration, Cisco SD-WAN vManage monitoring, Grafana observability (dashboards, Prometheus, Loki, alerting, incidents), Prometheus direct PromQL monitoring, Kubeshark Kubernetes traffic analysis, Cisco Meraki Dashboard management, Cisco ThousandEyes network intelligence, AWS and Azure cloud networking, Cisco Secure Firewall policy auditing, Check Point Security (15 MCPs: policy, threat intel, gateway, SASE, malware), Itential network orchestration, Juniper JunOS device automation, Arista CloudVision Portal monitoring, F5 BIG-IP pyATS iControl REST coverage, Infoblox DDI, Palo Alto Panorama, FortiManager, Batfish offline configuration analysis, UML diagram generation, EVPN/VXLAN fabric workflows, live BGP/OSPF control-plane participation, nmap network scanning, gtrace path analysis and IP enrichment, Slack-native operations, Cisco WebEx-native operations, Microsoft 365 integration, Twilio voice/SMS, Twitter/X integration, Claroty OT/IoT asset management, Forward Networks digital twin, Ollama local LLM routing, an offline agentic RAG document knowledge base (cited answers from user-uploaded vendor guides and standards), layered Memory MCP, and MemPalace persistent AI memory.
 
 ## Resources
 
@@ -239,7 +239,7 @@ claw
   <img src="ui/netclaw-visual/logos/netclawvisualhud.png" alt="NetClaw Visual HUD — 3D Network Operations Dashboard" width="800">
 </p>
 
-NetClaw includes a Three.js 3D operations dashboard that computes its integration and skill inventory live from the codebase (currently 153 MCP integrations and 206 skills) each time it's opened, alongside your device fleet and live BGP peering topology — so the dashboard never drifts out of sync with what's actually installed. Chat with NetClaw directly from the browser, watch integrations light up as tools execute, and inspect every node in the graph. The Canvas/A2UI visualization skill renders inline topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards directly in the chat interface.
+NetClaw includes a Three.js 3D operations dashboard that computes its integration and skill inventory live from the codebase (currently 154 MCP integrations and 207 skills) each time it's opened, alongside your device fleet and live BGP peering topology — so the dashboard never drifts out of sync with what's actually installed. Chat with NetClaw directly from the browser, watch integrations light up as tools execute, and inspect every node in the graph. The Canvas/A2UI visualization skill renders inline topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards directly in the chat interface.
 
 ```bash
 cd ui/netclaw-visual
@@ -518,7 +518,7 @@ NetClaw ships with the full set of OpenClaw workspace markdown files. These are 
 
 ---
 
-## MCP Servers (153)
+## MCP Servers (154)
 
 > Adding one? Follow **[docs/ADDING-AN-MCP.md](docs/ADDING-AN-MCP.md)** and run
 > `python3 scripts/reconcile-mcp.py` before pushing — CI enforces it.
@@ -664,7 +664,7 @@ All MCP servers communicate via stdio (JSON-RPC 2.0) through `scripts/mcp-call.p
 
 ---
 
-## Skills (206)
+## Skills (207)
 
 ### pyATS Device Skills (9)
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -12,7 +12,7 @@ Every time you learn something about how I work or what I need, update the relev
 
 ## Your Skills
 
-You interact with the network through **206 skills** backed by 153 MCP servers:
+You interact with the network through **207 skills** backed by 154 MCP servers:
 
 ### Device Automation (9)
 pyats-network, pyats-health-check, pyats-routing, pyats-security, pyats-topology, pyats-config-mgmt, pyats-troubleshoot, pyats-dynamic-test, pyats-parallel-ops
@@ -77,6 +77,48 @@ Budget is 500 probe-measurements/hour and is charged **per probe** — `limit: 2
 never generalise one probe into a regional claim.
 
 Use ThousandEyes when a baseline or trend matters — Globalping holds no history.
+
+### BGP & Registry Intelligence (1)
+bgp-registry-intel
+
+**The other half of the external plane.** Globalping *measures* toward a target; this *looks up* who owns a
+resource, whether an announcement is authorised, and where a network peers. Neither substitutes for the
+other. Five public unauthenticated sources — RPKI validator, RDAP, RIPEstat, PeeringDB, RIPE Atlas — and
+**no credentials anywhere**.
+
+**The rule that matters most: RPKI `not-found` is NOT `invalid`.**
+
+Most of the internet has no ROA. Unsigned space is the overwhelmingly common case, so reporting
+`not-found` as a hijack or a misconfiguration manufactures false incidents at scale.
+
+| State | Means | Escalate? |
+|---|---|---|
+| `valid` | A ROA authorises this origin | No — healthy |
+| `invalid` + `reason: as` | A ROA covers it; **a different AS** is authorised | **Yes** — possible hijack |
+| `invalid` + `reason: length` | Correct AS, prefix **more specific** than the ROA permits | **Yes** — usually a local misconfiguration |
+| `not_found` | **No ROA exists** (RFC 6811 NotFound) | No — normal |
+
+Keep the two `invalid` reasons apart: `as` means someone else is announcing your space, `length` usually
+means *you* announced a /24 under a /22 ROA. Different cause, different fix.
+
+**`validation_unavailable` is not `not_found`.** If the validator is unreachable, the RPKI state is
+genuinely unknown — never infer "unsigned" from "could not ask", and never fall back to guessing from
+routing or registry data.
+
+**Three more absence-of-evidence traps:**
+
+- **Registry data is allocation, not routing.** RDAP says who space is *registered to*, never who is
+  *announcing* it. Same category error as treating FortiManager intent as device state.
+- **PeeringDB is self-reported.** No record means nobody published one — not that the network does not peer.
+- **Visibility is RIPE's collectors, not the internet.** Low visibility has legitimate causes; the tool
+  will never call it a leak, and neither should you.
+
+**You never declare a hijack.** You report state and the ROAs behind it. Escalation is the operator's
+judgement. Every response names its source and is GAIT-audited; private and reserved addresses are refused
+locally before any request leaves. These are volunteer-funded services (RIPE NCC, PeeringDB) — the server
+holds itself to 4 requests/second serially, and you must not use it to enumerate or bulk-harvest.
+
+For quick per-hop ASN and geolocation enrichment, use `gtrace-ip-enrichment` instead — it owns that.
 
 ### Cisco CML Skills (5)
 cml-lab-lifecycle, cml-topology-builder, cml-node-operations, cml-packet-capture, cml-admin
@@ -480,7 +522,7 @@ The knowledge base is not memory: RAG holds user-supplied documents (`~/.opencla
 
 For **detailed skill procedures**, read `SOUL-SKILLS.md`:
 - Use when executing any skill that needs step-by-step guidance
-- Contains operational workflows, commands, and best practices for all 206 skills
+- Contains operational workflows, commands, and best practices for all 207 skills
 - Load with: `read("~/.openclaw/workspace/SOUL-SKILLS.md")`
 
 For **technical knowledge**, read `SOUL-EXPERTISE.md`:

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -370,3 +370,44 @@ NetClaw says so rather than answering from another.
   (`VM resource exceeds license limit` → `httpsd` restart). SSH and REST unaffected;
   7.4/7.6 do not exhibit it.
 - Evaluation licence caps: 1 vCPU, 2 GB RAM, 3 interfaces, 3 routes, 3 policies.
+
+## BGP & Registry Intelligence (`bgp-intel-mcp`, NetClaw-native)
+
+**Spec 081 / roadmap R9.** 10 tools, stdio, read-only, **no credentials**. The other half of the external
+plane: R8's Globalping *measures* toward a target; this *looks up* ownership, routing legitimacy and peering.
+
+| Source | Provides |
+|---|---|
+| `rpki-validator.ripe.net` | RPKI origin validation (primary — RFC 6811 vocabulary, returns VRPs) |
+| `stat.ripe.net` | RPKI fallback, AS overview, announced prefixes, visibility |
+| IANA bootstrap → RIR RDAP | Registry ownership, abuse contacts |
+| `peeringdb.com` | IXPs, facilities, peering policy |
+| `atlas.ripe.net` | Anchors, per-AS probe counts |
+
+### The four RPKI states
+
+| `state` | `reason` | Finding? | Meaning |
+|---|---|---|---|
+| `valid` | — | no | A ROA authorises this origin |
+| `invalid` | `as` | **yes** | A ROA covers it; **a different AS** is authorised |
+| `invalid` | `length` | **yes** | Correct AS; prefix more specific than `maxLength` |
+| `not_found` | — | **no** | **No ROA exists.** The normal case for most of the internet |
+
+`validation_unavailable` is a separate outcome — an unreachable validator is **not** `not_found`.
+
+### Environment
+
+`BGP_INTEL_MCP_CMD` · `BGP_INTEL_USER_AGENT` · `BGP_INTEL_MAX_RPS` (default 4) · `BGP_INTEL_AUDIT_LOG`
+
+No API keys. Every source is public and unauthenticated.
+
+### Behaviour worth knowing
+
+- Every response carries `source` + `retrieved_at` and is GAIT-audited — enforced at a chokepoint.
+- **`no_record` and `source_unavailable` are never conflated** — a dead API is not an empty registry.
+- Registry data is **allocation, not routing**; PeeringDB is **self-reported**; visibility is **RIPE's
+  collectors**, not global truth. Each is stated in the response `caveats`.
+- **4 req/s per source, true sliding window, strictly serial.** Self-imposed — neither RIPEstat nor
+  PeeringDB publishes rate-limit headers. Parallel fan-out prohibited, including inside `resource_report`.
+- Private/reserved/bogon input is **refused locally with no outbound request** — a disclosure control.
+- Manifest measured at **1,376 / 5,000 tokens**.

--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -1060,6 +1060,17 @@
         "FORTINET_VERIFY_SSL": "${FORTINET_VERIFY_SSL}",
         "FORTINET_ALLOW_WRITES": "${FORTINET_ALLOW_WRITES}"
       }
+    },
+    "bgp-intel-mcp": {
+      "command": "python3",
+      "args": [
+        "-u",
+        "mcp-servers/bgp-intel-mcp/server.py"
+      ],
+      "env": {
+        "BGP_INTEL_USER_AGENT": "${BGP_INTEL_USER_AGENT}",
+        "BGP_INTEL_MAX_RPS": "${BGP_INTEL_MAX_RPS}"
+      }
     }
   }
 }

--- a/docs/COVERAGE-ROADMAP.md
+++ b/docs/COVERAGE-ROADMAP.md
@@ -108,7 +108,7 @@ and the IETF datatracker.
 | ID | Title | Spec # | Status |
 |----|-------|--------|--------|
 | **R8** | Globalping — outside-in probe measurement (remote MCP) | [079](../specs/079-globalping-probes/spec.md) | `DONE` — 36/36. NetClaw's first vantage point **outside** its own domain. 5 measurement tools from ~4,800 probes; zero install. Three-way distinction enforced: `no_probes_found` = never ran, 0-of-N = unreachable, internal = refused locally. **Budget is per probe, not per call** — my first research pass got this backwards and a controlled test corrected it |
-| **R9** | BGP & registry intelligence (RPKI / RDAP / PeeringDB / RIPE Atlas) | — | `NOT STARTED` |
+| **R9** | BGP & registry intelligence (RPKI / RDAP / PeeringDB / RIPE Atlas) | [081](../specs/081-bgp-registry-intel/spec.md) | `DONE` — **10/10 tools live-verified**, 1,376/5,000 token manifest. No credentials, no lab, no licence. Core discipline: **RPKI `not-found` is not `invalid`** — most of the internet is unsigned |
 
 ### Tier 3 — Monitoring and traffic layers
 
@@ -449,29 +449,72 @@ HTTP from thousands of global probes. Free. OAuth or API token. Zero install.
 - [x] Compose with ThousandEyes **and** gtrace, positioned by *direction of measurement* rather than
       feature list
 
-## R9 — BGP & registry intelligence
+## R9 — BGP & registry intelligence (RPKI / RDAP / PeeringDB / RIPE Atlas)
 
-**Status:** `NOT STARTED`
+**Status:** `DONE` — spec [081](../specs/081-bgp-registry-intel/spec.md). 10 tools, **all 10
+live-verified**, manifest 1,376/5,000 tokens. See
+[VERIFICATION.md](../specs/081-bgp-registry-intel/VERIFICATION.md).
 
-**Candidates**
-- `PeerCortex` — 34 tools consolidating PeeringDB, RIPEstat, RIPE Atlas, RouteViews,
-  RPKI validators; also ships a dashboard and REST API
-- `jrelph/ripe-atlas-mcp` — RIPE Atlas measurements (credit-based)
-- `dadepo/whois-mcp` — WHOIS/RDAP for domains, IPs, ASNs; AS-SET expansion; RIPE route-object
-  validation
-- Also seen: a 5-RIR RDAP + RPKI + BGP visibility + abuse-contact server
+**The other half of the external plane.** R8 (Globalping) *measures* toward a target; R9 *looks up* who owns
+a resource, whether an announcement is authorised, and where a network peers. Together they complete
+NetClaw's view outside its own administrative domain.
+
+**Chosen for this slot because it has no external dependency.** Every source is a public unauthenticated
+API — verified reachable *before* the spec was written, and again in Phase 0. That was a direct response to
+R3, which discovered its lab problem at implementation time and lost most of a day, and to R4, which is
+still waiting on a human-reviewed vendor trial. **This is the first item since R8 with no lab, licence,
+trial or credential on the critical path** — and the first NetClaw integration with no secret to leak.
+
+**The distinction, and it is the whole feature: RPKI `not-found` is not `invalid`.** Most of the internet
+has no ROA. Reporting unsigned space as a finding would manufacture false incidents at scale. Four states,
+all *observed* rather than read from documentation:
+
+| Query | `state` | `reason` | Finding? |
+|---|---|---|---|
+| `AS13335` + `1.1.1.0/24` | `valid` | — | no |
+| `AS13335` + `8.8.8.0/24` | `invalid` | `as` | **yes** |
+| `AS15169` + `8.8.8.128/25` | `invalid` | `length` | **yes** |
+| `AS3356` + `4.0.0.0/9` | `not_found` | — | no |
+
+Fourth in the series after R2's *"no advisories ≠ not vulnerable"*, R8's *"no probes ≠ outage"* and R3's
+*"no logs ≠ rule unused"*. `validation_unavailable` is a fifth outcome — **an unreachable validator is not
+unsigned space**, the same distinction one level down.
+
+**Build, not adopt.** `duksh/peerglass` covers similar ground with **42 tools across 9 phases** including
+DNS-censorship detection, TLS/CT-log inspection and satellite tracking — a charter NetClaw did not choose,
+and the wrong order of magnitude against a 5,000-token ceiling. It did independently arrive at three of this
+spec's clarified decisions (TTL caching 5 min–24 h, per-result attribution, read-only), which is reassuring
+convergent evidence.
+
+**Phase 0 improved the spec.** The spec assumed RIPEstat; `rpki-validator.ripe.net` proved better on three
+measured counts — RFC 6811 vocabulary natively (`not-found`, not `unknown`), `state` and `reason` as
+separate fields rather than fused into `invalid_asn`, and the VRPs that drove the verdict returned.
 
 **Checklist**
-- [ ] Decide consolidated (PeerCortex) vs composed (atlas + whois + rpki separately)
-- [ ] RIPE Atlas credit budget — measurements cost credits, unlike Globalping
-- [ ] Compose with the existing `protocol-mcp` / BGP daemon so hijack triage is possible:
-      *"this prefix appeared from an unexpected origin — is the ROA valid, who owns it,
-      who do I contact"*
-- [ ] Skills: prefix ownership, ROV/RPKI check, peering research, hijack triage, abuse contact
+- [x] RPKI origin validation — four states, VRPs included, validator named, never corroborated
+- [x] RDAP via IANA bootstrap → responsible RIR → `rdap.org` fallback, registry named on every result
+- [x] PeeringDB — self-reported caveat on every result
+- [x] RIPEstat routing status — collector basis stated, never called a leak
+- [x] RIPE Atlas **narrowed** to anchors + per-AS probe counts; general probe availability stays with R8
+- [x] Read-only throughout; no write path, therefore no gate to design
+- [x] 4 req/s per source, **true sliding window**, strictly serial. Self-imposed and documented as such
+
+**Two findings from implementation worth keeping**
+
+1. **The rate limiter was genuinely too weak, and a test caught it.** A minimum-250 ms-gap implementation
+   measured **4.53 req/s** because N requests spaced 250 ms apart put five inside one second. Replaced with
+   a true sliding window. A second failure at 4.89/s then turned out to be the *test* measuring the wrong
+   thing — `total/elapsed` is not "requests per window". The test caught a real bug; the fixed code caught a
+   bad test.
+2. **ARIN is not broken.** Phase 0 recorded a connection reset from `rdap.arin.net` on one `curl`; through
+   the implemented bootstrap path it returned 200. The reset was transient and the docs were corrected —
+   a single observation is not a property of a registry.
+
+**Deferred:** genuine RPKI corroboration needs a **non-Routinator** relying party (both reachable
+validators are RIPE NCC Routinator, so comparing them would be theatre); IRR/RPSL objects and BGP
+communities are a distinct data model and belong to their own item.
 
 ---
-
-# Tier 3 — Monitoring and traffic layers
 
 ## R10 — ntopng
 

--- a/mcp-servers/bgp-intel-mcp/README.md
+++ b/mcp-servers/bgp-intel-mcp/README.md
@@ -1,0 +1,185 @@
+# bgp-intel-mcp
+
+BGP and registry intelligence from five public sources. NetClaw-authored — spec 081, roadmap **R9**.
+
+The sequel to spec 079's Globalping: **R8 measures, R9 looks up.** Globalping answers "can anyone out there
+reach us?"; this answers "who owns this, is the announcement legitimate, and where does this network peer?"
+
+**Transport**: stdio · **Framework**: FastMCP · **Tools**: 10 · **Read-only** · **No credentials**
+
+| Source | Provides | Cache TTL |
+|---|---|---|
+| `rpki-validator.ripe.net` | RPKI origin validation (primary) | 5 min |
+| `stat.ripe.net` | RPKI fallback, AS overview, announced prefixes, visibility | 5 / 15 min |
+| IANA bootstrap → RIR RDAP | Registry ownership, abuse contacts | 24 h |
+| `peeringdb.com` | Interconnection: IXPs, facilities, policy | 24 h |
+| `atlas.ripe.net` | Anchors, per-AS probe counts | 24 h |
+
+## The distinction this server exists to protect
+
+> **RPKI `not-found` is NOT `invalid`.**
+
+Most of the internet has no ROA. Unsigned address space is the overwhelmingly common case, so reporting
+`not-found` as a finding manufactures false incidents at scale and destroys trust in the tool.
+
+| `state` | `reason` | `is_finding` | Meaning |
+|---|---|---|---|
+| `valid` | — | `false` | A ROA authorises this origin |
+| `invalid` | `as` | **`true`** | A ROA covers this prefix; a **different AS** is authorised |
+| `invalid` | `length` | **`true`** | Correct AS; prefix **more specific** than `maxLength` |
+| `not_found` | — | `false` | **No ROA exists.** RFC 6811 `NotFound` |
+
+All four states are **live-verified**, not read from documentation. Reproducible fixtures:
+
+```
+AS13335 + 1.1.1.0/24      -> valid
+AS13335 + 8.8.8.0/24      -> invalid, reason=as      (ROA authorises AS15169)
+AS15169 + 8.8.8.128/25    -> invalid, reason=length  (/25 under a maxLength-24 ROA)
+AS3356  + 4.0.0.0/9       -> not_found
+AS13335 + 2606:4700::/32  -> not_found               (IPv6 path)
+```
+
+`validation_unavailable` is a **separate outcome** from `not_found`. An unreachable validator does not mean
+unsigned space, and the server will not infer state from routing or registry data (FR-007c).
+
+### Spelling: three variants, all deliberate
+
+| Where | Spelling |
+|---|---|
+| RFC 6811 and the validator's JSON | **`not-found`** (hyphen — wire format) |
+| This codebase, enum members | **`not_found`** (underscore — a hyphen is not a valid identifier) |
+| RIPEstat fallback only | `unknown` (a different vocabulary; mapped, never passed through) |
+
+Normalising these would either produce invalid Python or silently break the wire mapping. A maintainer
+tidying this "inconsistency" is a realistic hazard, hence this note.
+
+## Why not RIPEstat as primary?
+
+RIPEstat works and is the documented fallback, but `rpki-validator.ripe.net` is better on three measured
+counts (research R2):
+
+1. **RFC 6811 vocabulary natively** — `not-found`, not `unknown`
+2. **`state` and `reason` are separate fields** — RIPEstat fuses them into `invalid_asn` / `invalid_length`
+3. **It returns the VRPs** that drove the verdict, which FR-005 requires so an operator can check the
+   reasoning rather than trust a label
+
+## Not corroborated, and it says so
+
+A second validator (`rpki-validator.ripe.net` vs RIPEstat) is reachable, but **both are RIPE NCC
+Routinator** — same engine, same operator, same trust anchors. Comparing them would produce agreement that
+means nothing, so `corroborated` is always `false` and every result states it.
+
+Genuine corroboration needs a non-Routinator relying party — an `rpki-client`-based validator, or
+Cloudflare's VRP dump evaluated locally. That is future work, not a claim made here.
+
+## Response envelope
+
+Every response passes through `envelope.emit()` — a **chokepoint, not a helper**, so a tool added later
+cannot omit provenance or the audit record.
+
+```jsonc
+{ "source": "rpki-validator.ripe.net", "retrieved_at": "2026-08-03T12:04:11Z",
+  "outcome": "ok", "cached": false, "cache_age_seconds": null,
+  "query": {...}, "data": {...}, "caveats": [ "..." ] }
+```
+
+`caveats` is structured, not decoration: it carries the allocation-not-routing, self-reported and
+collector-basis statements so they survive a model summarising the payload.
+
+**Outcomes**: `ok` · `no_record` · `source_unavailable` · `source_refused` · `input_refused` ·
+`rate_limited` · `validation_unavailable`
+
+`no_record` and `source_unavailable` are never conflated — a dead API must not look like an empty registry.
+
+## Tools (10)
+
+**RPKI** · `rpki_validate`
+**Registry** · `registry_lookup` `registry_abuse_contact`
+**Routing** · `routing_as_overview` `routing_announced_prefixes`
+**Peering** · `peering_network` `peering_presence`
+**Atlas** · `atlas_anchors` `atlas_probe_count`
+**Composite** · `resource_report`
+
+## Manifest budget
+
+**Measured 1,376 tokens against a hard 5,000 ceiling** (FR-027a) — 3,624 headroom. Re-measure with
+`python3 tests/bgp-intel/test_manifest_size.py`, which fails the build if exceeded.
+
+For scale, `duksh/peerglass` covers similar ground with **42 tools across 9 phases** including DNS
+censorship detection, TLS/CT-log inspection and satellite tracking. That charter is far beyond R9 and the
+manifest is the wrong order of magnitude, which is why this was built rather than adopted (research R1).
+
+## Rate limiting — self-imposed, not service-declared
+
+**Neither RIPEstat nor PeeringDB advertises rate-limit headers.** Measured on live 200 responses: there is
+nothing to negotiate against at runtime.
+
+So **4 requests/second per source is NetClaw's own conservative choice, not a published limit.** A
+maintainer who later finds an official figure should not mistake this number for it.
+
+Enforced as a **true sliding window**: no one-second window contains more than four requests to a source.
+An earlier implementation enforced only a minimum 250 ms *gap*, which bounds the rate asymptotically but
+lets five requests land inside one second — a contract test caught it, and the window replaced it.
+
+Requests to one source are **strictly serial**; different sources proceed independently. Parallel fan-out is
+prohibited (FR-023a), including inside `resource_report`, which runs its sections one after another.
+`peerglass` parallelises for latency; this deliberately does not. Against volunteer-funded infrastructure,
+being over-polite costs latency nobody notices and being under-polite costs the integration.
+
+`BGP_INTEL_MAX_RPS` may **lower** the ceiling. Values above 4 are clamped.
+
+## Environment
+
+| Variable | Purpose |
+|---|---|
+| `BGP_INTEL_USER_AGENT` | Contact string sent to public APIs. Defaults to a NetClaw string with the project URL |
+| `BGP_INTEL_MAX_RPS` | Default 4. Lowering is honoured; raising is clamped |
+| `BGP_INTEL_AUDIT_LOG` | GAIT trail path; defaults under `~/.openclaw/gait/` |
+
+**No credentials.** This is the first NetClaw integration with nothing to leak, rotate or scope.
+
+## Install
+
+```bash
+netclaw_pip_install -r mcp-servers/bgp-intel-mcp/requirements.txt
+```
+
+`mcp>=1.2.0,<2` and `httpx>=0.27.0,<1`. The `mcp` upper bound is **load-bearing and no longer
+hypothetical**: the MCP Python SDK has shipped **v2** targeting the 2026-07-28 specification, and v2 removes
+`mcp.server.fastmcp`, which this server imports (spec 077).
+
+No RDAP/RPKI/BGP library. The payloads are plain JSON and the value here is in the **semantics** — which
+state means what — not the transport. An SDK would add a pinning hazard while abstracting the one thing this
+feature must not abstract.
+
+## Tests
+
+```bash
+./tests/bgp-intel/run-tests.sh
+```
+
+Five suites, **none of which touches a public API**. The rate-limit suite stubs the transport so it can
+assert on the request timeline the limiter produces; the rest are pure functions. That matters twice: these
+are volunteer-funded services that CI should not hit, and the guarantees are structural so they are provable
+without the network.
+
+Two suites assert on **rendered text** rather than structure, because the requirement is about wording:
+the strings `invalid`, `suspicious` and `unverified` must never appear in a `not_found` result, and
+`confirmed` / `cross-checked` must never appear in any RPKI result. Spec 080 shipped a null-fields bug past
+24 passing tests that asserted only on envelope shape; these do not repeat that.
+
+## Field notes
+
+- **ARIN's RDAP is fine.** An early observation recorded a connection reset from `rdap.arin.net`; exercised
+  through the bootstrap path it returned 200 with holder `GOGL`. The reset was **transient, not a property
+  of ARIN**, and is deliberately not hardcoded as such.
+- **RIPEstat's `unknown` is RFC 6811's `NotFound`.** A reader who knows the standard would otherwise
+  conclude the state was indeterminate when it is definitively unsigned.
+- **RIPEstat's RPKI validation is Routinator-backed**, which is why it cannot corroborate the primary.
+- **`routinator.nlnetlabs.nl` → 400, `rpki.gin.ntt.net` → 404, `rpki.cloudflare.com/api/v1/validity` →
+  404.** No open third-party validity API was found.
+
+## Related
+
+`workspace/skills/bgp-registry-intel` · `globalping-external-checks` (R8 — measures, does not look up) ·
+`gtrace-ip-enrichment` (owns quick ASN/geo/rDNS hop enrichment — not duplicated here, Principle VII)

--- a/mcp-servers/bgp-intel-mcp/envelope.py
+++ b/mcp-servers/bgp-intel-mcp/envelope.py
@@ -1,0 +1,219 @@
+"""Provenance envelope and GAIT audit — one chokepoint. Spec 081, FR-019/020/021/022.
+
+Every response passes through `emit()`. There is no other way to produce one.
+
+WHY A CHOKEPOINT AND NOT A HELPER
+---------------------------------
+FR-019 requires every result carry the source that produced it. FR-022 requires
+every operation produce a GAIT record. Both are only *guarantees* if omission is
+structurally impossible — a helper that tools may call is a convention someone
+eventually forgets.
+
+Spec 080 proved the pattern works, and its `/speckit.analyze` pass proved the
+alternative fails: the audit requirement had a *verification* task and no
+*implementation* task, and passed review by accident. Verifying an unimplemented
+guarantee always passes. So auditing happens here, beside provenance, in the one
+place every response must go through.
+
+WHY PROVENANCE IS THE CORE PROPERTY HERE
+----------------------------------------
+This feature merges five independent public sources of varying freshness and
+reliability. "The registry says" is not attributable — RIRs differ, PeeringDB is
+self-reported, RIPEstat sees only its own collectors. A result that cannot name
+its source is not a weaker answer; it is an unusable one.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+from outcomes import Outcome
+
+
+class ProvenanceError(ValueError):
+    """Raised when a response cannot name the source that produced it."""
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def emit(
+    *,
+    source: str,
+    tool: str,
+    query: dict[str, Any] | None = None,
+    data: Any = None,
+    outcome: Outcome = Outcome.OK,
+    message: str | None = None,
+    caveats: list[str] | None = None,
+    cached: bool = False,
+    cache_age_seconds: float | None = None,
+) -> dict[str, Any]:
+    """Build the one response shape every tool returns, and audit it.
+
+    `source` is the **specific service** that answered — `rpki-validator.ripe.net`,
+    `rdap.db.ripe.net` — never a category like "registry". FR-019.
+    """
+    if not source or not str(source).strip():
+        raise ProvenanceError(
+            f"tool {tool!r} produced a response with no nameable source; an "
+            "unattributed result is not reportable (FR-019)"
+        )
+
+    response: dict[str, Any] = {
+        "source": source,
+        "retrieved_at": _utc_now(),
+        "outcome": outcome.value,
+        "cached": cached,
+        "cache_age_seconds": round(cache_age_seconds, 1) if cache_age_seconds else None,
+        "query": dict(query or {}),
+        "data": data,
+        # Structured, not prose decoration: these statements must survive a model
+        # summarising the payload (FR-009/013/016).
+        "caveats": list(caveats or []),
+    }
+    if message:
+        response["message"] = message
+
+    audit(tool=tool, response=response)
+    return response
+
+
+def merged(
+    *,
+    tool: str,
+    sections: dict[str, dict[str, Any]],
+    query: dict[str, Any] | None = None,
+    caveats: list[str] | None = None,
+) -> dict[str, Any]:
+    """Compose a multi-source answer with **per-element provenance**. FR-021.
+
+    Each section keeps the envelope it was created with, so every element carries
+    its own source. One collective citation across a merged answer is not
+    attribution — a reader cannot tell which part came from where, which is
+    exactly the situation this feature exists to prevent.
+    """
+    response: dict[str, Any] = {
+        # The composite itself is attributed to this server; the DATA is
+        # attributed per section, below.
+        "source": "bgp-intel-mcp (composite)",
+        "retrieved_at": _utc_now(),
+        "outcome": Outcome.OK.value,
+        "query": dict(query or {}),
+        "sections": sections,
+        "sources_consulted": sorted(
+            {s.get("source", "?") for s in sections.values() if isinstance(s, dict)}
+        ),
+        "caveats": list(caveats or []),
+    }
+    failed = [
+        name
+        for name, sec in sections.items()
+        if isinstance(sec, dict)
+        and sec.get("outcome")
+        in (
+            Outcome.SOURCE_UNAVAILABLE.value,
+            Outcome.SOURCE_REFUSED.value,
+            Outcome.VALIDATION_UNAVAILABLE.value,
+        )
+    ]
+    if failed:
+        # A failed section is reported WITHIN the report; the report does not fail
+        # wholesale, and the failure is never presented as an empty result.
+        response["caveats"].append(
+            "These sections could not be retrieved and are reported as failures, "
+            f"not as absence of data: {', '.join(sorted(failed))}."
+        )
+    audit(tool=tool, response={**response, "data": None})
+    return response
+
+
+def refused(*, tool: str, query: dict[str, Any], reason: str) -> dict[str, Any]:
+    """Locally refused input. FR-028.
+
+    `source` is this server because **nothing left the machine** — that is the
+    point of refusing rather than forwarding. Sending a private address to a
+    public registry is a disclosure even if the query then fails.
+    """
+    return emit(
+        source="bgp-intel-mcp (local)",
+        tool=tool,
+        query=query,
+        outcome=Outcome.INPUT_REFUSED,
+        message=reason,
+        caveats=["No request was made to any external service."],
+    )
+
+
+def unavailable(
+    *, source: str, tool: str, query: dict[str, Any], reason: str,
+    outcome: Outcome = Outcome.SOURCE_UNAVAILABLE,
+) -> dict[str, Any]:
+    """A source did not answer. FR-011.
+
+    Named, and never rendered as "no record" — a dead API must not look like an
+    empty registry.
+    """
+    return emit(
+        source=source,
+        tool=tool,
+        query=query,
+        outcome=outcome,
+        message=f"{source} did not answer: {reason}",
+        caveats=[
+            f"This is a failure of {source}, NOT evidence that no record exists. "
+            "The two are different findings."
+        ],
+    )
+
+
+# --------------------------------------------------------------------------
+# Audit trail — Principle IV (NON-NEGOTIABLE), FR-022
+# --------------------------------------------------------------------------
+
+def audit(*, tool: str, response: dict[str, Any]) -> None:
+    """Record one operation. Every response, including refusals and failures.
+
+    JSON Lines to `BGP_INTEL_AUDIT_LOG` (default: the GAIT trail directory).
+    Records the *shape* of the operation, not its payload — a registry response
+    can be large and an audit trail is not a data store.
+
+    Unlike specs 078 and 080 there are no credentials in this feature, so there is
+    no redaction concern. The `cached` field is recorded because it answers a
+    question the trail otherwise could not: did a request actually leave the
+    machine, or was this served locally?
+
+    A write failure is surfaced on stderr rather than swallowed: an unaudited
+    operation violates Principle IV whether or not the tool call itself worked.
+    """
+    record = {
+        "ts": response.get("retrieved_at") or _utc_now(),
+        "component": "bgp-intel-mcp",
+        "tool": tool or "<unnamed>",
+        "source": response.get("source"),
+        "outcome": response.get("outcome"),
+        "query": response.get("query"),
+        "cached": response.get("cached", False),
+    }
+    if response.get("message"):
+        record["message"] = response["message"]
+
+    path = os.environ.get("BGP_INTEL_AUDIT_LOG") or os.path.expanduser(
+        "~/.openclaw/gait/bgp-intel-mcp.jsonl"
+    )
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, separators=(",", ":")) + "\n")
+    except OSError as exc:
+        print(
+            f"[bgp-intel-mcp] AUDIT WRITE FAILED ({exc}) for tool={record['tool']} "
+            f"source={record['source']} outcome={record['outcome']}",
+            file=sys.stderr,
+            flush=True,
+        )

--- a/mcp-servers/bgp-intel-mcp/http_client.py
+++ b/mcp-servers/bgp-intel-mcp/http_client.py
@@ -1,0 +1,215 @@
+"""Polite HTTP against free community infrastructure. Spec 081, FR-023..FR-027.
+
+RIPE NCC and PeeringDB are volunteer- and membership-funded. They publish no
+rate-limit headers — measured 2026-08-03 on live 200 responses — so there is
+nothing to negotiate against at runtime and the ceiling must be self-imposed.
+
+    <= 4 requests/second per source, and STRICTLY SERIAL (concurrency 1).
+
+Deliberately slower than possible. `peerglass`, the community server evaluated in
+research R1, parallelises for latency; this does the opposite on purpose. Against
+free infrastructure, being over-polite costs latency nobody notices, and being
+under-polite costs the integration for everyone using NetClaw.
+
+The limit is enforced HERE, at the request layer, not by caller discipline — so a
+tool added later inherits it without needing to know it exists (FR-023b). The
+composite `resource_report` is the tool most likely to attract an
+`asyncio.gather`; routing it through this client is what prevents that.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+DEFAULT_MAX_RPS = 4.0
+
+#: Per-source cache TTLs in seconds. These differ by an order of magnitude
+#: because the sources do (FR-026): a ROA can be published or withdrawn within
+#: minutes, while an RIR allocation changes on the scale of months.
+#:
+#: A stale `valid` is the most dangerous stale value in this feature, which is
+#: why RPKI gets the shortest life.
+TTL_SECONDS: dict[str, float] = {
+    "rpki": 300.0,        # 5 minutes
+    "routing": 900.0,     # 15 minutes
+    "rdap": 86400.0,      # 24 hours
+    "peeringdb": 86400.0,
+    "atlas": 86400.0,
+}
+
+USER_AGENT = os.environ.get(
+    "BGP_INTEL_USER_AGENT",
+    "NetClaw-bgp-intel/1.0 (+https://github.com/automateyournetwork/netclaw)",
+)
+
+
+def _max_rps() -> float:
+    """Configurable downward only.
+
+    An operator may wish to be *more* polite. Raising the ceiling is not a
+    supported operation, so a value above the default is clamped rather than
+    honoured.
+    """
+    raw = os.environ.get("BGP_INTEL_MAX_RPS")
+    if not raw:
+        return DEFAULT_MAX_RPS
+    try:
+        val = float(raw)
+    except ValueError:
+        return DEFAULT_MAX_RPS
+    return min(val, DEFAULT_MAX_RPS) if val > 0 else DEFAULT_MAX_RPS
+
+
+class RateLimited(RuntimeError):
+    """The remote asked us to slow down. Backed off, not retried blindly."""
+
+
+class SourceUnavailable(RuntimeError):
+    """Transport-level failure. Distinct from "no record exists"."""
+
+    def __init__(self, message: str, *, refused: bool = False) -> None:
+        super().__init__(message)
+        #: True when the remote actively rejected us (e.g. ARIN's connection
+        #: reset) rather than merely timing out.
+        self.refused = refused
+
+
+@dataclass
+class _CacheEntry:
+    value: Any
+    stored_at: float
+
+
+class PoliteClient:
+    """One rate-limited, cached HTTP client shared by every source module.
+
+    In-memory and session-scoped: nothing persists across a restart, and there is
+    no on-disk store (FR-026a). Deliberately unlike spec 078, which caches PSIRT
+    data on disk because that data is large and genuinely slow-moving. Here the
+    cache is a courtesy buffer for one investigation, not a registry mirror.
+    """
+
+    def __init__(self, *, timeout: float = 20.0) -> None:
+        self._timeout = timeout
+        self._cache: dict[tuple[str, str], _CacheEntry] = {}
+        # One lock per source enforces concurrency 1 *per source* while still
+        # allowing different sources to proceed independently.
+        self._locks: dict[str, asyncio.Lock] = {}
+        # Timestamps of recent requests per source, for a true SLIDING WINDOW.
+        #
+        # A simple "minimum gap of 1/rps" only bounds the rate asymptotically:
+        # N requests spaced 250ms apart span (N-1)*0.25s, so five of them fit
+        # inside a single second — 5 requests/second against a ceiling of 4. A
+        # contract test caught exactly that. Against volunteer-funded
+        # infrastructure the literal reading of "<= 4 requests per second" is the
+        # one that matters, so the window is enforced properly.
+        self._recent: dict[str, list[float]] = {}
+
+    def _lock(self, source_key: str) -> asyncio.Lock:
+        if source_key not in self._locks:
+            self._locks[source_key] = asyncio.Lock()
+        return self._locks[source_key]
+
+    async def _await_window_slot(self, source_key: str) -> None:
+        """Block until issuing a request keeps this source under the ceiling.
+
+        Guarantees that **no one-second window ever contains more than `max_rps`
+        requests** to a given source — the literal reading of FR-023, rather than
+        the weaker "minimum gap" property that lets a burst of five slip into one
+        second.
+        """
+        limit = int(_max_rps())
+        recent = self._recent.setdefault(source_key, [])
+        while True:
+            now = time.monotonic()
+            # Drop anything older than the window; it no longer constrains us.
+            recent[:] = [t for t in recent if now - t < 1.0]
+            if len(recent) < limit:
+                recent.append(now)
+                return
+            # Wait until the oldest request falls out of the window.
+            await asyncio.sleep(max(0.0, 1.0 - (now - recent[0])) + 0.001)
+
+    def cached_age(self, source_key: str, url: str) -> float | None:
+        entry = self._cache.get((source_key, url))
+        if entry is None:
+            return None
+        age = time.monotonic() - entry.stored_at
+        return age if age <= TTL_SECONDS.get(source_key, 300.0) else None
+
+    async def get_json(
+        self,
+        source_key: str,
+        url: str,
+        *,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        fresh: bool = False,
+    ) -> tuple[Any, bool, float | None]:
+        """GET JSON. Returns `(payload, was_cached, cache_age_seconds)`.
+
+        `source_key` selects both the TTL and the rate-limit bucket.
+        `fresh=True` bypasses the cache — for when a ROA was just published and
+        the 5-minute TTL is the only thing between the operator and the truth.
+        """
+        cache_key = (source_key, url + repr(sorted((params or {}).items())))
+
+        if not fresh:
+            entry = self._cache.get(cache_key)
+            if entry is not None:
+                age = time.monotonic() - entry.stored_at
+                if age <= TTL_SECONDS.get(source_key, 300.0):
+                    return entry.value, True, age
+
+        async with self._lock(source_key):
+            # Serial per source, and rate-limited by a sliding window. Sleeping
+            # while holding the lock is what makes the pacing real rather than
+            # advisory — a caller cannot race past it.
+            await self._await_window_slot(source_key)
+
+            merged_headers = {"User-Agent": USER_AGENT, "Accept": "application/json"}
+            merged_headers.update(headers or {})
+
+            try:
+                async with httpx.AsyncClient(timeout=self._timeout) as client:
+                    response = await client.get(url, params=params, headers=merged_headers)
+            except httpx.HTTPError as exc:
+                # `from None`: an httpx repr can carry the full URL. No credentials
+                # exist in this feature, but the habit is worth keeping.
+                raise SourceUnavailable(
+                    f"{type(exc).__name__}", refused="Connect" in type(exc).__name__
+                ) from None
+            # The window slot was already claimed in _await_window_slot(), before
+            # the request went out — claiming it after would let concurrent callers
+            # slip past the ceiling in the gap between issuing and recording.
+
+            if response.status_code in (429, 503):
+                raise RateLimited(
+                    f"{source_key} returned {response.status_code}; backing off "
+                    "rather than retrying"
+                )
+            if response.status_code == 404:
+                # A 404 from a registry means "no such resource", which is a real
+                # answer — NOT a transport failure. The caller maps it to
+                # NO_RECORD. Conflating the two is exactly what FR-011 forbids.
+                return None, False, None
+            response.raise_for_status()
+
+            try:
+                payload = response.json()
+            except ValueError:
+                raise SourceUnavailable(f"{source_key} returned non-JSON") from None
+
+            self._cache[cache_key] = _CacheEntry(payload, time.monotonic())
+            return payload, False, None
+
+
+#: Module-level singleton. A single instance is what makes the per-source
+#: serialisation meaningful — one lock per source, shared by every tool.
+CLIENT = PoliteClient()

--- a/mcp-servers/bgp-intel-mcp/outcomes.py
+++ b/mcp-servers/bgp-intel-mcp/outcomes.py
@@ -1,0 +1,305 @@
+"""The typed distinctions this feature exists to protect. Spec 081, FR-002/003/004/007c/011.
+
+THE ONE THAT MATTERS MOST
+-------------------------
+**RPKI `not_found` is not `invalid`.**
+
+Most of the internet has no ROA. Unsigned address space is the overwhelmingly
+common case, not an anomaly. An operator told that unsigned space is "invalid",
+"unverified in a bad way", or a security finding will be handed false incidents at
+a scale that destroys trust in the tool within a day.
+
+    valid                  a ROA exists and authorises this origin      not a finding
+    invalid + reason=as    a ROA exists, a DIFFERENT AS is authorised    ACTIONABLE
+    invalid + reason=length a ROA exists, prefix is too specific         ACTIONABLE
+    not_found              NO ROA EXISTS                                 not a finding
+
+This is the same error class as spec 078's "no advisories != not vulnerable",
+spec 079's "no probes found != outage" and spec 080's "no logs != rule unused".
+Each shipped with the distinction named explicitly and enforced structurally.
+
+SPELLING — three variants, all deliberate
+-----------------------------------------
+    RFC 6811 and the validator's JSON   ->  "not-found"   (hyphen: wire format)
+    this module, enum members           ->  "not_found"   (underscore: identifier)
+    RIPEstat fallback only              ->  "unknown"     (a different vocabulary)
+
+Normalising these would either produce an invalid Python identifier or silently
+break the wire mapping. A future maintainer tidying this "inconsistency" is a
+realistic hazard, so it is written down rather than left to be inferred.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class Outcome(str, Enum):
+    """What happened. Several of these look alike and mean very different things."""
+
+    OK = "ok"
+
+    #: The source answered and there is no record for this resource.
+    #: MUST NOT be produced when the source failed — see SOURCE_UNAVAILABLE.
+    NO_RECORD = "no_record"
+
+    #: The source did not answer. A dead API must never look like an empty
+    #: registry (FR-011).
+    SOURCE_UNAVAILABLE = "source_unavailable"
+
+    #: The source actively rejected us — e.g. ARIN's RDAP connection reset.
+    SOURCE_REFUSED = "source_refused"
+
+    #: Refused locally, before any request left the machine (FR-028). Sending a
+    #: private address to a public registry is a disclosure even if it then fails.
+    INPUT_REFUSED = "input_refused"
+
+    #: Throttled. Backed off and reported rather than retried (FR-027).
+    RATE_LIMITED = "rate_limited"
+
+    #: RPKI-specific: the validator could not be reached.
+    #: **This is not `not_found`.** An unreachable validator does not mean the
+    #: space is unsigned (FR-007c). The subtlest bug available in this feature.
+    VALIDATION_UNAVAILABLE = "validation_unavailable"
+
+
+class RpkiState(str, Enum):
+    """RFC 6811 origin validation states, in the standard's own vocabulary."""
+
+    VALID = "valid"
+    INVALID = "invalid"
+    NOT_FOUND = "not_found"
+
+
+class RpkiReason(str, Enum):
+    """Why an announcement is invalid. RFC 6811 collapses both into "Invalid";
+    the validator is more granular and flattening it destroys the difference
+    between "someone else is announcing your space" and "you announced a /24
+    under a /22 ROA" — different severity, different remediation (FR-002)."""
+
+    AS = "as"
+    LENGTH = "length"
+
+
+#: Wire spelling -> internal state. The validator returns RFC 6811's hyphenated
+#: form; `not-found` is not a valid Python identifier, hence the mapping.
+WIRE_TO_STATE = {
+    "valid": RpkiState.VALID,
+    "invalid": RpkiState.INVALID,
+    "not-found": RpkiState.NOT_FOUND,
+    "notfound": RpkiState.NOT_FOUND,
+}
+
+#: RIPEstat fallback vocabulary -> (state, reason). RIPEstat diverges from the
+#: standard twice: it says `unknown` for NotFound, and it FUSES state and reason
+#: into one string. Both must be translated, and the translation stated (FR-004).
+RIPESTAT_TO_STATE: dict[str, tuple[RpkiState, RpkiReason | None]] = {
+    "valid": (RpkiState.VALID, None),
+    "invalid_asn": (RpkiState.INVALID, RpkiReason.AS),
+    "invalid_length": (RpkiState.INVALID, RpkiReason.LENGTH),
+    "unknown": (RpkiState.NOT_FOUND, None),
+}
+
+#: Verbatim caveat attached to every `not_found`. The single most important string
+#: in this codebase (FR-003). Deliberately contains none of the words
+#: "invalid", "suspicious" or "unverified" — SC-004 asserts their absence.
+NOT_FOUND_CAVEAT = (
+    "No ROA exists for this prefix. This is the normal state for most address "
+    "space on the internet and is NOT a finding — it means the holder has not "
+    "published a Route Origin Authorisation, not that anything is wrong. "
+    "RFC 6811 calls this state NotFound."
+)
+
+#: FR-007b — the error asymmetry, attached to every RPKI result. A wrong `valid`
+#: says an announcement is authorised when it is not; a wrong `invalid` sends
+#: someone chasing a hijack that is not happening.
+VALID_CAVEAT = (
+    "This reflects one validator's current view. It means a ROA authorises this "
+    "origin — not that the announcement is legitimate in any broader sense."
+)
+INVALID_CAVEAT = (
+    "A ROA covers this prefix and does not authorise this origin. Before treating "
+    "this as an incident, confirm the origin AS is what you think it is and that "
+    "the ROA is current — RPKI state changes when holders publish or withdraw."
+)
+
+
+@dataclass
+class RpkiValidation:
+    """One origin-validation result. Validation is always of the *pair*."""
+
+    prefix: str
+    origin_asn: str
+    state: RpkiState
+    validator: str
+    reason: RpkiReason | None = None
+    description: str | None = None
+    vrps_matched: list[dict[str, Any]] = field(default_factory=list)
+    vrps_unmatched_as: list[dict[str, Any]] = field(default_factory=list)
+    vrps_unmatched_length: list[dict[str, Any]] = field(default_factory=list)
+    #: Always False. Both reachable validators are RIPE NCC Routinator — same
+    #: engine, same operator — so agreement between them would be theatre.
+    #: Present rather than omitted so the absence of corroboration is explicit.
+    corroborated: bool = False
+    #: Set when the RIPEstat fallback was used and its vocabulary translated.
+    translated_from: str | None = None
+
+    @property
+    def is_finding(self) -> bool:
+        """True only for `invalid`. FR-003/FR-009.
+
+        `valid` is healthy and `not_found` is the common case; neither is
+        something to escalate.
+        """
+        return self.state is RpkiState.INVALID
+
+    def authorised_origins(self) -> list[str]:
+        """What the ROA *does* permit — this is what makes an `invalid` actionable
+        rather than merely alarming (FR-006)."""
+        out = []
+        for vrp in self.vrps_unmatched_as + self.vrps_unmatched_length:
+            asn = vrp.get("asn") or vrp.get("origin")
+            if asn and asn not in out:
+                out.append(str(asn))
+        return out
+
+    def max_lengths(self) -> list[int]:
+        """maxLength values from covering ROAs — the other half of FR-006."""
+        out = []
+        for vrp in self.vrps_unmatched_length + self.vrps_unmatched_as:
+            ml = vrp.get("max_length") or vrp.get("maxLength")
+            if ml is not None:
+                try:
+                    v = int(ml)
+                except (TypeError, ValueError):
+                    continue
+                if v not in out:
+                    out.append(v)
+        return out
+
+    def caveats(self) -> list[str]:
+        """The statements that must survive a model summarising the payload."""
+        out: list[str] = []
+        if self.state is RpkiState.NOT_FOUND:
+            out.append(NOT_FOUND_CAVEAT)
+        elif self.state is RpkiState.VALID:
+            out.append(VALID_CAVEAT)
+        elif self.state is RpkiState.INVALID:
+            out.append(INVALID_CAVEAT)
+            if self.reason is RpkiReason.AS:
+                permitted = ", ".join(self.authorised_origins()) or "an unlisted AS"
+                out.append(
+                    f"The covering ROA authorises {permitted}, not {self.origin_asn}."
+                )
+            elif self.reason is RpkiReason.LENGTH:
+                mls = ", ".join(str(m) for m in self.max_lengths()) or "a shorter length"
+                out.append(
+                    f"The origin AS is authorised, but the ROA permits a maximum "
+                    f"prefix length of {mls}. This is usually a local "
+                    f"misconfiguration rather than a third party announcing your space."
+                )
+        # FR-007a — never imply corroboration that does not exist.
+        out.append(
+            f"Single-validator result from {self.validator}; not corroborated by an "
+            "independent validator."
+        )
+        if self.translated_from:
+            out.append(
+                f"State was translated from the {self.translated_from} vocabulary "
+                f"to RFC 6811 terms."
+            )
+        return out
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "prefix": self.prefix,
+            "origin_asn": self.origin_asn,
+            "state": self.state.value,
+            "reason": self.reason.value if self.reason else None,
+            # RFC 6811's own spelling, for readers who know the standard.
+            "rfc6811_state": "NotFound" if self.state is RpkiState.NOT_FOUND
+            else self.state.value.capitalize(),
+            "is_finding": self.is_finding,
+            "description": self.description,
+            "validator": self.validator,
+            "corroborated": self.corroborated,
+            "vrps_matched": self.vrps_matched,
+            "vrps_unmatched_as": self.vrps_unmatched_as,
+            "vrps_unmatched_length": self.vrps_unmatched_length,
+            "authorised_origins": self.authorised_origins(),
+        }
+
+
+def from_validator_json(payload: dict[str, Any], *, validator: str) -> RpkiValidation:
+    """Parse `rpki-validator.ripe.net/api/v1/validity/` — the primary source.
+
+    Shape measured live 2026-08-03 (research R2/R9):
+        {"validated_route": {"route": {"origin_asn","prefix"},
+          "validity": {"state","reason","description",
+                       "VRPs": {"matched","unmatched_as","unmatched_length"}}}}
+    """
+    route = (payload.get("validated_route") or {}).get("route") or {}
+    validity = (payload.get("validated_route") or {}).get("validity") or {}
+    vrps = validity.get("VRPs") or {}
+
+    raw_state = str(validity.get("state", "")).strip().lower()
+    state = WIRE_TO_STATE.get(raw_state)
+    if state is None:
+        raise ValueError(f"unrecognised RPKI state from {validator}: {raw_state!r}")
+
+    raw_reason = validity.get("reason")
+    reason = None
+    if state is RpkiState.INVALID and raw_reason:
+        try:
+            reason = RpkiReason(str(raw_reason).strip().lower())
+        except ValueError:
+            reason = None
+
+    return RpkiValidation(
+        prefix=route.get("prefix", ""),
+        origin_asn=route.get("origin_asn", ""),
+        state=state,
+        reason=reason,
+        description=validity.get("description"),
+        vrps_matched=list(vrps.get("matched") or []),
+        vrps_unmatched_as=list(vrps.get("unmatched_as") or []),
+        vrps_unmatched_length=list(vrps.get("unmatched_length") or []),
+        validator=validator,
+    )
+
+
+def from_ripestat_json(
+    payload: dict[str, Any], *, prefix: str, origin_asn: str, validator: str
+) -> RpkiValidation:
+    """Parse the RIPEstat fallback and translate its vocabulary. FR-004.
+
+    RIPEstat says `unknown` for RFC 6811's NotFound and fuses state with reason
+    into `invalid_asn` / `invalid_length`. Both are translated here, and
+    `translated_from` records that it happened so the response can say so.
+    """
+    data = payload.get("data") or {}
+    raw = str(data.get("status", "")).strip().lower()
+    mapped = RIPESTAT_TO_STATE.get(raw)
+    if mapped is None:
+        raise ValueError(f"unrecognised RIPEstat RPKI status: {raw!r}")
+    state, reason = mapped
+
+    roas = list(data.get("validating_roas") or [])
+    matched = [r for r in roas if str(r.get("validity", "")).lower() == "valid"]
+    unmatched_as = [r for r in roas if "asn" in str(r.get("validity", "")).lower()]
+    unmatched_len = [r for r in roas if "length" in str(r.get("validity", "")).lower()]
+
+    return RpkiValidation(
+        prefix=prefix,
+        origin_asn=origin_asn,
+        state=state,
+        reason=reason,
+        description=None,
+        vrps_matched=matched,
+        vrps_unmatched_as=unmatched_as,
+        vrps_unmatched_length=unmatched_len,
+        validator=validator,
+        translated_from="RIPEstat",
+    )

--- a/mcp-servers/bgp-intel-mcp/requirements.txt
+++ b/mcp-servers/bgp-intel-mcp/requirements.txt
@@ -1,0 +1,13 @@
+# BGP & Registry Intelligence — spec 081 (roadmap R9)
+#
+# Two packages. Deliberately no RDAP/RPKI/BGP library: the payloads are plain
+# JSON over HTTPS and the value of this feature is in the SEMANTICS — which state
+# means what — not the transport. An SDK would add a pinning hazard while
+# abstracting the one thing this feature must not abstract.
+#
+# The mcp upper bound is LOAD-BEARING and no longer hypothetical (spec 077):
+# the MCP Python SDK has shipped v2 targeting the 2026-07-28 spec, and v2 removes
+# mcp.server.fastmcp, which this server imports. An unbounded pin would resolve
+# that major and die on import for every new installer. Do not "tidy" it away.
+mcp>=1.2.0,<2
+httpx>=0.27.0,<1

--- a/mcp-servers/bgp-intel-mcp/server.py
+++ b/mcp-servers/bgp-intel-mcp/server.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""bgp-intel-mcp — BGP & registry intelligence. Spec 081 (roadmap R9).
+
+The sequel to spec 079's Globalping: R8 *measures* toward a target from outside;
+this *looks up* who owns a resource, whether an announcement is legitimate, and
+where a network peers.
+
+Four public unauthenticated sources. **No credentials exist in this feature** —
+nothing to leak, rotate or scope.
+
+Every response carries its `source` and `retrieved_at` structurally and is
+GAIT-audited, because it passes through `envelope.emit()` — a chokepoint, not a
+convention. Read-only throughout: there is no write path and therefore no gate.
+
+THE DISTINCTION THIS SERVER EXISTS TO PROTECT
+---------------------------------------------
+**RPKI `not_found` is not `invalid`.** Most of the internet has no ROA. Reporting
+unsigned space as a finding would manufacture false incidents at scale.
+
+Transport: stdio, FastMCP, JSON-RPC lifecycle (Principle V).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from mcp.server.fastmcp import FastMCP  # noqa: E402
+
+import envelope  # noqa: E402
+import validate  # noqa: E402
+from sources import atlas, peeringdb, rdap, rpki, routing  # noqa: E402
+from validate import InputRefused  # noqa: E402
+
+mcp = FastMCP("bgp-intel-mcp")
+
+
+# ---------------------------------------------------------------------------
+# RPKI — 1 tool
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def rpki_validate(prefix: str, origin_asn: str, fresh: bool = False) -> dict:
+    """Is this prefix legitimately announced by this AS? RPKI origin validation.
+
+    Returns one of four states, which mean very different things:
+      valid                  a ROA authorises this origin. Healthy.
+      invalid + reason=as    a ROA exists; a DIFFERENT AS is authorised. Actionable.
+      invalid + reason=length a ROA exists; the prefix is too specific. Actionable.
+      not_found              NO ROA exists. This is the NORMAL state for most of
+                             the internet and is NOT a finding.
+
+    Never reports a hijack — it reports state and the ROAs behind it. Escalation is
+    an operator judgement. Single validator; results say so explicitly.
+
+    fresh=true bypasses the 5-minute cache, for when a ROA was just published.
+    """
+    try:
+        pfx = str(validate.parse_prefix(prefix))
+        asn = validate.normalise_asn(origin_asn)
+    except InputRefused as exc:
+        return envelope.refused(
+            tool="rpki_validate",
+            query={"prefix": prefix, "origin_asn": origin_asn},
+            reason=str(exc),
+        )
+    return await rpki.validate(pfx, asn, fresh=fresh)
+
+
+# ---------------------------------------------------------------------------
+# Registry (RDAP) — 2 tools
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def registry_lookup(resource: str) -> dict:
+    """Who is this IP, prefix or ASN allocated to? Registry record via RDAP.
+
+    Returns holder, allocation range, responsible registry, abuse contacts.
+
+    This is ALLOCATION data — it says who the space is registered to, NOT who is
+    announcing it. For that use routing_announced_prefixes.
+    """
+    try:
+        kind, value = validate.parse_resource(resource)
+    except InputRefused as exc:
+        return envelope.refused(
+            tool="registry_lookup", query={"resource": resource}, reason=str(exc)
+        )
+    return await rdap.lookup(kind, value, tool="registry_lookup")
+
+
+@mcp.tool()
+async def registry_abuse_contact(resource: str) -> dict:
+    """Abuse contact for an IP, prefix or ASN. The common incident-response ask."""
+    try:
+        kind, value = validate.parse_resource(resource)
+    except InputRefused as exc:
+        return envelope.refused(
+            tool="registry_abuse_contact", query={"resource": resource}, reason=str(exc)
+        )
+    result = await rdap.lookup(kind, value, tool="registry_abuse_contact")
+    data = result.get("data")
+    if isinstance(data, dict):
+        result["data"] = {
+            "resource": value,
+            "holder": data.get("holder"),
+            "registry": data.get("registry"),
+            "abuse_contacts": data.get("abuse_contacts") or [],
+        }
+        if not data.get("abuse_contacts"):
+            result["caveats"].append(
+                "No abuse contact is published for this resource. Try the covering "
+                "allocation, or the registry's own abuse-reporting channel."
+            )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Routing — 2 tools
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def routing_as_overview(asn: str, fresh: bool = False) -> dict:
+    """Holder and allocation status for an ASN, and whether it is announced at all."""
+    try:
+        value = validate.normalise_asn(asn)
+    except InputRefused as exc:
+        return envelope.refused(
+            tool="routing_as_overview", query={"asn": asn}, reason=str(exc)
+        )
+    return await routing.as_overview(value, fresh=fresh)
+
+
+@mcp.tool()
+async def routing_announced_prefixes(asn: str, fresh: bool = False) -> dict:
+    """What prefixes does this AS announce, and how widely are they seen?
+
+    Visibility is from RIPE's route collectors, NOT a global view. Low visibility
+    has legitimate causes and is not evidence of a leak or hijack.
+    """
+    try:
+        value = validate.normalise_asn(asn)
+    except InputRefused as exc:
+        return envelope.refused(
+            tool="routing_announced_prefixes", query={"asn": asn}, reason=str(exc)
+        )
+    return await routing.announced_prefixes(value, fresh=fresh)
+
+
+# ---------------------------------------------------------------------------
+# Peering — 2 tools
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def peering_network(asn: str, fresh: bool = False) -> dict:
+    """This AS's PeeringDB record: network type, traffic profile, peering policy.
+
+    PeeringDB is SELF-REPORTED. No record means nobody published one — not that
+    the network does not peer.
+    """
+    try:
+        value = validate.normalise_asn(asn)
+    except InputRefused as exc:
+        return envelope.refused(tool="peering_network", query={"asn": asn}, reason=str(exc))
+    return await peeringdb.network(value, fresh=fresh)
+
+
+@mcp.tool()
+async def peering_presence(asn: str, fresh: bool = False) -> dict:
+    """Which IXPs and facilities does this AS report being present at?
+
+    Self-reported; absence is not evidence of absence.
+    """
+    try:
+        value = validate.normalise_asn(asn)
+    except InputRefused as exc:
+        return envelope.refused(tool="peering_presence", query={"asn": asn}, reason=str(exc))
+    return await peeringdb.presence(value, fresh=fresh)
+
+
+# ---------------------------------------------------------------------------
+# Atlas — 2 tools, deliberately narrow
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def atlas_anchors(country: str, fresh: bool = False) -> dict:
+    """RIPE Atlas anchors in a country — stable, always-on measurement targets.
+
+    For general probe availability by location, or to RUN a measurement, use the
+    Globalping skill instead. This reports only what Globalping does not cover.
+    """
+    try:
+        value = validate.parse_country(country)
+    except InputRefused as exc:
+        return envelope.refused(tool="atlas_anchors", query={"country": country}, reason=str(exc))
+    return await atlas.anchors(value, fresh=fresh)
+
+
+@mcp.tool()
+async def atlas_probe_count(asn: str, fresh: bool = False) -> dict:
+    """How many RIPE Atlas probes are inside this AS? Can it be measured from within?"""
+    try:
+        value = validate.normalise_asn(asn)
+    except InputRefused as exc:
+        return envelope.refused(tool="atlas_probe_count", query={"asn": asn}, reason=str(exc))
+    return await atlas.probe_count(value, fresh=fresh)
+
+
+# ---------------------------------------------------------------------------
+# Composite — 1 tool
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def resource_report(resource: str, origin_asn: str = "") -> dict:
+    """Everything known about an internet resource: registry, routing, peering, RPKI.
+
+    Each section carries its own source. Supply origin_asn alongside a prefix to
+    include RPKI validation.
+    """
+    tool = "resource_report"
+    try:
+        kind, value = validate.parse_resource(resource)
+    except InputRefused as exc:
+        return envelope.refused(tool=tool, query={"resource": resource}, reason=str(exc))
+
+    sections: dict[str, Any] = {}
+
+    # DELIBERATELY SERIAL — one await after another, never asyncio.gather.
+    # FR-023a prohibits parallel fan-out against these free services, and this is
+    # the tool most likely to attract a "make it faster" change. The rate limiter
+    # in http_client would serialise per source anyway; this makes the intent
+    # visible at the call site so nobody has to discover it.
+    sections["registry"] = await rdap.lookup(kind, value, tool=tool)
+
+    if kind == "asn":
+        sections["routing"] = await routing.as_overview(value, fresh=False)
+        sections["announcements"] = await routing.announced_prefixes(value, fresh=False)
+        sections["peering"] = await peeringdb.network(value, fresh=False)
+        sections["atlas"] = await atlas.probe_count(value, fresh=False)
+    else:
+        if origin_asn:
+            try:
+                asn = validate.normalise_asn(origin_asn)
+                sections["rpki"] = await rpki.validate(value, asn, fresh=False)
+            except InputRefused as exc:
+                sections["rpki"] = envelope.refused(
+                    tool=tool, query={"origin_asn": origin_asn}, reason=str(exc)
+                )
+
+    caveats = [
+        "Each section carries its own source; do not attribute one section's data "
+        "to another's origin.",
+    ]
+    if kind == "prefix" and not origin_asn:
+        caveats.append(
+            "RPKI validation was not performed because no origin_asn was supplied. "
+            "Validation is always of a prefix AND origin-AS pair — this is NOT a "
+            "'not-found' result."
+        )
+
+    # Report disagreement rather than resolving it (Edge Cases).
+    reg = (sections.get("registry") or {}).get("data") or {}
+    peer = (sections.get("peering") or {}).get("data") or {}
+    holder, name = reg.get("holder"), peer.get("name")
+    if holder and name and holder.strip().lower() != name.strip().lower():
+        caveats.append(
+            f"Registry holder ({holder!r}) and PeeringDB name ({name!r}) differ. "
+            "Both are reported as-is; this is common and not necessarily a problem."
+        )
+
+    return envelope.merged(tool=tool, sections=sections,
+                           query={"resource": resource, "origin_asn": origin_asn or None},
+                           caveats=caveats)
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/mcp-servers/bgp-intel-mcp/sources/__init__.py
+++ b/mcp-servers/bgp-intel-mcp/sources/__init__.py
@@ -1,0 +1,12 @@
+"""One module per data source.
+
+Split by source rather than by capability because each has its own endpoint shape,
+failure mode and cache TTL — and FR-021 requires per-element provenance, which is
+natural when each module owns its own attribution.
+
+    rpki       rpki-validator.ripe.net (primary), RIPEstat (fallback)
+    rdap       IANA bootstrap -> responsible RIR -> rdap.org fallback
+    routing    RIPEstat as-overview and routing-status
+    peeringdb  PeeringDB net / netixlan / netfac
+    atlas      RIPE Atlas anchors and per-AS probe counts ONLY
+"""

--- a/mcp-servers/bgp-intel-mcp/sources/atlas.py
+++ b/mcp-servers/bgp-intel-mcp/sources/atlas.py
@@ -1,0 +1,141 @@
+"""RIPE Atlas — deliberately narrow. Spec 081, FR-017/FR-017a/FR-018.
+
+Clarification Q1 narrowed this to the **two things Globalping does not provide**:
+
+  anchors          stable, always-on measurement targets. Globalping has no
+                   equivalent concept.
+  per-AS probe      "can this network be measured from *inside* it?" — which
+  counts            registry and routing data cannot answer.
+
+General probe-availability-by-location is **NOT implemented here**. Globalping's
+`locations` already owns it (spec 079), and duplicating it would breach Principle
+VII. `routed_to_globalping()` exists to say so explicitly rather than returning a
+subtly different answer to the same question.
+
+Measurement *execution* is also Globalping's (FR-018). Atlas measurement creation
+needs an API key and credits; only the read-only inventory half is in scope.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import envelope
+from http_client import CLIENT, RateLimited, SourceUnavailable
+from outcomes import Outcome
+
+SOURCE = "atlas.ripe.net"
+_ANCHORS = "https://atlas.ripe.net/api/v2/anchors/"
+_PROBES = "https://atlas.ripe.net/api/v2/probes/"
+
+MAX_ANCHORS = 100
+
+
+async def anchors(country: str, *, fresh: bool = False) -> dict[str, Any]:
+    """Atlas anchors in a country — stable reference targets."""
+    tool = "atlas_anchors"
+    query = {"country": country}
+    try:
+        payload, cached, age = await CLIENT.get_json(
+            "atlas", _ANCHORS,
+            params={"country": country, "page_size": MAX_ANCHORS}, fresh=fresh,
+        )
+    except RateLimited as exc:
+        return envelope.emit(source=SOURCE, tool=tool, query=query,
+                             outcome=Outcome.RATE_LIMITED, message=str(exc))
+    except SourceUnavailable as exc:
+        return envelope.unavailable(source=SOURCE, tool=tool, query=query, reason=str(exc))
+
+    results = (payload or {}).get("results") or []
+    if not results:
+        return envelope.emit(
+            source=SOURCE, tool=tool, query=query, outcome=Outcome.NO_RECORD,
+            message=f"No Atlas anchors are listed in {country}.",
+            data={"country": country, "anchors": [], "count": 0},
+        )
+
+    return envelope.emit(
+        source=SOURCE, tool=tool, query=query, cached=cached, cache_age_seconds=age,
+        data={
+            "country": country,
+            "anchors": [
+                {
+                    "id": a.get("id"),
+                    "fqdn": a.get("fqdn"),
+                    "city": a.get("city"),
+                    "asn_v4": a.get("as_v4"),
+                    "asn_v6": a.get("as_v6"),
+                    "is_disabled": a.get("is_disabled"),
+                }
+                for a in results
+            ],
+            "count": len(results),
+            "total_available": (payload or {}).get("count"),
+        },
+        caveats=[
+            "Anchors are stable, always-on Atlas measurement targets. To actually "
+            "run a measurement, use the Globalping skill — this tool only reports "
+            "what infrastructure exists."
+        ],
+    )
+
+
+async def probe_count(asn: str, *, fresh: bool = False) -> dict[str, Any]:
+    """How many Atlas probes sit inside a given AS.
+
+    Answers "is this network observable from within?" — useful before concluding
+    anything from an absence of measurement data.
+    """
+    tool = "atlas_probe_count"
+    query = {"asn": asn}
+    number = int(asn.removeprefix("AS"))
+    try:
+        payload, cached, age = await CLIENT.get_json(
+            "atlas", _PROBES,
+            # page_size=1: we want the count, not the probe list. Fetching
+            # thousands of probe records to count them would be rude.
+            params={"asn": number, "page_size": 1}, fresh=fresh,
+        )
+    except RateLimited as exc:
+        return envelope.emit(source=SOURCE, tool=tool, query=query,
+                             outcome=Outcome.RATE_LIMITED, message=str(exc))
+    except SourceUnavailable as exc:
+        return envelope.unavailable(source=SOURCE, tool=tool, query=query, reason=str(exc))
+
+    total = (payload or {}).get("count", 0)
+    connected = sum(
+        1 for p in ((payload or {}).get("results") or []) if p.get("status_name") == "Connected"
+    )
+    return envelope.emit(
+        source=SOURCE, tool=tool, query=query, cached=cached, cache_age_seconds=age,
+        data={
+            "asn": asn,
+            "probe_count": total,
+            "sampled_connected": connected,
+        },
+        caveats=[
+            "A probe count of zero means this AS cannot be measured from within by "
+            "Atlas. It says nothing about the network's health or reachability.",
+        ],
+    )
+
+
+def routed_to_globalping(what: str) -> dict[str, Any]:
+    """Refuse a request that belongs to Globalping, and name it. FR-017a/FR-018.
+
+    Returning a subtly different answer to the same question would be worse than
+    refusing: the caller would not know they had asked the wrong tool.
+    """
+    return envelope.emit(
+        source="bgp-intel-mcp (local)",
+        tool="atlas_routed",
+        query={"requested": what},
+        outcome=Outcome.INPUT_REFUSED,
+        message=(
+            f"{what} belongs to the Globalping skill (spec 079), not this feature. "
+            "Globalping measures from probes and reports general probe availability "
+            "by location; this feature only reports Atlas anchors and per-AS probe "
+            "density, which Globalping does not cover."
+        ),
+        caveats=["No request was made. Use globalping-external-checks instead."],
+    )

--- a/mcp-servers/bgp-intel-mcp/sources/peeringdb.py
+++ b/mcp-servers/bgp-intel-mcp/sources/peeringdb.py
@@ -1,0 +1,144 @@
+"""PeeringDB — interconnection data. Spec 081, FR-015/FR-016.
+
+THE ONE THING TO GET RIGHT
+--------------------------
+**PeeringDB is self-reported.** Operators maintain their own records. So an absent
+record means *nobody filled in the form* — not that the network does not peer.
+
+Reporting "no PeeringDB record" as "this AS does not peer" would be the same
+absence-of-evidence error as RPKI `not-found` meaning "invalid", and it would be
+wrong about a large number of networks that peer extensively and simply do not
+publish.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import envelope
+from http_client import CLIENT, RateLimited, SourceUnavailable
+from outcomes import Outcome
+
+SOURCE = "peeringdb.com"
+_NET = "https://www.peeringdb.com/api/net"
+_NETIXLAN = "https://www.peeringdb.com/api/netixlan"
+_NETFAC = "https://www.peeringdb.com/api/netfac"
+
+SELF_REPORTED_CAVEAT = (
+    "PeeringDB is self-reported: operators maintain their own records. Absence of "
+    "a record, an IXP, or a facility means nobody published it — NOT that the "
+    "network does not peer there."
+)
+
+
+async def _net_id(asn: str, *, fresh: bool = False) -> tuple[int | None, dict[str, Any] | None, bool, float | None]:
+    number = int(asn.removeprefix("AS"))
+    payload, cached, age = await CLIENT.get_json(
+        "peeringdb", _NET, params={"asn": number}, fresh=fresh
+    )
+    records = (payload or {}).get("data") or []
+    if not records:
+        return None, None, cached, age
+    return records[0].get("id"), records[0], cached, age
+
+
+async def network(asn: str, *, fresh: bool = False) -> dict[str, Any]:
+    """The AS's PeeringDB network record: type, traffic profile, policy, contacts."""
+    tool = "peering_network"
+    query = {"asn": asn}
+    try:
+        _, rec, cached, age = await _net_id(asn, fresh=fresh)
+    except RateLimited as exc:
+        return envelope.emit(source=SOURCE, tool=tool, query=query,
+                             outcome=Outcome.RATE_LIMITED, message=str(exc))
+    except SourceUnavailable as exc:
+        return envelope.unavailable(source=SOURCE, tool=tool, query=query, reason=str(exc))
+
+    if rec is None:
+        # FR-016. The wording here is the requirement.
+        return envelope.emit(
+            source=SOURCE, tool=tool, query=query, outcome=Outcome.NO_RECORD,
+            message=(
+                f"{asn} has no self-reported PeeringDB record. This is NOT evidence "
+                "that the network does not peer."
+            ),
+            caveats=[SELF_REPORTED_CAVEAT],
+        )
+
+    return envelope.emit(
+        source=SOURCE, tool=tool, query=query, cached=cached, cache_age_seconds=age,
+        data={
+            "asn": asn,
+            "name": rec.get("name"),
+            "aka": rec.get("aka") or None,
+            "network_type": rec.get("info_type"),
+            "traffic_estimate": rec.get("info_traffic"),
+            "traffic_ratio": rec.get("info_ratio"),
+            "scope": rec.get("info_scope"),
+            "policy_general": rec.get("policy_general"),
+            "policy_url": rec.get("policy_url") or None,
+            "irr_as_set": rec.get("irr_as_set") or None,
+            "website": rec.get("website") or None,
+            "ix_count": rec.get("ix_count"),
+            "fac_count": rec.get("fac_count"),
+        },
+        caveats=[SELF_REPORTED_CAVEAT],
+    )
+
+
+async def presence(asn: str, *, fresh: bool = False) -> dict[str, Any]:
+    """IXPs and facilities this AS reports being present at."""
+    tool = "peering_presence"
+    query = {"asn": asn}
+    try:
+        net_id, rec, cached, age = await _net_id(asn, fresh=fresh)
+        if net_id is None:
+            return envelope.emit(
+                source=SOURCE, tool=tool, query=query, outcome=Outcome.NO_RECORD,
+                message=(
+                    f"{asn} has no self-reported PeeringDB record, so no IXP or "
+                    "facility presence is published. This is NOT evidence that the "
+                    "network does not peer."
+                ),
+                caveats=[SELF_REPORTED_CAVEAT],
+            )
+        ixlans, _, _ = await CLIENT.get_json(
+            "peeringdb", _NETIXLAN, params={"net_id": net_id}, fresh=fresh
+        )
+        facs, _, _ = await CLIENT.get_json(
+            "peeringdb", _NETFAC, params={"net_id": net_id}, fresh=fresh
+        )
+    except RateLimited as exc:
+        return envelope.emit(source=SOURCE, tool=tool, query=query,
+                             outcome=Outcome.RATE_LIMITED, message=str(exc))
+    except SourceUnavailable as exc:
+        return envelope.unavailable(source=SOURCE, tool=tool, query=query, reason=str(exc))
+
+    ix = [
+        {
+            "ix_name": r.get("name"),
+            "speed_mbps": r.get("speed"),
+            "ipaddr4": r.get("ipaddr4"),
+            "ipaddr6": r.get("ipaddr6"),
+            "operational": r.get("operational"),
+            "is_rs_peer": r.get("is_rs_peer"),
+        }
+        for r in ((ixlans or {}).get("data") or [])
+    ]
+    fac = [
+        {"name": r.get("name"), "city": r.get("city"), "country": r.get("country")}
+        for r in ((facs or {}).get("data") or [])
+    ]
+
+    return envelope.emit(
+        source=SOURCE, tool=tool, query=query, cached=cached, cache_age_seconds=age,
+        data={
+            "asn": asn,
+            "name": (rec or {}).get("name"),
+            "ixps": ix,
+            "ixp_count": len(ix),
+            "facilities": fac,
+            "facility_count": len(fac),
+        },
+        caveats=[SELF_REPORTED_CAVEAT],
+    )

--- a/mcp-servers/bgp-intel-mcp/sources/rdap.py
+++ b/mcp-servers/bgp-intel-mcp/sources/rdap.py
@@ -1,0 +1,214 @@
+"""Registry records via RDAP. Spec 081, FR-008..FR-011.
+
+RDAP replaces scraped WHOIS with structured JSON, and RFC 7484 defines how to find
+the responsible registry: fetch IANA's bootstrap file, match the resource to an
+RIR, query that RIR directly.
+
+Doing it that way is not pedantry — it means FR-010's "name the responding
+registry" is satisfied **by construction**. We know which RIR we chose and why,
+rather than following an opaque redirect and reporting "the registry".
+
+ARIN
+----
+Measured 2026-08-03: `rdap.arin.net` resets the connection from this host
+(`Recv failure: Connection reset by peer`). Whether that is host-specific,
+transient, or a policy is unresolved (research open item 2), so it is handled as a
+generic per-source failure with a fallback — deliberately **not** hardcoded as
+"ARIN is broken."
+
+THE CATEGORY ERROR THIS MODULE MUST NOT MAKE
+--------------------------------------------
+RDAP says who a block is **allocated to**. It says nothing about who is
+**announcing** it. Presenting an RDAP holder as evidence about routing is the same
+mistake as presenting FortiManager intent as observed device state (spec 080), and
+every result here carries a caveat saying so.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from typing import Any
+
+import envelope
+from http_client import CLIENT, RateLimited, SourceUnavailable
+from outcomes import Outcome
+
+_BOOTSTRAP_V4 = "https://data.iana.org/rdap/ipv4.json"
+_BOOTSTRAP_V6 = "https://data.iana.org/rdap/ipv6.json"
+_BOOTSTRAP_ASN = "https://data.iana.org/rdap/asn.json"
+_FALLBACK = "https://rdap.org"
+
+ALLOCATION_CAVEAT = (
+    "This is allocation data: it says who the address space is registered to. It "
+    "is NOT evidence about who is currently announcing it. For that, use the "
+    "routing tools."
+)
+
+
+async def _bootstrap(url: str) -> list[Any]:
+    payload, _, _ = await CLIENT.get_json("rdap", url)
+    return (payload or {}).get("services") or []
+
+
+async def _resolve_registry_v4v6(network: Any) -> tuple[str | None, str | None]:
+    """Return `(base_url, registry_label)` for an IP network, per RFC 7484."""
+    url = _BOOTSTRAP_V4 if network.version == 4 else _BOOTSTRAP_V6
+    try:
+        services = await _bootstrap(url)
+    except (SourceUnavailable, RateLimited):
+        return None, None
+
+    best: tuple[int, str] | None = None
+    for entry in services:
+        ranges, urls = (entry + [[], []])[:2]
+        for cidr in ranges:
+            try:
+                candidate = ipaddress.ip_network(cidr, strict=False)
+            except ValueError:
+                continue
+            if candidate.version != network.version:
+                continue
+            if network.subnet_of(candidate):
+                # Longest match wins — bootstrap entries can overlap.
+                if best is None or candidate.prefixlen > best[0]:
+                    if urls:
+                        best = (candidate.prefixlen, urls[0].rstrip("/"))
+    if best is None:
+        return None, None
+    base = best[1]
+    return base, base.split("//")[-1].split("/")[0]
+
+
+async def _resolve_registry_asn(asn_number: int) -> tuple[str | None, str | None]:
+    try:
+        services = await _bootstrap(_BOOTSTRAP_ASN)
+    except (SourceUnavailable, RateLimited):
+        return None, None
+    for entry in services:
+        ranges, urls = (entry + [[], []])[:2]
+        for rng in ranges:
+            lo, _, hi = rng.partition("-")
+            try:
+                low = int(lo)
+                high = int(hi) if hi else low
+            except ValueError:
+                continue
+            if low <= asn_number <= high and urls:
+                base = urls[0].rstrip("/")
+                return base, base.split("//")[-1].split("/")[0]
+    return None, None
+
+
+async def lookup(resource_kind: str, resource: str, *, tool: str) -> dict[str, Any]:
+    """Look up an IP/prefix or ASN. `resource_kind` is 'prefix' or 'asn'."""
+    query = {"resource": resource, "kind": resource_kind}
+
+    if resource_kind == "asn":
+        number = int(resource.removeprefix("AS"))
+        base, label = await _resolve_registry_asn(number)
+        path = f"/autnum/{number}"
+    else:
+        network = ipaddress.ip_network(resource, strict=False)
+        base, label = await _resolve_registry_v4v6(network)
+        path = f"/ip/{network}"
+
+    attempts: list[tuple[str, str]] = []
+    if base:
+        attempts.append((base + path, label or base))
+    # rdap.org follows the bootstrap itself; used when direct resolution failed or
+    # the direct endpoint refused us (ARIN).
+    attempts.append((_FALLBACK + path, "rdap.org (bootstrap redirector)"))
+
+    last_error: str | None = None
+    refused = False
+    for url, registry in attempts:
+        try:
+            payload, cached, age = await CLIENT.get_json("rdap", url)
+        except RateLimited as exc:
+            return envelope.emit(
+                source=registry, tool=tool, query=query,
+                outcome=Outcome.RATE_LIMITED, message=str(exc),
+            )
+        except SourceUnavailable as exc:
+            last_error = str(exc)
+            refused = refused or exc.refused
+            continue
+
+        if payload is None:
+            # A 404 is a real answer: the registry has no such record.
+            return envelope.emit(
+                source=registry, tool=tool, query=query,
+                outcome=Outcome.NO_RECORD,
+                message=f"{registry} has no record for {resource}.",
+                caveats=[ALLOCATION_CAVEAT],
+            )
+
+        return envelope.emit(
+            source=registry,
+            tool=tool,
+            query=query,
+            data=_shape(payload, registry, base, attempts[0][1] == registry),
+            caveats=[ALLOCATION_CAVEAT],
+            cached=cached,
+            cache_age_seconds=age,
+        )
+
+    # FR-011: a source failure, naming the source — never "no record".
+    tried = ", ".join(r for _, r in attempts)
+    return envelope.unavailable(
+        source=tried,
+        tool=tool,
+        query=query,
+        reason=last_error or "no registry answered",
+        outcome=Outcome.SOURCE_REFUSED if refused else Outcome.SOURCE_UNAVAILABLE,
+    )
+
+
+def _shape(payload: dict[str, Any], registry: str, base: str | None, direct: bool) -> dict[str, Any]:
+    """Extract the fields an operator actually wants from an RDAP object."""
+    entities = payload.get("entities") or []
+
+    def _vcard_value(entity: dict[str, Any], key: str) -> str | None:
+        for item in (entity.get("vcardArray") or [None, []])[1] or []:
+            if isinstance(item, list) and item and item[0] == key:
+                return item[3] if len(item) > 3 else None
+        return None
+
+    holder = payload.get("name") or None
+    abuse: list[str] = []
+    contacts: list[dict[str, Any]] = []
+    for ent in entities:
+        roles = [str(r).lower() for r in (ent.get("roles") or [])]
+        email = _vcard_value(ent, "email")
+        contacts.append({
+            "handle": ent.get("handle"),
+            "roles": roles,
+            "name": _vcard_value(ent, "fn"),
+            "email": email,
+        })
+        if "abuse" in roles and email:
+            abuse.append(email)
+
+    return {
+        "holder": holder,
+        "handle": payload.get("handle"),
+        "allocation_range": payload.get("startAddress") and
+        f"{payload.get('startAddress')} - {payload.get('endAddress')}" or None,
+        "cidr": payload.get("cidr0_cidrs") or None,
+        "asn_range": (
+            f"{payload.get('startAutnum')} - {payload.get('endAutnum')}"
+            if payload.get("startAutnum") is not None else None
+        ),
+        "country": payload.get("country"),
+        "type": payload.get("type"),
+        "status": payload.get("status"),
+        "registry": registry,
+        # FR-010: not just which registry, but HOW it was chosen.
+        "registry_selected_via": "iana_bootstrap" if direct and base else "rdap_org_fallback",
+        "abuse_contacts": abuse,
+        "contacts": contacts,
+        "events": [
+            {"action": e.get("eventAction"), "date": e.get("eventDate")}
+            for e in (payload.get("events") or [])
+        ],
+    }

--- a/mcp-servers/bgp-intel-mcp/sources/routing.py
+++ b/mcp-servers/bgp-intel-mcp/sources/routing.py
@@ -1,0 +1,148 @@
+"""Routing status from RIPEstat. Spec 081, FR-012..FR-014.
+
+WHAT VISIBILITY IS NOT
+----------------------
+These figures come from **RIPE's route collectors**, not from a global view of the
+internet. A prefix seen by few peers has entirely legitimate explanations:
+
+  - a deliberately scoped announcement (no-export, a single upstream)
+  - anycast, where different collectors see different origins
+  - a very recent change that has not propagated to every collector
+
+So this module reports counts and the collector basis, and **never** attaches the
+words "leak" or "hijack" (FR-013, SC-009). Declaring a routing incident needs more
+evidence than one collector network's view, and it is an operator judgement.
+
+Three outcomes that look alike and are not (FR-014):
+    ok + prefixes         the AS announces these
+    no_record (empty)     the AS exists and announces nothing observed here
+    source_unavailable    RIPEstat did not answer
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import envelope
+from http_client import CLIENT, RateLimited, SourceUnavailable
+from outcomes import Outcome
+
+SOURCE = "stat.ripe.net"
+_OVERVIEW = "https://stat.ripe.net/data/as-overview/data.json"
+_ANNOUNCED = "https://stat.ripe.net/data/announced-prefixes/data.json"
+_ROUTING_STATUS = "https://stat.ripe.net/data/routing-status/data.json"
+
+COLLECTOR_CAVEAT = (
+    "Visibility is measured from RIPE NCC's route collectors, not from a global "
+    "view of the internet. Low visibility has legitimate causes — scoped "
+    "announcements, anycast, or recent changes — and is not by itself evidence of "
+    "a route leak or hijack."
+)
+
+#: Announced-prefix lists can be very large for a transit AS. Bounded and stated,
+#: never silently truncated.
+MAX_PREFIXES = 200
+
+
+async def as_overview(asn: str, *, fresh: bool = False) -> dict[str, Any]:
+    """Holder and allocation status for an ASN — distinct from what it announces."""
+    tool = "routing_as_overview"
+    query = {"asn": asn}
+    try:
+        payload, cached, age = await CLIENT.get_json(
+            "routing", _OVERVIEW, params={"resource": asn}, fresh=fresh
+        )
+    except RateLimited as exc:
+        return envelope.emit(source=SOURCE, tool=tool, query=query,
+                             outcome=Outcome.RATE_LIMITED, message=str(exc))
+    except SourceUnavailable as exc:
+        return envelope.unavailable(source=SOURCE, tool=tool, query=query, reason=str(exc))
+
+    data = (payload or {}).get("data") or {}
+    if not data or data.get("announced") is None and not data.get("holder"):
+        return envelope.emit(
+            source=SOURCE, tool=tool, query=query, outcome=Outcome.NO_RECORD,
+            message=f"RIPEstat has no overview for {asn}.",
+        )
+
+    return envelope.emit(
+        source=SOURCE, tool=tool, query=query, cached=cached, cache_age_seconds=age,
+        data={
+            "asn": asn,
+            "holder": data.get("holder"),
+            # `announced` is RIPEstat's own boolean for "is this AS visible at all".
+            "currently_announced": data.get("announced"),
+            "type": data.get("type"),
+            "block": (data.get("block") or {}).get("desc"),
+        },
+        caveats=[
+            "Holder is registry/allocation data. What the AS actually announces is "
+            "a separate question — use routing_announced_prefixes."
+        ],
+    )
+
+
+async def announced_prefixes(asn: str, *, fresh: bool = False) -> dict[str, Any]:
+    """Prefixes observed as announced by this AS, with visibility."""
+    tool = "routing_announced_prefixes"
+    query = {"asn": asn}
+    try:
+        payload, cached, age = await CLIENT.get_json(
+            "routing", _ANNOUNCED, params={"resource": asn}, fresh=fresh
+        )
+        status, _, _ = await CLIENT.get_json(
+            "routing", _ROUTING_STATUS, params={"resource": asn}, fresh=fresh
+        )
+    except RateLimited as exc:
+        return envelope.emit(source=SOURCE, tool=tool, query=query,
+                             outcome=Outcome.RATE_LIMITED, message=str(exc))
+    except SourceUnavailable as exc:
+        return envelope.unavailable(source=SOURCE, tool=tool, query=query, reason=str(exc))
+
+    data = (payload or {}).get("data") or {}
+    raw = data.get("prefixes") or []
+    sdata = (status or {}).get("data") or {}
+
+    if not raw:
+        # FR-014: "announces nothing observed" is a real finding, and is distinct
+        # from "the AS does not exist" and from "the query failed".
+        return envelope.emit(
+            source=SOURCE, tool=tool, query=query, outcome=Outcome.NO_RECORD,
+            message=(
+                f"No announcements observed for {asn} by RIPE's collectors. This "
+                "is distinct from the AS not existing, and from a failed query."
+            ),
+            caveats=[COLLECTOR_CAVEAT],
+            data={"asn": asn, "prefixes": [], "count": 0},
+        )
+
+    truncated = len(raw) > MAX_PREFIXES
+    prefixes = [
+        {"prefix": p.get("prefix"), "timelines": len(p.get("timelines") or [])}
+        for p in raw[:MAX_PREFIXES]
+    ]
+    caveats = [COLLECTOR_CAVEAT]
+    if truncated:
+        caveats.append(
+            f"Showing {MAX_PREFIXES} of {len(raw)} prefixes. The list was bounded, "
+            "not silently truncated."
+        )
+
+    return envelope.emit(
+        source=SOURCE, tool=tool, query=query, cached=cached, cache_age_seconds=age,
+        data={
+            "asn": asn,
+            "prefixes": prefixes,
+            "count": len(prefixes),
+            "total_available": len(raw),
+            "truncated": truncated,
+            "observed_neighbours": sdata.get("observed_neighbours"),
+            "announced_space": sdata.get("announced_space"),
+            "visibility": {
+                "ris_peers_seeing": (sdata.get("visibility") or {}).get("v4", {}).get("ris_peers_seeing"),
+                "total_ris_peers": (sdata.get("visibility") or {}).get("v4", {}).get("total_ris_peers"),
+            },
+            "collector_basis": "RIPE NCC RIS route collectors",
+        },
+        caveats=caveats,
+    )

--- a/mcp-servers/bgp-intel-mcp/sources/rpki.py
+++ b/mcp-servers/bgp-intel-mcp/sources/rpki.py
@@ -1,0 +1,136 @@
+"""RPKI origin validation — the flagship capability. Spec 081, FR-001..FR-007c.
+
+PRIMARY SOURCE: `rpki-validator.ripe.net/api/v1/validity/<asn>/<prefix>`
+
+Chosen over RIPEstat's `rpki-validation` on three measured grounds (research R2):
+
+  1. It reports RFC 6811 vocabulary natively — `not-found`, not `unknown`. The
+     translation risk is removed at source rather than papered over downstream.
+  2. `state` and `reason` are separate fields. RIPEstat fuses them into
+     `invalid_asn` / `invalid_length`, forcing string parsing to recover a
+     distinction FR-002 requires.
+  3. It returns the VRPs that drove the verdict, which FR-005 requires so an
+     operator can check the reasoning rather than trust a label.
+
+FALLBACK: RIPEstat, with its vocabulary translated and the translation stated.
+
+NOT CORROBORATION
+-----------------
+Both endpoints are RIPE NCC Routinator — same engine, same operator, same trust
+anchors (research R3). The fallback is for *availability*, not agreement.
+Comparing them would produce agreement that means nothing, so `corroborated` is
+always False and every result says so.
+
+An unreachable validator yields VALIDATION_UNAVAILABLE, never `not_found`
+(FR-007c). Inferring "unsigned" from "could not ask" is the subtlest bug available
+in this feature: it turns an outage into a confident, wrong, reassuring answer.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import quote
+
+import envelope
+import outcomes
+from http_client import CLIENT, RateLimited, SourceUnavailable
+from outcomes import Outcome
+
+PRIMARY = "rpki-validator.ripe.net"
+FALLBACK = "stat.ripe.net"
+
+_PRIMARY_URL = "https://rpki-validator.ripe.net/api/v1/validity/{asn}/{prefix}"
+_FALLBACK_URL = "https://stat.ripe.net/data/rpki-validation/data.json"
+
+TOOL = "rpki_validate"
+
+
+async def validate(prefix: str, origin_asn: str, *, fresh: bool = False) -> dict[str, Any]:
+    """Validate a prefix + origin-AS **pair**.
+
+    Validation is always of the pair — a prefix alone has no validity state, and a
+    tool that accepted one would be answering a different question than the caller
+    asked.
+    """
+    query = {"prefix": prefix, "origin_asn": origin_asn}
+
+    # --- primary -----------------------------------------------------------
+    url = _PRIMARY_URL.format(asn=quote(origin_asn, safe=""), prefix=quote(prefix, safe=""))
+    try:
+        payload, cached, age = await CLIENT.get_json("rpki", url, fresh=fresh)
+        if payload is not None:
+            result = outcomes.from_validator_json(payload, validator=PRIMARY)
+            return _emit(result, query, cached, age, source=PRIMARY)
+    except RateLimited as exc:
+        return envelope.emit(
+            source=PRIMARY, tool=TOOL, query=query,
+            outcome=Outcome.RATE_LIMITED, message=str(exc),
+            caveats=["No validation was performed; this is not a `not-found`."],
+        )
+    except (SourceUnavailable, ValueError):
+        pass  # fall through to the fallback
+
+    # --- fallback ----------------------------------------------------------
+    try:
+        payload, cached, age = await CLIENT.get_json(
+            "rpki", _FALLBACK_URL,
+            params={"resource": origin_asn, "prefix": prefix}, fresh=fresh,
+        )
+        if payload is not None:
+            result = outcomes.from_ripestat_json(
+                payload, prefix=prefix, origin_asn=origin_asn, validator=FALLBACK
+            )
+            return _emit(result, query, cached, age, source=FALLBACK)
+    except RateLimited as exc:
+        return envelope.emit(
+            source=FALLBACK, tool=TOOL, query=query,
+            outcome=Outcome.RATE_LIMITED, message=str(exc),
+            caveats=["No validation was performed; this is not a `not-found`."],
+        )
+    except (SourceUnavailable, ValueError):
+        pass
+
+    # --- neither answered --------------------------------------------------
+    # FR-007c. The distinction that matters most, one level down: we could not
+    # ASK, which is not the same as being told there is no ROA.
+    return envelope.emit(
+        source=f"{PRIMARY} (and fallback {FALLBACK})",
+        tool=TOOL,
+        query=query,
+        outcome=Outcome.VALIDATION_UNAVAILABLE,
+        message=(
+            "RPKI validation could not be performed: neither validator answered."
+        ),
+        caveats=[
+            "This is NOT a 'not-found' result. 'not-found' means no ROA exists; "
+            "this means the validator could not be reached, so the RPKI state of "
+            "this announcement is genuinely unknown.",
+            "NetClaw will not infer RPKI state from routing or registry data.",
+        ],
+    )
+
+
+def _emit(
+    result: outcomes.RpkiValidation,
+    query: dict[str, Any],
+    cached: bool,
+    age: float | None,
+    *,
+    source: str,
+) -> dict[str, Any]:
+    """Wrap a validation in the provenance envelope.
+
+    Note what is NOT here: no severity score, no "risk" field, no recommendation.
+    FR-007 forbids this tool declaring a hijack, an attack or an incident. It
+    reports state and the evidence behind it; escalation is the operator's call.
+    """
+    return envelope.emit(
+        source=source,
+        tool=TOOL,
+        query=query,
+        data=result.to_dict(),
+        outcome=Outcome.OK,
+        caveats=result.caveats(),
+        cached=cached,
+        cache_age_seconds=age,
+    )

--- a/mcp-servers/bgp-intel-mcp/validate.py
+++ b/mcp-servers/bgp-intel-mcp/validate.py
@@ -1,0 +1,150 @@
+"""Input refusal, before anything leaves the machine. Spec 081, FR-028/029/030.
+
+THIS IS A DISCLOSURE CONTROL, NOT A VALIDATION NICETY.
+
+Sending `10.0.0.1` or an internal hostname to a public registry is a disclosure
+even if the query then fails — the third party has already seen it. So private,
+reserved and bogon input is refused **locally**, with no outbound request. Spec 079
+applied exactly this reasoning to Globalping, and the same logic holds here.
+
+The secondary benefit is honesty: these ranges have no meaningful registry or RPKI
+answer, so forwarding them would produce a confusing empty result rather than a
+clear explanation.
+
+IPv4 and IPv6 throughout (FR-029) — verified live against RPKI, RDAP and RIPEstat.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from dataclasses import dataclass
+
+#: IPv4 ranges with no public registry meaning. `ipaddress` covers most of these
+#: via its own flags, but the documentation ranges and CGNAT need naming
+#: explicitly, and an explicit table is easier to audit than a chain of flags.
+_V4_REFUSED = [
+    (ipaddress.ip_network("0.0.0.0/8"), "unspecified / this-network"),
+    (ipaddress.ip_network("10.0.0.0/8"), "RFC1918 private"),
+    (ipaddress.ip_network("100.64.0.0/10"), "RFC6598 CGNAT shared address space"),
+    (ipaddress.ip_network("127.0.0.0/8"), "loopback"),
+    (ipaddress.ip_network("169.254.0.0/16"), "link-local"),
+    (ipaddress.ip_network("172.16.0.0/12"), "RFC1918 private"),
+    (ipaddress.ip_network("192.0.0.0/24"), "IETF protocol assignments"),
+    (ipaddress.ip_network("192.0.2.0/24"), "RFC5737 documentation (TEST-NET-1)"),
+    (ipaddress.ip_network("192.168.0.0/16"), "RFC1918 private"),
+    (ipaddress.ip_network("198.18.0.0/15"), "RFC2544 benchmarking"),
+    (ipaddress.ip_network("198.51.100.0/24"), "RFC5737 documentation (TEST-NET-2)"),
+    (ipaddress.ip_network("203.0.113.0/24"), "RFC5737 documentation (TEST-NET-3)"),
+    (ipaddress.ip_network("224.0.0.0/4"), "multicast"),
+    (ipaddress.ip_network("240.0.0.0/4"), "reserved"),
+]
+
+_V6_REFUSED = [
+    (ipaddress.ip_network("::/128"), "unspecified"),
+    (ipaddress.ip_network("::1/128"), "loopback"),
+    (ipaddress.ip_network("fc00::/7"), "RFC4193 unique-local"),
+    (ipaddress.ip_network("fe80::/10"), "link-local"),
+    (ipaddress.ip_network("2001:db8::/32"), "RFC3849 documentation"),
+    (ipaddress.ip_network("ff00::/8"), "multicast"),
+]
+
+_ASN_RE = re.compile(r"^(?:AS)?(\d+)$", re.IGNORECASE)
+
+
+class InputRefused(ValueError):
+    """Refused locally. No request was made."""
+
+
+@dataclass(frozen=True)
+class Prefix:
+    network: ipaddress.IPv4Network | ipaddress.IPv6Network
+
+    def __str__(self) -> str:
+        return str(self.network)
+
+    @property
+    def version(self) -> int:
+        return self.network.version
+
+
+def normalise_asn(value: str | int) -> str:
+    """Return a canonical `ASnnnn` string, or refuse. FR-030.
+
+    AS0 is refused: RFC 7607 reserves it and it cannot legitimately originate a
+    route, so a query about it is always a mistake worth naming.
+    """
+    raw = str(value).strip()
+    match = _ASN_RE.match(raw)
+    if not match:
+        raise InputRefused(
+            f"{raw!r} is not a valid AS number. Expected a number, optionally "
+            "prefixed with 'AS' — for example 'AS13335' or '13335'."
+        )
+    number = int(match.group(1))
+    if number == 0:
+        raise InputRefused(
+            "AS0 is reserved by RFC 7607 and cannot originate a route, so there is "
+            "nothing to look up."
+        )
+    if number > 4294967295:
+        raise InputRefused(f"AS{number} exceeds the 32-bit AS number range.")
+    return f"AS{number}"
+
+
+def parse_prefix(value: str) -> Prefix:
+    """Parse an IP or CIDR prefix, refusing anything with no public meaning.
+
+    Accepts a bare address (treated as a host prefix) or CIDR notation, v4 or v6.
+    """
+    raw = str(value).strip()
+    if not raw:
+        raise InputRefused("No address or prefix was supplied.")
+
+    try:
+        network = ipaddress.ip_network(raw, strict=False)
+    except ValueError:
+        try:
+            network = ipaddress.ip_network(ipaddress.ip_address(raw))
+        except ValueError:
+            raise InputRefused(
+                f"{raw!r} is not a valid IP address or CIDR prefix. Note that a "
+                "mixed address family (an IPv4 address with an IPv6 prefix length, "
+                "or vice versa) is rejected."
+            ) from None
+
+    table = _V4_REFUSED if network.version == 4 else _V6_REFUSED
+    for refused_net, why in table:
+        if network.subnet_of(refused_net) or refused_net.subnet_of(network):
+            raise InputRefused(
+                f"{network} falls in {refused_net} ({why}), which has no public "
+                "registry or RPKI record. This was refused locally and no request "
+                "was sent to any external service — sending internal addressing to "
+                "a public registry would be a disclosure even if the lookup failed. "
+                "For internal address space use NetClaw's own IPAM or device tooling."
+            )
+
+    return Prefix(network)
+
+
+def parse_resource(value: str) -> tuple[str, str]:
+    """Classify a free-form resource as `('asn', 'ASnnn')` or `('prefix', 'a/b')`.
+
+    Used by the tools that accept "an IP, prefix, or ASN" so a caller does not
+    have to pre-classify.
+    """
+    raw = str(value).strip()
+    if _ASN_RE.match(raw):
+        return "asn", normalise_asn(raw)
+    return "prefix", str(parse_prefix(raw))
+
+
+def parse_country(value: str) -> str:
+    """ISO 3166-1 alpha-2, upper-cased. FR-030."""
+    raw = str(value).strip().upper()
+    if not re.fullmatch(r"[A-Z]{2}", raw):
+        raise InputRefused(
+            f"{value!r} is not a two-letter ISO 3166-1 country code — for example "
+            "'NL' or 'CA'."
+        )
+    return raw

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -535,6 +535,7 @@ verify_component() {
         fmc)             verify_dir  "$name" "$FMC_MCP_DIR" ;;
         panorama)        verify_cmd_or_module "$name" palo-alto-mcp palo_alto_mcp "pip3 install iflow-mcp-cdot65-palo-alto-mcp" ;;
         fortinet)        verify_file "$name" "$FORTINET_MCP_DIR/server.py" ;;
+        bgp-intel)       verify_file "$name" "$BGP_INTEL_MCP_DIR/server.py" ;;
         checkpoint)      verify_dir  "$name" "$CHECKPOINT_MCP_DIR" ;;
         claroty)         verify_dir  "$name" "$CLAROTY_MCP_DIR" ;;
         nvd-cve)         verify_file "$name" "$NVD_MCP_DIR/mcp_nvd/main.py" ;;

--- a/scripts/lib/catalog.sh
+++ b/scripts/lib/catalog.sh
@@ -61,6 +61,7 @@ CATALOG=(
     "suzieq|Observability|SuzieQ|Network state queries, assertions, path tracing (bundled)"
     "kubeshark|Observability|Kubeshark|K8s L4/L7 traffic analysis, TLS decryption (remote)"
     "gtrace|Observability|gtrace|Traceroute (MPLS/ECMP/NAT), MTR, GlobalPing, ASN, geo (6 tools)"
+    "bgp-intel|Observability|BGP & Registry Intelligence|RPKI origin validation, RDAP ownership, PeeringDB peering, routing visibility (public APIs, no credentials)"
     "globalping|Observability|Globalping|Outside-in measurement from ~4800 global probes — ping, traceroute, DNS, MTR, HTTP (remote, no install)"
     "telemetry-receivers|Observability|Telemetry Receivers|SNMP trap, syslog, IPFIX/NetFlow receivers over UDP (3 servers)"
     "auvik|Observability|Auvik|Read-only network monitoring — inventory, alerts, lifecycle, performance (bundled, 20 tools)"
@@ -136,7 +137,7 @@ catalog_has() {
 # ── profiles ─────────────────────────────────────────────────────
 PROFILE_MINIMAL="pyats gait subnet-calc drawio-rfc"
 
-PROFILE_RECOMMENDED="pyats gait netbox servicenow nvd-cve subnet-calc wikipedia markmap \
+PROFILE_RECOMMENDED="bgp-intel pyats gait netbox servicenow nvd-cve subnet-calc wikipedia markmap \
 drawio-rfc uml packet-buddy nmap gtrace globalping suzieq batfish protocol n2n tts chrome-devtools rag-mcp"
 
 PROFILE_CISCO="pyats gait netbox servicenow aci ise catalyst-center meraki sdwan cml fmc \
@@ -147,7 +148,7 @@ fwrule subnet-calc drawio-rfc uml packet-buddy"
 
 PROFILE_CLOUD="aws azure gcp cloudflare terraform vault github gait drawio-rfc uml subnet-calc"
 
-PROFILE_SECURITY="ise fmc panorama fortinet checkpoint claroty zscaler nvd-cve cisco-psirt nmap \
+PROFILE_SECURITY="ise fmc panorama fortinet bgp-intel checkpoint claroty zscaler nvd-cve cisco-psirt nmap \
 fwrule gait servicenow"
 
 PROFILE_LABS="cml containerlab batfish protocol peering n2n in2n-production suzieq gait subnet-calc drawio-rfc uml"

--- a/scripts/lib/install-steps.sh
+++ b/scripts/lib/install-steps.sh
@@ -3826,6 +3826,25 @@ echo ""
 }
 
 # ── Globalping remote MCP (spec 079 / roadmap R8) ───────────────
+component_install_bgp_intel() {
+log_step "Installing BGP & Registry Intelligence MCP Server..."
+echo "  Source: mcp-servers/bgp-intel-mcp (NetClaw-authored, spec 081 / roadmap R9)"
+echo "  RPKI origin validation, RDAP ownership, PeeringDB peering, routing visibility"
+echo "  Public unauthenticated APIs — NO credentials required"
+
+BGP_INTEL_MCP_DIR="$REPO_ROOT/mcp-servers/bgp-intel-mcp"
+
+if [ -d "$BGP_INTEL_MCP_DIR" ]; then
+    netclaw_pip_install -r "$BGP_INTEL_MCP_DIR/requirements.txt" 2>/dev/null || \
+        log_warn "BGP-intel MCP dependency install failed (mcp, httpx)"
+    log_info "BGP-intel MCP prepared: $BGP_INTEL_MCP_DIR"
+else
+    log_warn "BGP-intel MCP directory missing: $BGP_INTEL_MCP_DIR"
+fi
+
+BGP_INTEL_MCP_CMD_DETECTED="python3 $BGP_INTEL_MCP_DIR/server.py"
+}
+
 component_install_globalping() {
 log_step "Enabling Globalping (remote MCP)..."
 echo "  Outside-in measurement from ~4,800 probes across ~1,390 ASNs:"

--- a/specs/081-bgp-registry-intel/VERIFICATION.md
+++ b/specs/081-bgp-registry-intel/VERIFICATION.md
@@ -1,0 +1,125 @@
+# Verification Report — BGP & Registry Intelligence (spec 081 / R9)
+
+**Date**: 2026-08-03 · **FR-036 / FR-037 / SC-020**
+
+FR-037 set a harder bar than spec 080 met: every source here is public and unauthenticated, so
+**near-total live verification was the expectation, not the aspiration.** Spec 080's excuse — appliances
+unavailable — does not exist.
+
+## Result: 10 of 10 tools live-verified
+
+| Tool | Status | Source that answered |
+|---|---|---|
+| `rpki_validate` | ✅ live | `rpki-validator.ripe.net` |
+| `registry_lookup` | ✅ live | `rdap.db.ripe.net`, `rdap.arin.net` |
+| `registry_abuse_contact` | ✅ live | `rdap.db.ripe.net` |
+| `routing_as_overview` | ✅ live | `stat.ripe.net` |
+| `routing_announced_prefixes` | ✅ live | `stat.ripe.net` |
+| `peering_network` | ✅ live | `peeringdb.com` |
+| `peering_presence` | ✅ live | `peeringdb.com` |
+| `atlas_anchors` | ✅ live | `atlas.ripe.net` |
+| `atlas_probe_count` | ✅ live | `atlas.ripe.net` |
+| `resource_report` | ✅ live | composite — **5 sections, 4 distinct sources** |
+
+**Nothing shipped unexercised.** Compare spec 080, which shipped 13 of 21 tools untouched because no
+FortiManager or FortiAnalyzer was deployed.
+
+## The four RPKI states — all observed, none inferred
+
+| Query | `state` | `reason` | RFC 6811 | `is_finding` |
+|---|---|---|---|---|
+| `AS13335` + `1.1.1.0/24` | `valid` | — | Valid | `false` |
+| `AS13335` + `8.8.8.0/24` | `invalid` | **`as`** | Invalid | **`true`** |
+| `AS15169` + `8.8.8.128/25` | `invalid` | **`length`** | Invalid | **`true`** |
+| `AS3356` + `4.0.0.0/9` | `not_found` | — | **NotFound** | `false` |
+| `AS13335` + `2606:4700::/32` | `not_found` | — | NotFound | `false` |
+
+The `length` case was **constructed deliberately**: `8.8.8.0/24` carries a ROA with `maxLength 24`, so
+announcing `8.8.8.128/25` with the *correct* origin AS is invalid on length alone. That is the distinction
+FR-002 forbids collapsing, and it is now demonstrable rather than asserted.
+
+## The central promise, asserted as text
+
+| Assertion | Result |
+|---|---|
+| `not_found` output contains "invalid" | ❌ absent |
+| `not_found` output contains "suspicious" | ❌ absent |
+| `not_found` output contains "unverified" | ❌ absent |
+| `not_found` output says "normal" and "not a finding" | ✅ present |
+| Any RPKI output contains "confirmed" / "cross-checked" | ❌ absent |
+| Every RPKI output says "not corroborated" and names its validator | ✅ present |
+
+These are **text** assertions on purpose. Spec 080 shipped `fgt_system_status` returning three `null`
+fields past 24 passing tests, because those tests asserted on envelope *shape* and never on content. A
+requirement about wording needs a test about wording.
+
+## Structural guarantees — verified without the network
+
+| Guarantee | Status |
+|---|---|
+| Every response names its source; a source-less response errors | ✅ |
+| Merged answers carry **per-element** provenance (SC-013) | ✅ 4 distinct sources in one report |
+| Every operation GAIT-audited, **including refusals and failures** | ✅ 30 records in the live run |
+| `no_record` ≠ `source_unavailable` | ✅ |
+| `validation_unavailable` ≠ `not_found` | ✅ |
+| Private/reserved/bogon refused **with no outbound request** | ✅ 16 classes, v4 and v6 |
+| No 1-second window exceeds 4 requests per source | ✅ observed from a request timeline |
+| Requests to one source never concurrent | ✅ zero overlapping intervals |
+| Different sources not serialised against each other | ✅ |
+| Per-source TTLs (RPKI 5 min ≠ RDAP 24 h) | ✅ |
+| `fresh=true` bypasses cache | ✅ |
+| `BGP_INTEL_MAX_RPS` cannot be raised above 4 | ✅ clamped |
+| Manifest ≤ 5,000 tokens | ✅ **1,376** |
+
+## Two things found during implementation that changed the work
+
+### The rate limiter was genuinely too weak
+
+The first implementation enforced a **minimum 250 ms gap** between requests. A contract test measuring the
+observed timeline failed at **4.53 requests/second**, and the cause was a fencepost: N requests spaced
+250 ms apart span (N−1)×0.25 s, so **five** fit inside one second against a ceiling of four.
+
+That is a real violation of FR-023's literal reading, against volunteer-funded infrastructure. Replaced
+with a **true sliding window**: no one-second window may contain more than four requests.
+
+A second round then failed at 4.89/s — and that time **the test was wrong, not the code**.
+`total_requests / total_elapsed` is not "requests in any window"; with a correct sliding window, requests
+1–4 fire immediately and the 5th waits for the 1st to age out, giving a misleading burst average while
+every actual window holds exactly four. The assertion was rewritten to check the invariant directly.
+
+Worth recording because the sequence matters: the test caught a real bug, then the fixed code caught a bad
+test.
+
+### ARIN is not broken
+
+Phase 0 recorded `rdap.arin.net` refusing connections (`Recv failure: Connection reset by peer`) from a
+single `curl`. Exercised through the implemented IANA-bootstrap path it returned **HTTP 200** with holder
+`GOGL`.
+
+**The reset was transient, not a property of ARIN.** The spec and research have been corrected. The design
+is unchanged and was right for a better reason than it was chosen for: bootstrap resolution plus a fallback
+handles a transient per-registry failure exactly as well as a permanent one, and FR-011's "name the source
+that failed" is correct either way.
+
+## What was not verified, and why
+
+| Not exercised | Why | Justified? |
+|---|---|---|
+| `rate_limited` outcome against a real throttle | No source throttled us at 4 req/s — the ceiling is conservative enough that provoking it would mean deliberately abusing a free service | **Yes.** Verified against a stub instead |
+| `source_refused` against a live refusal | ARIN's reset was not reproducible (see above) | **Yes.** Verified against a stub; the transient case is the honest finding |
+| PeeringDB `no_record` against a genuinely absent ASN | Research open item 3 — not closed. Logic is unit-tested, but no real ASN absent from PeeringDB was located | **Partially.** The path is tested, not live-observed |
+| RIPEstat RPKI **fallback** path | The primary validator never failed during verification | **Yes.** Translation logic is unit-tested including `unknown`→`not_found` and `invalid_asn`→(`invalid`,`as`) |
+
+Four items, each a case that requires the *unhappy* path of a healthy public service. Each is unit-tested
+and each is named here rather than glossed. That is the whole point of this document.
+
+## Gates
+
+| Check | Result |
+|---|---|
+| `reconcile-mcp.py` (4 surfaces) | ✅ exit 0 |
+| `verify-inventory-counts.py` | ✅ exit 0 — 207 skills, 154 integrations |
+| `trace-skill.py bgp-registry-intel` | ✅ exit 0 |
+| `tests/bgp-intel/run-tests.sh` (5 suites) | ✅ exit 0 |
+| `test_manifest_size.py` | ✅ 1,376 / 5,000 |
+| Bash / Node / JSON / Python syntax | ✅ all valid |

--- a/specs/081-bgp-registry-intel/checklists/requirements.md
+++ b/specs/081-bgp-registry-intel/checklists/requirements.md
@@ -1,0 +1,107 @@
+# Specification Quality Checklist: BGP & Registry Intelligence
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+**On "no implementation details":** the spec names specific data sources (RIPEstat, PeeringDB, RDAP,
+RIPE Atlas) and cites measured HTTP behaviour. This is deliberate and is not implementation leakage —
+those services *are* the capability, and their observed quirks are requirements. FR-004 exists only
+because RIPEstat's `unknown` diverges from RFC 6811's `NotFound`; FR-011 exists only because ARIN's
+RDAP resets the connection from this host. A spec that abstracted those away would have to be
+rediscovered during implementation, which is exactly what spec 080 paid for.
+
+Concrete NetClaw artifacts (`config/openclaw.json`, `catalog.sh`, `reconcile-mcp.py`) are likewise
+retained: Constitution Principle XI makes artifact coherence a non-negotiable **acceptance condition**,
+not a design choice.
+
+**Grounded before writing, not after.** Every capability was reachability-tested on 2026-08-03 before a
+line of spec was written, and all four RPKI states were observed live rather than read from
+documentation:
+
+| Observation | Result |
+|---|---|
+| `AS13335` + `1.1.1.0/24` | `valid` |
+| `AS13335` + `8.8.8.0/24` | `invalid_asn` (ROA authorises AS15169) |
+| `AS3356` + `4.0.0.0/9` | `unknown` — i.e. RFC 6811 `NotFound` |
+| ARIN RDAP | connection reset — unusable from this host |
+| `rdap.org` bootstrap, RIPE RDAP | 200 |
+| PeeringDB, RIPEstat, RIPE Atlas | 200, unauthenticated |
+| Rate-limit headers | **none advertised** by RIPEstat or PeeringDB |
+
+This is the direct lesson of R3/R4: front-load lab and API reality *before* committing to scope. Spec
+080 discovered its lab problem at implementation time and lost most of a day; R4 is currently waiting on
+a human-reviewed vendor trial. R9 was chosen for this slot precisely because its backends are public, and
+that choice was validated by testing rather than assumed.
+
+**Informed defaults taken** (all recorded in Assumptions):
+
+| Open question | Default | Why |
+|---|---|---|
+| Which RPKI validation source? | RIPEstat | The only one verified working; Cloudflare's documented path 404s. A corroborating second validator is desirable but not assumed available |
+| Which RDAP entry point? | Bootstrap / RIPE, not ARIN direct | Measured: ARIN resets. Not a preference |
+| RIPE Atlas scope | Read-only inventory only | Measurement needs credentials and credits, and R8 already owns outside-in measurement |
+| Write path | None | Registry lookups change nothing; there is no gate to design, unlike spec 080 |
+| IRR/RPSL, BGP communities | Deferred | Adjacent but a distinct data model; better as its own item than half-delivered |
+
+---
+
+## Post-clarification revalidation (2026-08-03)
+
+`/speckit.clarify` asked 5 questions; all 5 answered and integrated. Checklist re-run — **all items still
+pass**. Three of the five replaced unquantified adjectives or soft verbs with testable numbers, which was
+the main quality risk in the first draft.
+
+| # | Question | Answer | Spec impact |
+|---|---|---|---|
+| 1 | Does US5 survive the Globalping overlap? | **Kept, narrowed** to Atlas anchors + per-AS probe counts | US5 rewritten; FR-017 narrowed; new FR-017a routes general probe-availability to Globalping; SC-011 tightened |
+| 2 | Self-imposed request rate? | **≤ 4/s per source, strictly serial** | FR-023 became a number; new FR-023a bans parallel fan-out, FR-023b requires enforcement at the request layer; new SC-016a asserts it from an observed request timeline |
+| 3 | Cache lifetime and location? | **Per-source TTLs, in memory only** | FR-026 became a TTL table; FR-026a forbids an on-disk store; FR-026b requires cache-age reporting; FR-026c adds force-fresh; SC-017a/b added |
+| 4 | Tool-manifest ceiling? | **Same 5,000 tokens as spec 080** | New FR-027a/b/c and SC-020a, with a build-failing test |
+| 5 | One RPKI validator or two? | **One, named, explicitly uncorroborated** | New FR-007a/b/c and SC-005a/b; Assumptions rewritten to make corroboration a Phase 0 question |
+
+**Two answers worth recording the reasoning for**, because both were the *less* impressive-sounding option:
+
+**Q5 chose honesty over apparent rigour.** Requiring two validators reads stronger, but it would have
+specified a corroboration flow against Cloudflare's endpoint — which **404s as measured**. That is exactly
+the "assume the API, discover otherwise at implementation" failure that cost spec 080 most of a day. FR-007c
+now also forbids the subtle version of the same error: if the validator is unreachable, NetClaw reports
+*validation unavailable*, never falling back to inferring state from routing or registry data. **An
+unavailable validator is not a `not-found`** — which is the feature's core distinction reappearing one level
+down.
+
+**Q3 chose no persistent state.** Spec 078 caches PSIRT data on disk and is right to; that data is large and
+slow-moving. Here the goal is only to avoid hammering a free service within one investigation, so an
+in-memory buffer is sufficient and avoids a store to manage, back up, or leak. Per-source TTLs were
+necessary because RPKI and RDAP volatility differ by orders of magnitude — a single TTL would be wrong for
+at least one source, and a stale `valid` is the most dangerous stale value in the feature.
+
+**Still deferred to Phase 0 research** (correctly — these need evidence, not opinion): build-vs-adopt across
+any existing community BGP/RPKI MCP servers, and whether a second reachable RPKI validator exists.

--- a/specs/081-bgp-registry-intel/contracts/mcp-tools.md
+++ b/specs/081-bgp-registry-intel/contracts/mcp-tools.md
@@ -1,0 +1,168 @@
+# Contract — `bgp-intel-mcp` tool surface
+
+**Phase 1** · 2026-08-03 · Transport **stdio**, framework **FastMCP**, JSON-RPC lifecycle (Principle V).
+
+**Budget**: the entire `tools/list` response MUST measure **≤ 5,000 tokens** (FR-027a) — the same ceiling
+spec 080 set, carried as a repo-wide convention. This surface is ~10 tools and expected to pass with wide
+headroom; the ceiling exists to stop a later expansion, not to constrain the initial build.
+
+**Read-only.** No tool changes anything, anywhere. There is no write path and therefore no approval gate.
+
+---
+
+## Universal response envelope
+
+Every tool returns the shape in [data-model.md §1](../data-model.md). Enforced by `envelope.emit()`, a
+chokepoint rather than a convention.
+
+```jsonc
+{ "source": "...", "retrieved_at": "...", "outcome": "ok",
+  "cached": false, "cache_age_seconds": null,
+  "query": {...}, "data": {...}, "caveats": [] }
+```
+
+`caveats` is **structured, not prose decoration** — it carries the statements FR-009/013/016 require so they
+survive a model summarising the payload.
+
+---
+
+## RPKI — 1 tool
+
+### `rpki_validate(prefix, origin_asn, fresh=false)`
+
+Origin validation for a prefix + origin-AS **pair**. FR-001–FR-007c.
+
+Returns `state` ∈ `valid` · `invalid` · `not_found`, plus `reason` ∈ `as` · `length` · `null`, the VRPs that
+drove the verdict, the validator's name, and `corroborated: false`.
+
+**Contractual obligations — the core of this feature:**
+
+| Obligation | Requirement |
+|---|---|
+| `not_found` carries a caveat that this is **normal and not a finding** | FR-003 |
+| The words `invalid` / `suspicious` / `unverified` **never** appear in a `not_found` result | FR-003, SC-004 |
+| `not_found` is reported using the **RFC 6811 term**, and if the RIPEstat fallback was used its `unknown` is translated with the translation stated | FR-004, SC-005 |
+| `invalid/as` and `invalid/length` are **separately distinguishable** in output | FR-002, SC-003 |
+| An `invalid` result names **what the ROA does authorise** (permitted ASN and maxLength) | FR-006 |
+| The VRPs are included so the operator can check the reasoning, not trust a label | FR-005 |
+| The validator is named and `corroborated` is literally `false` | FR-007a, SC-005a |
+| The tool **never** says hijack, attack or incident | FR-007, SC-009 |
+| Validator unreachable ⇒ `validation_unavailable`, **never** `not_found` | FR-007c, SC-005b |
+
+`fresh=true` bypasses the 5-minute cache, for when a ROA was just published (FR-026c).
+
+---
+
+## Registry — 2 tools
+
+### `registry_lookup(resource)`
+IP, prefix or ASN → holder, allocation range, responsible registry, abuse contacts, events.
+
+### `registry_abuse_contact(resource)`
+Narrow convenience: just the abuse contacts. Exists because it is the single most common incident-response
+question and folding it into the full record forces a caller to parse.
+
+**Contractual obligations:**
+
+| Obligation | Requirement |
+|---|---|
+| The **responding registry is named**, plus how it was selected (`iana_bootstrap` / `rdap_org_fallback`) | FR-010, SC-006 |
+| Every record carries the caveat: **allocation data, not evidence about who is announcing** | FR-009 |
+| A registry that resets/times out ⇒ `source_refused` / `source_unavailable` **naming it** — never `no_record` | FR-011, SC-007 |
+
+---
+
+## Routing — 2 tools
+
+### `routing_as_overview(asn)`
+Holder and allocation status for an ASN — distinct from what it announces.
+
+### `routing_announced_prefixes(asn)`
+Observed announcements with per-prefix visibility.
+
+**Contractual obligations:**
+
+| Obligation | Requirement |
+|---|---|
+| `collector_basis` present on every result; visibility is **RIPE's collectors, not global truth** | FR-013, SC-008 |
+| The tool **never** attaches `leak` or `hijack` to a low-visibility prefix | FR-013, SC-009 |
+| "No announcements observed" ≠ "AS does not exist" ≠ "query failed" | FR-014 |
+| Large result sets are **bounded and say so** (`truncated`, `total_available`) — never silently cut | Edge Cases |
+
+---
+
+## Peering — 2 tools
+
+### `peering_network(asn)`
+PeeringDB network record: type, traffic profile, policy, contacts.
+
+### `peering_presence(asn)`
+IXPs and facilities.
+
+**Contractual obligations:**
+
+| Obligation | Requirement |
+|---|---|
+| Every result carries the caveat: **self-reported** | FR-016 |
+| No record ⇒ `no_record` with the caveat that this is **not evidence the network does not peer** | FR-016, SC-010 |
+
+---
+
+## Atlas — 2 tools, deliberately narrow
+
+### `atlas_anchors(country)`
+Atlas anchors — stable, always-on measurement targets. Globalping has no equivalent.
+
+### `atlas_probe_count(asn)`
+How many Atlas probes sit inside a given AS — "can this network be measured from within?"
+
+**Contractual obligations:**
+
+| Obligation | Requirement |
+|---|---|
+| General probe-availability-by-location is **not implemented**; such a request is routed to Globalping's `locations` | FR-017a, SC-011 |
+| A request to **run** a measurement is routed to Globalping (R8) | FR-018, SC-011 |
+
+---
+
+## Composite — 1 tool
+
+### `resource_report(resource)`
+
+The question an operator actually asks: *"what do I know about this prefix/ASN?"* Runs RPKI (if a prefix +
+origin can be determined), registry, routing and peering, and returns one report.
+
+**Contractual obligations:**
+
+| Obligation | Requirement |
+|---|---|
+| **Per-element provenance** — each section carries its own `source`, never one collective citation | FR-021, SC-013 |
+| Sub-queries run **serially**, respecting 4/s per source. No parallel fan-out | FR-023a, SC-016a |
+| A failed section is reported as failed **within** the report; the report does not fail wholesale | FR-011 |
+| Where sources disagree (RDAP holder vs PeeringDB name), the **disagreement is reported**, not resolved | Edge Cases |
+
+This is the tool most at risk of quietly violating FR-023a, because "fetch four things" invites
+`asyncio.gather`. It must not.
+
+---
+
+## Total surface: 10 tools
+
+1 RPKI · 2 registry · 2 routing · 2 peering · 2 Atlas · 1 composite.
+
+**A design target, not a measurement.** FR-027a/b require the real `tools/list` token count be measured and
+enforced by a build-failing test once the surface exists.
+
+---
+
+## Error semantics
+
+Every outcome in [data-model.md §2](../data-model.md) is reachable from this surface. Four obligations that
+are easy to get wrong and are therefore contractual:
+
+1. **`source_unavailable` names the source** and is never rendered as an empty result (FR-011).
+2. **`input_refused` happens locally with no outbound request** — private, reserved and bogon input never
+   reaches a public registry, because sending it is a disclosure even if the query fails (FR-028, SC-015).
+3. **`rate_limited` produces backoff and a reported condition**, never a retry storm (FR-027, SC-018).
+4. **`validation_unavailable` is distinguishable from RPKI `not_found`** in output (FR-007c, SC-005b) — the
+   feature's core distinction, one level down, and the subtlest bug available here.

--- a/specs/081-bgp-registry-intel/data-model.md
+++ b/specs/081-bgp-registry-intel/data-model.md
@@ -1,0 +1,251 @@
+# Data Model — BGP & Registry Intelligence (spec 081)
+
+**Phase 1** · 2026-08-03 · Stateless server. These are **response shapes and typed distinctions**, not
+persisted records. Nothing is written to disk (FR-026a).
+
+---
+
+## 1. The provenance envelope — every response, no exceptions
+
+Every response passes through `envelope.emit()`. There is no path to a client that bypasses it (FR-019/020).
+
+```jsonc
+{
+  "source": "rpki-validator.ripe.net",   // REQUIRED — the specific service, never a category
+  "retrieved_at": "2026-08-03T12:04:11Z",
+  "outcome": "ok",
+  "cached": false,                        // true + cache_age_seconds when served from cache (FR-026b)
+  "cache_age_seconds": null,
+  "query": { ... },                       // what was actually asked, echoed back
+  "data": { ... },
+  "caveats": []                           // the "this is not what you think" statements
+}
+```
+
+**Validation rule (FR-019)**: a response whose `source` cannot be named MUST be an error, not an
+unattributed answer. "The registry says" is not attributable; RIRs differ in freshness and completeness.
+
+**Validation rule (FR-021)**: where a result merges data from more than one service, **each element carries
+its own source**. One collective citation across a merged answer is not attribution.
+
+`caveats` is a structured field, not decoration. It carries the statements FR-009, FR-013 and FR-016
+require — self-reported, collector-based, allocation-not-routing — so they cannot be lost when a model
+summarises the payload.
+
+---
+
+## 2. Outcomes — the typed distinctions
+
+```
+ok                        data returned
+no_record                 the source answered; there is no record for this resource
+source_unavailable        the source did not answer. NOT "no record"
+source_refused            the source actively rejected us (e.g. ARIN's connection reset)
+input_refused             private/reserved/bogon/malformed — refused locally, no request made
+rate_limited              throttled; backed off rather than retried
+validation_unavailable    RPKI-specific: the validator could not be reached
+```
+
+| Never collapse | Because |
+|---|---|
+| `no_record` vs `source_unavailable` | A dead API must never look like an empty registry (FR-011) |
+| `no_record` vs `input_refused` | We refused, versus they had nothing |
+| `validation_unavailable` vs RPKI `not_found` | **FR-007c.** An unreachable validator is not "unsigned" |
+
+That last row is the feature's core distinction reappearing one level down, and the subtlest bug available
+here.
+
+---
+
+## 3. RPKI validation — the flagship entity
+
+### `RpkiValidation`
+
+| Field | Notes |
+|---|---|
+| `prefix`, `origin_asn` | Validation is always of the **pair**, never a prefix alone |
+| `state` | `valid` · `invalid` · `not_found` — RFC 6811 vocabulary. **See the spelling note below** |
+| `reason` | `as` · `length` · `null`. Populated **only** when `state == invalid` |
+| `description` | The validator's own human-readable sentence |
+| `vrps_matched[]` | VRPs that matched — the evidence for `valid` |
+| `vrps_unmatched_as[]` | Covering VRPs whose ASN differs — the evidence for `invalid`/`as` |
+| `vrps_unmatched_length[]` | Covering VRPs whose maxLength is exceeded — evidence for `invalid`/`length` |
+| `validator` | Named on every result (FR-007a) |
+| `corroborated` | **Always `false`.** See below |
+| `is_finding` | `true` only for `invalid`. See below |
+
+### The four states, all live-verified (research R9)
+
+| State | `reason` | Meaning | `is_finding` |
+|---|---|---|---|
+| `valid` | — | A ROA authorises this origin | `false` |
+| `invalid` | `as` | A ROA covers this prefix; **a different AS** is authorised | **`true`** |
+| `invalid` | `length` | A ROA covers this prefix; **it is more specific** than `maxLength` | **`true`** |
+| `not_found` | — | **No ROA exists.** The common case | **`false`** |
+
+**Rule (FR-003), the single most important in this model:** `not_found` MUST carry an explicit caveat that
+this is normal for most address space and is **not** a finding. The words `invalid`, `suspicious` and
+`unverified` MUST NOT appear in a `not_found` result.
+
+**Rule (FR-002):** `reason` is a separate field precisely so `invalid/as` and `invalid/length` stay
+distinguishable. RFC 6811 collapses both to "Invalid"; the validator is more granular, and flattening it
+destroys the difference between *"someone else is announcing your space"* and *"you announced a /24 under a
+/22 ROA."* Different severity, different remediation.
+
+**Rule (FR-007a):** `corroborated` is a literal `false`, not omitted. Both reachable validators are RIPE NCC
+Routinator — same engine, same operator (research R3) — so agreement between them would be theatre. The
+field exists to make the absence of corroboration explicit rather than implied.
+
+**Rule (FR-004):** the RIPEstat fallback returns `unknown` for what the standard calls `NotFound`, and fuses
+`invalid_asn`/`invalid_length`. When the fallback is used, the mapping to this model MUST be applied and the
+translation stated. Passing the raw string through is prohibited.
+
+### Spelling: `not-found` on the wire, `not_found` in code — deliberately
+
+Three spellings are in play and the difference is **intentional**, not drift:
+
+| Where | Spelling | Why |
+|---|---|---|
+| RFC 6811, and the validator's JSON | **`not-found`** | The standard's term and the wire format |
+| This model, enum members, Python identifiers | **`not_found`** | A hyphen is not valid in an identifier |
+| RIPEstat fallback only | `unknown` | A different vocabulary entirely — mapped, never passed through |
+
+Normalising these to one spelling would either produce an invalid Python identifier or silently break the
+wire mapping. A future maintainer tidying this "inconsistency" is a realistic hazard, which is why it is
+written down rather than left to be inferred.
+
+---
+
+## 4. Registry records (RDAP)
+
+### `RegistryRecord`
+
+| Field | Notes |
+|---|---|
+| `resource` | The IP, prefix or ASN queried |
+| `holder` | Registered organisation |
+| `allocation_range` | The block the resource sits in |
+| `registry` | **Which RIR answered** — required (FR-010) |
+| `registry_selected_via` | `iana_bootstrap` · `rdap_org_fallback` — how we chose (research R4) |
+| `abuse_contacts[]` | Email/phone where published |
+| `events[]` | Registration/last-changed dates where published |
+
+**Rule (FR-009):** every registry record carries the caveat that this is **allocation data, not evidence
+about who is announcing the space.** Presenting an RDAP holder as a routing fact is the same category error
+as presenting FortiManager intent as device state (spec 080).
+
+**Rule (FR-011):** a registry that resets, times out or refuses yields `source_refused` /
+`source_unavailable` **naming that registry** — never `no_record`. ARIN's connection reset from this host is
+the live example, and it must not be hardcoded as "ARIN is broken" (research R4).
+
+---
+
+## 5. Routing status
+
+### `AsOverview` · `AnnouncedPrefixes`
+
+| Field | Notes |
+|---|---|
+| `asn`, `holder` | Allocation-level identity |
+| `announced_prefixes[]` | Each with observed visibility |
+| `visibility.peers_seeing` / `peers_total` | Raw counts, not a score |
+| `collector_basis` | Required — whose collectors (FR-013) |
+| `truncated`, `total_available` | Set when bounded; never silently cut |
+
+**Rule (FR-013):** visibility is **RIPE's collector view, not global truth.** Low visibility has legitimate
+explanations — deliberately scoped announcements, anycast, no-export. The words `leak` and `hijack` MUST NOT
+be attached by the tool (SC-009).
+
+**Rule (FR-014):** "no announcements observed" is distinct from "the AS does not exist" and from "the query
+failed". Three different facts.
+
+---
+
+## 6. Peering data
+
+### `PeeringRecord`
+
+`asn` · `name` · `info_type` · `info_traffic` · `policy_general` · `ixps[]` · `facilities[]` · `contacts[]`
+
+**Rule (FR-016):** PeeringDB is **self-reported**. An absent record is `no_record` with the caveat that this
+is **not evidence the network does not peer** — it is evidence nobody updated the record. Absence of
+evidence again.
+
+---
+
+## 7. Atlas inventory — deliberately narrow
+
+### `AtlasAnchor` · `AsProbeCount`
+
+`anchors[]` (id, fqdn, country, status) · `asn` + `probe_count` + `probes_connected`
+
+**Rule (FR-017a):** general probe-availability-by-location is **not modelled here.** Globalping's
+`locations` owns it; a request for it is routed there. This entity exists only for anchors and per-AS
+density, the two things Globalping has no equivalent of (clarification Q1).
+
+---
+
+## 8. Request discipline
+
+### `SourceBudget` (internal, one per source)
+
+| Field | Value |
+|---|---|
+| `max_rps` | **4** |
+| `max_concurrency` | **1** — strictly serial (FR-023a) |
+| `user_agent` | Identifies NetClaw + a contact reference (FR-025) |
+
+**Rule (FR-023b):** enforced at the request layer, so a tool added later inherits it without knowing it
+exists. Not caller discipline.
+
+### `CacheEntry` (in memory only)
+
+| Source | TTL |
+|---|---|
+| RPKI validation | **5 min** — a ROA can appear or vanish in minutes; a stale `valid` is the most dangerous stale value here |
+| Routing status / AS overview | 15 min |
+| RDAP | 24 h |
+| PeeringDB | 24 h |
+| Atlas | 24 h |
+
+**Rule (FR-026a):** in-memory, session-scoped. **No on-disk store.** Deliberately unlike spec 078, which
+caches PSIRT data on disk because that data is large and genuinely slow-moving.
+
+**Rule (FR-026b/c):** a cached response reports `cached: true` **and** `cache_age_seconds`, and a caller can
+force a fresh lookup — for the case where a ROA was just published and the 5-minute TTL is the only thing
+between the operator and the truth.
+
+---
+
+## 9. Input validation — refused before any request leaves
+
+`validate.py` refuses, **locally, with no outbound request** (FR-028):
+
+- RFC1918 · loopback · link-local · CGNAT (100.64/10) · multicast · reserved
+- Documentation ranges (192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24, 2001:db8::/32)
+- IPv6 ULA (fc00::/7) · unspecified · unique-local
+- Malformed: bad prefix length, non-numeric ASN, mixed address family, AS0
+
+**Rule (FR-028):** this is a **disclosure control**, not a validation nicety. Sending an internal address to
+a public registry is a disclosure even if the query then fails — the same reasoning spec 079 applied to
+Globalping.
+
+**Rule (FR-029):** IPv4 and IPv6 across every capability. Verified live for RPKI, RDAP and routing status
+(research R10).
+
+---
+
+## 10. Audit records (GAIT) — FR-022, Principle IV
+
+Emitted from the same chokepoint as provenance, so a new tool cannot skip it.
+
+| Field | Notes |
+|---|---|
+| `ts`, `component`, `tool` | |
+| `query` | The resource asked about |
+| `source`, `outcome` | |
+| `cached` | Whether a request actually left the machine |
+
+Includes **refusals and failures**. There are no credentials in this feature, so unlike specs 078 and 080
+there is no redaction concern — but the record still carries only the shape of the operation, not bulk
+payload.

--- a/specs/081-bgp-registry-intel/plan.md
+++ b/specs/081-bgp-registry-intel/plan.md
@@ -1,0 +1,250 @@
+# Implementation Plan: BGP & Registry Intelligence (RPKI / RDAP / PeeringDB / RIPEstat)
+
+**Branch**: `081-bgp-registry-intel` | **Date**: 2026-08-03 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/081-bgp-registry-intel/spec.md`
+**Research**: [research.md](./research.md) — **read R2 first**; it changes the primary data source
+**Roadmap**: R9 — Tier 2, "the internet / external plane"
+
+## Summary
+
+Spec 079 (R8) gave NetClaw a vantage point outside its own domain: Globalping *measures* toward a target.
+This feature answers the questions that follow — **who is this allocated to, is this announcement
+legitimate, where does this network peer** — from four public, unauthenticated sources.
+
+Build `mcp-servers/bgp-intel-mcp/`. Four capability areas plus a narrowed Atlas pair, ~10 tools, read-only
+throughout. No credentials exist anywhere in this feature, which removes an entire class of risk present in
+specs 078 and 080.
+
+The engineering weight is not in the HTTP. It is in **four distinctions that are trivially easy to collapse
+and dangerous when collapsed**, chief among them: **RPKI `not-found` is not `invalid`.** Most of the
+internet has no ROA; reporting unsigned space as a finding would manufacture false incidents at scale.
+
+**Phase 0 changed the primary source.** The spec assumed RIPEstat. `rpki-validator.ripe.net` is better on
+three counts — RFC 6811 vocabulary natively, `state` and `reason` as separate fields, and the VRPs that drove
+the verdict included. All four states are now live-verified against it (research R9).
+
+## Technical Context
+
+**Language/Version**: Python 3.10+, system interpreter. No dedicated venv — two pure-HTTP packages move
+nothing shared (unlike spec 076).
+
+**Primary Dependencies**: `mcp>=1.2.0,<2` and `httpx>=0.27.0,<1`. Identical to specs 078 and 080. The `mcp`
+upper bound is **load-bearing and now urgent**: Phase 0 confirmed the MCP Python SDK has shipped **v2**
+targeting the 2026-07-28 spec, and v2 removes `mcp.server.fastmcp`, which this server imports. Spec 077's
+rule is no longer hypothetical.
+
+No RDAP/RPKI/BGP library. The payloads are plain JSON and the value is in the **semantics** — which state
+means what — not the transport. An SDK would add a pinning hazard while abstracting the one thing this
+feature must not abstract.
+
+**Storage**: **None on disk.** Per-source in-memory TTL cache only (clarification Q3): RPKI 5 min, routing
+15 min, RDAP/PeeringDB/Atlas 24 h. Deliberately unlike spec 078, which caches PSIRT data on disk because
+that data is large and slow-moving; here the cache is a courtesy buffer for one investigation, not a
+registry mirror.
+
+**Testing**: Contract tests over pure functions — envelope/provenance, the four RPKI states, input
+refusal, rate limiter, cache TTLs. Live integration tests against all four public sources, which — unlike
+spec 080 — need no lab, no credentials and no licence. Harness follows `tests/reconcile/run-tests.sh`
+(spec 075): bash + stdlib.
+
+**Target Platform**: Linux. Outbound HTTPS only.
+
+**Project Type**: New vendored MCP server + skill + installer catalog entry.
+
+**Performance Goals**: None. Deliberately **slower than possible** — FR-023a prohibits parallel fan-out.
+
+**Constraints**: ≤ 4 req/s per source, strictly serial (FR-023). Manifest ≤ 5,000 tokens (FR-027a).
+Read-only — no write path exists to gate. Every response carries source + retrieval time + outcome
+structurally (FR-019). No ASN/geo enrichment: `gtrace` owns it (FR-032).
+
+**Scale/Scope**: 4 data sources, ~10 tools, 5 user stories, 54 FRs, 28 SCs.
+
+**No external blockers.** Every source is public and reachable today — verified before the spec was written
+and again in Phase 0. This is the first item since R8 with no lab, licence, trial or entitlement on the
+critical path, which is precisely why it was selected while R4 waits on a vendor trial.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+| Principle | Applies | Assessment |
+|---|---|---|
+| **I — Safety-First (NON-NEGOTIABLE)** | **Yes — inverted** | No device is touched and nothing is changed. The safety risk here is not damage but **false conclusions**: a wrong `valid` says an announcement is authorised when it is not; a wrong `invalid` sends someone chasing a hijack that is not happening. FR-007b makes that asymmetry explicit |
+| II — Read-Before-Write | N/A | Read-only feature; there is no write to precede |
+| III — ITSM-Gated Changes | N/A | No changes are made. **Deliberately N/A, not "inherited"** — spec 076 was caught claiming inheritance where nothing existed, and the honest answer here is that the principle does not apply |
+| **IV — Immutable Audit Trail** | **Yes** | FR-022: every operation GAIT-logged **by construction**, at the same chokepoint as provenance. Spec 080's `/speckit.analyze` caught this exact requirement with a verification task and no implementing task; Stage 2 carries the implementation |
+| **V — MCP-Native** | **Yes** | FastMCP, stdio, JSON-RPC lifecycle |
+| VI — Multi-Vendor Neutrality | **Yes — vendor-free** | Registries and RIRs, not vendors. Nothing here is vendor-specific |
+| **VII — Skill Modularity** | **Yes — drove two clarifications** | FR-032 keeps ASN/geo enrichment with `gtrace`; FR-017a keeps general probe availability with Globalping. Q1 narrowed US5 specifically to avoid duplication |
+| VIII — Verify After Change | N/A | No changes |
+| **IX — Security by Default** | **Yes** | No credentials to steal. FR-028 refuses private/reserved input **before** any outbound request, so internal addressing is never disclosed to a third party — the same discipline spec 079 applied to Globalping |
+| **X — Observability** | **Yes** | Provenance on every result is the feature's core observability property. HUD node required by XI |
+| **XI — Artifact Coherence (NON-NEGOTIABLE)** | **Yes — every touchpoint** | FR-038: registration, catalog, profiles, install fn, **both** HUD entries, README/SOUL counts **and** a SOUL capability section, SKILL.md, `.env.example`, `TOOLS.md`, server README. Gated by `reconcile-mcp.py` |
+| XII — Documentation-as-Code | Yes | Server README + SKILL.md, same PR |
+| **XIII — Credential Safety** | **Yes — trivially** | There are no credentials. `.env.example` gains only optional tuning variables. This is the first roadmap item with no secret to leak |
+| XIV — Human-in-the-Loop | N/A | No external communications, no writes |
+| XV — Backwards Compatibility | Yes — low risk | Two pure-HTTP packages; nothing shared moves |
+| XVI — Spec-Driven Development | Yes | Spec ratified, 5 clarifications resolved, plan precedes implementation |
+| XVII — Milestone Documentation | Yes | Blog post at completion, presented for review before publishing |
+
+**Gate result: PASS.** No violations requiring justification.
+
+**Four principles are genuinely N/A here (II, III, VIII, XIV), and that is stated rather than fudged.** Spec
+076 was caught claiming Principle III was "inherited from the existing approval path" when nothing
+implemented it. A read-only feature that queries public registries has no change to gate, and pretending
+otherwise to fill a table cell would be the same dishonesty in a different direction.
+
+**Post-Phase-1 re-check (2026-08-03): still PASS.** Principle I is strengthened by design: the four
+distinctions are enforced as distinct typed outcomes rather than prose, so a caller cannot collapse them
+even by accident. Principle IV is satisfied at the same chokepoint as provenance, so the spec-080 defect
+cannot recur.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/081-bgp-registry-intel/
+├── spec.md              # Ratified; 5 clarifications
+├── plan.md              # This file
+├── research.md          # Phase 0 — R2 changed the primary source; R9 verified all four states
+├── data-model.md        # Phase 1
+├── quickstart.md        # Phase 1
+├── contracts/
+│   └── mcp-tools.md     # Phase 1 — tool surface, provenance envelope, outcome semantics
+├── checklists/
+│   └── requirements.md  # Spec quality (PASS, revalidated after clarification)
+└── tasks.md             # Phase 2 — /speckit.tasks
+```
+
+### Source Code (repository root)
+
+```text
+mcp-servers/bgp-intel-mcp/
+├── server.py                # FastMCP entry point, stdio; tool registration
+├── envelope.py              # CHOKEPOINT: source + retrieved_at + outcome + GAIT (FR-019/020/022)
+├── outcomes.py              # The typed distinctions — RPKI states, source-failure vs no-record
+├── http_client.py           # Rate limiter (4/s serial per source) + TTL cache + User-Agent (FR-023/025/026)
+├── validate.py              # Input refusal: private/reserved/bogon/malformed, v4 + v6 (FR-028/029/030)
+├── sources/
+│   ├── rpki.py              # rpki-validator.ripe.net primary, RIPEstat fallback (research R2)
+│   ├── rdap.py              # IANA bootstrap -> direct RIR -> rdap.org fallback (research R4)
+│   ├── routing.py           # RIPEstat as-overview + routing-status
+│   ├── peeringdb.py         # PeeringDB net/ixlan
+│   └── atlas.py             # Anchors + per-AS probe counts ONLY (FR-017a)
+├── requirements.txt         # mcp>=1.2.0,<2 · httpx>=0.27.0,<1
+└── README.md
+
+workspace/skills/bgp-registry-intel/   # ONE skill — see Structure Decision
+config/openclaw.json                   # + registration, repo-relative paths
+scripts/lib/catalog.sh                 # + entry, + PROFILE_SECURITY / PROFILE_RECOMMENDED
+scripts/lib/install-steps.sh           # + component_install_bgp_intel()
+ui/netclaw-visual/server.js            # + node list entry AND annotation map entry (TWO edits)
+tests/bgp-intel/                       # contract tests + live integration tests
+```
+
+**Structure Decision**: `sources/` splits by **data source**, because each has its own endpoint shape,
+failure mode and TTL — and FR-021 requires per-element provenance, which is natural when each module owns
+its own attribution. `envelope.py` is a **chokepoint** every response passes through: FR-019 and FR-022 are
+only guarantees if omission is structurally impossible, which spec 080 proved works.
+
+`outcomes.py` is separate from `envelope.py` deliberately. The four RPKI states and the
+source-failure-vs-no-record distinction are the feature's *domain logic*, not its plumbing, and giving them
+their own module means the distinction is reviewable in one place rather than scattered across five source
+modules.
+
+**One skill, not four.** Unlike spec 080 — where three appliances with three credential sets justified three
+skills under Principle VII — these four sources answer facets of a **single** operator question: "what do I
+know about this internet resource?" A user asking about a suspicious prefix wants RPKI *and* registry *and*
+routing in one answer. Splitting them would force the model to orchestrate four skills for one question.
+
+## Implementation ordering
+
+**Distinctions and provenance before any source; sources before composition.**
+
+```
+Stage 1  Server skeleton, deps, envelope.py + outcomes.py + contract tests   (FR-019/020/022, FR-002)
+Stage 2  GAIT audit inside the chokepoint + its tests                        (FR-022, Principle IV)
+Stage 3  http_client.py: rate limiter, TTL cache, User-Agent + tests         (FR-023–027)
+Stage 4  validate.py: input refusal, v4 + v6 + tests                         (FR-028–030)
+Stage 5  US1 — RPKI: all four states, VRPs included, validator named         (FR-001–007c)
+Stage 6  US2 — RDAP: bootstrap resolution, per-registry attribution          (FR-008–011)
+Stage 7  US3 — routing status; US4 — PeeringDB                               (FR-012–016)
+Stage 8  US5 — Atlas anchors + per-AS probe counts only                      (FR-017–018)
+Stage 9  Manifest measurement against the 5,000-token ceiling                (FR-027a/b/c)
+Stage 10 Artifact coherence: registration, catalog, installer, HUD, docs     (FR-038–042)
+Stage 11 Skill, verification table, honest reporting                         (FR-031–033, FR-036/037)
+```
+
+**Stages 1–2 before any source.** The four RPKI states are the feature's reason to exist. Writing a source
+first and adding the distinction afterwards produces exactly the code that collapses `not-found` into
+`invalid`, because collapsing is the path of least resistance once you already hold a string from an API.
+
+**Stage 3 before Stage 5** so no source can be written that bypasses the rate limiter. FR-023b requires
+enforcement at the request layer precisely so a tool added later inherits it without knowing it exists.
+
+**Stage 4 before Stage 5** so private-address refusal exists before anything can call out. FR-028 is a
+disclosure control, not a validation nicety — the same reasoning spec 079 applied to Globalping.
+
+**Stage 9 before Stage 10** so registration never lands a manifest that breaches the ceiling.
+
+**Stage 5 is the MVP.** US1 alone — "is this announcement legitimate?" — delivers the capability nothing
+else in NetClaw has, and the four remaining sources are additive.
+
+## Key design decisions
+
+**Build, not adopt** (research R1). `peerglass` covers a similar surface with **42 tools across 9 phases**
+including satellite tracking and DNS-censorship detection. Adopting it means either registering a charter
+NetClaw did not choose or suppressing most of it, and 42 tools is the wrong order of magnitude against a
+5,000-token ceiling. Notably it arrived independently at three of this spec's clarified decisions — TTL
+caching in the 5-minute-to-24-hour band, per-result attribution, read-only — which is reassuring convergent
+evidence rather than borrowed design.
+
+**`rpki-validator.ripe.net`, not RIPEstat** (research R2). It reports RFC 6811 vocabulary natively
+(`not-found`, not `unknown`), separates `state` from `reason` instead of fusing them into `invalid_asn`, and
+returns the VRPs that drove the verdict. FR-004's translation requirement survives only for the RIPEstat
+fallback path.
+
+**One validator, and say so** (research R3). A second endpoint is reachable, but **both are RIPE NCC
+Routinator** — same engine, same operator, same trust anchors. Comparing them would produce agreement that
+means nothing. FR-007a's "explicitly uncorroborated" is therefore evidence-based, not a shrug.
+
+**Deliberately serial** (FR-023a). `peerglass` parallelises for latency; this does the opposite. Against
+volunteer-funded infrastructure, being over-polite costs latency nobody notices and being under-polite
+costs the integration.
+
+**Per-source TTLs, in memory** (clarification Q3). A stale `valid` is the most dangerous stale value in the
+feature, so RPKI gets 5 minutes while RDAP gets 24 hours. One global TTL would be wrong for at least one
+source. Nothing on disk: no store to manage, back up or leak.
+
+**An unavailable validator is not a `not-found`** (FR-007c). The feature's core distinction, one level down
+— and the subtlest bug available here. When the validator is unreachable, NetClaw must not infer state from
+routing data, registry data, or the absence of a ROA.
+
+## Complexity Tracking
+
+> No Constitution Check violations require justification.
+
+| Item | Note |
+|---|---|
+| Four sources, one skill | Deliberate departure from spec 080's one-skill-per-plane. These answer facets of one question; splitting would force four-skill orchestration for a single ask |
+| `outcomes.py` separate from `envelope.py` | The distinctions are domain logic, not plumbing. Keeping them in one reviewable module is the point of the feature |
+| Two RPKI endpoints in one module | Primary + documented fallback with different vocabularies. FR-004 exists for the fallback; collapsing to one endpoint would lose resilience |
+| Rate limiter slower than necessary | Not an oversight (FR-023a). Free community infrastructure |
+
+## Phase 2 preview
+
+`/speckit.tasks` will produce the dependency-ordered list. Expected shape: Stage 1 blocks everything;
+Stage 2 folds into the same chokepoint; Stage 3 and Stage 4 both block Stages 5–8; Stages 5–8 are
+independently deliverable per user story; Stage 9 blocks Stage 10.
+
+Three items carried from research as **tasks, not assumptions**:
+
+1. **Measure the manifest** once the surface exists — cannot be done earlier.
+2. **Confirm ARIN's reset is not host-specific** before documenting it as a property of ARIN rather than of
+   this environment.
+3. **Find an ASN genuinely absent from PeeringDB** for SC-010, rather than assuming one exists.
+
+Unlike specs 080 and (pending) 4, **no task here waits on an external party.** Every source is public.
+FR-037 therefore sets a harder bar than R3 met: near-total live verification is the expectation, and any
+unexercised capability must be justified explicitly or cut.

--- a/specs/081-bgp-registry-intel/quickstart.md
+++ b/specs/081-bgp-registry-intel/quickstart.md
@@ -1,0 +1,121 @@
+# Quickstart — BGP & Registry Intelligence (spec 081 / R9)
+
+> **There is nothing to obtain.** No lab, no licence, no trial, no API key, no account. Every source is a
+> public unauthenticated API. This is the first roadmap item since R8 with no external dependency on the
+> critical path — which is exactly why it was chosen while R4 waits on a vendor trial.
+
+## Install
+
+```bash
+netclaw_pip_install -r mcp-servers/bgp-intel-mcp/requirements.txt
+```
+
+Two packages: `mcp>=1.2.0,<2` and `httpx>=0.27.0,<1`. The `mcp` upper bound is **load-bearing** — v2 exists
+and removes `mcp.server.fastmcp`, which this server imports (spec 077).
+
+## Configure
+
+Nothing is required. All variables are optional tuning:
+
+```bash
+BGP_INTEL_USER_AGENT=          # override the contact string sent to public APIs
+BGP_INTEL_MAX_RPS=             # default 4 — lower it, never raise it
+BGP_INTEL_AUDIT_LOG=           # GAIT trail path; defaults under ~/.openclaw/gait/
+```
+
+**There are no credentials.** Nothing to leak, rotate or scope.
+
+## Verify
+
+```bash
+./tests/bgp-intel/run-tests.sh                  # contract tests, no network
+python3 tests/bgp-intel/test_manifest_size.py   # must be <= 5,000 tokens
+python3 scripts/reconcile-mcp.py                # must exit 0
+python3 scripts/trace-skill.py bgp-registry-intel
+```
+
+Live smoke tests — these hit real public APIs, so keep them few:
+
+```bash
+python3 $MCP_CALL "$BGP_INTEL_MCP_CMD" rpki_validate '{"prefix":"1.1.1.0/24","origin_asn":"AS13335"}'
+python3 $MCP_CALL "$BGP_INTEL_MCP_CMD" registry_lookup '{"resource":"8.8.8.8"}'
+python3 $MCP_CALL "$BGP_INTEL_MCP_CMD" routing_as_overview '{"asn":"AS15169"}'
+```
+
+Every response must carry `source` and `retrieved_at`. **A response missing either is a bug, not a quirk** —
+that guarantee is the point of the feature.
+
+## The four RPKI states, with real test fixtures
+
+These are verified live (research R9) and make good regression cases:
+
+| Query | Expected | Note |
+|---|---|---|
+| `AS13335` + `1.1.1.0/24` | `valid` | Healthy |
+| `AS13335` + `8.8.8.0/24` | `invalid`, `reason: as` | ROA authorises AS15169 |
+| `AS15169` + `8.8.8.128/25` | `invalid`, `reason: length` | Correct AS, but `/25` under a `maxLength 24` ROA |
+| `AS3356` + `4.0.0.0/9` | `not_found` | **No ROA. The common case** |
+| `AS13335` + `2606:4700::/32` | `not_found` | IPv6 path (FR-029) |
+
+**The `not_found` case is the one to watch.** If its output ever contains the words *invalid*, *suspicious*
+or *unverified*, the feature has broken its central promise. Most of the internet is unsigned; treating that
+as a finding would manufacture false incidents at scale.
+
+## Reading the results
+
+**`not_found` means no ROA exists.** It is normal. It is not a hijack, not a misconfiguration, not a
+security finding. Roughly speaking most address space is unsigned.
+
+**`invalid` splits two ways, and the split matters:**
+- `reason: as` → a ROA covers this prefix and authorises **a different AS**. Possible hijack. Actionable.
+- `reason: length` → correct AS, but the prefix is **more specific** than the ROA permits. Usually your own
+  misconfiguration, and a different fix.
+
+**`validation_unavailable` is not `not_found`.** If the validator is unreachable you get the former, and
+NetClaw will not guess from routing or registry data.
+
+**Registry data is allocation, not routing.** RDAP tells you who a block is *allocated to*, never who is
+*announcing* it. Use `routing_announced_prefixes` for the latter.
+
+**PeeringDB is self-reported.** No record means nobody filled the form, not that the network does not peer.
+
+**Visibility is RIPE's collectors.** Low visibility has legitimate causes — scoped announcements, anycast,
+no-export. The tool will not call it a leak, and neither should you without more evidence.
+
+## Which tool owns what
+
+| Question | Use |
+|---|---|
+| "Is this announcement RPKI-authorised?" | `rpki_validate` — **nothing else in NetClaw does this** |
+| "Who holds this block? Abuse contact?" | `registry_lookup` / `registry_abuse_contact` |
+| "What does this AS announce?" | `routing_announced_prefixes` |
+| "Where does this AS peer?" | `peering_network` / `peering_presence` |
+| "Everything about this resource" | `resource_report` |
+| **"Quick: who owns this traceroute hop, and where is it?"** | **`gtrace-ip-enrichment`** — not this |
+| **"Can the outside reach us? Measure from N countries"** | **`globalping-external-checks`** (R8) — not this |
+
+Those last two are load-bearing boundaries, not politeness. `gtrace` already does ASN/geo/rDNS enrichment
+and this feature deliberately does not duplicate it (Principle VII). Globalping *measures*; this *looks up*.
+
+## Being a good citizen
+
+These are volunteer-funded services (RIPE NCC, PeeringDB). The server holds itself to **≤ 4 requests/second
+per source, strictly serial** — no parallel fan-out, even for `resource_report`, which runs its four
+sub-queries one after another.
+
+That is deliberately slower than possible. Against free community infrastructure, being over-polite costs
+latency nobody notices; being under-polite costs the integration for everyone.
+
+Repeated lookups come from an in-memory cache with per-source TTLs — RPKI 5 minutes, RDAP 24 hours — and a
+cached response says so and reports its age. Pass `fresh=true` when a ROA was just published.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `input_refused` on a private address | Working as designed — RFC1918/reserved input is never sent to a public registry | Use an internal tool; this feature is for public resources |
+| `source_refused` naming ARIN | Measured: `rdap.arin.net` resets the connection from this host | Automatic fallback via IANA bootstrap / `rdap.org`. Retry from another path before concluding ARIN is broken |
+| Everything is `not_found` | Probably correct — most space is unsigned | Confirm with a known-signed prefix like `1.1.1.0/24` + `AS13335` |
+| `validation_unavailable` | Validator unreachable | Not a `not_found`. Check egress to `rpki-validator.ripe.net` |
+| Results feel stale | Per-source TTL cache | Check `cached` / `cache_age_seconds`; pass `fresh=true` |
+| `rate_limited` | Self-imposed 4/s ceiling reached | Expected under heavy batch use. It backs off; do not raise `BGP_INTEL_MAX_RPS` |

--- a/specs/081-bgp-registry-intel/research.md
+++ b/specs/081-bgp-registry-intel/research.md
@@ -1,0 +1,256 @@
+# Phase 0 Research — BGP & Registry Intelligence (spec 081 / roadmap R9)
+
+**Date**: 2026-08-03 · **Branch**: `081-bgp-registry-intel`
+
+Everything below was tested against live endpoints. Where something was **not** verified, it says so.
+
+**Read R2 first** — it changes the primary data source the spec assumed, and improves the feature.
+
+---
+
+## R1 — Build, adopt, or wrap? → **Build**
+
+### The candidate that matters: `duksh/peerglass`
+
+A "deterministic MCP server for internet resource intelligence" whose stated scope overlaps R9 almost
+exactly. Measured:
+
+| Property | Value |
+|---|---|
+| Tools | **42**, across 9 "phases" |
+| Language / licence | Python, `httpx`, FastAPI · MIT |
+| Traction | **1 star**, 49 commits |
+| Data sources | 5-RIR RDAP, Cloudflare VRP for RPKI, RIPEstat for BGP, PeeringDB, IANA bootstrap |
+| Caching | **TTL 5 min – 24 h depending on tool** |
+| Attribution | Results include the originating RIR/API |
+| Writes | None — query-only |
+
+### Why not adopt
+
+1. **42 tools against a 5,000-token ceiling.** Even before measuring, a 42-tool manifest is the wrong
+   order of magnitude for FR-027a. R9's whole surface should be ~10.
+2. **Scope far beyond R9.** Its phases include DNS censorship detection, TLS/CT-log inspection, threat
+   intel, **satellite tracking**, and "humanitarian/crisis" tooling. Adopting it means registering all of
+   that, or suppressing most of it. Either way NetClaw inherits a charter it did not choose — and several
+   of those areas belong to other roadmap items (R13 for NSM, R12 for logs).
+3. **1 star, 49 commits.** Not a criticism of the author, but a real maintenance-risk input for something
+   sitting on the routing-security path.
+4. **RPKI source differs from ours.** It uses Cloudflare's VRP service; R2 below establishes a better
+   source that reports RFC 6811 vocabulary natively.
+
+### What adoption still gives us — and it is genuinely reassuring
+
+`peerglass` arrived independently at **three of the design decisions this spec's clarification session
+chose**: TTL caching in the 5-minute-to-24-hour band, per-result source attribution, and read-only
+throughout. That is convergent evidence rather than borrowed design — two independent attempts at this
+problem reaching the same conclusions is a signal the conclusions are right.
+
+Also noted for reference: `simplebytes-com/rdap-mcp` (RDAP only) and a Go PeeringDB/IXP server. Both are
+narrower than R9 and neither changes the decision.
+
+**Decision: build** `mcp-servers/bgp-intel-mcp/`.
+**Rejected**: adopt `peerglass` (manifest size, charter creep, single-star maintenance risk); wrap it
+(inherits its 42-tool surface and its RPKI source choice).
+
+---
+
+## R2 — The RPKI source: switch from RIPEstat to `rpki-validator.ripe.net`
+
+The spec was written assuming **RIPEstat** (`/data/rpki-validation/`), because that is what was verified
+before drafting. A better endpoint exists and was verified during Phase 0.
+
+### Side by side, both measured
+
+| | RIPEstat `rpki-validation` | **`rpki-validator.ripe.net/api/v1/validity/`** |
+|---|---|---|
+| valid | `valid` | `valid` |
+| wrong origin AS | `invalid_asn` | `invalid` + **`reason: "as"`** |
+| max-length violation | `invalid_length` | `invalid` + `reason: "length"` |
+| no ROA | **`unknown`** | **`not-found`** ← RFC 6811's own term |
+| VRPs behind the verdict | not returned | **returned**: `matched`, `unmatched_as`, `unmatched_length` |
+| Human-readable reason | no | **yes** — `"At least one VRP Covers the Route Prefix, but no VRP ASN matches the route origin ASN"` |
+
+Live sample:
+
+```json
+{"validated_route": {"route": {"origin_asn": "AS13335", "prefix": "8.8.8.0/24"},
+  "validity": {"state": "invalid", "reason": "as",
+    "VRPs": {"matched": [], "unmatched_as": [ ... ]}}}}
+```
+
+**Three reasons this is the better primary source:**
+
+1. **It speaks RFC 6811 natively.** `not-found`, not `unknown`. FR-004 exists purely because RIPEstat's
+   vocabulary diverges from the standard; using this endpoint removes the translation risk at source rather
+   than papering over it downstream.
+2. **`state` and `reason` are separate fields.** RIPEstat fuses them into `invalid_asn` / `invalid_length`,
+   forcing string parsing to recover a distinction FR-002 requires. Here it is structured.
+3. **It returns the VRPs.** FR-005 requires the ROAs that drove the verdict be included so an operator can
+   check the reasoning. RIPEstat does not provide them; this does.
+
+**Decision**: `rpki-validator.ripe.net` is the primary RPKI source. RIPEstat remains a documented fallback,
+and **FR-004's vocabulary translation still applies to it** — if the fallback is used, `unknown` must still
+be reported as RFC 6811 `NotFound`.
+
+---
+
+## R3 — Is corroboration between two validators possible? → **No, and the clarified answer stands**
+
+Clarification Q5 chose "single validator, named, explicitly uncorroborated," deferring corroboration until a
+second validator was verified reachable. One now is. But it does **not** enable corroboration:
+
+- **RIPEstat's RPKI validation is itself Routinator-backed** (per RIPE's own API documentation).
+- **`rpki-validator.ripe.net` is Routinator**, operated by RIPE NCC.
+
+Same engine, same operator, same trust anchors, same relying-party software. Comparing them would produce
+agreement that means nothing — **corroboration theatre**, worse than none because it implies independence
+that does not exist.
+
+Also checked: `routinator.nlnetlabs.nl` → 400; `rpki.gin.ntt.net` → 404. Neither offers an open validity API.
+Cloudflare's `rpki.cloudflare.com/api/v1/validity/...` → 404, as recorded in the spec; `peerglass` uses
+Cloudflare's **VRP dump** instead, which is a different integration (fetch and evaluate locally) and a
+materially larger piece of work.
+
+**Decision**: single validator, per FR-007a. The clarified answer is unchanged, but the *reason* is now
+stronger and evidence-based: not "we could not find a second one" but **"the available second one is not
+independent."** Genuine corroboration would need a non-Routinator relying party — `rpki-client`-based, or
+Cloudflare's VRP evaluated locally — and that is a future item, not a Phase 0 assumption.
+
+---
+
+## R4 — RDAP entry point
+
+> **CORRECTED 2026-08-03 during implementation.** ARIN's RDAP was recorded below as
+> refusing connections, based on a single `curl` observation. **That was wrong, or at least not
+> durable.** Exercised through the implemented bootstrap path, `rdap.arin.net/registry/ip/8.8.8.8/32`
+> returned **HTTP 200** with holder `GOGL`. The earlier reset was transient or specific to that
+> request path — **not a property of ARIN**, and it must not be documented as one.
+>
+> The design is unchanged and was right for a better reason than the one it was chosen for: bootstrap
+> resolution plus a fallback handles a *transient* per-registry failure exactly as well as a permanent
+> one, and FR-011's "name the source that failed" is correct either way. Research open item 2 is now
+> **closed** rather than carried into implementation.
+
+| Endpoint | Result |
+|---|---|
+| `rdap.arin.net` direct | ⚠️ one observed connection reset; **later returned 200** — transient, see above |
+| `rdap.org` bootstrap redirector | ✅ 200 (follows redirects to the responsible RIR) |
+| `rdap.db.ripe.net` direct | ✅ 200 |
+| IANA bootstrap (`data.iana.org/rdap/ipv4.json`) | ✅ 200 — authoritative RIR-to-range map |
+
+**Decision**: resolve the responsible RIR from the **IANA bootstrap file**, then query that RIR directly,
+falling back to `rdap.org` when the direct endpoint fails. This is the RFC 7484 mechanism and it means
+FR-010's "name the responding registry" is satisfied by construction — we know which RIR we chose and why.
+
+ARIN's reset is treated as a per-source failure (FR-011), not an absence of record. It may be host-specific
+or transient; it MUST NOT be hardcoded as "ARIN is broken."
+
+---
+
+## R5 — Dependencies: two packages, matching specs 078 and 080
+
+```
+mcp>=1.2.0,<2
+httpx>=0.27.0,<1
+```
+
+The `mcp` upper bound is **load-bearing**, and Phase 0 turned up fresh confirmation: the MCP Python SDK has
+released **v2, a rework targeting the 2026-07-28 MCP specification**. `mcp` 2.x removes
+`mcp.server.fastmcp`, which this server imports. An unbounded pin would resolve that major and die on
+import for every new installer — exactly the failure spec 077 exists to prevent, now with a live v2 in the
+wild rather than a hypothetical one.
+
+No third-party RDAP/RPKI/BGP library. The payloads are plain JSON over HTTPS and the value here is in the
+*semantics* — which state means what — not in transport. An SDK would add a pinning hazard and abstract the
+one thing this feature must not abstract.
+
+**No dedicated venv** (unlike spec 076): two pure-HTTP packages move nothing shared.
+
+---
+
+## R6 — Rate limits: undocumented, so self-imposed
+
+Neither RIPEstat nor PeeringDB advertises `RateLimit`, `X-RateLimit` or `Retry-After` headers — measured on
+live 200 responses. There is nothing to negotiate against at runtime.
+
+FR-023's **≤ 4 req/s per source, strictly serial** is therefore a deliberately conservative self-imposed
+figure, and the documentation must say so (FR-024) rather than let a later maintainer mistake it for a
+service-declared limit.
+
+`peerglass` uses "async parallel queries" to minimise latency. This spec deliberately does the opposite
+(FR-023a): against volunteer-funded infrastructure, being over-polite costs latency nobody notices, and
+being under-polite costs the integration.
+
+---
+
+## R7 — The `gtrace` boundary is real and narrow
+
+`gtrace-ip-enrichment` already ships `asn_lookup` — returning ASN, organisation, network range **and
+registry** — plus `geo_lookup`. That genuinely overlaps RDAP.
+
+| Question | Owner |
+|---|---|
+| "Quick: who owns this traceroute hop, and where is it?" | **`gtrace`** — enrichment, geo, rDNS |
+| "Authoritatively: what is the registry record, abuse contact, allocation?" | **this feature** |
+| "Is this announcement RPKI-authorised?" | **this feature** — gtrace has no RPKI |
+| "What does this AS announce? Where does it peer?" | **this feature** |
+
+**Decision**: no ASN-enrichment or geolocation tool here. FR-032 draws the line and the skill must name
+`gtrace` for hop enrichment. Principle VII.
+
+---
+
+## R8 — Atlas: what the narrowed US5 actually needs
+
+Clarification Q1 narrowed US5 to **anchors** and **per-AS probe counts**. Verified: `atlas.ripe.net/api/v2/`
+serves `anchors/` and `probes/` read-only, unauthenticated, with filters including `asn` and `country`.
+Measurement *creation* needs a key and credits — out of scope, routed to R8 (FR-018).
+
+---
+
+## Summary of decisions
+
+| # | Decision | Drives |
+|---|---|---|
+| R1 | Build `bgp-intel-mcp`; `peerglass` rejected but validates three design choices | FR-027a |
+| R2 | **`rpki-validator.ripe.net` primary** — RFC 6811 native, returns VRPs, `reason` separate | FR-002, FR-004, FR-005 |
+| R3 | Single validator confirmed correct — the second one is not independent | FR-007a |
+| R4 | IANA bootstrap → direct RIR → `rdap.org` fallback | FR-010, FR-011 |
+| R5 | `mcp>=1.2.0,<2` + `httpx>=0.27.0,<1`; no venv; **mcp 2.0 is real** | FR-042 |
+| R6 | 4 req/s serial, self-imposed and documented as such | FR-023, FR-024 |
+| R7 | No ASN/geo enrichment here — `gtrace` owns it | FR-032 |
+| R8 | Atlas anchors + per-AS probe counts only | FR-017, FR-017a |
+
+## R9 — All four RPKI states verified against the primary source
+
+Closed during Phase 0. Every state FR-002 requires is now **observed**, not inferred from documentation:
+
+| Query | `state` | `reason` | Description (verbatim) |
+|---|---|---|---|
+| `AS13335` + `1.1.1.0/24` | `valid` | — | "At least one VRP Matches the Route Prefix" |
+| `AS13335` + `8.8.8.0/24` | `invalid` | **`as`** | "…no VRP ASN matches the route origin ASN" |
+| `AS15169` + `8.8.8.128/25` | `invalid` | **`length`** | "…the Route Prefix length is greater" |
+| `AS3356` + `4.0.0.0/9` | **`not-found`** | — | no covering VRP |
+
+The `length` case was constructed deliberately: `8.8.8.0/24` has a ROA with `maxLength 24`, so announcing
+`8.8.8.128/25` with the *correct* origin AS is invalid on length alone. That is the distinction FR-002
+forbids collapsing, and it is now demonstrable rather than asserted.
+
+## R10 — IPv6 verified across every source
+
+| Source | IPv6 query | Result |
+|---|---|---|
+| RPKI validator | `AS13335` + `2606:4700::/32` | ✅ verdict returned (`not-found`) |
+| RDAP (RIPE) | `2001:67c:2e8::` | ✅ 200 |
+| RIPEstat routing-status | `2606:4700::/32` | ✅ 200 |
+
+FR-029 is satisfiable. Note the RPKI result is `not-found` for that pair, which is a useful test fixture in
+its own right — an IPv6 prefix that returns the *common* state rather than the exceptional one.
+
+## Still open — carried as tasks, not assumptions
+
+1. **Measure the manifest** once the surface exists (FR-027a/b). Cannot be done before the tools exist.
+2. ~~Confirm ARIN's reset is not host-specific~~ — **CLOSED during implementation.** ARIN returned 200
+   through the bootstrap path. The reset was transient; the correction is recorded in R4.
+3. **Confirm PeeringDB behaviour for an AS with no record** — needed for SC-010, and requires finding an ASN
+   that is genuinely absent from PeeringDB rather than assuming one.

--- a/specs/081-bgp-registry-intel/spec.md
+++ b/specs/081-bgp-registry-intel/spec.md
@@ -1,0 +1,495 @@
+# Feature Specification: BGP & Registry Intelligence (RPKI / RDAP / PeeringDB / RIPEstat)
+
+**Feature Branch**: `081-bgp-registry-intel`
+**Created**: 2026-08-03
+**Status**: Draft
+**Roadmap**: R9 — Tier 2, "the internet / external plane"
+
+## Overview
+
+Spec 079 (R8) gave NetClaw its first vantage point **outside** its own administrative domain: Globalping
+measures *toward* a public target from ~4,800 probes. It answers "can anyone out there reach us?"
+
+It cannot answer the questions that follow. When a prefix appears in a routing table, a firewall log, or a
+traceroute hop, an operator needs to know: **who is this allocated to? is this announcement legitimate?
+where does this network peer?** Those are registry and routing-database questions, and NetClaw has no way
+to ask them.
+
+This feature adds that. Five public, unauthenticated data sources — RPKI origin validation, RDAP registry
+records, PeeringDB peering data, RIPEstat routing status, and RIPE Atlas probe inventory.
+
+Together with R8 it completes the external plane: R8 **measures**, R9 **looks up**. Neither substitutes
+for the other, and the skill must say so.
+
+## The distinction this feature exists to protect
+
+### RPKI `unknown` is not `invalid`
+
+**Most of the internet has no ROA.** Unsigned address space is the overwhelmingly common case, not an
+anomaly. An operator who is told that unsigned space is "invalid", "unverified in a bad way", or a security
+finding will be handed false incidents at a scale that destroys trust in the tool within a day.
+
+Measured live on 2026-08-03 against RIPEstat, and **the API does not use RFC 6811's vocabulary**:
+
+| Query | RIPEstat `status` | RFC 6811 name | What it means | Actionable? |
+|---|---|---|---|---|
+| `AS13335` + `1.1.1.0/24` | `valid` | Valid | A ROA exists and authorises this origin | No — this is healthy |
+| `AS13335` + `8.8.8.0/24` | **`invalid_asn`** | Invalid | A ROA exists for `AS15169`; this origin is not authorised | **Yes — possible hijack** |
+| *(max-length violation)* | **`invalid_length`** | Invalid | A ROA exists; the prefix is more specific than `maxLength` | **Yes — usually a misconfiguration, different fix** |
+| `AS3356` + `4.0.0.0/9` | **`unknown`** | **NotFound** | **No ROA exists at all** | **No — the common case** |
+
+Three consequences the spec must carry:
+
+1. **`unknown` MUST NOT be reported as a problem.** It is the default state of most address space.
+2. **RIPEstat's names differ from the standard's.** `unknown` means RFC 6811 `NotFound`. Passing the API's
+   raw string through without saying so invites a reader who knows RFC 6811 to conclude something is
+   genuinely unknown or indeterminate, when in fact it is definitively unsigned.
+3. **`invalid_asn` and `invalid_length` are different findings with different remediations.** RFC 6811
+   collapses both to `Invalid`; the API is more granular, and flattening that away destroys the distinction
+   between "someone else is announcing your space" and "you announced a /24 under a /22 ROA."
+
+This is the same error class as spec 078's *"no advisories ≠ not vulnerable"*, spec 079's *"no probes found
+≠ outage"*, and spec 080's *"no logs ≠ rule unused"*. Each shipped with the distinction named explicitly and
+enforced structurally, and this feature does the same.
+
+### Three further "this is not what you think it is" cases
+
+- **Registry ownership is a claim, not routing truth.** RDAP says who a block is *allocated to*. It says
+  nothing about who is *announcing* it. Presenting an RDAP holder as evidence about routing is the same
+  category error as presenting FortiManager intent as device state (spec 080).
+- **PeeringDB is self-reported.** Operators maintain their own records. A missing facility is not evidence
+  the network is absent from it; it is evidence nobody updated the record.
+- **RIPEstat visibility is RIPE's collectors' view, not global truth.** A prefix seen by few peers may be
+  an intentionally scoped announcement, not a leak.
+
+## Clarifications
+
+### Session 2026-08-03
+
+- Q: Does US5 (RIPE Atlas inventory) survive, given it borders Globalping's existing `locations` capability? → A: **Kept, but narrowed** to what Globalping genuinely lacks — RIPE Atlas **anchors** (stable, well-known measurement targets) and **per-AS probe counts**. General probe-availability listing stays with Globalping; this feature MUST NOT reimplement it.
+- Q: What request rate does NetClaw hold itself to against these free services? → A: **≤ 4 requests/second per source, and strictly serial (concurrency 1) per source.** No parallel fan-out across prefixes or ASNs — batch questions iterate. Chosen because it is testable, cannot be exceeded by a fan-out added later, and the latency cost is irrelevant for interactive lookups while the cost of being blocked is not.
+- Q: Cache lifetime and location? → A: **Per-source TTLs, in memory only** — RPKI ~5 min, routing status ~15 min, RDAP and PeeringDB ~24 h. Nothing persists across a restart. Per-source because volatility differs by an order of magnitude (a ROA can appear in minutes; an allocation changes in months), and in-memory because the goal is not hammering a free service *within one investigation*, not mirroring a registry.
+- Q: Does the spec-080 tool-manifest ceiling apply here? → A: **Yes — the same 5,000-token ceiling and the same build-failing test.** A repo-wide convention is worth more than a per-feature optimum: the check is copy-pasteable and a future maintainer inherits the guardrail without rediscovering why it exists. It will pass with large headroom, which is the point — a ceiling that never binds still prevents someone adding forty tools.
+- Q: Single RPKI validator, or corroborate against two? → A: **Single source (RIPEstat), named on every result, with an explicit statement that the verdict is unconfirmed by a second validator.** Corroboration is deferred until a second validator is verified reachable — specifying a corroboration flow against an endpoint we have not confirmed would repeat the R3 mistake of assuming an API and discovering otherwise at implementation time.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Is this announcement legitimate? (Priority: P1)
+
+An unfamiliar prefix appears — in a BGP table, a firewall log, a traceroute hop. The operator asks whether
+the origin AS is authorised to announce it.
+
+**Why this priority**: It is the question with real operational consequence, and the one most easily
+answered wrongly. It is also where the `unknown`/`invalid` distinction lives, which is the reason this
+feature is a spec rather than a wrapper.
+
+**Independent Test**: query a known-good pair, a deliberately mismatched pair, and unsigned space; confirm
+three distinct outcomes with three distinct explanations.
+
+**Acceptance Scenarios**:
+
+1. **Given** a prefix and origin AS with a matching ROA, **When** validation is requested, **Then** NetClaw
+   reports **valid** and states that the announcement is RPKI-authorised.
+2. **Given** a prefix whose ROA names a different AS, **When** validation is requested, **Then** NetClaw
+   reports **invalid — wrong origin AS**, names the AS the ROA *does* authorise, and flags it as actionable.
+3. **Given** a prefix more specific than its ROA's `maxLength`, **When** validation is requested, **Then**
+   NetClaw reports **invalid — prefix too specific**, distinct from the wrong-AS case, and notes the
+   remediation differs.
+4. **Given** address space with no ROA, **When** validation is requested, **Then** NetClaw reports **no ROA
+   exists (RFC 6811 NotFound)**, states explicitly that this is **normal and not a finding**, and MUST NOT
+   describe it as invalid, suspicious, or unverified-in-a-bad-way.
+5. **Given** any RPKI result, **When** it is reported, **Then** the ROA(s) that drove the decision are
+   included, so the operator can see *why* rather than trusting a verdict.
+
+---
+
+### User Story 2 — Who is this allocated to, and how do I contact them? (Priority: P1)
+
+An operator has an IP or ASN and needs the registry record: holder, allocation, abuse contact.
+
+**Why this priority**: This is the single most frequent external lookup in incident response, and it is
+currently done by shelling out to `whois` or a browser. It is also independently useful with nothing else
+implemented.
+
+**Independent Test**: look up an IP and an ASN across at least two different RIRs and confirm holder and
+abuse contact are returned with the responding registry named.
+
+**Acceptance Scenarios**:
+
+1. **Given** an IP address, **When** a registry lookup is requested, **Then** NetClaw returns the holder,
+   allocation range, registry, and abuse contact where published.
+2. **Given** an ASN, **When** a registry lookup is requested, **Then** NetClaw returns the holder and
+   contacts.
+3. **Given** any registry result, **When** it is reported, **Then NetClaw states that this is allocation
+   data and not evidence about who is announcing the space** (see the distinction above).
+4. **Given** a registry that refuses or fails, **When** the lookup runs, **Then** NetClaw names the registry
+   that failed and reports the failure as a failure — never as "no record exists".
+
+---
+
+### User Story 3 — What does this AS announce, and how visible is it? (Priority: P2)
+
+An operator wants an AS's announced prefixes and how widely each is seen.
+
+**Independent Test**: query a large well-known AS and a small one; confirm prefix counts and per-prefix
+visibility, with the collector basis stated.
+
+**Acceptance Scenarios**:
+
+1. **Given** an ASN, **When** routing status is requested, **Then** NetClaw returns announced prefixes and
+   an AS overview (holder, allocation status).
+2. **Given** a prefix with low visibility, **When** reported, **Then** NetClaw states this is **RIPE's
+   collector view** and that low visibility has legitimate explanations — it MUST NOT be presented as a
+   route leak or a fault.
+3. **Given** an AS announcing nothing, **When** queried, **Then** NetClaw reports **no announcements
+   observed**, distinct from "the AS does not exist" and from "the query failed".
+
+---
+
+### User Story 4 — Where does this network peer? (Priority: P2)
+
+Interconnection questions: which IXPs and facilities does an AS use, what is its traffic profile, who is
+the technical contact.
+
+**Independent Test**: query an AS with rich PeeringDB records and one with none; confirm both are handled
+without conflating "no record" with "does not peer".
+
+**Acceptance Scenarios**:
+
+1. **Given** an ASN, **When** peering data is requested, **Then** NetClaw returns the network record,
+   IXP presence and facilities where published.
+2. **Given** an AS with no PeeringDB record, **When** queried, **Then** NetClaw reports **no self-reported
+   record**, and states explicitly that this is **not evidence the network does not peer**.
+
+---
+
+### User Story 5 — Atlas anchors and per-AS probe density (Priority: P3)
+
+Read-only RIPE Atlas inventory, **narrowed to the two things Globalping does not provide**: **anchors** —
+stable, well-known, always-on measurement targets useful as reference endpoints — and **per-AS probe
+counts**, which tell an operator whether a given network is observable from inside at all.
+
+**Why this priority**: Narrow but genuinely non-overlapping. General probe-availability listing belongs to
+Globalping's `locations` and is explicitly **not** reimplemented here (Principle VII). Anchors are a
+distinct concept Globalping has no equivalent of, and per-AS density answers "can anyone measure this
+network from within it?" which registry data cannot.
+
+**Independent Test**: list anchors for a country and probe counts for a named AS; confirm neither
+duplicates Globalping's `locations` output, and that a request to *measure* is routed to R8.
+
+**Acceptance Scenarios**:
+
+1. **Given** a country, **When** anchors are requested, **Then** NetClaw returns Atlas anchors with status.
+2. **Given** an ASN, **When** probe density is requested, **Then** NetClaw returns how many Atlas probes are
+   present in that AS.
+3. **Given** a request for general probe availability by location, **When** it reaches this feature, **Then**
+   NetClaw routes it to Globalping's `locations` rather than answering from Atlas.
+4. **Given** a request to *run* a measurement, **When** it reaches this feature, **Then** NetClaw routes it
+   to Globalping (R8) and does not attempt it here.
+
+---
+
+### Edge Cases
+
+- **A source is down or rate-limiting.** NetClaw names the source that failed and reports a failure.
+  A dead API MUST NOT produce an empty-but-successful-looking answer.
+- **ARIN's RDAP refuses us.** Measured: `Recv failure: Connection reset by peer` from
+  `rdap.arin.net` on this host. Bootstrap redirection and RIPE's RDAP both return 200. A single
+  registry being unreachable MUST NOT fail the whole lookup silently.
+- **Sources disagree.** RDAP holder and PeeringDB name differ, or RIPEstat shows an announcement the
+  registry does not explain. NetClaw reports the disagreement rather than choosing a winner.
+- **Private, reserved, or bogon input** — RFC1918, loopback, documentation ranges, unallocated space.
+  These have no meaningful registry or RPKI answer and MUST be refused locally with an explanation, not
+  sent to a public API.
+- **An AS or prefix that does not exist.** Distinct from "exists but unsigned" and from "query failed".
+- **Very large result sets** — an AS announcing thousands of prefixes. Bounded and stated, never silently
+  truncated.
+- **IPv6 throughout.** Every capability MUST accept IPv6 prefixes and addresses, not just IPv4.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### RPKI origin validation — the core
+
+- **FR-001**: NetClaw MUST report RPKI origin validation state for a prefix + origin-AS pair.
+- **FR-002**: The four observed states MUST be reported distinctly: **valid**, **invalid (wrong origin
+  AS)**, **invalid (prefix too specific / maxLength)**, and **no ROA exists**. Collapsing any two is
+  prohibited.
+- **FR-003**: "No ROA exists" MUST be accompanied by an explicit statement that **this is the normal state
+  for most address space and is not a finding**. It MUST NOT be described as invalid, suspicious,
+  unverified, or a security concern.
+- **FR-004**: NetClaw MUST translate the source's vocabulary to the standard's and say it is doing so:
+  RIPEstat's `unknown` is RFC 6811 **NotFound**. Passing the raw string through unexplained is prohibited.
+- **FR-005**: The ROA(s) that determined the verdict MUST be included in the result, so the operator can
+  verify the reasoning rather than trusting a label.
+- **FR-006**: An `invalid` result MUST name what the ROA *does* authorise (the permitted origin AS and
+  `maxLength`), because that is what makes it actionable.
+- **FR-007**: NetClaw MUST NOT declare a hijack, an incident, or an attack. It reports RPKI state; incident
+  declaration is an operator judgement (see Out of Scope).
+- **FR-007a**: Validation comes from a **single validator**, and the result MUST name it. NetClaw MUST NOT
+  present an RPKI verdict as independently confirmed, corroborated, or cross-checked, because it is none of
+  those things.
+- **FR-007b**: The asymmetry MUST be reflected in how results are framed. A wrong `valid` tells an operator
+  an announcement is authorised when it may not be; a wrong `invalid` sends them chasing a hijack that is
+  not happening. Both are worse than an honest "this is one validator's view."
+- **FR-007c**: If the validator is unreachable, NetClaw MUST report **validation unavailable** — naming the
+  validator — and MUST NOT fall back to inferring state from routing data, registry data, or the absence of
+  a ROA. An unavailable validator is not a `not-found`.
+
+#### Registry records (RDAP)
+
+- **FR-008**: NetClaw MUST return registry records for an IP address or ASN: holder, allocation range,
+  responsible registry, and abuse contact where published.
+- **FR-009**: Every registry result MUST state that it is **allocation data, not evidence about who is
+  announcing the space**.
+- **FR-010**: The **responding registry MUST be named** on every result. "The registry says" is not
+  attributable; RIRs differ in completeness and freshness.
+- **FR-011**: A registry that refuses, times out, or resets MUST be reported as a **source failure naming
+  that registry** — never as an absence of record. ARIN's reset (Edge Cases) is the live example.
+
+#### Routing status
+
+- **FR-012**: NetClaw MUST return an AS overview and its observed announced prefixes.
+- **FR-013**: Visibility figures MUST state the **collector basis** and MUST NOT be presented as global
+  ground truth or as evidence of a leak.
+- **FR-014**: "No announcements observed" MUST be distinct from "AS does not exist" and from "query
+  failed".
+
+#### Peering data
+
+- **FR-015**: NetClaw MUST return an AS's PeeringDB network record, IXP presence and facilities where
+  published.
+- **FR-016**: Every peering result MUST state that PeeringDB is **self-reported**, and an absent record
+  MUST be reported as "no self-reported record", explicitly **not** as evidence the network does not peer.
+
+#### Measurement inventory
+
+- **FR-017**: NetClaw MUST be able to report, read-only, RIPE Atlas **anchors** by country and **probe
+  counts by AS** — and nothing broader.
+- **FR-017a**: General probe-availability-by-location MUST NOT be implemented here. Globalping's
+  `locations` already owns it (Principle VII); a request for it MUST be routed there.
+- **FR-018**: This feature MUST NOT run measurements. A request to measure MUST be routed to Globalping
+  (spec 079).
+
+#### Source attribution and provenance — structural
+
+- **FR-019**: Every response MUST carry, as **structured fields rather than prose**: the **source** that
+  produced it, the **time** it was retrieved, and its **outcome**. A result whose source cannot be named
+  MUST be an error rather than an unattributed answer.
+- **FR-020**: Attribution and audit MUST be enforced at a **single chokepoint** through which every
+  response passes, so a tool added later cannot omit them. Spec 080 proved this works and spec 080's
+  `/speckit.analyze` pass proved the alternative fails: an audit requirement with a verification task and
+  no implementing task passes review by accident.
+- **FR-021**: Where a question is answered from more than one source, **each element MUST carry its own
+  source**. A merged answer with one collective citation is not attributable.
+- **FR-022**: Every operation MUST produce a GAIT record by construction (Principle IV), including
+  refusals and failures.
+
+#### Being a good citizen of free services
+
+- **FR-023**: These are volunteer-funded community services (RIPE NCC, PeeringDB). NetClaw MUST hold itself
+  to **≤ 4 requests per second per source** and **strict serialisation (concurrency 1) per source**.
+- **FR-023a**: **Parallel fan-out is prohibited.** A question spanning many prefixes or ASNs MUST iterate
+  serially, not dispatch concurrently. This is the rule most likely to be broken by a later "make it
+  faster" change, so it is a requirement rather than guidance.
+- **FR-023b**: The limit MUST be enforced in code at the request layer, not left to caller discipline —
+  a tool added later must inherit it without having to know it exists.
+- **FR-024**: Actual rate limits MUST be **measured and documented**, not assumed. Measured 2026-08-03:
+  **neither RIPEstat nor PeeringDB advertises rate-limit headers**, so there is nothing to negotiate
+  against at runtime. FR-023's ceiling is therefore a deliberately conservative self-imposed figure rather
+  than a service-declared one, and the documentation MUST say so — a later maintainer who finds a published
+  limit should not mistake this number for that.
+- **FR-025**: NetClaw MUST identify itself in requests (a `User-Agent` naming NetClaw and a contact
+  reference), which is the courtesy these services ask of automated consumers.
+- **FR-026**: Repeated identical lookups MUST be served from an **in-memory cache with per-source TTLs**,
+  because the sources differ in volatility by an order of magnitude:
+
+  | Source | TTL | Why |
+  |---|---|---|
+  | RPKI validation | **5 minutes** | A ROA can be published or withdrawn within minutes; a stale `valid` is the most dangerous stale value here |
+  | Routing status / AS overview | **15 minutes** | Announcements change on minutes-to-hours |
+  | RDAP registry records | **24 hours** | Allocations change on months |
+  | PeeringDB records | **24 hours** | Self-reported, updated rarely |
+  | Atlas anchors / probe counts | **24 hours** | Infrastructure inventory, slow-moving |
+
+- **FR-026a**: The cache MUST be **in-memory and session-scoped**. Nothing persists across a restart, and
+  this feature MUST NOT create an on-disk store. It is a courtesy buffer for one investigation, not a
+  registry mirror — unlike spec 078, which legitimately caches PSIRT data on disk because that data is
+  large and genuinely slow-moving.
+- **FR-026b**: A response served from cache MUST say so **and report the age of the cached value**, so an
+  operator chasing a fast-moving RPKI change can tell whether they are looking at a fresh answer.
+- **FR-026c**: A caller MUST be able to force a fresh lookup, bypassing the cache, for the case where a ROA
+  was just published and the 5-minute TTL is the thing standing between the operator and the truth.
+- **FR-027**: On rate-limit or throttle response, NetClaw MUST back off and report the condition rather
+  than retrying blindly.
+
+#### Tool-manifest budget
+
+- **FR-027a**: The registered tool manifest MUST NOT exceed **5,000 tokens**, measured as the token count of
+  the serialised `tools/list` response. This is the same ceiling and the same measurement method spec 080
+  established, carried deliberately as a repo-wide convention rather than re-derived per feature.
+- **FR-027b**: The measurement MUST be enforced by a **build-failing test**, not a manual check. A ceiling
+  nobody verifies is a comment.
+- **FR-027c**: The measured figure MUST be recorded in the server documentation. This surface is expected to
+  pass with wide headroom; the ceiling exists to stop a later expansion, not to constrain the initial build.
+
+#### Input validation
+
+- **FR-028**: Private, reserved, loopback, link-local, documentation and unallocated ranges MUST be
+  **refused locally before any outbound request**, with an explanation of why they have no registry answer.
+- **FR-029**: Both IPv4 and IPv6 MUST be supported across every capability.
+- **FR-030**: Malformed input (bad prefix length, non-numeric AS, mixed family) MUST be rejected with a
+  message naming the problem, not passed through to a remote API.
+
+#### Composition boundaries (Principle VII)
+
+- **FR-031**: The boundary against **Globalping (spec 079)** MUST be stated in both directions: Globalping
+  *measures from* probes toward a target; this feature *looks up* registry and routing state. Neither
+  substitutes for the other.
+- **FR-032**: The boundary against the existing **`gtrace-ip-enrichment`** skill MUST be stated and
+  respected. `gtrace` already provides `asn_lookup` (ASN, organisation, network range, registry) and
+  `geo_lookup` for quick hop enrichment. This feature MUST NOT duplicate quick ASN/geo enrichment; it owns
+  **authoritative registry records, RPKI validation, routing status and peering data**. Where they overlap,
+  the skill MUST name which tool to use for which question.
+- **FR-033**: The boundary against **`nvd-cve`/`cisco-psirt`** MUST be stated: those answer "is this
+  software vulnerable"; this answers "is this routing legitimate". Unrelated planes.
+
+#### Read-only
+
+- **FR-034**: Every capability is read-only. This feature MUST introduce no write path, no device access,
+  and therefore no approval or change-record gate.
+- **FR-035**: NetClaw MUST NOT be directed to enumerate, sweep or bulk-harvest registry data. Lookups are
+  in service of a specific operational question.
+
+#### Honest verification reporting
+
+- **FR-036**: On completion, the feature MUST state **per capability** what was exercised against a live
+  API and what was only checked statically.
+- **FR-037**: Because every source here is publicly reachable with no credentials, **near-total live
+  verification is the expectation** — not the aspiration. Spec 080 shipped 13 of 21 tools unexercised
+  because appliances were unavailable; that excuse does not exist here, and any unexercised capability
+  MUST be justified explicitly or cut.
+
+#### Artifact coherence (Principle XI)
+
+- **FR-038**: All of the following MUST be updated, none assumed: registration in `config/openclaw.json`
+  with **repo-relative paths** (or an `EXTERNAL_INTEGRATIONS` entry with a stated reason);
+  `scripts/lib/catalog.sh` entry **and curated profile membership**; `scripts/lib/install-steps.sh` install
+  function; **both** HUD entries in `ui/netclaw-visual/server.js` (node list *and* annotation map);
+  `README.md` and `SOUL.md` including counts **and** a SOUL capability section; `SKILL.md`;
+  `.env.example`; `TOOLS.md`; a server `README.md`.
+- **FR-039**: `python3 scripts/reconcile-mcp.py` MUST exit 0 across all four surfaces.
+- **FR-040**: `python3 scripts/verify-inventory-counts.py` MUST exit 0 with counts updated from the current
+  206 skills / 153 integrations.
+- **FR-041**: `python3 scripts/trace-skill.py <skill>` MUST resolve for every skill added.
+- **FR-042**: Any dependency pin on a package whose submodule is imported MUST be upper-bounded, and
+  installation MUST use `netclaw_pip_install`, never a bare `pip`/`pip3` (spec 077).
+
+### Key Entities
+
+- **Prefix** — an IPv4 or IPv6 network. The unit of RPKI validation and routing observation.
+- **Origin AS** — the autonomous system announcing a prefix. Validation is always of the *pair*.
+- **ROA** — a Route Origin Authorisation: which AS may announce which prefix, up to a `maxLength`. The
+  evidence behind every RPKI verdict.
+- **Validation state** — one of: valid · invalid (wrong AS) · invalid (too specific) · no ROA. Four values,
+  never fewer.
+- **Registry record** — allocation data for a resource: holder, range, registry, abuse contact. A claim of
+  allocation, not of routing.
+- **AS overview** — holder and allocation status for an ASN, distinct from what it announces.
+- **Peering record** — an AS's self-reported interconnection: IXPs, facilities, traffic profile.
+- **Source** — the specific service that produced a datum. Carried on every response; never implied.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A ROA-matching prefix/AS pair is reported **valid** with the authorising ROA included.
+- **SC-002**: A prefix whose ROA names a different AS is reported **invalid — wrong origin AS**, naming the
+  AS the ROA authorises. Verified live against a deliberately mismatched pair.
+- **SC-003**: A maxLength violation is reported **invalid — too specific**, and is distinguishable in the
+  output from SC-002.
+- **SC-004**: Unsigned space is reported as **no ROA exists**, with an explicit statement that this is
+  normal and not a finding — and the words "invalid", "suspicious" and "unverified" do not appear in that
+  result.
+- **SC-005**: The response for unsigned space names the RFC 6811 term **NotFound** alongside the source's
+  own `unknown`, so the vocabulary mismatch cannot mislead.
+- **SC-005a**: Every RPKI result names its validator and states that the verdict is **not corroborated by a
+  second validator**; the words "confirmed", "verified" and "cross-checked" do not appear.
+- **SC-005b**: With the validator unreachable, the result is **validation unavailable** naming the
+  validator — and is distinguishable in the output from "no ROA exists".
+- **SC-006**: An IP and an ASN are each resolved to holder and abuse contact, across **at least two
+  different RIRs**, with the responding registry named on each.
+- **SC-007**: A registry failure (ARIN's connection reset is the live case) is reported as a **named source
+  failure**, and does not present as "no record found".
+- **SC-008**: An AS's announced prefixes and overview are retrieved, with the collector basis stated.
+- **SC-009**: A low-visibility prefix is reported without the words "leak" or "hijack" attached by the tool.
+- **SC-010**: An AS with no PeeringDB record is reported as "no self-reported record", explicitly not as
+  "does not peer".
+- **SC-011**: Atlas **anchors** are listed for a country and **probe counts** returned for a named AS;
+  a request for general probe availability by location is routed to Globalping's `locations`, and a request
+  to *run* a measurement is routed to Globalping.
+- **SC-012**: **Every** response carries a structured source and retrieval time — asserted mechanically
+  across all tools, not spot-checked.
+- **SC-013**: A multi-source answer carries per-element attribution, not one collective citation.
+- **SC-014**: Every operation, including refusals and failures, produces a GAIT record.
+- **SC-015**: RFC1918, loopback, documentation and unallocated inputs are each **refused locally with no
+  outbound request made**, and the refusal explains why.
+- **SC-016**: IPv6 works across every capability, verified with at least one real IPv6 prefix.
+- **SC-016a**: Request rate against any single source never exceeds **4/second**, and requests to one
+  source are never concurrent — asserted by a test that issues a multi-target batch and observes the
+  request timeline, not by inspection.
+- **SC-017**: Requests identify NetClaw via `User-Agent`; a repeated identical lookup within a session is
+  served from cache, says so, and **reports the cached value's age**.
+- **SC-017a**: A forced-fresh lookup bypasses the cache and issues a real request, verified by observing
+  that the request occurred.
+- **SC-017b**: RPKI results expire from cache in 5 minutes while RDAP results survive, confirming TTLs are
+  genuinely per-source rather than one global value.
+- **SC-018**: A throttle response produces backoff and a reported condition, not a retry storm.
+- **SC-019**: The skill states the Globalping boundary, and states which of `gtrace`'s existing
+  `asn_lookup`/`geo_lookup` questions belong to `gtrace` rather than here.
+- **SC-020**: A per-capability verification table exists distinguishing live-exercised from static-only,
+  with **every** capability live-exercised or its absence explicitly justified.
+- **SC-020a**: The registered tool manifest measures **≤ 5,000 tokens**, with the figure recorded and the
+  check enforced by a test that fails the build if exceeded.
+- **SC-021**: `reconcile-mcp.py` exits 0 across all four surfaces; `verify-inventory-counts.py` exits 0
+  with updated counts; `trace-skill.py` resolves for every new skill.
+- **SC-022**: `SOUL.md` gains a capability section describing the external plane and its routing
+  boundaries — not merely an incremented count.
+
+## Assumptions
+
+- **All five sources are public and unauthenticated for the capabilities in scope.** Verified reachable
+  2026-08-03: RDAP (via bootstrap and RIPE), PeeringDB, RIPEstat (`as-overview`, `routing-status`,
+  `rpki-validation`), RIPE Atlas read-only — all HTTP 200 with no credentials.
+- **ARIN's RDAP is unreachable from this host** (connection reset). The bootstrap redirector and RIPE's
+  RDAP both work, so registry lookups remain viable; this is a source-selection consequence, not a blocker.
+- **RIPEstat is the sole RPKI validation source**, and the feature is explicit about that rather than
+  implying corroboration (FR-007a). Cloudflare's `rpki.cloudflare.com/api/v1/validity/...` 404s as measured;
+  whether that is a moved path or a withdrawn endpoint is a **Phase 0 research question**. If a second
+  validator is found reliably reachable, adding corroboration is a clean follow-on — the source-attribution
+  machinery (FR-019/FR-021) already supports per-element provenance, so agreement/disagreement reporting
+  would slot in without redesign.
+- **Rate limits are undocumented in responses.** Neither RIPEstat nor PeeringDB advertises rate-limit
+  headers, so courtesy behaviour must be derived from published policy rather than negotiated at runtime.
+- **RIPE Atlas *measurement* execution requires credentials and credits; read-only inventory does not.**
+  Only the read-only half is in scope, which is also why FR-018 routes measurement to R8.
+- **`gtrace`'s existing enrichment stays as it is.** This feature does not modify it; FR-032 draws the
+  boundary rather than absorbing it.
+- **No credentials, therefore no secret handling beyond the usual.** There is no API key to leak, which
+  removes a whole class of risk present in specs 078 and 080.
+
+## Out of Scope
+
+- **Hijack detection or alerting.** This feature reports RPKI state and routing observations. Declaring an
+  incident, correlating events over time, or paging someone is an operator judgement and a different
+  product (FR-007).
+- **Continuous BGP monitoring or historical analysis.** These are point-in-time lookups. Trend and
+  time-series work belongs to a monitoring platform, not here.
+- **Running RIPE Atlas measurements** — credentials, credits, and R8 already owns outside-in measurement
+  (FR-018).
+- **Operating an RPKI validator.** NetClaw consumes published validation; running Routinator or similar is
+  an infrastructure decision, not an integration.
+- **Quick per-hop ASN/geo enrichment** — already delivered by `gtrace-ip-enrichment` (FR-032).
+- **IRR / RPSL objects (`route:`, `as-set`) and BGP communities.** Adjacent and genuinely useful, but a
+  distinct data model and a separate body of work; deliberately deferred rather than half-done.

--- a/specs/081-bgp-registry-intel/tasks.md
+++ b/specs/081-bgp-registry-intel/tasks.md
@@ -1,0 +1,280 @@
+# Tasks: BGP & Registry Intelligence (RPKI / RDAP / PeeringDB / RIPEstat)
+
+**Input**: Design documents from `/specs/081-bgp-registry-intel/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/mcp-tools.md, quickstart.md
+**Roadmap**: R9 — Tier 2, "the internet / external plane"
+
+**Tests**: Included, and mandatory. SC-012 requires provenance be asserted *mechanically across all tools,
+not spot-checked*; SC-016a requires the rate limit be proven from an observed request timeline. Neither is
+demonstrable by inspection. Spec 080 also shipped a null-fields bug past 24 passing tests, so this task list
+separates **structural** tests (no network) from **live** tests (real APIs) and requires both.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1 RPKI · US2 registry · US3 routing · US4 peering · US5 Atlas
+
+## Path Conventions
+
+New vendored server at `mcp-servers/bgp-intel-mcp/`, one skill at
+`workspace/skills/bgp-registry-intel/`, tests at `tests/bgp-intel/`. Per plan.md "Source Code".
+
+---
+
+## ⚠️ No external blockers — and that raises the bar
+
+Unlike spec 080 (three appliances, a licence saga, 13 of 21 tools unexercised) and R4 (waiting on a
+human-reviewed vendor trial), **every source here is public and reachable today**. Verified before the spec
+was written and again in Phase 0.
+
+FR-037 therefore sets a harder standard: **near-total live verification is the expectation, not the
+aspiration.** Any capability that ships unexercised must be justified explicitly or cut.
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Create `mcp-servers/bgp-intel-mcp/` with a `sources/` subpackage and `__init__.py` files per plan.md
+- [ ] T002 Add `.gitignore` negation for `mcp-servers/bgp-intel-mcp/` — the repo ignores `mcp-servers/*` broadly and a new server dir is otherwise silently untracked (docs/ADDING-AN-MCP.md step 1)
+- [ ] T003 Write `requirements.txt` with `mcp>=1.2.0,<2` and `httpx>=0.27.0,<1`, including the comment that the upper bound is load-bearing — **mcp v2 now exists** and removes `mcp.server.fastmcp` (spec 077, research R5)
+- [ ] T004 Create `server.py` FastMCP skeleton, stdio transport, JSON-RPC lifecycle (Principle V), no tools yet
+- [ ] T005 [P] Create `tests/bgp-intel/run-tests.sh` following `tests/reconcile/run-tests.sh` — bash + stdlib, no new framework
+
+---
+
+## Phase 2: The distinctions and provenance (BLOCKS EVERYTHING)
+
+**This phase is the feature.** The four RPKI states are why this is a spec and not a wrapper.
+
+- [ ] T006 Implement `outcomes.py` with the RPKI state model: `state` ∈ `valid`/`invalid`/`not_found` and `reason` ∈ `as`/`length`/`None`, as **separate fields** (FR-002, data-model §3)
+- [ ] T007 Implement the `Outcome` enum in `outcomes.py` with all seven values from data-model §2, keeping `no_record`, `source_unavailable` and `input_refused` distinct (FR-011)
+- [ ] T008 Add `validation_unavailable` as its own outcome, **distinct from `not_found`** — an unreachable validator is not unsigned space (FR-007c). This is the subtlest bug available in this feature
+- [ ] T009 Implement `is_finding` in `outcomes.py`: `true` **only** for `invalid`. `not_found` and `valid` are both non-findings (FR-003)
+- [ ] T010 Implement the RIPEstat vocabulary mapping in `outcomes.py`: `unknown`→`not_found`, `invalid_asn`→(`invalid`,`as`), `invalid_length`→(`invalid`,`length`), for the fallback path only (FR-004)
+- [ ] T011 Implement `envelope.py` `emit()` stamping `source`, `retrieved_at`, `outcome`, `cached`, `cache_age_seconds`, `query`, `data`, `caveats` (FR-019, data-model §1)
+- [ ] T012 Make `envelope.py` a **chokepoint** — a wrapper every tool response must pass through, so provenance cannot be omitted by a tool added later (FR-020)
+- [ ] T013 Enforce in `envelope.py` that a response with no nameable `source` is an **error**, not an unattributed answer (FR-019)
+- [ ] T014 Implement `caveats` as a **structured field** carrying the FR-009/013/016 statements, so they survive a model summarising the payload
+- [ ] T015 [P] Contract test `tests/bgp-intel/test_outcomes.py`: all four RPKI states distinct; `not_found` has `is_finding=False`; `validation_unavailable` ≠ `not_found` — **no network** (SC-004, SC-005b)
+- [ ] T016 [P] Contract test `tests/bgp-intel/test_envelope.py`: every envelope carries source + retrieved_at; a source-less response errors — **no network** (SC-012)
+- [ ] T017 [P] Contract test asserting the strings `invalid`, `suspicious` and `unverified` **never appear** in a rendered `not_found` result (SC-004) — the feature's central promise, tested as text
+- [ ] T017a [P] Contract test asserting the strings `confirmed`, `verified` and `cross-checked` **never appear** in **any** RPKI result, and that `corroborated` is literally `false` (SC-005a, FR-007a). Both reachable validators are RIPE NCC Routinator, so implying corroboration would be false — this is tested as text because it is a claim about wording, not structure
+- [ ] T017b [P] Contract test asserting a `not_found` result and a `validation_unavailable` result are **distinguishable in rendered output**, not merely different enum values (SC-005b, FR-007c)
+
+---
+
+## Phase 3: Audit (same chokepoint — Principle IV)
+
+> Placed here, not at the end, because `/speckit.analyze` caught spec 080 with an audit **verification**
+> task and no **implementation** task. Verifying an unimplemented guarantee passes by accident.
+
+- [ ] T018 Implement GAIT emission **inside** `envelope.emit()` so every operation is audited by construction (FR-022, Principle IV)
+- [ ] T019 Ensure the audit record carries tool, query, source, outcome, `cached`, and timestamp — the shape of the operation, not bulk payload (data-model §10)
+- [ ] T020 Ensure refusals and failures are audited too, not only successes — a refused private-address lookup is an operation that happened
+- [ ] T021 Surface a GAIT write failure rather than swallowing it: an unaudited operation violates Principle IV whether the tool call worked or not
+- [ ] T022 [P] Contract test `tests/bgp-intel/test_audit.py`: every invocation including refusals emits exactly one record — **no network** (FR-022)
+
+---
+
+## Phase 4: Request discipline (BLOCKS all source work)
+
+- [ ] T023 Implement `http_client.py` with a per-source rate limiter: **≤ 4 req/s and concurrency 1** (FR-023)
+- [ ] T024 Enforce the limit **at the request layer**, not by caller discipline, so a tool added later inherits it without knowing it exists (FR-023b)
+- [ ] T025 Implement the per-source TTL cache in memory: RPKI 5 min, routing 15 min, RDAP/PeeringDB/Atlas 24 h (FR-026, data-model §8)
+- [ ] T026 Ensure the cache is **in-memory and session-scoped** — no on-disk store, deliberately unlike spec 078 (FR-026a)
+- [ ] T027 Report `cached` **and** `cache_age_seconds` on cached responses (FR-026b)
+- [ ] T028 Implement `fresh=true` cache bypass, for when a ROA was just published and the 5-min TTL is the only thing hiding the truth (FR-026c)
+- [ ] T029 Set a `User-Agent` identifying NetClaw plus a contact reference (FR-025, SC-017)
+- [ ] T030 Implement backoff on throttle → `rate_limited` outcome, never a retry storm (FR-027, SC-018)
+- [ ] T031 [P] Contract test `tests/bgp-intel/test_rate_limit.py`: a multi-target batch never exceeds 4/s and never issues concurrent requests to one source, asserted from an **observed request timeline** against a local stub — **no external network** (SC-016a)
+- [ ] T032 [P] Contract test `tests/bgp-intel/test_cache.py`: RPKI entries expire at 5 min while RDAP survives, proving TTLs are genuinely per-source; `fresh=true` bypasses (SC-017a, SC-017b)
+
+---
+
+## Phase 5: Input refusal (BLOCKS all source work)
+
+> Before Phase 6 because FR-028 is a **disclosure control**, not a validation nicety. Sending an internal
+> address to a public registry is a disclosure even if the query then fails — spec 079's reasoning.
+
+- [ ] T033 Implement `validate.py` refusing RFC1918, loopback, link-local, CGNAT 100.64/10, multicast, reserved (FR-028)
+- [ ] T034 Refuse documentation ranges (192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24, 2001:db8::/32) and IPv6 ULA fc00::/7 (FR-028)
+- [ ] T035 Refuse malformed input: bad prefix length, non-numeric ASN, mixed address family, AS0 (FR-030)
+- [ ] T036 Ensure refusal happens **before any outbound request** and yields `input_refused` with an explanation (FR-028)
+- [ ] T037 Support IPv4 **and** IPv6 across all validation paths (FR-029)
+- [ ] T038 [P] Contract test `tests/bgp-intel/test_validate.py`: each refused class is refused with **no request issued**, verified by a stub that records calls — **no network** (SC-015)
+- [ ] T038a [P] Contract test asserting the server exposes **no tool that mutates anything** — every registered tool is a read (FR-034). Structurally true today because no write code exists; the test keeps it true when someone later adds a tool
+
+---
+
+## Phase 6: US1 — RPKI origin validation (P1) 🎯 MVP
+
+**Goal**: answer "is this announcement legitimate?" — the capability nothing else in NetClaw has.
+
+**Independent test**: query the four fixture pairs from quickstart.md and confirm four distinct outcomes.
+
+- [ ] T039 [US1] Implement `sources/rpki.py` against **`rpki-validator.ripe.net/api/v1/validity/`** as primary — RFC 6811 vocabulary natively, `state`/`reason` separate, VRPs included (FR-001, research R2)
+- [ ] T040 [US1] Parse and return `vrps_matched`, `vrps_unmatched_as`, `vrps_unmatched_length` so the operator can check the reasoning rather than trust a label (FR-005)
+- [ ] T041 [US1] Include the validator's own `description` sentence, and name the validator on every result with `corroborated: false` (FR-007a)
+- [ ] T042 [US1] Implement the RIPEstat fallback path, applying the T010 vocabulary mapping and **stating that a translation occurred** (FR-004)
+- [ ] T043 [US1] On `invalid`, name **what the ROA does authorise** — permitted ASN and maxLength — because that is what makes it actionable (FR-006)
+- [ ] T044 [US1] Attach the `not_found` caveat: normal for most address space, **not a finding** (FR-003)
+- [ ] T044a [US1] Frame results to reflect the **error asymmetry** (FR-007b): a `valid` result states it reflects one validator's current view and is not a guarantee of legitimacy; an `invalid` result states what would need checking before treating it as an incident. A wrong `valid` says an announcement is authorised when it is not; a wrong `invalid` sends someone chasing a hijack that is not happening. Both are worse than an honest single-validator view
+- [ ] T045 [US1] Ensure the tool never emits the words hijack, attack or incident (FR-007, SC-009)
+- [ ] T046 [US1] Map validator-unreachable to `validation_unavailable`, and **never** infer state from routing, registry, or absence of a ROA (FR-007c)
+- [ ] T047 [US1] Register `rpki_validate(prefix, origin_asn, fresh)` in `server.py` per contracts
+- [ ] T048 [US1] **Live-verify all four states** against the fixtures: `AS13335`+`1.1.1.0/24`→valid; `AS13335`+`8.8.8.0/24`→invalid/as; `AS15169`+`8.8.8.128/25`→invalid/length; `AS3356`+`4.0.0.0/9`→not_found (SC-001, SC-002, SC-003, SC-004, SC-005)
+- [ ] T049 [US1] **Live-verify IPv6**: `AS13335`+`2606:4700::/32` returns a verdict (SC-016, FR-029)
+
+**Checkpoint**: US1 alone is a shippable MVP.
+
+---
+
+## Phase 7: US2 — Registry records (P1)
+
+- [ ] T050 [US2] Implement `sources/rdap.py` resolving the responsible RIR from the **IANA bootstrap file** (RFC 7484), then querying that RIR directly (research R4)
+- [ ] T051 [US2] Implement the `rdap.org` fallback for when a direct RIR endpoint fails
+- [ ] T052 [US2] Return holder, allocation range, registry, abuse contacts, events; **name the responding registry and how it was selected** (FR-008, FR-010)
+- [ ] T053 [US2] Attach the caveat: **allocation data, not evidence about who is announcing** (FR-009)
+- [ ] T054 [US2] Map a registry reset/timeout/refusal to `source_refused`/`source_unavailable` **naming that registry** — never `no_record` (FR-011)
+- [ ] T055 [US2] Register `registry_lookup` and `registry_abuse_contact` per contracts
+- [ ] T056 [US2] **Live-verify across at least two different RIRs**, with the registry named on each (SC-006)
+- [ ] T057 [US2] **Live-verify the ARIN failure path** yields a named source failure, not "no record" (SC-007)
+- [ ] T058 [US2] Retry ARIN from a different network path to establish whether the reset is host-specific — **do not document it as a property of ARIN until confirmed** (research open item 2)
+
+---
+
+## Phase 8: US3 — Routing status (P2) · US4 — Peering (P2)
+
+- [ ] T059 [P] [US3] Implement `sources/routing.py` for RIPEstat `as-overview` and `routing-status` (FR-012)
+- [ ] T060 [US3] Return per-prefix visibility with **`collector_basis`** on every result (FR-013)
+- [ ] T061 [US3] Ensure the tool never attaches `leak` or `hijack` to a low-visibility prefix (FR-013, SC-009)
+- [ ] T062 [US3] Distinguish "no announcements observed" from "AS does not exist" from "query failed" (FR-014)
+- [ ] T063 [US3] Bound large result sets with `truncated` and `total_available` — never silently cut
+- [ ] T064 [P] [US4] Implement `sources/peeringdb.py` for the network record, IXPs and facilities (FR-015)
+- [ ] T065 [US4] Attach the **self-reported** caveat to every result; absent record ⇒ `no_record` with "not evidence the network does not peer" (FR-016)
+- [ ] T066 [US3][US4] Register `routing_as_overview`, `routing_announced_prefixes`, `peering_network`, `peering_presence`
+- [ ] T067 [US3] **Live-verify** an AS overview and announced prefixes with collector basis stated (SC-008)
+- [ ] T068 [US4] **Live-verify** a rich PeeringDB record, and find an ASN **genuinely absent** from PeeringDB to verify the no-record path rather than assuming one exists (SC-010, research open item 3)
+
+---
+
+## Phase 9: US5 — Atlas, narrowed (P3)
+
+- [ ] T069 [US5] Implement `sources/atlas.py` for **anchors by country** and **probe count by AS** — and nothing broader (FR-017)
+- [ ] T070 [US5] Ensure general probe-availability-by-location is **not implemented**; such a request is routed to Globalping's `locations` (FR-017a)
+- [ ] T071 [US5] Route any request to *run* a measurement to Globalping (R8), never attempt it here (FR-018)
+- [ ] T072 [US5] Register `atlas_anchors` and `atlas_probe_count`
+- [ ] T073 [US5] **Live-verify** anchors for a country and probe count for an AS (SC-011)
+
+---
+
+## Phase 10: Composite report and manifest budget
+
+- [ ] T074 Implement `resource_report(resource)` running RPKI, registry, routing and peering into one report
+- [ ] T075 Ensure **per-element provenance** — each section carries its own source, never one collective citation (FR-021, SC-013)
+- [ ] T076 Run sub-queries **serially**. This is the tool most likely to attract an `asyncio.gather`; FR-023a prohibits it
+- [ ] T077 Report a failed section **within** the report; the report does not fail wholesale (FR-011)
+- [ ] T078 Report source **disagreement** (RDAP holder vs PeeringDB name) rather than resolving it silently
+- [ ] T079 Measure the serialised `tools/list` token count with `count_tokens` and **record the number** (FR-025 measurement, FR-027a)
+- [ ] T080 Assert the manifest is **≤ 5,000 tokens**; merge tools or fold parameters if exceeded (FR-027a)
+- [ ] T081 [P] Contract test `tests/bgp-intel/test_manifest_size.py` failing the build if the ceiling is breached — **no network** (FR-027b, SC-020a)
+- [ ] T082 [P] Document the measured figure in the server README (FR-027c)
+- [ ] T083 **Live-verify** `resource_report` returns per-element provenance and runs serially (SC-013, SC-016a)
+
+---
+
+## Phase 11: Artifact coherence (Principle XI — NON-NEGOTIABLE)
+
+- [ ] T084 Register `bgp-intel-mcp` in `config/openclaw.json` with **repo-relative** paths, `command` + `args` separate — never an absolute path under `/home/` (docs/ADDING-AN-MCP.md step 2)
+- [ ] T085 Add a catalog entry to `scripts/lib/catalog.sh` under an appropriate category
+- [ ] T086 Add the component to **curated profiles** — `PROFILE_SECURITY` and `PROFILE_RECOMMENDED`. A component in no profile appears only in the fine-tune checklist, the gap that caught spec 076
+- [ ] T087 Add `component_install_bgp_intel()` to `scripts/lib/install-steps.sh` using `netclaw_pip_install`, **never** bare `pip`/`pip3` (spec 077, FR-042)
+- [ ] T088 Add the HUD **node list** entry in `ui/netclaw-visual/server.js` — `{ id, name, prefixes }`
+- [ ] T089 Add the HUD **annotation map** entry in `ui/netclaw-visual/server.js`. **Both are required**; the annotation alone renders no node
+- [ ] T090 [P] Update `README.md` — description, architecture, **and the counts** (206→207 skills, 153→154 integrations)
+- [ ] T091 Update `SOUL.md` counts **and** add a capability section describing the external plane and its routing boundaries — a bumped count does not tell the agent what it can do (FR-038, SC-022)
+- [ ] T092 [P] Update `.env.example` with the three optional tuning variables, **names and descriptions only**. Note explicitly that this integration needs **no credentials**
+- [ ] T093 [P] Update `TOOLS.md` with the BGP/registry reference including the four-state table
+- [ ] T094 [P] Write `mcp-servers/bgp-intel-mcp/README.md` — tools, sources, the four states, rate-limit posture, measured manifest count
+- [ ] T094a Record in the README that **neither RIPEstat nor PeeringDB advertises rate-limit headers** and that the 4 req/s figure is therefore **NetClaw's own conservative choice, not a service-declared limit** (FR-024). A later maintainer who finds a published limit must not mistake this number for it
+- [ ] T094b Record in the README the deliberate **`not-found` (wire) vs `not_found` (code)** distinction: the validator returns the hyphenated RFC 6811 spelling, the internal model uses the underscored identifier. They are intentionally different and "fixing" either to match the other would break the mapping
+- [ ] T095 Run `python3 scripts/reconcile-mcp.py`; must exit 0 across all four surfaces (FR-039, SC-021). Check the exit code **directly** — never through a pipe, which reports the pipe's status
+- [ ] T096 Run `python3 scripts/verify-inventory-counts.py`; must exit 0 with updated counts (FR-040)
+
+---
+
+## Phase 12: Skill and honest reporting
+
+- [ ] T097 Create `workspace/skills/bgp-registry-intel/SKILL.md` — **one skill**, because these four sources answer facets of one operator question (plan.md Structure Decision)
+- [ ] T098 State the four RPKI states in the skill, with **`not_found` explicitly marked normal and not a finding** (FR-003)
+- [ ] T099 State the boundary against **Globalping (R8)**: Globalping measures, this looks up (FR-031)
+- [ ] T100 State the boundary against **`gtrace-ip-enrichment`**: `gtrace` owns quick ASN/geo/rDNS hop enrichment, this owns authoritative registry, RPKI, routing and peering (FR-032, SC-019)
+- [ ] T101 State the boundary against `nvd-cve`/`cisco-psirt`: software vulnerability vs routing legitimacy (FR-033)
+- [ ] T102 State the three "not what you think" caveats in the skill: registry ≠ routing, PeeringDB self-reported, visibility is collector-based
+- [ ] T102a State in the skill that these lookups serve a **specific operational question** and MUST NOT be used to enumerate, sweep or bulk-harvest registry data (FR-035). These are volunteer-funded services; the rate limiter enforces politeness mechanically, but the skill must not *direct* NetClaw toward harvesting in the first place
+- [ ] T102b State in the skill the **error asymmetry** from T044a, so an operator reading an `invalid` knows what to check before escalating (FR-007b)
+- [ ] T103 Run `python3 scripts/trace-skill.py bgp-registry-intel`; must resolve (FR-041)
+- [ ] T104 Build the per-capability verification table distinguishing **live-exercised** from **static-only** (FR-036, SC-020)
+- [ ] T105 **Justify or cut** any capability not live-exercised. Every source is public, so FR-037 gives no excuse — this is a harder bar than spec 080 met
+- [ ] T106 Confirm every operation during verification produced a GAIT record (FR-022, SC-014)
+- [ ] T107 Update `docs/COVERAGE-ROADMAP.md` R9 status to `DONE` with the outcome, following the R1/R2/R3/R8 format
+- [~] T108 ~~Draft the milestone blog post~~ — **SKIPPED by operator decision** (Principle XVII). R3's post was also written but never published; a backlog of unpublished drafts is worse than none. Revisit as a batched write-up across R3/R9 if wanted.
+
+---
+
+## Dependencies
+
+```
+Phase 1 (Setup)
+   └─> Phase 2 (outcomes + envelope)        ← BLOCKS EVERYTHING. The distinctions ARE the feature
+          └─> Phase 3 (GAIT in the chokepoint)
+                 ├─> Phase 4 (rate limit + cache) ─┐
+                 └─> Phase 5 (input refusal) ──────┤
+                                                   ├─> Phase 6  (US1 RPKI)  🎯 MVP
+                                                   ├─> Phase 7  (US2 registry)
+                                                   ├─> Phase 8  (US3 routing, US4 peering)
+                                                   └─> Phase 9  (US5 Atlas)
+                                                          └─> Phase 10 (composite + manifest)
+                                                                 └─> Phase 11 (artifacts)
+                                                                        └─> Phase 12 (skill + reporting)
+```
+
+**Story independence**: US1–US5 are each independently deliverable once Phases 4 and 5 land. Only Phase 10's
+`resource_report` depends on more than one story.
+
+**Phases 4 and 5 both gate all source work** — the rate limiter so no source can bypass it, input refusal so
+nothing can call out with a private address.
+
+## Parallel opportunities
+
+- **Phase 2**: T015, T016, T017 parallel with each other
+- **Phase 3**: T022 parallel with Phase 4 start
+- **Phase 4/5**: T031, T032, T038 parallel
+- **Phase 8**: T059 and T064 parallel (different files)
+- **Phase 11**: T090, T092, T093, T094 parallel
+
+**Note**: parallel *task execution* is fine. Parallel *HTTP requests to one source* is prohibited (FR-023a).
+
+## Implementation strategy
+
+**MVP = Phases 1 → 2 → 3 → 4 → 5 → 6.** That delivers RPKI origin validation with all four states, full
+provenance and audit — the capability nothing else in NetClaw has. Phases 7–9 are additive; Phase 10's
+composite needs at least two sources.
+
+**Phase 2 is not optional scaffolding — it is the deliverable.** Writing a source first and adding the
+distinction afterwards produces exactly the code that collapses `not_found` into `invalid`, because
+collapsing is the path of least resistance once you already hold a string from an API.
+
+**Total: 116 tasks** — 108 from the initial pass plus nine added by `/speckit.analyze` remediation:
+
+| Added | Closes |
+|---|---|
+| T017a, T017b | **SC-005a** forbidden-words test, and rendered-output distinguishability of `not_found` vs `validation_unavailable` |
+| T038a | **FR-034** read-only assertion — keeps it true when a tool is added later |
+| T044a, T102b | **FR-007b** the valid/invalid error asymmetry, in output framing and in the skill |
+| T094a | **FR-024** documenting that 4 req/s is self-imposed, not service-declared |
+| T094b | The deliberate `not-found` (wire) vs `not_found` (code) spelling, so nobody "fixes" it into a bug |
+| T102a | **FR-035** no enumeration, sweeping or bulk-harvesting of registry data |
+
+**Every task can be completed today.** Nothing waits on a licence, trial, appliance or vendor — which is why
+FR-037's near-total live verification is an expectation here rather than an aspiration.

--- a/tests/bgp-intel/run-tests.sh
+++ b/tests/bgp-intel/run-tests.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Contract tests for bgp-intel-mcp — spec 081 (roadmap R9).
+#
+# Bash + stdlib only, following tests/reconcile/run-tests.sh (spec 075).
+#
+# EVERY TEST HERE RUNS WITHOUT TOUCHING A PUBLIC API. The rate-limit suite stubs
+# the transport so it can assert on the request timeline the limiter produces;
+# the rest are pure functions. That matters twice over: these are volunteer-funded
+# services that should not be hit by CI, and the guarantees under test are
+# structural, so they are provable without the network.
+#
+# Live verification against the real sources is separate and lives in the task
+# list (T048, T049, T056, T057, T067, T068, T073, T083).
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+FAILED=0
+run() {
+    local name="$1" path="$2"
+    echo
+    echo "=============================================================="
+    echo "  $name"
+    echo "=============================================================="
+    python3 "$path" || { FAILED=$((FAILED + 1)); return 1; }
+}
+
+run "outcomes    — the four RPKI states (FR-002/003/004, SC-004/005)" tests/bgp-intel/test_outcomes.py
+run "envelope    — provenance + GAIT (FR-019/021/022, SC-012/013/014)" tests/bgp-intel/test_envelope.py
+run "validate    — local refusal as disclosure control (FR-028, SC-015)" tests/bgp-intel/test_validate.py
+run "rate limit  — sliding window + TTL cache (FR-023/026, SC-016a/017)" tests/bgp-intel/test_rate_limit.py
+run "surface     — read-only + <= 5,000 token ceiling (FR-034/027a)"           tests/bgp-intel/test_manifest_size.py
+
+echo
+echo "=============================================================="
+if [ "$FAILED" -eq 0 ]; then
+    echo "  ALL SUITES PASSED"
+    exit 0
+fi
+echo "  $FAILED SUITE(S) FAILED"
+exit 1

--- a/tests/bgp-intel/test_envelope.py
+++ b/tests/bgp-intel/test_envelope.py
@@ -1,0 +1,163 @@
+"""Provenance and audit at the chokepoint. Spec 081, SC-012/SC-013/SC-014, FR-022.
+
+No network. These assert the two guarantees that make merged multi-source answers
+usable at all: every result names its source, and every operation leaves a trail.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "mcp-servers", "bgp-intel-mcp"))
+
+_AUDIT = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
+os.environ["BGP_INTEL_AUDIT_LOG"] = _AUDIT.name
+
+import envelope  # noqa: E402
+from envelope import ProvenanceError  # noqa: E402
+from outcomes import Outcome  # noqa: E402
+
+FAILURES: list[str] = []
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  PASS  {name}")
+    else:
+        FAILURES.append(f"{name}: {detail}")
+        print(f"  FAIL  {name} — {detail}")
+
+
+def records() -> list[dict]:
+    with open(_AUDIT.name, encoding="utf-8") as fh:
+        return [json.loads(l) for l in fh if l.strip()]
+
+
+def reset() -> None:
+    open(_AUDIT.name, "w").close()
+
+
+def test_every_response_names_its_source() -> None:
+    """FR-019/SC-012. 'The registry says' is not attributable — RIRs differ in
+    freshness and completeness, PeeringDB is self-reported, RIPEstat sees only its
+    own collectors."""
+    r = envelope.emit(source="rdap.db.ripe.net", tool="t", data={"x": 1})
+    check("source present", r["source"] == "rdap.db.ripe.net")
+    check("retrieved_at present", bool(r["retrieved_at"]))
+    check("outcome present", r["outcome"] == "ok")
+    check("caveats is a list", isinstance(r["caveats"], list))
+
+
+def test_sourceless_response_is_an_error() -> None:
+    """FR-019. An unattributed answer is not a weaker answer; it is unusable."""
+    for bad in ("", "   ", None):
+        try:
+            envelope.emit(source=bad, tool="t", data={})  # type: ignore[arg-type]
+            check(f"source={bad!r} rejected", False, "no exception raised")
+        except ProvenanceError:
+            check(f"source={bad!r} rejected", True)
+
+
+def test_merged_answers_carry_per_element_provenance() -> None:
+    """FR-021/SC-013. One collective citation across a merged answer is not
+    attribution — a reader cannot tell which part came from where."""
+    reset()
+    a = envelope.emit(source="rdap.db.ripe.net", tool="t", data={"holder": "X"})
+    b = envelope.emit(source="peeringdb.com", tool="t", data={"name": "Y"})
+    m = envelope.merged(tool="resource_report", sections={"registry": a, "peering": b})
+    check("each section keeps its own source",
+          m["sections"]["registry"]["source"] != m["sections"]["peering"]["source"])
+    check("sources_consulted lists both",
+          set(m["sources_consulted"]) == {"rdap.db.ripe.net", "peeringdb.com"},
+          str(m["sources_consulted"]))
+
+
+def test_failed_section_is_named_inside_the_report() -> None:
+    """FR-011. A failure inside a composite is reported as a failure, and the
+    report does not fail wholesale."""
+    dead = envelope.unavailable(source="stat.ripe.net", tool="t", query={},
+                                reason="timeout")
+    ok = envelope.emit(source="peeringdb.com", tool="t", data={})
+    m = envelope.merged(tool="resource_report", sections={"routing": dead, "peering": ok})
+    joined = " ".join(m["caveats"]).lower()
+    check("failed section named in caveats", "routing" in joined, joined[:120])
+    check("caveat says failure not absence", "not as absence" in joined, joined[:160])
+
+
+def test_source_failure_never_reads_as_no_record() -> None:
+    """FR-011. A dead API must not look like an empty registry."""
+    r = envelope.unavailable(source="rdap.arin.net", tool="t", query={}, reason="reset")
+    check("outcome is a failure", r["outcome"] == Outcome.SOURCE_UNAVAILABLE.value)
+    check("failure names the source", "rdap.arin.net" in r["message"])
+    joined = " ".join(r["caveats"]).lower()
+    check("caveat distinguishes failure from absence",
+          "not evidence that no record exists" in joined, joined[:140])
+
+
+def test_local_refusal_makes_no_request() -> None:
+    """FR-028. Refusing locally is a disclosure control — the source is this
+    server precisely because nothing left the machine."""
+    r = envelope.refused(tool="registry_lookup", query={"resource": "10.0.0.1"},
+                         reason="RFC1918")
+    check("outcome is input_refused", r["outcome"] == Outcome.INPUT_REFUSED.value)
+    check("source is local", "local" in r["source"])
+    check("caveat says no request was made",
+          any("no request" in c.lower() for c in r["caveats"]))
+
+
+def test_cache_reports_age() -> None:
+    """FR-026b. An operator chasing a fast-moving RPKI change must be able to tell
+    whether they are looking at a fresh answer."""
+    r = envelope.emit(source="s", tool="t", data={}, cached=True, cache_age_seconds=42.44)
+    check("cached flag set", r["cached"] is True)
+    check("age reported and rounded", r["cache_age_seconds"] == 42.4, str(r["cache_age_seconds"]))
+    fresh = envelope.emit(source="s", tool="t", data={})
+    check("uncached reports no age", fresh["cache_age_seconds"] is None)
+
+
+def test_every_operation_is_audited() -> None:
+    """FR-022/SC-014, Principle IV. Including refusals and failures."""
+    reset()
+    envelope.emit(source="s1", tool="rpki_validate", data={})
+    envelope.refused(tool="registry_lookup", query={"resource": "127.0.0.1"}, reason="loopback")
+    envelope.unavailable(source="s2", tool="peering_network", query={}, reason="timeout")
+    rs = records()
+    check("three operations -> three records", len(rs) == 3, f"got {len(rs)}")
+    outs = {r["outcome"] for r in rs}
+    check("refusal and failure both audited",
+          {"input_refused", "source_unavailable"} <= outs, str(outs))
+    check("records name the component",
+          all(r["component"] == "bgp-intel-mcp" for r in rs))
+    check("records carry cached flag", all("cached" in r for r in rs))
+
+
+def main() -> int:
+    print("envelope + audit contract tests (no network required)")
+    for fn in (
+        test_every_response_names_its_source,
+        test_sourceless_response_is_an_error,
+        test_merged_answers_carry_per_element_provenance,
+        test_failed_section_is_named_inside_the_report,
+        test_source_failure_never_reads_as_no_record,
+        test_local_refusal_makes_no_request,
+        test_cache_reports_age,
+        test_every_operation_is_audited,
+    ):
+        print(f"\n{fn.__name__}")
+        fn()
+    os.unlink(_AUDIT.name)
+    print()
+    if FAILURES:
+        print(f"{len(FAILURES)} FAILED")
+        for f in FAILURES:
+            print(f"  - {f}")
+        return 1
+    print("all envelope contract tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/bgp-intel/test_manifest_size.py
+++ b/tests/bgp-intel/test_manifest_size.py
@@ -1,0 +1,131 @@
+"""Manifest token budget. Spec 081, FR-027a/b/c, SC-020a.
+
+HARD CEILING: 5,000 tokens for the entire `tools/list` response.
+
+This exists because the manifest is loaded into EVERY conversation whether or not
+Fortinet is in play, so its cost is paid by every unrelated task. The clarification
+that set the number rejected "don't make it too big" as untestable.
+
+It is also why this server has ~21 parameterised tools instead of mirroring the
+community servers, which ship 106 (FortiManager), 69 (FortiAnalyzer) and 204+
+(FortiOS) — any one of which blows the budget several times over on its own.
+
+Counting: the Anthropic SDK's `count_tokens` when available (the method feature
+006 established), otherwise a conservative character-based estimate. The estimate
+is deliberately pessimistic so a passing local run cannot be an optimistic one.
+
+Runs with NO appliance.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "mcp-servers", "bgp-intel-mcp"))
+
+CEILING = 5000
+
+
+def count_tokens(text: str) -> tuple[int, str]:
+    """Return (tokens, method). Prefers a real tokenizer; falls back pessimistically."""
+    try:
+        import anthropic  # type: ignore
+
+        client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY", "x"))
+        result = client.messages.count_tokens(
+            model="claude-sonnet-5",
+            messages=[{"role": "user", "content": text}],
+        )
+        return result.input_tokens, "anthropic.count_tokens"
+    except Exception:  # noqa: BLE001 - offline/no key is normal in CI
+        # ~3.4 chars/token for JSON with many short identifiers. Lower divisor =
+        # higher estimate = fails sooner. Erring toward false alarm is correct
+        # for a budget check.
+        return int(len(text) / 3.4), "char-estimate (conservative)"
+
+
+#: Verbs that would indicate a mutating tool. FR-034 — this feature queries public
+#: registries and changes nothing, so there is no write path and no approval gate
+#: to design. That is structurally true today only because no write code exists;
+#: this keeps it true when someone later adds a tool.
+_MUTATING_HINTS = (
+    "create", "update", "delete", "remove", "set_", "add_", "modify",
+    "install", "apply", "commit", "push", "write", "patch", "put_",
+)
+
+
+def check_read_only(tools) -> list[str]:
+    """Return a list of problems. FR-034."""
+    problems = []
+    for t in tools:
+        name = t.name.lower()
+        for hint in _MUTATING_HINTS:
+            if name.startswith(hint) or f"_{hint}" in name:
+                problems.append(f"tool {t.name!r} looks mutating (matched {hint!r})")
+        desc = (t.description or "").lower()
+        # A read-only server should never describe itself as changing anything.
+        for phrase in ("this will change", "modifies the", "writes to"):
+            if phrase in desc:
+                problems.append(f"tool {t.name!r} description implies mutation: {phrase!r}")
+    return problems
+
+
+async def build_manifest() -> tuple[str, int, list[str]]:
+    import server
+
+    tools = await server.mcp.list_tools()
+    readonly_problems = check_read_only(tools)
+    payload = [
+        {
+            "name": t.name,
+            "description": t.description or "",
+            "inputSchema": t.inputSchema,
+        }
+        for t in tools
+    ]
+    return json.dumps(payload, separators=(",", ":")), len(tools), readonly_problems
+
+
+def main() -> int:
+    manifest, tool_count, readonly_problems = asyncio.run(build_manifest())
+    tokens, method = count_tokens(manifest)
+
+    print("BGP-intel manifest budget (FR-027a)")
+    print(f"  tools registered : {tool_count}")
+    print(f"  serialised bytes : {len(manifest):,}")
+    print(f"  measured tokens  : {tokens:,}   [{method}]")
+    print(f"  ceiling          : {CEILING:,}")
+    print(f"  headroom         : {CEILING - tokens:,}")
+    print()
+    print("  for scale, the community server this replaces:")
+    print("    duksh/peerglass                42 tools (9 phases)")
+    print("      (incl. DNS censorship, TLS/CT logs, satellite tracking —")
+    print("       a charter far beyond R9; see research R1)")
+    print()
+
+    print("  read-only surface (FR-034):", "OK" if not readonly_problems else "FAIL")
+    for p in readonly_problems:
+        print(f"    - {p}")
+    print()
+
+    if readonly_problems:
+        print("FAIL: this server must be read-only — it queries public registries and")
+        print("changes nothing, so there is no write path and no approval gate (FR-034).")
+        return 1
+
+    if tokens > CEILING:
+        print(f"FAIL: manifest exceeds the {CEILING:,}-token ceiling by {tokens - CEILING:,}.")
+        print("Merge tools or fold parameters. The ceiling wins over the surface")
+        print("(FR-026a) — a Fortinet integration that taxes every unrelated")
+        print("conversation is a net loss.")
+        return 1
+
+    print(f"PASS: manifest is within budget ({tokens:,} <= {CEILING:,}).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/bgp-intel/test_outcomes.py
+++ b/tests/bgp-intel/test_outcomes.py
@@ -1,0 +1,185 @@
+"""The distinctions, tested. Spec 081, SC-004/SC-005/SC-005a/SC-005b.
+
+Runs with NO network. These are the guarantees the feature exists to make, and they
+are structural, so they are provable without touching a public API.
+
+Spec 080 shipped a null-fields bug past 24 passing tests because its tests asserted
+on the envelope and not on content. Two of the tests here assert on **rendered
+text** for exactly that reason: "the word 'invalid' must not appear in a not-found
+result" is a claim about wording, and only a text assertion catches it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "mcp-servers", "bgp-intel-mcp"))
+
+import outcomes  # noqa: E402
+from outcomes import Outcome, RpkiReason, RpkiState, RpkiValidation  # noqa: E402
+
+FAILURES: list[str] = []
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  PASS  {name}")
+    else:
+        FAILURES.append(f"{name}: {detail}")
+        print(f"  FAIL  {name} — {detail}")
+
+
+def make(state: RpkiState, reason: RpkiReason | None = None, **kw) -> RpkiValidation:
+    return RpkiValidation(
+        prefix=kw.pop("prefix", "192.0.66.0/24"),
+        origin_asn=kw.pop("origin_asn", "AS64500"),
+        state=state,
+        reason=reason,
+        validator="rpki-validator.ripe.net",
+        **kw,
+    )
+
+
+def test_four_states_are_distinct() -> None:
+    """FR-002. RFC 6811 has three states; the validator gives four outcomes because
+    it separates the two reasons for invalidity. Collapsing them is prohibited."""
+    combos = {
+        (RpkiState.VALID, None),
+        (RpkiState.INVALID, RpkiReason.AS),
+        (RpkiState.INVALID, RpkiReason.LENGTH),
+        (RpkiState.NOT_FOUND, None),
+    }
+    check("four distinct (state, reason) combinations exist", len(combos) == 4)
+    check("invalid/as != invalid/length", RpkiReason.AS.value != RpkiReason.LENGTH.value)
+
+
+def test_only_invalid_is_a_finding() -> None:
+    """FR-003/FR-009. The heart of the feature."""
+    check("valid is not a finding", make(RpkiState.VALID).is_finding is False)
+    check("not_found is NOT a finding", make(RpkiState.NOT_FOUND).is_finding is False)
+    check("invalid/as IS a finding", make(RpkiState.INVALID, RpkiReason.AS).is_finding is True)
+    check("invalid/length IS a finding", make(RpkiState.INVALID, RpkiReason.LENGTH).is_finding is True)
+
+
+def test_not_found_never_reads_as_a_problem() -> None:
+    """SC-004 — the feature's central promise, asserted as text.
+
+    Most of the internet has no ROA. If this result ever reads as a problem, the
+    tool manufactures false incidents at scale."""
+    blob = json.dumps(
+        {"data": make(RpkiState.NOT_FOUND).to_dict(),
+         "caveats": make(RpkiState.NOT_FOUND).caveats()}
+    ).lower()
+    for word in ("invalid", "suspicious", "unverified"):
+        check(f"not_found output omits {word!r}", word not in blob,
+              f"found {word!r} in a not_found result")
+    check("not_found says it is normal", "normal" in blob)
+    check("not_found says it is not a finding", "not a finding" in blob)
+
+
+def test_rfc6811_vocabulary_is_reported() -> None:
+    """FR-004/SC-005. A reader who knows RFC 6811 must not be misled by a source's
+    private vocabulary."""
+    d = make(RpkiState.NOT_FOUND).to_dict()
+    check("not_found reports RFC 6811 'NotFound'", d["rfc6811_state"] == "NotFound", d["rfc6811_state"])
+    check("valid reports 'Valid'", make(RpkiState.VALID).to_dict()["rfc6811_state"] == "Valid")
+
+
+def test_corroboration_is_never_implied() -> None:
+    """SC-005a/FR-007a. Both reachable validators are RIPE NCC Routinator, so
+    claiming corroboration would be false."""
+    v = make(RpkiState.VALID)
+    blob = json.dumps({"data": v.to_dict(), "caveats": v.caveats()}).lower()
+    check("corroborated is literally False", v.to_dict()["corroborated"] is False)
+    for word in ("confirmed", "cross-checked", "independently verified"):
+        check(f"output omits {word!r}", word not in blob, f"found {word!r}")
+    check("output says 'not corroborated'", "not corroborated" in blob)
+    check("output names the validator", "rpki-validator.ripe.net" in blob)
+
+
+def test_validation_unavailable_is_not_not_found() -> None:
+    """FR-007c/SC-005b. The core distinction, one level down — and the subtlest bug
+    available here. 'Could not ask' is not 'there is no ROA'."""
+    check("distinct outcome values",
+          Outcome.VALIDATION_UNAVAILABLE.value != "not_found")
+    check("VALIDATION_UNAVAILABLE is not an RpkiState",
+          Outcome.VALIDATION_UNAVAILABLE.value not in {s.value for s in RpkiState})
+
+
+def test_source_failure_is_not_no_record() -> None:
+    """FR-011. A dead API must never look like an empty registry."""
+    vals = {Outcome.NO_RECORD.value, Outcome.SOURCE_UNAVAILABLE.value,
+            Outcome.SOURCE_REFUSED.value, Outcome.INPUT_REFUSED.value}
+    check("four failure-ish outcomes remain distinct", len(vals) == 4, str(vals))
+
+
+def test_invalid_names_what_the_roa_authorises() -> None:
+    """FR-006. What makes an invalid actionable rather than merely alarming."""
+    v = make(RpkiState.INVALID, RpkiReason.AS,
+             vrps_unmatched_as=[{"asn": "AS15169", "prefix": "8.8.8.0/24", "max_length": "24"}])
+    check("authorised origin extracted", v.authorised_origins() == ["AS15169"], str(v.authorised_origins()))
+    check("caveat names the permitted AS", any("AS15169" in c for c in v.caveats()))
+    ml = make(RpkiState.INVALID, RpkiReason.LENGTH,
+              vrps_unmatched_length=[{"asn": "AS15169", "max_length": 24}])
+    check("maxLength extracted", ml.max_lengths() == [24], str(ml.max_lengths()))
+    check("length caveat mentions misconfiguration",
+          any("misconfiguration" in c for c in ml.caveats()))
+
+
+def test_ripestat_vocabulary_translation() -> None:
+    """FR-004. RIPEstat says `unknown` for NotFound and fuses state with reason."""
+    payload = {"data": {"status": "unknown", "validating_roas": []}}
+    v = outcomes.from_ripestat_json(payload, prefix="4.0.0.0/9", origin_asn="AS3356",
+                                   validator="stat.ripe.net")
+    check("unknown -> not_found", v.state is RpkiState.NOT_FOUND, v.state.value)
+    check("translation is recorded", v.translated_from == "RIPEstat", str(v.translated_from))
+    check("translation is stated in caveats", any("translated" in c.lower() for c in v.caveats()))
+
+    fused = {"data": {"status": "invalid_asn", "validating_roas": []}}
+    v2 = outcomes.from_ripestat_json(fused, prefix="8.8.8.0/24", origin_asn="AS13335",
+                                     validator="stat.ripe.net")
+    check("invalid_asn -> (invalid, as)",
+          v2.state is RpkiState.INVALID and v2.reason is RpkiReason.AS,
+          f"{v2.state}/{v2.reason}")
+
+
+def test_wire_spelling_is_accepted() -> None:
+    """The deliberate hyphen/underscore split: the wire says `not-found`, the code
+    says `not_found`. Normalising either would break something."""
+    payload = {"validated_route": {"route": {"prefix": "4.0.0.0/9", "origin_asn": "AS3356"},
+                                   "validity": {"state": "not-found", "VRPs": {}}}}
+    v = outcomes.from_validator_json(payload, validator="rpki-validator.ripe.net")
+    check("hyphenated wire form maps to NOT_FOUND", v.state is RpkiState.NOT_FOUND)
+    check("enum member uses the underscore", RpkiState.NOT_FOUND.value == "not_found")
+
+
+def main() -> int:
+    print("RPKI distinction contract tests (no network required)")
+    for fn in (
+        test_four_states_are_distinct,
+        test_only_invalid_is_a_finding,
+        test_not_found_never_reads_as_a_problem,
+        test_rfc6811_vocabulary_is_reported,
+        test_corroboration_is_never_implied,
+        test_validation_unavailable_is_not_not_found,
+        test_source_failure_is_not_no_record,
+        test_invalid_names_what_the_roa_authorises,
+        test_ripestat_vocabulary_translation,
+        test_wire_spelling_is_accepted,
+    ):
+        print(f"\n{fn.__name__}")
+        fn()
+    print()
+    if FAILURES:
+        print(f"{len(FAILURES)} FAILED")
+        for f in FAILURES:
+            print(f"  - {f}")
+        return 1
+    print("all outcome contract tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/bgp-intel/test_rate_limit.py
+++ b/tests/bgp-intel/test_rate_limit.py
@@ -1,0 +1,246 @@
+"""Rate limiting and caching, proven from an observed request timeline.
+
+Spec 081, SC-016a/SC-017a/SC-017b, FR-023/023a/023b/026.
+
+**No external network.** The client's HTTP call is monkeypatched with a stub that
+records the wall-clock moment of every request, so the assertion is about the
+*timeline the limiter produces*, not about a remote service's behaviour.
+
+SC-016a demands exactly this: the limit is asserted from an observed timeline
+rather than by reading the code. A rate limiter that is correct by inspection and
+wrong under concurrency is the normal failure mode.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "mcp-servers", "bgp-intel-mcp"))
+
+import http_client  # noqa: E402
+from http_client import PoliteClient  # noqa: E402
+
+FAILURES: list[str] = []
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  PASS  {name}")
+    else:
+        FAILURES.append(f"{name}: {detail}")
+        print(f"  FAIL  {name} — {detail}")
+
+
+class _Resp:
+    status_code = 200
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        return None
+
+
+class _StubAsyncClient:
+    """Records (source-ish url, start, end) for every request."""
+
+    timeline: list[tuple[str, float, float]] = []
+    concurrent_now = 0
+    max_concurrent = 0
+
+    def __init__(self, *a, **kw):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def get(self, url, params=None, headers=None):
+        cls = type(self)
+        cls.concurrent_now += 1
+        cls.max_concurrent = max(cls.max_concurrent, cls.concurrent_now)
+        start = time.monotonic()
+        # A real request takes time; without this the limiter's spacing would be
+        # the only thing separating calls and overlap would be undetectable.
+        await asyncio.sleep(0.02)
+        end = time.monotonic()
+        cls.concurrent_now -= 1
+        cls.timeline.append((url, start, end))
+        return _Resp({"ok": True, "url": url})
+
+
+def _install_stub() -> None:
+    _StubAsyncClient.timeline = []
+    _StubAsyncClient.max_concurrent = 0
+    _StubAsyncClient.concurrent_now = 0
+    http_client.httpx.AsyncClient = _StubAsyncClient  # type: ignore[assignment]
+
+
+def test_requests_to_one_source_are_never_concurrent() -> None:
+    """FR-023a. The rule most likely to be broken by a later 'make it faster'
+    change, which is why it is tested rather than documented."""
+    _install_stub()
+    client = PoliteClient()
+
+    async def run():
+        await asyncio.gather(*[
+            client.get_json("rpki", f"https://example.test/{i}") for i in range(6)
+        ])
+
+    asyncio.run(run())
+    check("6 requests were made", len(_StubAsyncClient.timeline) == 6,
+          str(len(_StubAsyncClient.timeline)))
+    check("max concurrency to one source is 1",
+          _StubAsyncClient.max_concurrent == 1,
+          f"observed {_StubAsyncClient.max_concurrent}")
+
+    # No two intervals overlap.
+    spans = sorted((s, e) for _, s, e in _StubAsyncClient.timeline)
+    overlaps = sum(1 for i in range(1, len(spans)) if spans[i][0] < spans[i - 1][1])
+    check("no overlapping request intervals", overlaps == 0, f"{overlaps} overlaps")
+
+
+def test_no_one_second_window_exceeds_the_ceiling() -> None:
+    """FR-023, asserted as the actual invariant: **no sliding one-second window
+    contains more than 4 requests to a source.**
+
+    Note what is deliberately NOT asserted: `total_requests / total_elapsed`. That
+    average is not the guarantee and is misleading at the start of a burst — with a
+    correct sliding window, requests 1-4 fire immediately and the 5th waits for the
+    1st to age out, giving an *average* near 4.9/s while every actual window holds
+    exactly 4. An earlier version of this test asserted the average, failed, and
+    the real finding was that the limiter enforced only a minimum *gap* — which
+    bounds the rate asymptotically but lets five requests land inside one second.
+    The limiter now enforces the window; this asserts that directly.
+    """
+    _install_stub()
+    client = PoliteClient()
+
+    async def run():
+        for i in range(9):
+            await client.get_json("routing", f"https://example.test/r{i}")
+
+    asyncio.run(run())
+    starts = sorted(s for _, s, _ in _StubAsyncClient.timeline)
+    check("9 requests were made", len(starts) == 9, str(len(starts)))
+
+    worst = 0
+    worst_at = 0.0
+    for origin in starts:
+        in_window = sum(1 for s in starts if origin <= s < origin + 1.0)
+        if in_window > worst:
+            worst, worst_at = in_window, origin
+    check("no 1s window holds more than 4 requests", worst <= 4,
+          f"found {worst} requests within one second starting at t={worst_at:.3f}")
+
+    # Sanity: the ceiling is actually being reached, so the test is not passing
+    # merely because everything was slow.
+    check("the ceiling is genuinely exercised", worst == 4, f"observed max {worst}")
+
+
+def test_different_sources_are_not_serialised_against_each_other() -> None:
+    """The limit is per source. Serialising *everything* globally would be
+    needlessly slow without being any politer to a given service."""
+    _install_stub()
+    client = PoliteClient()
+
+    async def run():
+        await asyncio.gather(
+            client.get_json("rpki", "https://example.test/a"),
+            client.get_json("rdap", "https://example.test/b"),
+            client.get_json("peeringdb", "https://example.test/c"),
+        )
+
+    t0 = time.monotonic()
+    asyncio.run(run())
+    elapsed = time.monotonic() - t0
+    check("three different sources proceed in parallel", elapsed < 0.5,
+          f"{elapsed:.2f}s — sources appear globally serialised")
+
+
+def test_cache_hit_avoids_a_request_and_reports_age() -> None:
+    """FR-026/026b."""
+    _install_stub()
+    client = PoliteClient()
+
+    async def run():
+        a = await client.get_json("rdap", "https://example.test/same")
+        b = await client.get_json("rdap", "https://example.test/same")
+        return a, b
+
+    (_, c1, _), (_, c2, age2) = asyncio.run(run())
+    check("first call is not cached", c1 is False)
+    check("second call is cached", c2 is True)
+    check("cached call reports an age", age2 is not None and age2 >= 0, str(age2))
+    check("only one request actually left", len(_StubAsyncClient.timeline) == 1,
+          str(len(_StubAsyncClient.timeline)))
+
+
+def test_fresh_bypasses_the_cache() -> None:
+    """FR-026c. For when a ROA was just published and the 5-minute TTL is the only
+    thing between the operator and the truth."""
+    _install_stub()
+    client = PoliteClient()
+
+    async def run():
+        await client.get_json("rpki", "https://example.test/x")
+        await client.get_json("rpki", "https://example.test/x", fresh=True)
+
+    asyncio.run(run())
+    check("fresh=True issued a second request", len(_StubAsyncClient.timeline) == 2,
+          str(len(_StubAsyncClient.timeline)))
+
+
+def test_ttls_are_per_source() -> None:
+    """FR-026/SC-017b. A single TTL would be wrong for at least one source: a ROA
+    can appear in minutes, an RIR allocation changes in months."""
+    ttl = http_client.TTL_SECONDS
+    check("RPKI TTL is 5 minutes", ttl["rpki"] == 300.0, str(ttl.get("rpki")))
+    check("RDAP TTL is 24 hours", ttl["rdap"] == 86400.0, str(ttl.get("rdap")))
+    check("RPKI expires far sooner than RDAP", ttl["rpki"] < ttl["rdap"] / 100)
+    check("routing sits between them", ttl["rpki"] < ttl["routing"] < ttl["rdap"])
+
+
+def test_max_rps_cannot_be_raised() -> None:
+    """An operator may be more polite; raising the ceiling is not supported."""
+    os.environ["BGP_INTEL_MAX_RPS"] = "100"
+    check("attempt to raise is clamped", http_client._max_rps() == 4.0,
+          str(http_client._max_rps()))
+    os.environ["BGP_INTEL_MAX_RPS"] = "1"
+    check("lowering is honoured", http_client._max_rps() == 1.0)
+    del os.environ["BGP_INTEL_MAX_RPS"]
+
+
+def main() -> int:
+    print("rate limit + cache contract tests (stubbed transport, no external network)")
+    for fn in (
+        test_requests_to_one_source_are_never_concurrent,
+        test_no_one_second_window_exceeds_the_ceiling,
+        test_different_sources_are_not_serialised_against_each_other,
+        test_cache_hit_avoids_a_request_and_reports_age,
+        test_fresh_bypasses_the_cache,
+        test_ttls_are_per_source,
+        test_max_rps_cannot_be_raised,
+    ):
+        print(f"\n{fn.__name__}")
+        fn()
+    print()
+    if FAILURES:
+        print(f"{len(FAILURES)} FAILED")
+        for f in FAILURES:
+            print(f"  - {f}")
+        return 1
+    print("all rate-limit and cache contract tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/bgp-intel/test_validate.py
+++ b/tests/bgp-intel/test_validate.py
@@ -1,0 +1,151 @@
+"""Input refusal as a disclosure control. Spec 081, SC-015, FR-028/029/030.
+
+No network — and that is the point. The property under test is that **no request is
+made**, which is only meaningful if the test itself makes none.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "mcp-servers", "bgp-intel-mcp"))
+
+import validate  # noqa: E402
+from validate import InputRefused  # noqa: E402
+
+FAILURES: list[str] = []
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  PASS  {name}")
+    else:
+        FAILURES.append(f"{name}: {detail}")
+        print(f"  FAIL  {name} — {detail}")
+
+
+def refuses(value: str, label: str) -> None:
+    try:
+        validate.parse_prefix(value)
+        check(f"refuses {label} ({value})", False, "accepted")
+    except InputRefused as exc:
+        msg = str(exc).lower()
+        check(f"refuses {label} ({value})", True)
+        if "no request was sent" not in msg and "refused locally" not in msg:
+            FAILURES.append(f"{label}: refusal does not state no request was sent")
+            print(f"  FAIL  {label} refusal omits the disclosure statement")
+
+
+def test_private_and_reserved_v4_refused() -> None:
+    """The whole point: sending 10.0.0.1 to a public registry is a disclosure even
+    if the lookup then fails."""
+    for value, label in [
+        ("10.0.0.1", "RFC1918 /8"),
+        ("192.168.2.130", "RFC1918 /16"),
+        ("172.16.5.5", "RFC1918 /12"),
+        ("127.0.0.1", "loopback"),
+        ("169.254.1.1", "link-local"),
+        ("100.64.0.1", "CGNAT"),
+        ("224.0.0.1", "multicast"),
+        ("192.0.2.5", "TEST-NET-1 documentation"),
+        ("198.51.100.5", "TEST-NET-2 documentation"),
+        ("203.0.113.5", "TEST-NET-3 documentation"),
+        ("0.0.0.0", "this-network"),
+    ]:
+        refuses(value, label)
+
+
+def test_private_and_reserved_v6_refused() -> None:
+    """FR-029 — IPv6 gets the same treatment, not an afterthought."""
+    for value, label in [
+        ("::1", "v6 loopback"),
+        ("fc00::1", "v6 unique-local"),
+        ("fe80::1", "v6 link-local"),
+        ("2001:db8::1", "v6 documentation"),
+        ("ff02::1", "v6 multicast"),
+    ]:
+        refuses(value, label)
+
+
+def test_public_addresses_accepted() -> None:
+    """The refusal must not be so broad it blocks the feature's actual purpose."""
+    for value in ("8.8.8.8", "1.1.1.0/24", "193.0.6.139", "2606:4700::/32", "2001:67c:2e8::"):
+        try:
+            p = validate.parse_prefix(value)
+            check(f"accepts public {value}", True)
+        except InputRefused as exc:
+            check(f"accepts public {value}", False, str(exc)[:80])
+
+
+def test_malformed_input_rejected_with_a_reason() -> None:
+    """FR-030. Named problems, not a generic failure."""
+    for value, label in [
+        ("not-an-ip", "garbage"),
+        ("1.1.1.1/99", "impossible v4 prefix length"),
+        ("", "empty"),
+        ("999.1.1.1", "octet out of range"),
+    ]:
+        try:
+            validate.parse_prefix(value)
+            check(f"rejects {label}", False, "accepted")
+        except InputRefused:
+            check(f"rejects {label}", True)
+
+
+def test_asn_normalisation() -> None:
+    check("AS13335 -> AS13335", validate.normalise_asn("AS13335") == "AS13335")
+    check("13335 -> AS13335", validate.normalise_asn("13335") == "AS13335")
+    check("as13335 -> AS13335", validate.normalise_asn("as13335") == "AS13335")
+    for bad, label in [("AS0", "AS0 reserved by RFC 7607"),
+                       ("ASfoo", "non-numeric"),
+                       ("AS4294967296", "beyond 32-bit")]:
+        try:
+            validate.normalise_asn(bad)
+            check(f"rejects {label}", False, "accepted")
+        except InputRefused:
+            check(f"rejects {label}", True)
+
+
+def test_resource_classification() -> None:
+    check("ASN classified", validate.parse_resource("AS13335") == ("asn", "AS13335"))
+    kind, val = validate.parse_resource("8.8.8.8")
+    check("IP classified as prefix", kind == "prefix", kind)
+    check("bare IP becomes host prefix", val == "8.8.8.8/32", val)
+
+
+def test_country_codes() -> None:
+    check("nl -> NL", validate.parse_country("nl") == "NL")
+    for bad in ("NLD", "N", "12"):
+        try:
+            validate.parse_country(bad)
+            check(f"rejects {bad!r}", False, "accepted")
+        except InputRefused:
+            check(f"rejects {bad!r}", True)
+
+
+def main() -> int:
+    print("input refusal contract tests (no network — that IS the test)")
+    for fn in (
+        test_private_and_reserved_v4_refused,
+        test_private_and_reserved_v6_refused,
+        test_public_addresses_accepted,
+        test_malformed_input_rejected_with_a_reason,
+        test_asn_normalisation,
+        test_resource_classification,
+        test_country_codes,
+    ):
+        print(f"\n{fn.__name__}")
+        fn()
+    print()
+    if FAILURES:
+        print(f"{len(FAILURES)} FAILED")
+        for f in FAILURES:
+            print(f"  - {f}")
+        return 1
+    print("all validation contract tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ui/netclaw-visual/server.js
+++ b/ui/netclaw-visual/server.js
@@ -66,6 +66,7 @@ const INTEGRATION_CATALOG = [
   { id: 'thousandeyes', name: 'ThousandEyes', category: 'Observability', prefixes: ['te-'], color: '#ffb703', transport: 'http', toolEstimate: 29, description: 'Synthetic and path-aware external monitoring.' },
   { id: 'kubeshark', name: 'Kubeshark', category: 'Observability', prefixes: ['kubeshark-'], color: '#ffcb77', transport: 'http', toolEstimate: 6, description: 'Kubernetes packet and flow visibility.' },
   { id: 'gtrace', name: 'gtrace', category: 'Observability', prefixes: ['gtrace-'], color: '#bde0fe', transport: 'stdio', toolEstimate: 6, description: 'Path tracing and IP enrichment.' },
+  { id: 'bgp-intel', name: 'BGP & Registry Intel', category: 'Observability', prefixes: ['rpki_', 'registry_', 'routing_', 'peering_', 'atlas_', 'resource_'], color: '#8ac926', transport: 'stdio', toolEstimate: 10, description: 'RPKI origin validation, RDAP ownership, PeeringDB peering, routing visibility. Public APIs, no credentials. not-found is NOT invalid.' },
   { id: 'globalping', name: 'Globalping', category: 'Observability', prefixes: ['globalping-'], color: '#00b4d8', transport: 'http', toolEstimate: 12, description: 'Outside-in measurement from ~4,800 probes across ~1,390 ASNs — ping, traceroute, DNS, MTR and HTTP toward a public target. The only vantage point NetClaw has outside its own administrative domain. Public endpoints only; "no probes matched" is not "the service is down".' },
   { id: 'suzieq', name: 'SuzieQ', category: 'Observability', prefixes: ['suzieq-'], color: '#a8dadc', transport: 'stdio', toolEstimate: 5, description: 'Network state queries, assertions, summaries, and path tracing.' },
   { id: 'aws', name: 'AWS', category: 'Cloud', prefixes: ['aws-'], color: '#f77f00', transport: 'http', toolEstimate: 55, description: 'Networking, monitoring, security, cost, and diagram generation in AWS.' },
@@ -240,6 +241,11 @@ const ENV_MAP = {
     env: ['CVP', 'CVPTOKEN'],
     files: [],
     notes: 'CloudVision Portal hostname and service account token.',
+  },
+  'bgp-intel': {
+    env: ['BGP_INTEL_MCP_CMD', 'BGP_INTEL_USER_AGENT', 'BGP_INTEL_MAX_RPS', 'BGP_INTEL_AUDIT_LOG'],
+    files: ['mcp-servers/bgp-intel-mcp/server.py'],
+    notes: 'No credentials required — all five sources are public unauthenticated APIs. Read-only. Self-imposed 4 req/s serial ceiling against volunteer-funded infrastructure (RIPE NCC, PeeringDB). Every response carries its source and is GAIT-audited. RPKI not-found means no ROA exists and is NOT a finding.',
   },
   fortinet: {
     env: [

--- a/workspace/skills/bgp-registry-intel/SKILL.md
+++ b/workspace/skills/bgp-registry-intel/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: bgp-registry-intel
+description: "BGP and registry intelligence — RPKI origin validation (is this announcement authorised?), RDAP registry ownership and abuse contacts, PeeringDB interconnection data, RIPEstat routing status and prefix visibility, RIPE Atlas anchors. Use when investigating an unfamiliar prefix or ASN, checking whether a BGP announcement is RPKI-valid, finding who owns address space or who to report abuse to, or determining what an AS announces and where it peers."
+version: 1.0.0
+license: Apache-2.0
+tags: [bgp, rpki, rdap, whois, peeringdb, routing, registry, internet, security, external]
+user-invocable: true
+metadata:
+  { "openclaw": { "requires": { "bins": ["python3"], "env": ["BGP_INTEL_MCP_CMD"] } } }
+---
+
+# BGP & Registry Intelligence
+
+## MCP Server
+
+- **Server**: `bgp-intel-mcp` (NetClaw-authored, spec 081 / roadmap R9)
+- **Command**: `$BGP_INTEL_MCP_CMD`
+- **Transport**: stdio
+- **Credentials**: **none.** Every source is a public unauthenticated API
+- **Mode**: read-only. There is no write path
+
+## The one rule that matters most
+
+> ### RPKI `not-found` is NOT `invalid`.
+
+**Most of the internet has no ROA.** Unsigned address space is the overwhelmingly common case, not an
+anomaly. If you report `not-found` as a hijack, a misconfiguration, or a security finding, you will
+generate false incidents at scale and the operator will stop trusting you.
+
+| State | Means | Actionable? |
+|---|---|---|
+| `valid` | A ROA authorises this origin AS | **No** — healthy |
+| `invalid` + `reason: as` | A ROA covers this prefix; **a different AS** is authorised | **Yes** — possible hijack |
+| `invalid` + `reason: length` | Correct AS, but the prefix is **more specific** than the ROA permits | **Yes** — usually a local misconfiguration, different fix |
+| `not_found` | **No ROA exists.** RFC 6811 calls this NotFound | **No** — the normal case |
+
+The two `invalid` reasons are different findings. `as` means someone else is announcing your space;
+`length` usually means *you* announced a /24 under a /22 ROA. Never collapse them.
+
+**`validation_unavailable` is not `not_found`.** If the validator is unreachable you get the former, and
+the RPKI state is genuinely unknown. Do not infer "unsigned" from "could not ask", and do not fall back to
+guessing from routing or registry data.
+
+## Tools (10, all read-only)
+
+| Tool | Answers |
+|---|---|
+| `rpki_validate` | Is this prefix legitimately announced by this AS? **Nothing else in NetClaw does this** |
+| `registry_lookup` | Who is this IP/prefix/ASN allocated to? |
+| `registry_abuse_contact` | Who do I report abuse to? |
+| `routing_as_overview` | Who holds this ASN; is it announced at all? |
+| `routing_announced_prefixes` | What does this AS announce, and how visible is it? |
+| `peering_network` | Network type, traffic profile, peering policy |
+| `peering_presence` | Which IXPs and facilities? |
+| `atlas_anchors` | Atlas anchors in a country (stable measurement targets) |
+| `atlas_probe_count` | Can this AS be measured from inside? |
+| `resource_report` | Everything about a resource, one call, per-section sourcing |
+
+## Three more "this is not what you think it is"
+
+- **Registry data is allocation, not routing.** RDAP tells you who address space is *registered to*. It says
+  nothing about who is *announcing* it. Use `routing_announced_prefixes` for that. Treating an RDAP holder
+  as a routing fact is the same category error as treating FortiManager intent as device state.
+- **PeeringDB is self-reported.** No record means nobody filled in the form — **not** that the network does
+  not peer. Many networks peer extensively and publish nothing.
+- **Visibility is RIPE's collectors, not the internet.** Low visibility has legitimate causes: scoped
+  announcements, no-export, anycast, a recent change. The tool will never call it a leak, and neither should
+  you without more evidence.
+
+## Every response carries its source
+
+```jsonc
+{ "source": "rpki-validator.ripe.net", "retrieved_at": "...", "outcome": "ok",
+  "cached": false, "cache_age_seconds": null, "data": {...}, "caveats": [...] }
+```
+
+`caveats` carries the statements above — read them, they are not decoration. `resource_report` gives each
+section **its own** source; never attribute one section's data to another's origin.
+
+Failures name the source that failed. **`source_unavailable` is never "no record found"** — a dead API and
+an empty registry are different facts.
+
+## Workflow: an unfamiliar prefix appears
+
+1. `rpki_validate` with the prefix **and** the origin AS. Validation is always of the pair.
+2. Read the state carefully against the table above. If `not_found`, **stop treating it as a problem.**
+3. `registry_lookup` — who holds it, and who to contact.
+4. `routing_announced_prefixes` on the origin AS — is this consistent with what it normally announces?
+5. `peering_network` — is this a transit provider, content network, or enterprise? It changes what "normal"
+   looks like.
+6. Escalate only on `invalid`, and only after checking that the origin AS is what you think it is and the
+   ROA is current. **This skill does not declare incidents** — that is your judgement.
+
+## Workflow: who do I complain to?
+
+1. `registry_abuse_contact` on the address.
+2. If none is published, try the covering allocation with `registry_lookup`.
+3. `peering_network` often has a technical contact when the registry does not.
+
+## Boundaries — which tool owns what
+
+| Question | Use |
+|---|---|
+| "Can the outside reach us? Measure from N countries" | **`globalping-external-checks`** (R8) — Globalping *measures*; this *looks up* |
+| "Quick: who owns this traceroute hop, and where is it?" | **`gtrace-ip-enrichment`** — it owns ASN/geo/rDNS enrichment |
+| "Is this software version vulnerable?" | `nvd-cve` / `cisco-psirt` — different plane entirely |
+| "Is this *routing* legitimate?" | **this skill** |
+
+Those first two are load-bearing, not politeness. `gtrace` already does quick ASN and geolocation lookups
+and this skill deliberately does not duplicate them (Principle VII). For general Atlas/Globalping probe
+availability by location, or to run any measurement, go to Globalping.
+
+## Being a good citizen
+
+RIPE NCC and PeeringDB are volunteer- and membership-funded. The server holds itself to **≤ 4 requests per
+second per source, strictly serial** — even `resource_report` runs its sections one after another.
+
+**Do not use these tools to enumerate, sweep, or bulk-harvest registry data.** Look things up in service of
+a specific operational question. The rate limiter enforces politeness mechanically; the judgement about
+*what to ask* is yours.
+
+Repeated lookups come from a cache with per-source lifetimes — RPKI 5 minutes, registry 24 hours — and a
+cached answer says so and reports its age. Pass `fresh=true` when a ROA was just published and you need to
+see through the cache.
+
+## Important rules
+
+- **`not_found` is normal.** Say so when you report it.
+- **Keep the two `invalid` reasons apart.** Different cause, different fix.
+- **Never say hijack or attack.** Report state and evidence; escalation is the operator's.
+- **Private and reserved addresses are refused locally**, before any request leaves — sending internal
+  addressing to a public registry is a disclosure even if the lookup fails.
+- **Single validator.** Results are never corroborated; they say so.


### PR DESCRIPTION
Closes roadmap **R9** — Tier 2, "the internet / external plane."

## The other half of the external plane

Spec 079 (R8) gave NetClaw its first vantage point outside its own domain: Globalping **measures** toward a
target. This **looks up** who owns a resource, whether an announcement is authorised, and where a network
peers. Neither substitutes for the other, and both skills state the boundary.

**10 tools · four public sources · read-only · no credentials.** The first NetClaw integration with no
secret to leak, rotate or scope.

## Why this item, now

Every source was verified reachable **before the spec was written**, and again in Phase 0. That was a
deliberate response to R3 — which discovered its lab problem at implementation time and lost most of a day —
and to R4, which is still waiting on a human-reviewed vendor trial.

**No lab, no licence, no trial, no entitlement on the critical path.**

## The distinction this feature exists to protect

> **RPKI `not-found` is NOT `invalid`.**

Most of the internet has no ROA. Reporting unsigned space as a finding would manufacture false incidents at
scale. Four states, all **observed live** rather than read from documentation:

| Query | `state` | `reason` | Finding? |
|---|---|---|---|
| `AS13335` + `1.1.1.0/24` | `valid` | — | no |
| `AS13335` + `8.8.8.0/24` | `invalid` | `as` | **yes** — ROA authorises AS15169 |
| `AS15169` + `8.8.8.128/25` | `invalid` | `length` | **yes** — `/25` under a `maxLength 24` ROA |
| `AS3356` + `4.0.0.0/9` | **`not_found`** | — | **no — the normal case** |

Fourth in the series after R2's *"no advisories ≠ not vulnerable"*, R8's *"no probes ≠ outage"* and R3's
*"no logs ≠ rule unused"*.

A fifth outcome carries the same distinction one level down: **`validation_unavailable` is not
`not_found`.** An unreachable validator is not unsigned space, and the server refuses to infer state from
routing or registry data.

## Build, not adopt

`duksh/peerglass` covers similar ground with **42 tools across 9 phases** including DNS-censorship
detection, TLS/CT-log inspection and satellite tracking — a charter NetClaw did not choose, and the wrong
order of magnitude against a 5,000-token ceiling.

It did independently arrive at three of this spec's clarified decisions (TTL caching 5 min–24 h,
per-result attribution, read-only), which is reassuring **convergent evidence** rather than borrowed design.

## Phase 0 improved the spec

The spec assumed RIPEstat. **`rpki-validator.ripe.net` is better on three measured counts**: RFC 6811
vocabulary natively (`not-found`, not `unknown`), `state` and `reason` as separate fields rather than fused
into `invalid_asn`, and the VRPs behind each verdict returned.

Corroboration was confirmed **impossible**: both reachable validators are RIPE NCC Routinator — same engine,
same operator — so comparing them would be theatre. `corroborated` is always `false` and every result says so.

## Structural guarantees

`envelope.emit()` is a **chokepoint**. Every response carries `source` + `retrieved_at` and emits a GAIT
record by construction. Merged answers carry **per-element** provenance — one collective citation across a
multi-source answer is not attribution.

`no_record`, `source_unavailable` and `input_refused` are distinct outcomes. **A dead API must never look
like an empty registry.**

Private/reserved/bogon input is refused **locally, before any request leaves** — a disclosure control, not a
validation nicety.

**4 req/s per source as a true sliding window, strictly serial.** Parallel fan-out prohibited, including
inside `resource_report`.

## Verification — 10 of 10 live

**Nothing shipped unexercised.** Compare R3, which shipped 13 of 21 tools untouched because no appliance was
available. Manifest measured **1,376 / 5,000 tokens**.

Four unhappy paths are named as **unverified** in
[`VERIFICATION.md`](specs/081-bgp-registry-intel/VERIFICATION.md) rather than glossed — each requires the
failure mode of a healthy public service, and each is unit-tested instead.

### Two findings from implementation

**The rate limiter was genuinely too weak.** A minimum-250 ms-gap version measured **4.53 req/s**, because
N requests spaced 250 ms apart put *five* inside one second. Replaced with a true sliding window. A second
failure at 4.89/s then turned out to be the **test** measuring the wrong thing — `total / elapsed` is not
requests-per-window. The test caught a real bug; the fixed code caught a bad test.

**ARIN is not broken.** Phase 0 recorded a connection reset from `rdap.arin.net` on one `curl`; through the
implemented bootstrap path it returned 200 with holder `GOGL`. A single observation is not a property of a
registry, and the docs were corrected.

## Process

`/speckit.analyze` found **7 issues (2 HIGH)** — all fixed, then re-verified to **100% requirement
traceability**: all 54 FRs and 28 SCs cite a task. One remediation task (the read-only surface assertion)
was found unimplemented during final review and completed, with a check that it fires on a mutating tool
name rather than passing vacuously.

## Artifacts (Principle XI)

Registration with repo-relative paths · catalog entry with **`PROFILE_SECURITY` and `PROFILE_RECOMMENDED`** ·
install function · `install.sh` verification case · **both** HUD entries · `SKILL.md` · `.env.example` ·
`TOOLS.md` · server README · SOUL capability section · counts 206→207 skills, 153→154 integrations.

`reconcile-mcp.py`, `verify-inventory-counts.py`, `verify-catalog-coverage.py`, `trace-skill.py` and all
five test suites exit 0. Fortinet suites re-run as a regression check.

## Deferred

Genuine RPKI corroboration needs a **non-Routinator** relying party. IRR/RPSL objects and BGP communities
are a distinct data model and belong to their own item. Blog post skipped by operator decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)