### PR TITLE
fix(082): complete R3 — admin/link conflation, iN2N member wiring, session isolation

### DIFF
--- a/docs/ADDING-AN-MCP.md
+++ b/docs/ADDING-AN-MCP.md
@@ -133,6 +133,14 @@ is needed, and your own live gateway's contents are irrelevant.
 [ ] mcp-servers/<name>/README.md created
 [ ] scripts/reconcile-mcp.py exits 0
 [ ] GAIT session logged
+
+--- only if an iN2N member should use it (see the section below) ---
+[ ] Server registered in the MEMBER's own config (OPENCLAW_CONFIG_PATH)
+[ ] Credentials added to the member's .env slice
+[ ] SKILL.md synced into the member's workspace
+[ ] N2N_MEMBER_SCOPE updated in .env AND the member.scope column in federation.db
+[ ] scripts/in2n-profiles.py prefixes match SKILL names (not tool names)
+[ ] systemctl --user restart netclaw-mesh.service  (Border caches the roster)
 ```
 
 ---
@@ -147,6 +155,96 @@ is needed, and your own live gateway's contents are irrelevant.
 | `docs: README.md:N: claims 198` | Counts not updated | Update them |
 | `docs: could not locate 'installer prose'` | Prose was reworded so the check can no longer find it | Restore a matchable phrasing or update the pattern |
 | Server not visible after install | Missing `cwd` | Confirm `normalize-mcp-cwd.py` ran |
+
+---
+
+## If an iN2N member should use it (five more artifacts)
+
+**Established by spec 080 (R3), after three live Slack attempts failed with
+`IN2N_ERR_NO_CAPABLE_MEMBER` on a server that was correctly registered.**
+
+Steps 1–7 above wire a server into the **Border Claw**. They do nothing for a member.
+
+**An iN2N member is a separate claw.** It has its own config, its own `.env`, its own workspace, and its
+capabilities are recorded in the Border's database — not read from the repo at request time. Registering a
+server on the Border makes it invisible to every member.
+
+Worse, the Border **caches the member roster in memory**, so even a correct database row does not take
+effect until the mesh daemon reloads.
+
+### The five
+
+**1. Register the server in the member's own config**
+
+```bash
+# The member's config path is in its .env as OPENCLAW_CONFIG_PATH
+grep OPENCLAW_CONFIG_PATH migration-staging/members/<member>/.env
+```
+
+Add the same `mcp.servers` entry you added to the Border's config, including `cwd`. A member config
+typically contains only `memory-mcp` until you do this.
+
+**2. Add credentials to the member's `.env`**
+
+The member does not inherit the Border's environment. Its `.env` is a least-privilege slice, and the
+integration's variables must be added to it explicitly.
+
+**3. Sync the skills into the member's workspace**
+
+```bash
+cp workspace/skills/<skill>/SKILL.md ~/.openclaw-<risk>-<member>/workspace/skills/<skill>/
+```
+
+**4. Widen the member's scope — in TWO places**
+
+`N2N_MEMBER_SCOPE` in the member's `.env` **and** the `scope` column of the `member` table in
+`~/.openclaw/n2n/federation.db`. The `.env` governs what the member announces; the database is what
+`n2n_route` consults when deciding who can answer.
+
+If the skill belongs to a profile, update `scripts/in2n-profiles.py` so a future regeneration keeps it.
+**`prefixes` there matches SKILL NAMES, not tool names** — setting it to tool prefixes silently resolves to
+zero specialty skills, which is worse than leaving it alone.
+
+```bash
+python3 scripts/in2n-profiles.py scope <profile>   # verify it resolves to the skills you expect
+```
+
+**5. Restart the mesh daemon**
+
+```bash
+systemctl --user restart netclaw-mesh.service
+```
+
+Without this the Border keeps routing against the stale in-memory roster and returns
+`IN2N_ERR_NO_CAPABLE_MEMBER` for a capability that is, on disk, present.
+
+### Verify
+
+```bash
+python3 -c "
+import sqlite3, os, json
+c = sqlite3.connect(os.path.expanduser('~/.openclaw/n2n/federation.db'))
+r = c.execute('SELECT state, scope FROM member WHERE member_id=?', ('<risk>/<member>',)).fetchone()
+print('state:', r[0])
+print('specialty:', [x['name'] for x in json.loads(r[1]) if x.get('tier')=='specialty'])
+"
+```
+
+State must read `active` and the specialty list must contain your skills.
+
+### Why this is not in the checklist above
+
+None of it is caught by `reconcile-mcp.py`. That gate verifies a *fresh installer* can obtain the
+integration, which is the property it was built for — and `migration-staging/` is untracked local state, so
+it is correctly outside the gate's remit. Nothing statically verifies that a member which *should* have a
+capability actually does.
+
+Members are also **cold-started on demand** and idle-exit after 900s, so a member being absent from
+`systemctl --user list-units` is normal and not evidence of a problem.
+
+**A refusal from a member is not necessarily a bug.** In spec 080's case the member correctly declined a
+device-plane question because it only owned a manager-plane skill, and named the right skill in its
+refusal. That is the plane discipline working. The bug was that no member carried the named skill.
 
 ## Pinning rules (spec 077 — enforced by the gate)
 

--- a/mcp-servers/fortinet-mcp/planes/device.py
+++ b/mcp-servers/fortinet-mcp/planes/device.py
@@ -121,37 +121,98 @@ async def system_status(client: FortiOSClient, vdom: str | None = None) -> dict[
 
 
 async def list_interfaces(client: FortiOSClient, vdom: str | None = None) -> dict[str, Any]:
-    """Interfaces with link state, per VDOM (FR-015/FR-018)."""
+    """Interfaces with **administrative and operational state reported separately**.
+
+    FR-015/FR-018.
+
+    ADMIN STATUS IS NOT LINK STATE, and conflating them was a real defect in the
+    first version of this tool — found by NetClaw itself during live testing, which
+    observed that only link state was exposed and said so unprompted.
+
+        admin_status  from cmdb/system/interface  — is the interface ENABLED?
+        link          from monitor/system/interface — is the carrier UP?
+
+    An interface that is administratively **down** with a live carrier reports
+    `link: true` and looks perfectly healthy if you only read the monitor endpoint.
+    That is the same class of error as this feature's manager-vs-device distinction,
+    one level down, and in our own code.
+
+    `role` and `allowaccess` come from the same config read and matter for policy
+    work: an interface's zone/role determines which rules can reference it.
+    """
     tool = "fgt_list_interfaces"
     try:
-        raw = await client.get("monitor/system/interface", vdom=vdom)
+        runtime = await client.get("monitor/system/interface", vdom=vdom)
+        # Config read. If it fails we still report runtime state, but say that
+        # admin status is unknown rather than implying the interface is enabled.
+        try:
+            config = await client.get("cmdb/system/interface", vdom=vdom)
+        except RestError:
+            config = None
     except RestError as exc:
         if exc.outcome is Outcome.PLANE_UNREACHABLE:
             return unreachable(Plane.DEVICE, client.source, str(exc), tool=tool)
         return emit(Plane.DEVICE, source=client.source, outcome=exc.outcome,
                     message=str(exc), tool=tool)
 
-    # Measured: this endpoint returns a dict keyed by interface name, not a list.
-    entries = raw.values() if isinstance(raw, dict) else (raw or [])
-    interfaces = [
-        {
-            "name": i.get("name"),
-            "alias": i.get("alias") or None,
-            "ip": i.get("ip"),
-            "mask": i.get("mask"),
-            "link": i.get("link"),
-            "speed": i.get("speed"),
-            "mac": i.get("mac"),
-            "rx_errors": i.get("rx_errors"),
-            "tx_errors": i.get("tx_errors"),
-        }
-        for i in entries
-    ]
+    # Measured: monitor returns a DICT KEYED BY INTERFACE NAME, cmdb returns a LIST.
+    entries = runtime.values() if isinstance(runtime, dict) else (runtime or [])
+    cfg_by_name = {
+        c.get("name"): c for c in (config or []) if isinstance(c, dict) and c.get("name")
+    }
+
+    interfaces = []
+    for i in entries:
+        name = i.get("name")
+        cfg = cfg_by_name.get(name) or {}
+        admin = cfg.get("status")
+        interfaces.append(
+            {
+                "name": name,
+                "alias": i.get("alias") or cfg.get("alias") or None,
+                # Administrative intent — is this interface enabled at all?
+                "admin_status": admin,
+                # Operational reality — is the carrier up?
+                "link": i.get("link"),
+                # The combination worth naming: enabled in config, no carrier.
+                "admin_up_link_down": (admin == "up" and i.get("link") is False),
+                "ip": i.get("ip"),
+                "mask": i.get("mask"),
+                "type": cfg.get("type"),
+                "role": cfg.get("role"),
+                "allowaccess": cfg.get("allowaccess"),
+                "speed": i.get("speed"),
+                "mac": i.get("mac"),
+                "rx_errors": i.get("rx_errors"),
+                "tx_errors": i.get("tx_errors"),
+            }
+        )
+
+    notes = []
+    if config is None:
+        notes.append(
+            "Interface configuration could not be read, so admin_status, role and "
+            "allowaccess are unknown — NOT assumed enabled. Only operational link "
+            "state is reported here."
+        )
+    else:
+        notes.append(
+            "admin_status is administrative intent (config); link is operational "
+            "carrier state. An interface can be admin-down with link up, or "
+            "admin-up with no carrier — they are different facts."
+        )
+    admin_down = [i["name"] for i in interfaces if i.get("admin_status") == "down"]
+    if admin_down:
+        notes.append(
+            f"Administratively disabled: {', '.join(admin_down)}. These will not "
+            "pass traffic regardless of link state."
+        )
+
     return emit(
         Plane.DEVICE, source=client.source, scope=_scope(client, vdom),
         data={"interfaces": interfaces, "count": len(interfaces)},
         outcome=Outcome.OK if interfaces else Outcome.EMPTY_RESULT,
-        tool=tool,
+        notes=notes, tool=tool,
     )
 
 

--- a/mcp-servers/protocol-mcp/bgp/federation/service.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/service.py
@@ -1845,8 +1845,23 @@ class FederationService:
             if self.risk.role() == "member":
                 prompt = (f"Execute the '{skill}' skill for the following request "
                           f"and return only the result:\n\n{input_text}")
+                # Session key is per TASK, not per skill. Keying on the skill name
+                # alone (`in2n-{skill}`) had two faults, found while testing
+                # spec 080's Fortinet skills:
+                #
+                #   1. Concurrent delegations of the SAME skill contended on one
+                #      session JSONL and deadlocked — three parallel
+                #      `fortigate-ops` calls hung; serial re-runs were clean.
+                #   2. Worse: two UNRELATED Border requests to the same skill
+                #      shared a conversation, so one requester's context could
+                #      bleed into another's answer.
+                #
+                # A delegated skill invocation is a discrete request/response —
+                # there is no multi-turn conversation with a member — so per-task
+                # isolation costs nothing and removes both faults. Trade-off: one
+                # session file per delegation rather than per skill.
                 output, tokens = await run_agent_turn(
-                    prompt, session_key=f"in2n-{skill}",
+                    prompt, session_key=f"in2n-{skill}-{task_id}",
                     timeout_s=self.invoker.skill_timeout, local=True, model=member_model)
             else:
                 output, tokens = await self.invoker._exec_skill_gateway(skill, input_text)

--- a/specs/080-fortinet-coverage/VERIFICATION.md
+++ b/specs/080-fortinet-coverage/VERIFICATION.md
@@ -26,7 +26,7 @@ run.
 | Capability | Status | Evidence |
 |---|---|---|
 | `fgt_system_status` | ✅ live | 200; hostname/serial/version returned |
-| `fgt_list_interfaces` | ✅ live | 200; 2 interfaces, real counters |
+| `fgt_list_interfaces` | ✅ live | 200; 2 interfaces. **Extended 2026-08-03** to report `admin_status` (config) separately from `link` (carrier) — the conflation NetClaw reported itself |
 | `fgt_get_routes` | ✅ live | 200; 2 routes (static default + connected) |
 | `fgt_get_policies` | ✅ live | 200; `empty_result` on an empty ruleset |
 | `fgt_vpn_tunnels` | ⚠️ **partial** | Endpoint verified 200; **no tunnel configured**, so only the empty path ran |
@@ -35,10 +35,23 @@ run.
 | GAIT audit emission | ✅ live | 5 records written during the live run |
 | Empty ≠ error | ✅ live | `empty_result` distinguished from `plane_unreachable` |
 
-**FR-016 caveat, stated plainly:** phase 1 / phase 2 separation is **implemented and
-unit-tested, but not exercised against a real tunnel.** The licence caps the device
-at 3 interfaces, and no IPsec peer existed. The populated shape is coded from the
-FortiOS field layout, not observed. **Treat as unverified until a tunnel exists.**
+**FR-016 caveat, and an attempt that failed instructively (2026-08-03):** phase 1 /
+phase 2 separation is **implemented and unit-tested, but cannot be exercised on an
+evaluation-licensed FortiGate.**
+
+Defining a phase1-interface with an unreachable peer — intended to produce a real
+populated tunnel structure with phase 1 down — **wedged the REST API**. `httpsd`
+stopped answering (HTTP 000) while SSH, ping and `get system status` all stayed
+healthy, so the damage was invisible from the CLI. The eval licence caps the unit at
+3 interfaces and an IPsec tunnel creates a virtual one; the API did not recover
+until the phase1 was deleted, at which point it returned 200 immediately.
+
+**Conclusion: this is not verifiable on the eval tier**, and the attempt is
+recorded so nobody repeats it. Coverage is instead provided by
+`tests/fortinet/test_device_plane.py`, which proves phase-1-up/phase-2-down is
+representable, that per-selector detail survives, and that no collapsed `status`
+field exists. The populated *field mapping* remains coded from the FortiOS layout
+rather than observed — genuinely unverified, and stated as such.
 
 ### Manager plane — NOT VERIFIED
 
@@ -95,7 +108,9 @@ exists so nobody mistakes the second group for the first.
 1. **FortiManager-VM** (15-day trial, separate entitlement) → 8 manager tools plus
    `fgt_compare_with_manager`, the P1 story.
 2. **FortiAnalyzer-VM** (15-day trial, 6 GB/day) → 4 analyzer tools.
-3. **One IPsec tunnel** on the FortiGate → the populated phase-1/phase-2 shape.
+3. ~~One IPsec tunnel on the FortiGate~~ — **not possible on the eval tier.** Attempted 2026-08-03 and it
+   wedged the REST API (see the FR-016 note above). Needs a licensed unit with headroom above the
+   3-interface cap, or a second FortiGate to peer with.
 4. **A ServiceNow instance** → the real CR lookup in gate 2.
 
 ## The bug the tests could not have caught

--- a/tests/fortinet/run-tests.sh
+++ b/tests/fortinet/run-tests.sh
@@ -34,6 +34,7 @@ run() {
 run "envelope    — plane/scope attribution (FR-005/009, SC-002a)" tests/fortinet/test_envelope.py
 run "audit       — GAIT trail (FR-023, Principle IV, SC-011)"     tests/fortinet/test_audit.py
 run "credentials — by-name-only disclosure (FR-029, SC-012)"      tests/fortinet/test_credentials.py
+run "device plane — admin vs link, VPN phase 1 vs 2 (FR-015/016)" tests/fortinet/test_device_plane.py
 
 echo
 echo "=============================================================="

--- a/tests/fortinet/test_device_plane.py
+++ b/tests/fortinet/test_device_plane.py
@@ -1,0 +1,166 @@
+"""Device-plane distinctions. Spec 080 + spec 082 completion, FR-015/FR-016/FR-018.
+
+No appliance. Two conflations are tested here, both of which shipped in spec 080's
+first version and were found by the running system rather than by these tests:
+
+  1. admin status vs link state  — an admin-down interface with a live carrier
+     reads as healthy if you only read the monitor endpoint.
+  2. VPN phase 1 vs phase 2      — collapsing them hides the most common IPsec
+     fault, where IKE is up and no traffic passes.
+
+Deliberately NOT verified live: setting a real interface administratively down.
+`port1` is the management path on the lab unit, and disabling it to prove a test
+would cost access to the device. The stub proves the logic; the live run proves
+the field mapping.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "mcp-servers", "fortinet-mcp"))
+
+_AUDIT = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
+os.environ["FORTINET_AUDIT_LOG"] = _AUDIT.name
+
+from planes import device  # noqa: E402
+
+FAILURES: list[str] = []
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  PASS  {name}")
+    else:
+        FAILURES.append(f"{name}: {detail}")
+        print(f"  FAIL  {name} — {detail}")
+
+
+class StubClient:
+    """Minimal FortiOSClient stand-in returning canned payloads per path."""
+
+    def __init__(self, payloads: dict, fail: set[str] | None = None) -> None:
+        self._payloads = payloads
+        self._fail = fail or set()
+        self.source = "stub-fortigate"
+        self.device_name = "STUBSERIAL01"
+
+    async def resolve_identity(self) -> str:
+        return self.device_name
+
+    async def get(self, path, vdom=None, **kw):
+        if path in self._fail:
+            from transport.rest import RestError
+            raise RestError(f"stub failure for {path}")
+        return self._payloads.get(path)
+
+    async def get_envelope(self, path, vdom=None, **kw):
+        return {"results": self._payloads.get(path), "serial": "STUBSERIAL01",
+                "version": "v7.6.7", "build": 3704}
+
+
+def test_admin_down_is_not_link_down() -> None:
+    """The conflation NetClaw itself reported. An interface enabled in config with
+    no carrier, and one DISABLED in config with a live carrier, must be
+    distinguishable — the second is the dangerous one, because monitor alone
+    reports it as up."""
+    c = StubClient({
+        "monitor/system/interface": {
+            "port1": {"name": "port1", "link": True, "ip": "10.1.1.1", "mask": 24},
+            "port2": {"name": "port2", "link": True, "ip": "10.2.2.1", "mask": 24},
+            "port3": {"name": "port3", "link": False, "ip": "0.0.0.0", "mask": 0},
+        },
+        "cmdb/system/interface": [
+            {"name": "port1", "status": "up", "role": "wan", "type": "physical"},
+            # The trap: administratively DISABLED but the carrier is live.
+            {"name": "port2", "status": "down", "role": "lan", "type": "physical"},
+            {"name": "port3", "status": "up", "role": "lan", "type": "physical"},
+        ],
+    })
+    r = asyncio.run(device.list_interfaces(c))
+    by = {i["name"]: i for i in r["data"]["interfaces"]}
+
+    check("admin-up + link-up reads healthy",
+          by["port1"]["admin_status"] == "up" and by["port1"]["link"] is True)
+    check("admin-DOWN with live carrier is reported admin_status=down",
+          by["port2"]["admin_status"] == "down",
+          f"got {by['port2']['admin_status']!r} — this interface passes no traffic")
+    check("that interface still shows link=True (why monitor alone misleads)",
+          by["port2"]["link"] is True)
+    check("admin-up + link-down is flagged",
+          by["port3"]["admin_up_link_down"] is True)
+    check("admin-down interfaces are named in notes",
+          any("port2" in n for n in r["notes"]), str(r["notes"])[:120])
+    check("role is populated from config", by["port1"]["role"] == "wan")
+
+
+def test_missing_config_does_not_imply_enabled() -> None:
+    """If the config read fails, admin status is UNKNOWN — never assumed up.
+    Assuming enabled would recreate the exact conflation, silently."""
+    c = StubClient(
+        {"monitor/system/interface": {"port1": {"name": "port1", "link": True}}},
+        fail={"cmdb/system/interface"},
+    )
+    r = asyncio.run(device.list_interfaces(c))
+    i = r["data"]["interfaces"][0]
+    check("admin_status is None, not 'up'", i["admin_status"] is None, repr(i["admin_status"]))
+    check("notes say admin status is unknown, not assumed",
+          any("NOT assumed enabled" in n for n in r["notes"]), str(r["notes"])[:140])
+
+
+def test_vpn_phases_reported_separately() -> None:
+    """FR-016. A tunnel with phase 1 up and phase 2 down is neither up nor down —
+    it is a selector/proxy-ID mismatch, and collapsing the two hides it."""
+    c = StubClient({
+        "monitor/vpn/ipsec": [
+            {"name": "to-branch", "rgwy": "203.0.113.9", "lgwy": "198.51.100.2",
+             "connection_count": 1, "proxyid_num": 1,
+             "proxyid": [{"p2name": "sel-1", "status": "down",
+                          "proxy_src": [], "proxy_dst": []}]},
+        ],
+    })
+    r = asyncio.run(device.vpn_tunnels(c))
+    t = r["data"]["tunnels"][0]
+    check("phase1 and phase2 are separate fields",
+          "phase1_status" in t and "phase2_status" in t)
+    check("phase1 up while phase2 down is representable",
+          t["phase1_status"] == "up" and t["phase2_status"] == "down",
+          f"p1={t['phase1_status']} p2={t['phase2_status']}")
+    check("per-selector detail is preserved", len(t["phase2_selectors"]) == 1)
+    check("no single collapsed 'status' field exists", "status" not in t, str(list(t)))
+
+
+def test_no_tunnels_is_none_defined_not_all_down() -> None:
+    c = StubClient({"monitor/vpn/ipsec": []})
+    r = asyncio.run(device.vpn_tunnels(c))
+    joined = " ".join(r["notes"]).lower()
+    check("empty tunnel list is 'none defined'", "none defined" in joined, joined[:100])
+    check("and explicitly not 'all down'", "not 'all down'" in joined or "not all down" in joined)
+
+
+def main() -> int:
+    print("device-plane distinction tests (no appliance required)")
+    for fn in (
+        test_admin_down_is_not_link_down,
+        test_missing_config_does_not_imply_enabled,
+        test_vpn_phases_reported_separately,
+        test_no_tunnels_is_none_defined_not_all_down,
+    ):
+        print(f"\n{fn.__name__}")
+        fn()
+    os.unlink(_AUDIT.name)
+    print()
+    if FAILURES:
+        print(f"{len(FAILURES)} FAILED")
+        for f in FAILURES:
+            print(f"  - {f}")
+        return 1
+    print("all device-plane distinction tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes the follow-ups spec 080 (R3) identified but did not fix. **All three were found by the running
system, not by review.**

## 1. `fgt_list_interfaces` conflated administrative and operational state

**NetClaw reported this itself, unprompted**, during live Slack testing: the tool exposed only link state,
not admin status or zone/role.

That's a real defect of the same class this feature exists to fight — `cmdb` carries administrative intent,
`monitor` carries operational reality:

```
status = 'up'     ← ADMIN (config)        an interface admin-DOWN with a live
link   = True     ← CARRIER (operational)  carrier reads as healthy from monitor alone
```

Now reports both separately, flags `admin_up_link_down`, and if the config read fails reports admin status
as **unknown rather than assuming enabled** — which would recreate the conflation silently.

## 2. iN2N member wiring was undocumented — the highest-value fix

This silently breaks **every future integration**, not just Fortinet.

Steps 1–7 of `docs/ADDING-AN-MCP.md` wire a server into the Border Claw and do **nothing** for a member. A
member is a separate claw with its own config, `.env`, workspace and Border-registered scope — and the
Border **caches the member roster in memory**, so a correct database row does not take effect until
`netclaw-mesh` restarts.

R3's first three live Slack attempts returned `IN2N_ERR_NO_CAPABLE_MEMBER` against a server that was
correctly registered.

Adds a five-artifact section plus checklist entries, including the trap that `in2n-profiles.py` `prefixes`
matches **skill names, not tool names** — setting them to tool prefixes silently resolves to *zero*
specialty skills, which is worse than leaving it alone.

Not caught by `reconcile-mcp.py`, and correctly so: that gate verifies a fresh installer can obtain an
integration, and `migration-staging/` is untracked local state outside its remit.

## 3. Member sessions were keyed per skill, not per invocation

```python
session_key=f"in2n-{skill}"    # task_id was created 3 lines above, unused
```

Two faults, and the visible one was the lesser:

- Concurrent delegations of the same skill contended on one session JSONL and **deadlocked**
- Worse: two **unrelated** Border requests to the same skill shared a conversation — **cross-request
  context bleed**

Now `in2n-{skill}-{task_id}`. A delegated invocation is a discrete request/response, so per-task isolation
costs nothing. **Touches shared iN2N infrastructure — applies to all members.**

## An attempt that failed, recorded so nobody repeats it

Defining an IPsec phase1 to exercise the populated phase-1/phase-2 shape **wedged the FortiGate's REST
API**. `httpsd` stopped answering (HTTP 000) while SSH, ping and `get system status` all stayed healthy —
invisible from the CLI. The eval licence caps interfaces at 3 and an IPsec tunnel creates a virtual one; the
API recovered immediately on deleting the phase1. **The device was restored to its prior state.**

FR-016 is therefore **not live-verifiable on the eval tier**, and `VERIFICATION.md` now says so rather than
listing it as pending work.

## Tests

New `tests/fortinet/test_device_plane.py` — 16 assertions, no appliance — covers both distinctions including
the dangerous case (admin-down with `link: True`). Live admin-down was deliberately **not** tested on
`port1`: it is the management path, and disabling it to prove a test would cost access to the device.

All gates green: `reconcile-mcp.py`, both Fortinet and BGP-intel suites.

## Still open, needs hardware

The 12 unverified manager/analyzer tools need FortiManager-VM and FortiAnalyzer-VM (15-day trials). Recorded
in `VERIFICATION.md`, not claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)