### PR TITLE
feat(082): Document generation — docx/pptx/xlsx/pdf — R18

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -705,3 +705,32 @@ BGP_INTEL_USER_AGENT=
 BGP_INTEL_MAX_RPS=
 # GAIT audit trail path. Defaults under ~/.openclaw/gait/
 BGP_INTEL_AUDIT_LOG=
+
+# ─────────────────────────────────────────────────────────────────────
+# Document Generation — spec 082 (roadmap R18)
+# Server: mcp-servers/document-mcp
+#
+# NO CREDENTIALS REQUIRED. This server writes files and touches no device
+# and no ticket. Everything below is optional tuning; the defaults are
+# what you want unless you have a reason otherwise.
+#
+# The four libraries it needs (python-docx, openpyxl, python-pptx,
+# PyMuPDF) are already installed by rag-mcp (feature 062), which READS
+# these formats. This server WRITES them.
+# ─────────────────────────────────────────────────────────────────────
+# Command the two document skills invoke
+DOCUMENT_MCP_CMD=
+# Where generated documents land. Defaults to workspace/output/document-mcp/
+# — persistent, timestamped, and never overwritten, so a regenerated report
+# cannot replace one already attached to a ticket. There is deliberately no
+# fallback to a temp directory: an unwritable path is reported as a failure.
+DOCUMENT_OUTPUT_DIR=
+# Data rows per worksheet before truncation. Default 50000. When a bound is
+# applied it is written INTO the document, not only into the tool response.
+DOCUMENT_MAX_ROWS=
+# Blocks per Word document before truncation. Default 5000.
+DOCUMENT_MAX_BLOCKS=
+# Slides per deck before truncation. Default 200.
+DOCUMENT_MAX_SLIDES=
+# GAIT audit trail path. Defaults under ~/.openclaw/gait/
+DOCUMENT_AUDIT_LOG=

--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ mcp-servers/multivendor-cli-mcp/.venv/
 !mcp-servers/halo-mcp/
 !mcp-servers/fortinet-mcp/
 !mcp-servers/bgp-intel-mcp/
+!mcp-servers/document-mcp/
 
 # Traces
 trace.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,8 @@ Auto-generated from all feature plans. Last updated: 2026-08-03
 - None. Stateless proxy to three appliance APIs. Change baselines (US3) write under a (080-fortinet-coverage)
 - Python 3.10+, system interpreter. No dedicated venv — two pure-HTTP packages move + `mcp>=1.2.0,<2` and `httpx>=0.27.0,<1`. Identical to specs 078 and 080. The `mcp` (081-bgp-registry-intel)
 - **None on disk.** Per-source in-memory TTL cache only (clarification Q3): RPKI 5 min, routing (081-bgp-registry-intel)
+- Python 3.10+, system interpreter. No dedicated venv — the four libraries are already (082-document-generation)
+- none. Files land in `workspace/output/document-mcp/` (gitignored, feature 046's convention). (082-document-generation)
 
 - Python 3.10+ + FastMCP (MCP framework), grpcio + grpcio-tools (gRPC transport), pygnmi (gNMI client library), protobuf, cryptography (TLS handling) (003-gnmi-mcp-server)
 
@@ -129,9 +131,9 @@ cd src [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLO
 Python 3.10+: Follow standard conventions
 
 ## Recent Changes
+- 082-document-generation: Added Python 3.10+, system interpreter. No dedicated venv — the four libraries are already
 - 081-bgp-registry-intel: Added Python 3.10+, system interpreter. No dedicated venv — two pure-HTTP packages move + `mcp>=1.2.0,<2` and `httpx>=0.27.0,<1`. Identical to specs 078 and 080. The `mcp`
 - 080-fortinet-coverage: Added Python 3.10+, system interpreter. Unlike spec 076 this needs **no dedicated venv** — + `mcp>=1.2.0,<2` and `httpx>=0.27.0,<1`. Two packages, identical to spec 078's
-- 078-cisco-psirt-vulnerability: Added on-disk cache, one JSON file per `(ostype, version)` under `~/.openclaw/cisco-psirt/`. No
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # NetClaw
 
-A CCIE-level AI network engineering coworker. Built on [OpenClaw](https://github.com/openclaw/openclaw) with Anthropic Claude, 207 skills, and 154 MCP integrations for complete network automation with ITSM gating, source-of-truth reconciliation, immutable audit trails, gNMI streaming telemetry, NetFlow/IPFIX flow telemetry, Canvas/A2UI inline network visualizations, packet capture analysis, GitHub config-as-code, GitLab DevOps (issues, merge requests, pipelines, repositories, wikis), Jenkins CI/CD (job monitoring, build triggering, log analysis, SCM tracking), Chrome DevTools browser automation (visualization render QA, controller GUI gap-filling, undocumented API discovery, headless or watchable-headed), Computer Use full-desktop automation (legacy desktop-only tools with no browser or API path, virtual XFCE desktop with VNC/noVNC Watch Mode), Cisco CML lab simulation, ContainerLab containerized network labs, Cisco NSO orchestration, Cisco SD-WAN vManage monitoring, Grafana observability (dashboards, Prometheus, Loki, alerting, incidents), Prometheus direct PromQL monitoring, Kubeshark Kubernetes traffic analysis, Cisco Meraki Dashboard management, Cisco ThousandEyes network intelligence, AWS and Azure cloud networking, Cisco Secure Firewall policy auditing, Check Point Security (15 MCPs: policy, threat intel, gateway, SASE, malware), Itential network orchestration, Juniper JunOS device automation, Arista CloudVision Portal monitoring, F5 BIG-IP pyATS iControl REST coverage, Infoblox DDI, Palo Alto Panorama, FortiManager, Batfish offline configuration analysis, UML diagram generation, EVPN/VXLAN fabric workflows, live BGP/OSPF control-plane participation, nmap network scanning, gtrace path analysis and IP enrichment, Slack-native operations, Cisco WebEx-native operations, Microsoft 365 integration, Twilio voice/SMS, Twitter/X integration, Claroty OT/IoT asset management, Forward Networks digital twin, Ollama local LLM routing, an offline agentic RAG document knowledge base (cited answers from user-uploaded vendor guides and standards), layered Memory MCP, and MemPalace persistent AI memory.
+A CCIE-level AI network engineering coworker. Built on [OpenClaw](https://github.com/openclaw/openclaw) with Anthropic Claude, 209 skills, and 155 MCP integrations for complete network automation with ITSM gating, source-of-truth reconciliation, immutable audit trails, gNMI streaming telemetry, NetFlow/IPFIX flow telemetry, Canvas/A2UI inline network visualizations, packet capture analysis, GitHub config-as-code, GitLab DevOps (issues, merge requests, pipelines, repositories, wikis), Jenkins CI/CD (job monitoring, build triggering, log analysis, SCM tracking), Chrome DevTools browser automation (visualization render QA, controller GUI gap-filling, undocumented API discovery, headless or watchable-headed), Computer Use full-desktop automation (legacy desktop-only tools with no browser or API path, virtual XFCE desktop with VNC/noVNC Watch Mode), Cisco CML lab simulation, ContainerLab containerized network labs, Cisco NSO orchestration, Cisco SD-WAN vManage monitoring, Grafana observability (dashboards, Prometheus, Loki, alerting, incidents), Prometheus direct PromQL monitoring, Kubeshark Kubernetes traffic analysis, Cisco Meraki Dashboard management, Cisco ThousandEyes network intelligence, AWS and Azure cloud networking, Cisco Secure Firewall policy auditing, Check Point Security (15 MCPs: policy, threat intel, gateway, SASE, malware), Itential network orchestration, Juniper JunOS device automation, Arista CloudVision Portal monitoring, F5 BIG-IP pyATS iControl REST coverage, Infoblox DDI, Palo Alto Panorama, FortiManager, Batfish offline configuration analysis, UML diagram generation, EVPN/VXLAN fabric workflows, live BGP/OSPF control-plane participation, nmap network scanning, gtrace path analysis and IP enrichment, Slack-native operations, Cisco WebEx-native operations, Microsoft 365 integration, Twilio voice/SMS, Twitter/X integration, Claroty OT/IoT asset management, Forward Networks digital twin, Ollama local LLM routing, an offline agentic RAG document knowledge base (cited answers from user-uploaded vendor guides and standards), layered Memory MCP, and MemPalace persistent AI memory.
 
 ## Resources
 
@@ -239,7 +239,7 @@ claw
   <img src="ui/netclaw-visual/logos/netclawvisualhud.png" alt="NetClaw Visual HUD — 3D Network Operations Dashboard" width="800">
 </p>
 
-NetClaw includes a Three.js 3D operations dashboard that computes its integration and skill inventory live from the codebase (currently 154 MCP integrations and 207 skills) each time it's opened, alongside your device fleet and live BGP peering topology — so the dashboard never drifts out of sync with what's actually installed. Chat with NetClaw directly from the browser, watch integrations light up as tools execute, and inspect every node in the graph. The Canvas/A2UI visualization skill renders inline topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards directly in the chat interface.
+NetClaw includes a Three.js 3D operations dashboard that computes its integration and skill inventory live from the codebase (currently 155 MCP integrations and 209 skills) each time it's opened, alongside your device fleet and live BGP peering topology — so the dashboard never drifts out of sync with what's actually installed. Chat with NetClaw directly from the browser, watch integrations light up as tools execute, and inspect every node in the graph. The Canvas/A2UI visualization skill renders inline topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards directly in the chat interface.
 
 ```bash
 cd ui/netclaw-visual
@@ -518,7 +518,7 @@ NetClaw ships with the full set of OpenClaw workspace markdown files. These are 
 
 ---
 
-## MCP Servers (154)
+## MCP Servers (155)
 
 > Adding one? Follow **[docs/ADDING-AN-MCP.md](docs/ADDING-AN-MCP.md)** and run
 > `python3 scripts/reconcile-mcp.py` before pushing — CI enforces it.
@@ -628,6 +628,9 @@ NetClaw ships with the full set of OpenClaw workspace markdown files. These are 
 | 116 | Multivendor CLI Driver | Built-in (`multivendor-cli-mcp`) | stdio (Python, dedicated venv) | Nornir/NAPALM/Netmiko reach to ~90 platform families no other NetClaw server covers — MikroTik RouterOS, VyOS, SONiC, Nokia SR Linux, Extreme, Huawei, Dell, Ubiquiti EdgeOS. Read-only by default; writes are single-pathed per platform (refuses config change on Cisco/Junos and names the owning server). Runs from its own virtualenv because napalm/netmiko resolve cryptography 49.x while NCFED's X.509 stack needs the system 46.x (10 tools: 8 read + 2 gated writes) |
 | 117 | Cisco PSIRT Advisories | Built-in (`cisco-psirt-mcp`) | stdio (Python) | Cisco PSIRT openVuln API via OAuth2 — is the version a device is actually running affected by a published advisory? Covers IOS, IOS-XE, NX-OS, ASA, FTD, FMC, ACI, with severity/CVSS/CVE per advisory. Read-only and device-free (versions come from pyATS or multivendor-cli). Five typed outcomes keep "Cisco published nothing" distinct from "the question was never asked" — an empty list is never reported as *not vulnerable*. De-duplicates by version and caches 6h to live inside the 5/sec + 30/min budget. IOS-XR is not an OSType on this API (404) and is refused rather than attempted (6 tools) |
 | 118 | Globalping | [jsDelivr Globalping](https://www.globalping.io) | Remote HTTP (official MCP) | Outside-in network measurement from ~4,800 probes across ~1,390 autonomous systems — ping, traceroute, DNS, MTR and HTTP run *toward* a public target. NetClaw's only vantage point outside its own administrative domain, so it can finally answer "is it us or the internet?". Zero install (hosted endpoint, bearer token). Public endpoints only — private/internal targets are refused locally before any call goes out. Budget 500 probe-measurements/hour, charged per probe (5 measurement tools + budget/probe-availability queries) |
+| 119 | Fortinet | Built-in (`fortinet-mcp`) | stdio (Python) | Three planes behind one server — FortiManager policy *intent* (ADOMs, packages, objects, revisions, install preview), FortiGate observed *state* (interfaces, routes, policies, VPN), FortiAnalyzer observed *traffic* (logs, policy activity). Every response carries which plane answered and its scope, so "no logs in the window" is never reported as "the rule is unused". Read-only unless `FORTINET_ALLOW_WRITES=true`, and a write still needs human approval AND an approved change record — two independent gates (21 tools) |
+| 120 | BGP & Registry Intelligence | Built-in (`bgp-intel-mcp`) | stdio (Python) | RPKI origin validation, RDAP registry ownership and abuse contacts, PeeringDB interconnection, RIPEstat routing visibility, RIPE Atlas anchors. Five public unauthenticated sources — **no credentials anywhere**. The other half of the external plane: Globalping *measures* toward a target, this *looks up* who owns it and whether an announcement is authorised. RPKI `not-found` means no ROA exists and is **not** a finding — most of the internet is unsigned. Self-imposed 4 req/s sliding window against volunteer-funded infrastructure (10 tools) |
+| 121 | Document Generation | Built-in (`document-mcp`) | stdio (Python) | The deliverable layer: change-record `.docx`, interface-audit `.xlsx`, executive `.pptx`, and filling existing PDF forms — from real NetClaw data, not typed by hand. No credentials; writes files and touches no device and no ticket. Every value must arrive tagged with its source, so a missing figure renders as `NOT AVAILABLE — <reason>` and never as a blank cell; a value without a source is refused. Per-element provenance and a Sources section in every file, stamped at one chokepoint and GAIT-audited. Office templates are refused (scratch-only); output is timestamped and never overwritten (6 tools) |
 ### Additional Server Notes
 
 All MCP servers communicate via stdio (JSON-RPC 2.0) through `scripts/mcp-call.py`, except where noted below (HTTP/remote endpoints).
@@ -664,7 +667,7 @@ All MCP servers communicate via stdio (JSON-RPC 2.0) through `scripts/mcp-call.p
 
 ---
 
-## Skills (207)
+## Skills (209)
 
 ### pyATS Device Skills (9)
 
@@ -852,13 +855,15 @@ All MCP servers communicate via stdio (JSON-RPC 2.0) through `scripts/mcp-call.p
 | **aap-eda** | Event-Driven Ansible operations (12 tools): activation lifecycle management (list, create, enable, disable, restart, delete), rulebook listing and inspection, decision environment management, event stream monitoring. Reactive automation triggered by external events flowing into EDA rulebooks. |
 | **aap-lint** | ansible-lint playbook and role validation (9 tools): lint playbook content with configurable profiles (min/basic/moderate/safety/shared/production), lint individual files and role directories, list available rules and tags, syntax validation, best practice checking with severity categorization, project-wide analysis with per-file issue reporting, version info. Quality gate for Ansible content before AAP deployment. |
 
-### Enterprise Platform Skills (3)
+### Enterprise Platform Skills (5)
 
 | Skill | What It Does |
 |-------|-------------|
 | **infoblox-ddi** | Infoblox DNS, DHCP, and IPAM operations: zone and record lookup, DHCP scope and lease review, IP utilization checks, and pre-change address validation. |
 | **paloalto-panorama** | Panorama-managed firewall governance: device groups, templates, security policy and NAT search, object review, and commit validation. |
 | **fortimanager-ops** | FortiManager policy operations: ADOM inventory, package and rule review, revision history, and install-preview checks. |
+| **fortigate-ops** | FortiGate observed state: system status, interfaces (administrative vs operational state kept separate), routing table, policy list, and IPsec tunnel health with phase 1 and phase 2 reported independently. |
+| **fortianalyzer-ops** | FortiAnalyzer traffic evidence: log queries over an explicit time window, per-policy activity, and managed-device inventory. An empty window is reported as "no logs in this window", never as "the rule is unused". |
 
 ### Cisco RADKit Skills (1)
 
@@ -1194,6 +1199,13 @@ Both `browser-gui-inspect` and `desktop-gui-inspect` support Watch Mode — just
 | **twitter-heartbeat** | Autonomous periodic tweeting and mention monitoring to maintain NetClaw's Twitter/X presence with CCIE-level content |
 | **twitter-respond** | Generate and post replies to Twitter/X mentions and conversations |
 | **twitter-share** | Manual tweet posting with content guardrails and human approval flow |
+
+### Document Generation Skills (2)
+
+| Skill | Purpose |
+|-------|---------|
+| **document-generation** | The `document-mcp` tool surface — `.docx`/`.xlsx`/`.pptx` from tagged values, PDF form inspection and filling, and the no-fabrication discipline. A value with no source is refused; a missing value renders as `NOT AVAILABLE`, never as a blank |
+| **network-report-documents** | The four NetClaw compositions — change record from a real ServiceNow CR plus device state, interface/config audit workbook, executive summary deck with an embedded diagram, and filling a required PDF form |
 
 ### Visualization Skills (2)
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -12,7 +12,7 @@ Every time you learn something about how I work or what I need, update the relev
 
 ## Your Skills
 
-You interact with the network through **207 skills** backed by 154 MCP servers:
+You interact with the network through **209 skills** backed by 155 MCP servers:
 
 ### Device Automation (9)
 pyats-network, pyats-health-check, pyats-routing, pyats-security, pyats-topology, pyats-config-mgmt, pyats-troubleshoot, pyats-dynamic-test, pyats-parallel-ops
@@ -77,6 +77,51 @@ Budget is 500 probe-measurements/hour and is charged **per probe** — `limit: 2
 never generalise one probe into a regional claim.
 
 Use ThousandEyes when a baseline or trend matters — Globalping holds no history.
+
+### Document Generation (2)
+document-generation, network-report-documents
+
+**The deliverable layer.** Every other capability here produces *findings*. This turns a finding into a
+change-record `.docx` an approver will accept, an interface-audit `.xlsx` for a compliance reviewer, an
+executive `.pptx`, or a required PDF form filled from real device and ticket data. Your output lands in
+front of change advisory boards, auditors and directors — people who work in Office documents, not JSON.
+
+**The rule that matters most: a document must never fabricate to fill a blank.**
+
+Tool output is ephemeral — read once, in context, by the person who asked. **A document is not.** It gets
+emailed, attached to a ticket, filed for audit, and read months later by someone who was not there, and it
+carries the authority of its formatting. A professional-looking change record with a plausible invented
+number is a far more effective way to launder a guess into an official record than any amount of terminal
+output, because nobody re-derives a figure that is already in a table in a `.docx`.
+
+So **never infer, estimate, interpolate, or carry forward a stale value to complete a document.** Every
+value you send is one of three shapes, and the server refuses anything else:
+
+| You send | The document shows |
+|---|---|
+| `{"v": x, "src": "<tool>"}` | `x`, with a visible source |
+| `{"v": ""}` | `(empty)` — the source *was* consulted and returned nothing |
+| `{"unavailable": "<why>"}` | `NOT AVAILABLE — <why>` |
+| `{"failed": "<why>"}` | `RETRIEVAL FAILED — <why>` |
+| a value with no `src`, or a bare scalar | **refused** |
+
+A device that did not answer says so, in the document. Never `N/A`, never a blank cell, never a sensible
+default. A device that failed to respond is a **different fact** from one that returned nothing, and a
+failed device appears as a marked row rather than being omitted — a shorter spreadsheet reads as a smaller
+estate, which is a false statement about the network.
+
+Provenance is **visible**: a Source column on every table row, a Sources section in every file, generation
+time and NetClaw attribution on every page. Word comments, document metadata and speaker notes are written
+additively but never count — they are collapsed by default, stripped on paste, and absent in print.
+
+Three limits worth knowing before you promise something: **no Office templates** (scratch-only — a corporate
+template's empty field is the strongest fabrication pressure in the feature, so one supplied is refused
+rather than ignored); **no Word footnotes** (`python-docx` has no API for them, so attribution is inline);
+and **a filled PDF carries no Sources section**, because it is the customer's form. Say so when you hand it
+over.
+
+Files are timestamped and **never overwritten** — a regenerated report cannot silently replace the one
+already attached to a ticket. Tell the operator the path.
 
 ### BGP & Registry Intelligence (1)
 bgp-registry-intel
@@ -522,7 +567,7 @@ The knowledge base is not memory: RAG holds user-supplied documents (`~/.opencla
 
 For **detailed skill procedures**, read `SOUL-SKILLS.md`:
 - Use when executing any skill that needs step-by-step guidance
-- Contains operational workflows, commands, and best practices for all 207 skills
+- Contains operational workflows, commands, and best practices for all 209 skills
 - Load with: `read("~/.openclaw/workspace/SOUL-SKILLS.md")`
 
 For **technical knowledge**, read `SOUL-EXPERTISE.md`:

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -411,3 +411,70 @@ No API keys. Every source is public and unauthenticated.
   PeeringDB publishes rate-limit headers. Parallel fan-out prohibited, including inside `resource_report`.
 - Private/reserved/bogon input is **refused locally with no outbound request** — a disclosure control.
 - Manifest measured at **1,376 / 5,000 tokens**.
+
+## Document Generation (`document-mcp`, NetClaw-native)
+
+**Spec 082 / roadmap R18.** 6 tools, stdio, **no credentials**. Writes files; touches no device and no
+ticket, so there is no approval gate here. This is the deliverable layer — every other NetClaw capability
+produces findings, this turns a finding into something you can attach to a change record.
+
+| Format | Tool | Built from |
+|---|---|---|
+| `.docx` | `docx_write` | Ordered blocks: heading, paragraph, figure, table, keyvalue, image, pagebreak |
+| `.xlsx` | `xlsx_write` | Sheets of tagged rows, plus `failed_rows` for devices that could not be reached |
+| `.pptx` | `pptx_write` | Slides: bullets, figure, image |
+| `.pdf` | `pdf_inspect_form` / `pdf_fill_form` | An existing fillable form's **named** fields |
+| — | `list_documents` | Finding something generated earlier |
+
+### The one rule
+
+**A document must never fabricate to fill a blank.** Tool output is ephemeral; a document is emailed, filed
+and read months later by someone who was not there, and it carries the authority of its formatting. So every
+value is one of three tagged shapes — `{"v":…, "src":…}`, `{"unavailable": reason}`, `{"failed": reason}` —
+and a bare scalar or a value with no `src` is **refused**. There is no way to express "missing" as a blank.
+
+### Environment
+
+`DOCUMENT_MCP_CMD` · `DOCUMENT_OUTPUT_DIR` (default `workspace/output/document-mcp/`) ·
+`DOCUMENT_MAX_ROWS` (50000) · `DOCUMENT_MAX_BLOCKS` (5000) · `DOCUMENT_MAX_SLIDES` (200) ·
+`DOCUMENT_AUDIT_LOG`
+
+No API keys. Nothing to rotate.
+
+### Behaviour worth knowing
+
+- **Provenance is visible, never hidden.** Source column per table row, per-figure parenthetical in prose, a
+  visible source box on every slide, and a Sources section in every file. Word comments, document metadata
+  and speaker notes are written *additively* but never count — they are collapsed by default, stripped on
+  paste, and absent in print.
+- **`python-docx` has no footnote API** (measured), so `.docx` attribution is inline. More visible than a
+  footnote, not less.
+- **openpyxl writes a leading `=` as a live formula.** Measured: `ws["A1"] = "=1+1"` produces
+  `<c r="A1"><f>1+1</f>…`. Every string cell is forced to `inlineStr`, so a FortiGate interface description
+  or a ServiceNow short-description cannot put executing content into an auditor's spreadsheet.
+- **Admin and operational state must be separate columns.** A merged `status` column is refused — the
+  distinction spec 080's completion established.
+- **Failed devices are rows, not omissions.** A shorter spreadsheet reads as a smaller estate. The banner
+  reports attempted / returned / failed.
+- **Sources that disagree are both rendered** with their origins and a caveat. NetClaw does not pick a
+  winner.
+- **Office templates are refused, not ignored** — scratch-only, because a template's empty field is the
+  strongest fabrication pressure in the feature. PDF forms are supported precisely because their fields are
+  explicitly named and machine-readable.
+- **A filled PDF carries no Sources section** — it is the customer's document. For that one format
+  provenance lives in the response and the GAIT record. Stated rather than papered over.
+- **Files are never overwritten.** `O_EXCL` create with a collision suffix, so a regenerated report cannot
+  replace one already attached to a ticket. An unwritable output directory is a reported failure with no
+  temp-directory fallback.
+- **`ok` means complete.** Any gap forces `written_with_gaps`; a caller cannot report a gapped document as
+  clean.
+- Every call, **including refusals**, is GAIT-audited at the chokepoint.
+- Manifest measured at **1,232 / 5,000 tokens**.
+
+### Boundaries
+
+`drawio-diagram` / `markmap-viz` / `uml-diagram` / `threejs-network-viz` produce **diagrams** — this
+**embeds** them and never redraws. `rag-mcp` (feature 062) **reads** these formats for ingestion; this
+**writes** them, sharing the same four libraries with identical bounds.
+`servicenow-change-workflow` owns the CR lifecycle; this renders a document from one.
+`slack-report-delivery` / `webex-report-delivery` **send** documents; this only writes them.

--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -1089,6 +1089,17 @@
         "BGP_INTEL_USER_AGENT": "${BGP_INTEL_USER_AGENT}",
         "BGP_INTEL_MAX_RPS": "${BGP_INTEL_MAX_RPS}"
       }
+    },
+    "document-mcp": {
+      "command": "python3",
+      "args": [
+        "-u",
+        "mcp-servers/document-mcp/server.py"
+      ],
+      "env": {
+        "DOCUMENT_OUTPUT_DIR": "${DOCUMENT_OUTPUT_DIR}",
+        "DOCUMENT_MAX_ROWS": "${DOCUMENT_MAX_ROWS}"
+      }
     }
   }
 }

--- a/docs/COVERAGE-ROADMAP.md
+++ b/docs/COVERAGE-ROADMAP.md
@@ -132,7 +132,7 @@ and the IETF datatracker.
 
 | ID | Title | Spec # | Status |
 |----|-------|--------|--------|
-| **R18** | Document generation — docx / pptx / xlsx / pdf | — | `NOT STARTED` |
+| **R18** | Document generation — docx / pptx / xlsx / pdf | 082 | `IN PROGRESS` |
 | **R19** | Google Workspace (official) | — | `NOT STARTED` |
 | **R20** | Notion + Linear (official) | — | `NOT STARTED` |
 | **R21** | GitOps + Azure DevOps (ArgoCD / Flux) | — | `NOT STARTED` |
@@ -647,25 +647,52 @@ files is an excellent analysis substrate for exports.
 
 ## R18 — Document generation (docx / pptx / xlsx / pdf)
 
-**Status:** `NOT STARTED` · **Best effort-to-value ratio on the roadmap**
+**Status:** `IN PROGRESS` — spec `082-document-generation` · **Best effort-to-value ratio on the roadmap**
 
 NetClaw can render Three.js topologies, drawio, markmap, UML, Blender and UE5 — but cannot
 produce a change-record `.docx`, an exec `.pptx`, an interface-audit `.xlsx`, or fill a PDF.
 Its output lands in front of enterprise humans.
 
-**Source:** `anthropics/skills` — `skills/docx`, `skills/pptx`, `skills/xlsx`, `skills/pdf`,
-official and source-available.
+**Source (reference only — see the licence finding):** `anthropics/skills` — `skills/docx`,
+`skills/pptx`, `skills/xlsx`, `skills/pdf`.
 
-**Checklist**
-- [ ] Vendor the four official skills; note their license terms
-- [ ] Confirm Python deps (`python-docx`, `openpyxl`, `python-pptx`, PDF tooling) — several are
-      already present for `rag-mcp` (feature 062)
+> **⚠️ Correction, measured 2026-08-03 — "vendor the four official skills" cannot be done.**
+> This section originally called R18 a vendor-first item. It is not. The four `anthropics/skills`
+> document skills are **source-available and "provided for demonstration and educational purposes
+> only"** — *not* Apache-2.0. (The repo's **example** skills are Apache-2.0; the document skills
+> specifically are not.) NetClaw ships Apache-2.0 skills, so vendoring them is **not licence-
+> compatible**, and spec 082 additionally rules out any installer or runtime fetch for them.
+>
+> R18 is therefore **build-rather-than-adopt for a licensing reason** — a different situation from
+> R1/R3/R9, where the community options were technically inadequate. Upstream remains valuable as
+> **reference for which capabilities matter** (tracked changes, find-and-replace, PDF form filling
+> and merge/split, template-vs-scratch modes); reading it to decide *what* to build is legitimate,
+> copying it is not.
+
+**Checklist** *(revised by spec 082's clarification session)*
+- [x] ~~Vendor the four official skills~~ — **struck on licence grounds.** Record the terms
+      explicitly, cite upstream as capability reference, and ship **no vendored copy, no installer,
+      no runtime fetch**
+- [x] Confirm Python deps — **all four already installed** via `rag-mcp` (feature 062):
+      `python-docx` 1.2.0, `openpyxl` 3.1.5, `python-pptx` 1.0.2, PyMuPDF 1.28.0. Note that rag-mcp
+      declares them **unpinned**, a latent spec-077 hazard (PyMuPDF is imported as `fitz`); spec 082
+      adds upper bounds in both places without moving any installed version
 - [ ] Define the output location convention (persistent workspace output dir, timestamped,
       never overwritten — matching feature 046)
 - [ ] NetClaw-specific wrapper skills: change record, incident report, interface/config audit
       workbook, exec summary deck
 - [ ] Compose with existing report-delivery skills (`slack-report-delivery`,
-      `webex-report-delivery`) so generated documents can actually be sent
+      `webex-report-delivery`) so generated documents can actually be sent — **note:** spec 082 puts
+      *sending* out of scope (Principle XIV); it writes files, the delivery skills send them
+
+**Scope decisions from spec 082** (so they are not re-litigated):
+- One MCP server owns all document writing, stamping generation time, attribution and per-element
+  provenance at a single chokepoint; skills own the compositions and contain no writing logic
+- Provenance must be **visible** — source column per spreadsheet row, per-figure source in documents
+  and decks, plus a sources section in every file. Cell comments and document metadata do **not**
+  satisfy it
+- `.docx`/`.xlsx`/`.pptx` are built **from scratch**; corporate-template population is a follow-on.
+  PDF form filling stays, because a PDF form's fields are explicitly named and machine-readable
 
 ## R19 — Google Workspace (official)
 
@@ -792,7 +819,8 @@ R0 is mandatory and first. After that, the value-ordered sequence:
 
 1. **R0** — config reconciliation *(foundation; blocks all)*
 2. **R1** — Nornir/Netmiko *(~100 platforms, one server)*
-3. **R18** — document generation *(free, official, closes the deliverable gap)*
+3. **R18** — document generation *(closes the deliverable gap; libraries already installed, but
+   **built rather than vendored** — the upstream skills are demonstration-only, not Apache-2.0)*
 4. **R8** — Globalping *(remote MCP, zero install, opens the external plane)*
 5. **R2** — Cisco Support APIs *(closes PSIRT/EoL/bug in the deepest vendor)*
 6. **R3** — Fortinet *(largest single-vendor absence)*

--- a/mcp-servers/azure-network-mcp/requirements.txt
+++ b/mcp-servers/azure-network-mcp/requirements.txt
@@ -1,5 +1,7 @@
 mcp[cli]>=1.0.0,<2
-azure-identity>=1.15.0
+# Upper bound added by spec 082: the code does `from azure.identity import ...`, an
+# attribute import whose next major can remove it. Bound describes the current major.
+azure-identity>=1.15.0,<2
 azure-mgmt-network>=26.0.0
 azure-mgmt-resource>=23.0.0
 azure-mgmt-dns>=8.1.0

--- a/mcp-servers/document-mcp/README.md
+++ b/mcp-servers/document-mcp/README.md
@@ -1,0 +1,131 @@
+# document-mcp
+
+**Spec 082 / roadmap R18.** NetClaw-authored. FastMCP, stdio, 6 tools, **no credentials**.
+
+Turns a NetClaw finding into a deliverable: a change-record `.docx`, an interface-audit `.xlsx`, an
+executive `.pptx`, or an existing PDF form filled from real data.
+
+This server writes files. It touches no device and no ticket, so there is no approval gate here.
+
+## The one rule
+
+> **A document must never fabricate to fill a blank.**
+
+Tool output is ephemeral — read once, in context, by the person who asked. A document is emailed, attached
+to a ticket, filed for audit, and read months later by someone who was not there, and it carries the
+authority of its formatting. A professional-looking change record with a plausible invented number is a far
+more effective way to launder a guess into an official record than any amount of terminal output, because
+nobody re-derives a figure that is already in a table in a `.docx`.
+
+So every populated field is a **tagged value** — exactly one of:
+
+```jsonc
+{"v": "fgt-01", "src": "fgt_system_status", "device": "fgt-01", "as_of": "2026-08-03T13:58:00Z"}
+{"unavailable": "device did not answer within timeout"}
+{"failed": "FortiGate plane unreachable: connection refused"}
+```
+
+A value with no `src` is refused. A bare scalar is refused. `{"v": ""}` is legal and means *the source was
+consulted and genuinely returned empty* — a different fact from `unavailable`, rendered differently.
+Nothing ever renders as `N/A`, `0`, `-`, or an empty cell.
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `docx_write` | Word document from ordered blocks (heading, paragraph, figure, table, keyvalue, image, pagebreak) |
+| `xlsx_write` | Workbook from sheets of tagged rows plus `failed_rows` |
+| `pptx_write` | Deck from slides (bullets, figure, image) |
+| `pdf_inspect_form` | List a PDF's real named fields — call before filling |
+| `pdf_fill_form` | Fill named fields into a new file; reports `unfilled` and `unmatched` |
+| `list_documents` | Find something generated earlier |
+
+Manifest measured at **1,232 / 5,000 tokens**.
+
+## Install
+
+```bash
+./scripts/install.sh                      # select "document"
+# or
+netclaw_pip_install -r mcp-servers/document-mcp/requirements.txt
+```
+
+The four libraries are almost certainly already installed — `rag-mcp` (feature 062) brings them in to
+**read** these formats. This server **writes** them. Bounds are identical in both declarations so one shared
+install satisfies both; nothing here moves an installed version.
+
+## Environment (all optional)
+
+| Variable | Default |
+|---|---|
+| `DOCUMENT_MCP_CMD` | command the skills invoke |
+| `DOCUMENT_OUTPUT_DIR` | `workspace/output/document-mcp/` |
+| `DOCUMENT_MAX_ROWS` | 50000 data rows per worksheet |
+| `DOCUMENT_MAX_BLOCKS` | 5000 blocks per Word document |
+| `DOCUMENT_MAX_SLIDES` | 200 slides per deck |
+| `DOCUMENT_AUDIT_LOG` | `~/.openclaw/gait/document-mcp.jsonl` |
+
+No API keys. Nothing to rotate.
+
+## Layout
+
+```
+server.py            FastMCP entrypoint, 6 tools
+envelope.py          THE CHOKEPOINT — emit/refused + GAIT. Every response passes through it
+outcomes.py          Outcome enum + the tagged-value vocabulary and its rendering
+provenance.py        SourceLedger accumulation, DocumentStamp, the Sources model
+output.py            O_EXCL timestamped writer — an existing file is never opened for writing
+sanitize.py          untrusted text; the openpyxl forced-string mitigation
+guards.py            shared refusals: templates, merged status, embedded-image paths, bounds
+writers/
+  docx_writer.py     inline Source column, per-page footer, Sources section
+  xlsx_writer.py     per-row Source column, failed rows, banner, Sources sheet
+  pptx_writer.py     visible on-slide source box, Sources slide
+  pdf_writer.py      named-field fill, unfilled/unmatched reporting
+```
+
+The writer filenames carry a `_writer` suffix for readability and to stay safe if `writers/` is ever
+flattened into this directory. They do **not** shadow the third-party packages at this layout — that was
+measured (research D14) after an earlier draft claimed otherwise.
+
+## Behaviour worth knowing
+
+- **Provenance is visible, never hidden.** Source column per table row, per-figure parenthetical in prose, a
+  visible source box on every slide, a Sources section in every file. Word comments, document metadata and
+  speaker notes are written *additively* but never count — they are collapsed by default, stripped on paste,
+  and absent in print.
+- **`python-docx` has no footnote API** (measured), so `.docx` attribution is inline.
+- **openpyxl writes a leading `=` as a live formula.** Measured: `ws["A1"] = "=1+1"` produces
+  `<c r="A1"><f>1+1</f>…`. Every string cell is forced to `inlineStr` at one helper, so a device description
+  cannot put executing content into an auditor's spreadsheet.
+- **Admin and operational state must be separate columns** — a merged `status` column is refused.
+- **Failed devices are rows, not omissions.** A banner reports attempted / returned / failed.
+- **Sources that disagree are both rendered**, with a caveat. No winner is picked.
+- **Office templates are refused, not ignored.** PDF forms are supported precisely because their fields are
+  explicitly named and machine-readable.
+- **A filled PDF carries no Sources section** — it is the customer's document. Provenance for that one
+  format lives in the response and the GAIT record.
+- **Files are never overwritten** (`O_EXCL` + collision suffix). An unwritable output directory is a
+  reported failure with no temp-directory fallback.
+- **`ok` means complete.** Any gap forces `written_with_gaps`, and a caller cannot override it.
+- Every call, **including refusals**, is GAIT-audited at the chokepoint.
+
+## Boundaries
+
+| Concern | Owner |
+|---|---|
+| Drawing diagrams | `drawio-diagram`, `markmap-viz`, `uml-diagram`, `threejs-network-viz` — this **embeds** their output |
+| Reading documents | `rag-mcp` (feature 062) — same libraries, opposite direction |
+| Change-record lifecycle | `servicenow-change-workflow` — this renders a document from one |
+| Sending documents | `slack-report-delivery`, `webex-report-delivery` |
+
+## Tests
+
+```bash
+bash tests/document/run-tests.sh    # no network, no credentials
+```
+
+240 assertions across seven suites. **They reopen every generated file and assert on what is inside it** —
+spec 080 shipped a tool returning three nulls past 24 passing tests because its suites asserted on envelope
+shape and never on payload content, and this feature's entire output is content. One suite asserts against
+raw worksheet XML, which is the only thing that catches the openpyxl formula conversion.

--- a/mcp-servers/document-mcp/envelope.py
+++ b/mcp-servers/document-mcp/envelope.py
@@ -1,0 +1,187 @@
+"""The chokepoint. Spec 082, FR-005a/005b, FR-006..FR-010, FR-034.
+
+EVERY response this server produces passes through emit() or refused(). There is no
+other exit. That is what makes provenance and GAIT structural rather than a convention
+a writer is asked to follow — the pattern specs 080 and 081 used, applied to a format
+that outlives the session.
+
+Audited by inspection 2026-08-03 (task T024): the four writers construct bytes and hand
+them back; only server.py calls emit()/refused(); output.reserve() is the sole path that
+creates a file, and every caller of it returns through emit(). No writer imports
+`audit` directly.
+
+Two things a caller CANNOT do, by construction:
+
+  1. Set generated_at or generated_by. They are stamped here (FR-005b), so a document
+     cannot claim to have been produced at a time of the caller's choosing.
+  2. Report a gapped document as clean. emit() recounts the gaps from the ledger and
+     forces WRITTEN_WITH_GAPS, so "ok" always means complete.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+
+from outcomes import Outcome
+from provenance import DocumentStamp, SourceLedger, utc_now
+
+COMPONENT = "document-mcp"
+
+
+class ProvenanceError(RuntimeError):
+    """A document was about to be emitted with nothing to attribute it to. Raised, not
+    logged — an unattributed artefact is not shippable."""
+
+
+def emit(
+    *,
+    tool: str,
+    outcome: Outcome = Outcome.OK,
+    artifact: dict[str, Any] | None = None,
+    ledger: SourceLedger | None = None,
+    stamp: DocumentStamp | None = None,
+    data: Any = None,
+    caveats: list[str] | None = None,
+    message: str | None = None,
+) -> dict[str, Any]:
+    caveats = list(caveats or [])
+
+    # FR-007, mirroring spec 081's source guard. An artefact with an empty ledger has
+    # no nameable origin, which is the exact failure this feature exists to prevent.
+    if artifact is not None and (ledger is None or ledger.is_empty):
+        raise ProvenanceError(
+            f"tool {tool!r} produced a document with no nameable source. An "
+            f"unattributed document is not emittable — it looks authoritative and "
+            f"cannot be checked (FR-007)"
+        )
+
+    gaps = ledger.gaps if ledger else {"unavailable": 0, "failed": 0}
+
+    # A caller cannot report a gapped document as clean.
+    if artifact is not None and outcome is Outcome.OK and any(gaps.values()):
+        outcome = Outcome.WRITTEN_WITH_GAPS
+
+    if stamp is not None and stamp.truncated and outcome in (Outcome.OK, Outcome.WRITTEN_WITH_GAPS):
+        outcome = Outcome.TRUNCATED
+        caveats.append(stamp.truncation_text())
+
+    if any(gaps.values()):
+        caveats.append(
+            f"{gaps['unavailable']} field(s) had no data and {gaps['failed']} "
+            f"retrieval(s) failed. Both are stated explicitly in the document — this "
+            f"document is incomplete and says so"
+        )
+
+    response: dict[str, Any] = {
+        "source": COMPONENT,
+        "tool": tool,
+        "generated_at": stamp.generated_at if stamp else utc_now(),
+        "generated_by": stamp.generated_by if stamp else None,
+        "outcome": outcome.value,
+        "artifact": artifact,
+        "sources_consulted": (
+            [
+                {
+                    "src": r.src,
+                    "device": r.device or None,
+                    "as_of": r.as_of or None,
+                    "element_count": r.element_count,
+                    "status": r.status,
+                }
+                for r in ledger.records
+            ]
+            if ledger
+            else []
+        ),
+        "gaps": gaps,
+        "caveats": caveats,
+    }
+    if data is not None:
+        response["data"] = data
+    if message:
+        response["message"] = message
+
+    audit(tool=tool, response=response)
+    return response
+
+
+def refused(
+    *,
+    tool: str,
+    reason: str,
+    outcome: Outcome,
+    query: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """A refusal. Produces NO artifact and is audited exactly like a success —
+    the GAIT trail must show what NetClaw declined as well as what it did."""
+    response = {
+        "source": COMPONENT,
+        "tool": tool,
+        "generated_at": utc_now(),
+        "outcome": outcome.value,
+        "artifact": None,
+        "sources_consulted": [],
+        "gaps": {"unavailable": 0, "failed": 0},
+        "caveats": [],
+        "message": reason,
+    }
+    if query:
+        response["query"] = query
+    audit(tool=tool, response=response)
+    return response
+
+
+_SECRET_HINTS = ("token", "key", "password", "secret", "session", "cookie", "apikey", "auth")
+
+
+def _redact(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            k: ("<redacted>" if any(h in k.lower() for h in _SECRET_HINTS) else _redact(v))
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact(v) for v in value]
+    return value
+
+
+def audit(*, tool: str, response: dict[str, Any]) -> None:
+    """One JSON line per call, success or refusal. FR-034.
+
+    Called from inside emit() and refused(), never by a caller — the defect
+    /speckit.analyze caught in specs 076 and 080 was GAIT having verification but no
+    implementation, and a chokepoint is the only way that cannot recur.
+    """
+    record = {
+        "ts": response.get("generated_at") or utc_now(),
+        "component": COMPONENT,
+        "tool": tool or "<unnamed>",
+        "outcome": response.get("outcome"),
+        "artifact_path": (response.get("artifact") or {}).get("path")
+        if isinstance(response.get("artifact"), dict)
+        else None,
+        "sources": [s.get("src") for s in response.get("sources_consulted", [])],
+        "gaps": response.get("gaps"),
+    }
+    if response.get("message"):
+        record["message"] = response["message"]
+    if response.get("query"):
+        record["query"] = _redact(response["query"])
+
+    path = os.environ.get("DOCUMENT_AUDIT_LOG") or os.path.expanduser(
+        "~/.openclaw/gait/document-mcp.jsonl"
+    )
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, separators=(",", ":")) + "\n")
+    except OSError as exc:
+        print(
+            f"[document-mcp] AUDIT WRITE FAILED ({exc}) for tool={record['tool']} "
+            f"outcome={record['outcome']}",
+            file=sys.stderr,
+            flush=True,
+        )

--- a/mcp-servers/document-mcp/guards.py
+++ b/mcp-servers/document-mcp/guards.py
@@ -1,0 +1,147 @@
+"""Shared refusals. Spec 082, FR-023a, FR-014, FR-015, FR-027a.
+
+These live in one place so all three Office writers reuse them. `/speckit.analyze`
+caught the alternative: template rejection had been implemented for `.docx` only, which
+is how a decision taken in clarification quietly applies to one format out of three.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from outcomes import Outcome, ValueRefused
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+TEMPLATE_KEYS = ("template", "template_path", "template_file", "base_document", "starting_document")
+
+_TEMPLATE_REFUSAL = (
+    "Office templates are out of scope for this feature (FR-023a). `.docx`, `.xlsx` "
+    "and `.pptx` are built from scratch, because a corporate template's empty field is "
+    "the strongest fabrication pressure in the whole feature — placeholder-matching in "
+    "Word is the guessing version of the problem. PDF forms ARE supported, precisely "
+    "because their fields are explicitly named and machine-readable, so 'no data for "
+    "this field' is unambiguous rather than inferred. Corporate-template support is a "
+    "follow-on feature with its own fabrication analysis. Refusing here rather than "
+    "ignoring the parameter, so you do not receive an unbranded document believing it "
+    "is branded."
+)
+
+
+def reject_template(payload: dict) -> None:
+    """FR-023a. Refuse rather than silently ignore."""
+    supplied = [k for k in TEMPLATE_KEYS if payload.get(k)]
+    if supplied:
+        raise ValueRefused(
+            f"template parameter(s) supplied: {', '.join(supplied)}. {_TEMPLATE_REFUSAL}",
+            Outcome.REFUSED_TEMPLATE,
+        )
+
+
+# ── merged admin/operational state (FR-015) ─────────────────────────────────
+
+_MERGED_HEADERS = {"status", "state", "updown", "up/down", "linkstatus", "interfacestatus", "portstatus"}
+
+
+def _norm(header: str) -> str:
+    return re.sub(r"[^a-z/]", "", str(header).lower())
+
+
+def reject_merged_status(columns: list[str], sheet_name: str = "") -> None:
+    """FR-015. Admin state (what the config says) and operational state (what the wire
+    says) are different facts — spec 080's completion established this after NetClaw
+    itself reported the conflation on a real FortiGate.
+
+    A sheet that ALREADY carries both separately may legitimately also carry a derived
+    summary column, so the refusal only fires when the merged column is the only one.
+    """
+    normed = [_norm(c) for c in columns]
+    has_admin = any("admin" in n for n in normed)
+    has_oper = any(("oper" in n or "link" in n and "status" not in n) for n in normed)
+    if has_admin and has_oper:
+        return
+    for original, n in zip(columns, normed):
+        if n in _MERGED_HEADERS:
+            where = f" on sheet {sheet_name!r}" if sheet_name else ""
+            raise ValueRefused(
+                f"column {original!r}{where} merges administrative and operational "
+                f"state into one value. They are different facts: an interface can be "
+                f"administratively up with no carrier, and a document that collapses "
+                f"them tells the reader an interface is 'up' when nothing is passing. "
+                f"Provide separate columns (e.g. 'Admin state' and 'Oper state'), or "
+                f"keep this one alongside them.",
+                Outcome.REFUSED_MERGED_STATUS,
+            )
+
+
+# ── embedded images must come from a real diagram skill (FR-014) ────────────
+
+def resolve_embedded_image(path: str, src: str, label: str) -> Path:
+    """FR-014/FR-035: this server embeds diagrams, it never draws them. The path must
+    be a real file inside the workspace output tree — i.e. something a diagram skill
+    actually produced — and `src` must name the skill that produced it."""
+    if not src or not str(src).strip():
+        raise ValueRefused(
+            f"{label}: an embedded image requires 'src' naming the skill that produced "
+            f"it (drawio-diagram, markmap-viz, uml-diagram, threejs-network-viz). This "
+            f"server embeds diagrams and never draws them (FR-014)",
+            Outcome.SOURCE_MISSING,
+        )
+
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute():
+        candidate = _REPO_ROOT / candidate
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError:
+        raise ValueRefused(
+            f"{label}: image {path!r} does not exist. A document must not claim to "
+            f"show a diagram that was never generated",
+            Outcome.SOURCE_MISSING,
+        ) from None
+
+    allowed = (_REPO_ROOT / "workspace" / "output").resolve()
+    if not str(resolved).startswith(str(allowed) + "/"):
+        raise ValueRefused(
+            f"{label}: image {path!r} is outside {allowed}. Embedded diagrams must be "
+            f"artefacts produced by a NetClaw diagram skill, not arbitrary files",
+            Outcome.SOURCE_MISSING,
+        )
+    return resolved
+
+
+# ── bounds (FR-027a) ────────────────────────────────────────────────────────
+
+import os  # noqa: E402  (kept local to the bounds section for readability)
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return default
+
+
+def max_rows() -> int:
+    return _env_int("DOCUMENT_MAX_ROWS", 50_000)
+
+
+def max_blocks() -> int:
+    return _env_int("DOCUMENT_MAX_BLOCKS", 5_000)
+
+
+def max_slides() -> int:
+    return _env_int("DOCUMENT_MAX_SLIDES", 200)
+
+
+def apply_bound(items: list, bound: int) -> tuple[list, bool]:
+    """Returns (kept, truncated). The bound itself is written INTO the document by the
+    caller — stating it only in the tool response would hide it from the one person who
+    matters, the eventual reader."""
+    if len(items) <= bound:
+        return items, False
+    return items[:bound], True

--- a/mcp-servers/document-mcp/outcomes.py
+++ b/mcp-servers/document-mcp/outcomes.py
@@ -1,0 +1,257 @@
+"""The typed vocabulary this feature exists to protect. Spec 082, FR-001..FR-005c.
+
+Specs 078, 079, 080 and 081 each protected a distinction in *tool output*, which is
+ephemeral — read once, in context, by the person who just asked. A document is none of
+those things. It gets emailed, attached to a ticket, filed for audit, and read months
+later by someone who was not there, and it carries the authority of its formatting.
+
+So the honest representation has to be the ONLY EXPRESSIBLE one. A caller cannot hand
+this server a missing value as an empty string and have it render as a blank cell,
+because a bare scalar is not an accepted shape at all.
+
+Three shapes, exactly one of which every populated field must be:
+
+    {"v": <scalar>, "src": "...", "device": "...", "as_of": "..."}
+    {"unavailable": "<reason>"}
+    {"failed": "<reason>"}
+
+`{"v": ""}` is legal and means *the source was consulted and genuinely returned empty*.
+That is a different fact from `unavailable`, and it renders differently.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class Outcome(str, Enum):
+    """Response vocabulary. Following spec 081's split — the enum lives here, not in
+    envelope.py, because the distinctions are the domain and the envelope is plumbing."""
+
+    OK = "ok"
+    # Written, and it contains unavailable or failed elements. DELIBERATELY DISTINCT
+    # from OK: a caller must not be able to read "success" and assume completeness.
+    WRITTEN_WITH_GAPS = "written_with_gaps"
+    # Written, and a bound was applied. The bound is stated IN the document (FR-027).
+    TRUNCATED = "truncated"
+
+    # ── refusals: these are disclosure controls, not validation niceties ──
+    REFUSED_UNATTRIBUTED = "refused_unattributed"
+    REFUSED_UNTYPED = "refused_untyped"
+    REFUSED_TEMPLATE = "refused_template"
+    REFUSED_MERGED_STATUS = "refused_merged_status"
+
+    NOT_FILLABLE = "not_fillable"
+    OUTPUT_UNWRITABLE = "output_unwritable"
+    SOURCE_MISSING = "source_missing"
+
+
+class ValueRefused(ValueError):
+    """A value could not be accepted. Carries the outcome so the caller's refusal is
+    typed rather than a generic error string."""
+
+    def __init__(self, message: str, outcome: Outcome = Outcome.REFUSED_UNTYPED) -> None:
+        super().__init__(message)
+        self.outcome = outcome
+
+
+# ── the three shapes ────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class TaggedValue:
+    """Exactly one of `value` / `unavailable` / `failed` is meaningful, discriminated
+    by `kind`."""
+
+    kind: str  # "value" | "unavailable" | "failed"
+    value: Any = None
+    src: str = ""
+    device: str = ""
+    as_of: str = ""
+    reason: str = ""
+
+    @property
+    def is_gap(self) -> bool:
+        return self.kind in ("unavailable", "failed")
+
+
+_ACCEPTED_SHAPES = (
+    'accepted shapes are '
+    '{"v": <value>, "src": "<tool or system>", "device": "<optional>", "as_of": "<optional ISO-8601>"} '
+    'or {"unavailable": "<reason>"} '
+    'or {"failed": "<reason>"}'
+)
+
+# Deliberately permissive on offset/precision, strict on shape. A date with no time is
+# a legitimate as-of; "yesterday" is not.
+_ISO = re.compile(
+    r"^\d{4}-\d{2}-\d{2}"
+    r"(?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:?\d{2})?)?$"
+)
+
+
+def parse_tagged(raw: Any, field_path: str) -> TaggedValue:
+    """Parse one field. Refuses anything that would let missing data look present.
+
+    FR-005c: the caller MUST NOT be able to express a missing value as a plain empty
+    string that renders as a blank cell.
+    """
+    if not isinstance(raw, dict):
+        raise ValueRefused(
+            f"{field_path}: expected a tagged value, got a bare "
+            f"{type(raw).__name__} ({raw!r}). A bare scalar is refused because it "
+            f"cannot distinguish 'the source returned this' from 'there was no "
+            f"source' — {_ACCEPTED_SHAPES}",
+            Outcome.REFUSED_UNTYPED,
+        )
+
+    present = [k for k in ("v", "unavailable", "failed") if k in raw]
+    if len(present) != 1:
+        got = ", ".join(present) if present else "none"
+        raise ValueRefused(
+            f"{field_path}: exactly one of 'v', 'unavailable' or 'failed' must be "
+            f"present, found {got}. {_ACCEPTED_SHAPES}",
+            Outcome.REFUSED_UNTYPED,
+        )
+
+    tag = present[0]
+
+    if tag in ("unavailable", "failed"):
+        reason = raw[tag]
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueRefused(
+                f"{field_path}: '{tag}' requires a reason. An unavailable with no "
+                f"reason is a blank wearing a label — it tells the eventual reader "
+                f"nothing they could not have guessed from an empty cell",
+                Outcome.REFUSED_UNTYPED,
+            )
+        return TaggedValue(kind=tag, reason=reason.strip())
+
+    # tag == "v"
+    src = raw.get("src")
+    if not isinstance(src, str) or not src.strip():
+        raise ValueRefused(
+            f"{field_path}: a value requires 'src' naming the tool or system it came "
+            f"from. An unattributed figure in a durable artefact is not renderable — "
+            f"it looks authoritative and cannot be checked (FR-007)",
+            Outcome.REFUSED_UNATTRIBUTED,
+        )
+
+    as_of = raw.get("as_of", "") or ""
+    if as_of and not _ISO.match(str(as_of)):
+        raise ValueRefused(
+            f"{field_path}: 'as_of' must be ISO-8601, got {as_of!r}. An unparseable "
+            f"as-of is worse than none: it looks like a date and is not one",
+            Outcome.REFUSED_UNTYPED,
+        )
+
+    return TaggedValue(
+        kind="value",
+        value=raw["v"],
+        src=src.strip(),
+        device=str(raw.get("device", "") or "").strip(),
+        as_of=str(as_of).strip(),
+    )
+
+
+# ── rendering ───────────────────────────────────────────────────────────────
+
+EMPTY_MARKER = "(empty)"
+UNAVAILABLE_PREFIX = "NOT AVAILABLE"
+FAILED_PREFIX = "RETRIEVAL FAILED"
+
+# Every string a gap must never render as. This list IS the requirement (FR-001) and
+# is asserted at runtime rather than only in a test, because a document that ships a
+# plausible blank has already done the damage by the time a test would catch it.
+_FORBIDDEN_GAP_RENDERINGS = {"", "-", "--", "n/a", "na", "none", "null", "0", "tbd", "unknown"}
+
+
+def render_tagged(tv: TaggedValue) -> str:
+    """The display string. FR-001: a gap never renders as a plausible blank."""
+    if tv.kind == "value":
+        if tv.value is None:
+            # A caller sent {"v": null, "src": ...}. That is a source reporting a null,
+            # not a missing field — say so rather than printing "None".
+            return "(null)"
+        if isinstance(tv.value, str) and tv.value == "":
+            return EMPTY_MARKER
+        if isinstance(tv.value, bool):
+            return "true" if tv.value else "false"
+        return str(tv.value)
+
+    if tv.kind == "unavailable":
+        out = f"{UNAVAILABLE_PREFIX} — {tv.reason}"
+    else:
+        out = f"{FAILED_PREFIX} — {tv.reason}"
+
+    # Runtime guard, not decoration. If a future edit lets a gap collapse to something
+    # that reads as data, this raises at generation time instead of shipping.
+    if out.strip().lower() in _FORBIDDEN_GAP_RENDERINGS:
+        raise ValueRefused(
+            f"internal: a {tv.kind} value rendered as {out!r}, which reads as data "
+            f"rather than as an absence (FR-001)",
+            Outcome.REFUSED_UNTYPED,
+        )
+    return out
+
+
+def render_source(tv: TaggedValue) -> str:
+    """The visible attribution string. Never hidden — FR-008a rules out cell comments,
+    tooltips and document properties as the mechanism, because they are collapsed by
+    default, stripped on paste, and absent in print."""
+    if tv.kind == "unavailable":
+        return "— (no data)"
+    if tv.kind == "failed":
+        return "— (retrieval failed)"
+    parts = [tv.src]
+    if tv.device:
+        parts.append(tv.device)
+    return " · ".join(parts)
+
+
+def render_as_of(tv: TaggedValue) -> str:
+    """The SOURCE's own as-of, kept distinct from the document's generation time
+    (FR-010). Data collected on Monday and rendered on Friday is a Monday fact."""
+    if tv.kind != "value":
+        return ""
+    return tv.as_of or "(not stated by source)"
+
+
+# ── disagreement (FR-027b) ──────────────────────────────────────────────────
+
+@dataclass
+class Disagreement:
+    """Two sources reporting different values for the same label. Both are rendered
+    with their own origins; neither is dropped and no winner is picked."""
+
+    label: str
+    values: list[TaggedValue] = field(default_factory=list)
+
+    def caveat(self) -> str:
+        srcs = ", ".join(sorted({v.src for v in self.values if v.src}))
+        return (
+            f"{self.label}: sources disagree ({srcs}). Both values are shown with "
+            f"their origins; NetClaw has not reconciled them"
+        )
+
+
+def find_disagreements(labelled: list[tuple[str, TaggedValue]]) -> list[Disagreement]:
+    """Group by label and report any label where two attributed values differ.
+
+    A document that hides a disagreement asserts a certainty the data does not support,
+    which is the same failure as fabricating — just quieter.
+    """
+    by_label: dict[str, list[TaggedValue]] = {}
+    for label, tv in labelled:
+        if tv.kind == "value":
+            by_label.setdefault(label, []).append(tv)
+
+    out: list[Disagreement] = []
+    for label, values in by_label.items():
+        distinct = {str(v.value) for v in values}
+        distinct_srcs = {v.src for v in values}
+        if len(distinct) > 1 and len(distinct_srcs) > 1:
+            out.append(Disagreement(label=label, values=values))
+    return out

--- a/mcp-servers/document-mcp/output.py
+++ b/mcp-servers/document-mcp/output.py
@@ -1,0 +1,150 @@
+"""Where documents land. Spec 082, FR-016..FR-020.
+
+Follows feature 046's convention (workspace/skills/threejs-network-viz/output.py) —
+persistent, timestamped, uniquely named, gitignored — with one deliberate tightening.
+
+046 relies on timestamp uniqueness alone. Two documents generated in the same second
+collide, and `write_text` would silently replace the first. FR-018 says a file MUST
+NEVER be overwritten, because a regenerated report must not replace the one already
+attached to a ticket. So this opens with O_EXCL and suffixes on collision. The
+difference between "unlikely to overwrite" and "cannot" is the whole requirement.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Resolved from __file__ so it works regardless of the caller's cwd — the same reason
+# feature 046 does it this way. mcp-servers/document-mcp/output.py → repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_DIR = _REPO_ROOT / "workspace" / "output" / "document-mcp"
+
+EXTENSIONS = {"docx": "docx", "xlsx": "xlsx", "pptx": "pptx", "pdfform": "pdf"}
+
+
+class OutputUnwritable(OSError):
+    """The output directory is missing or not writable. Reported as a failure — there
+    is deliberately NO fallback to a temp directory the operator will never find."""
+
+
+def output_dir() -> Path:
+    override = os.environ.get("DOCUMENT_OUTPUT_DIR")
+    return Path(override).expanduser() if override else _DEFAULT_DIR
+
+
+def safe_id(output_id: str) -> str:
+    """`output_id` is the caller's identifier; this is its sanitised form. Same
+    sanitiser as feature 046."""
+    cleaned = "".join(c if c.isalnum() or c in "-_" else "_" for c in (output_id or "document"))
+    return cleaned[:80] or "document"
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+@dataclass
+class OutputArtifact:
+    path: str
+    bytes: int
+    created_at: str
+    collision_suffix: int | None = None
+
+    def as_dict(self) -> dict:
+        return {
+            "path": self.path,
+            "bytes": self.bytes,
+            "created_at": self.created_at,
+            "collision_suffix": self.collision_suffix,
+        }
+
+
+def _ensure_dir() -> Path:
+    d = output_dir()
+    try:
+        d.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise OutputUnwritable(f"output directory {d} could not be created: {exc}") from exc
+    if not os.access(d, os.W_OK):
+        raise OutputUnwritable(f"output directory {d} is not writable")
+    return d
+
+
+def reserve(kind: str, output_id: str) -> tuple[Path, int | None]:
+    """Exclusively create the destination file and return its path.
+
+    Returns the path of a file that now exists and was empty a moment ago. Nothing
+    that already existed is ever opened for writing.
+    """
+    directory = _ensure_dir()
+    ext = EXTENSIONS.get(kind, kind)
+    base = f"{kind}-{_timestamp()}-{safe_id(output_id)}"
+
+    suffix: int | None = None
+    attempt = 0
+    while True:
+        name = f"{base}.{ext}" if attempt == 0 else f"{base}-{attempt + 1}.{ext}"
+        path = directory / name
+        try:
+            fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        except FileExistsError:
+            attempt += 1
+            suffix = attempt + 1
+            if attempt > 999:
+                raise OutputUnwritable(
+                    f"could not find a free filename under {directory} after 1000 attempts"
+                )
+            continue
+        except OSError as exc:
+            raise OutputUnwritable(f"could not create {path}: {exc}") from exc
+        os.close(fd)
+        return path, suffix
+
+
+def finalize(path: Path, suffix: int | None) -> OutputArtifact:
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        raise OutputUnwritable(f"wrote {path} but could not stat it: {exc}") from exc
+    try:
+        rel = str(path.relative_to(_REPO_ROOT))
+    except ValueError:
+        rel = str(path)
+    return OutputArtifact(
+        path=rel,
+        bytes=size,
+        created_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        collision_suffix=suffix,
+    )
+
+
+def list_outputs(kind: str | None = None, limit: int = 50) -> list[dict]:
+    """What has been generated, newest first, so an operator can find a file."""
+    d = output_dir()
+    if not d.is_dir():
+        return []
+    entries = []
+    for p in d.iterdir():
+        if not p.is_file():
+            continue
+        if kind and not p.name.startswith(f"{kind}-"):
+            continue
+        try:
+            st = p.stat()
+        except OSError:
+            continue
+        entries.append(
+            {
+                "name": p.name,
+                "kind": p.name.split("-", 1)[0],
+                "bytes": st.st_size,
+                "modified": datetime.fromtimestamp(st.st_mtime, timezone.utc).strftime(
+                    "%Y-%m-%dT%H:%M:%SZ"
+                ),
+            }
+        )
+    entries.sort(key=lambda e: e["modified"], reverse=True)
+    return entries[: max(1, min(limit, 500))]

--- a/mcp-servers/document-mcp/provenance.py
+++ b/mcp-servers/document-mcp/provenance.py
@@ -1,0 +1,158 @@
+"""Provenance that outlives the session. Spec 082, FR-006..FR-010.
+
+A number in a spreadsheet cell with no provenance is WORSE than no spreadsheet: it
+looks authoritative and cannot be checked. So every element carries its source, every
+file carries a Sources section, and every document states when it was generated.
+
+Per FR-008a none of this may live in a hidden mechanism. Cell comments, tooltips and
+document metadata properties are collapsed by default, stripped on copy-paste, and
+absent in print — which are exactly the paths a document takes on its way to the person
+who was not in the room.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from outcomes import TaggedValue
+
+VERSION = "1.0.0"
+GENERATED_BY = f"NetClaw document-mcp {VERSION}"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass
+class SourceRecord:
+    src: str
+    device: str = ""
+    as_of: str = ""
+    element_count: int = 0
+    gap_count: int = 0
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return (self.src, self.device)
+
+    @property
+    def status(self) -> str:
+        """`partial` when a source produced both values and gaps — a source that half
+        worked must not be reported as clean."""
+        if self.element_count == 0:
+            return "failed"
+        if self.gap_count:
+            return "partial"
+        return "ok"
+
+    def label(self) -> str:
+        return f"{self.src} · {self.device}" if self.device else self.src
+
+
+class SourceLedger:
+    """Accumulates attribution from every TaggedValue the writers touch.
+
+    The writers do not decide whether to record — they hand every value here on the way
+    past, and the Sources section is built from what accumulated. That is what makes
+    FR-009's per-element attribution structural rather than a habit.
+    """
+
+    def __init__(self) -> None:
+        self._records: dict[tuple[str, str], SourceRecord] = {}
+        self._gaps = {"unavailable": 0, "failed": 0}
+
+    def record(self, tv: TaggedValue) -> TaggedValue:
+        """Register a value and return it unchanged, so call sites read as
+        `ledger.record(tv)` inline."""
+        if tv.kind == "value":
+            key = (tv.src, tv.device)
+            rec = self._records.get(key)
+            if rec is None:
+                rec = SourceRecord(src=tv.src, device=tv.device)
+                self._records[key] = rec
+            rec.element_count += 1
+            # Keep the latest as-of seen for this source.
+            if tv.as_of and tv.as_of > rec.as_of:
+                rec.as_of = tv.as_of
+        else:
+            self._gaps[tv.kind] += 1
+            # A gap still belongs to whatever was being asked of a source, but the
+            # caller did not name one — record it against the document as a whole so
+            # the Sources section reports the shortfall rather than hiding it.
+            key = ("(no source reached)", "")
+            rec = self._records.get(key)
+            if rec is None:
+                rec = SourceRecord(src="(no source reached)")
+                self._records[key] = rec
+            rec.gap_count += 1
+        return tv
+
+    def attribute_gap_to(self, src: str, device: str = "") -> None:
+        """Optional: attribute a gap to a named source that was reached and came back
+        empty, which is a different fact from never reaching one."""
+        key = (src, device)
+        rec = self._records.setdefault(key, SourceRecord(src=src, device=device))
+        rec.gap_count += 1
+
+    @property
+    def records(self) -> list[SourceRecord]:
+        return sorted(self._records.values(), key=lambda r: (r.src, r.device))
+
+    @property
+    def gaps(self) -> dict[str, int]:
+        return dict(self._gaps)
+
+    @property
+    def has_gaps(self) -> bool:
+        return any(self._gaps.values())
+
+    @property
+    def is_empty(self) -> bool:
+        return not self._records
+
+    def as_rows(self) -> list[list[str]]:
+        """Rows for the Sources section/sheet/slide, in every format."""
+        return [
+            [
+                r.src,
+                r.device or "—",
+                r.as_of or "(not stated by source)",
+                str(r.element_count),
+                r.status,
+            ]
+            for r in self.records
+        ]
+
+    SOURCE_COLUMNS = ["Source", "Device / record", "As of", "Elements", "Status"]
+
+
+@dataclass
+class DocumentStamp:
+    """When it was generated and by what. FR-006.
+
+    Read six months later, "as of" is the difference between a record and a misleading
+    artefact. Neither field is caller-supplied — both are set here (FR-005b).
+    """
+
+    tool: str
+    generated_at: str = field(default_factory=utc_now)
+    generated_by: str = GENERATED_BY
+    truncated: bool = False
+    bound_applied: int | None = None
+    bound_kind: str = ""
+
+    def footer_text(self) -> str:
+        return f"Generated by {self.generated_by} at {self.generated_at} · tool: {self.tool}"
+
+    def truncation_text(self) -> str:
+        """Stated INSIDE the document, not only in the tool response the eventual
+        reader never sees (FR-027)."""
+        if not self.truncated:
+            return ""
+        return (
+            f"TRUNCATED — this document shows the first {self.bound_applied:,} "
+            f"{self.bound_kind}. The source contained more. Raise the bound or narrow "
+            f"the query to see the rest."
+        )

--- a/mcp-servers/document-mcp/requirements.txt
+++ b/mcp-servers/document-mcp/requirements.txt
@@ -1,0 +1,24 @@
+# Document generation — spec 082 (roadmap R18)
+#
+# Every one of these is ALREADY INSTALLED on this system, brought in by feature
+# 062's rag-mcp, which READS these formats for ingestion. This server WRITES
+# them. Same libraries, opposite direction.
+#
+# These bounds therefore describe what is already resolved — they move nothing.
+# Measured 2026-08-03: python-docx 1.2.0, openpyxl 3.1.5, python-pptx 1.0.2,
+# PyMuPDF 1.28.0. Spec 076's cryptography incident is the reason that sentence
+# is here: moving a shared pin to satisfy one feature breaks the other.
+#
+# The mcp upper bound is LOAD-BEARING (spec 077, restated by spec 081): the MCP
+# Python SDK has shipped v2, and v2 removes mcp.server.fastmcp, which this
+# server imports. An unbounded pin resolves that major and dies on import for
+# every new installer. Do not "tidy" it away.
+#
+# PyMuPDF is declared as `pymupdf` but imported as `fitz`. That distribution/
+# module rename is exactly why scripts/check-dependency-pins.py needed the alias
+# map this feature added — a name-matching checker cannot see the connection.
+mcp>=1.2.0,<2
+python-docx>=1.1,<2
+openpyxl>=3.1,<4
+python-pptx>=1.0,<2
+pymupdf>=1.24,<2

--- a/mcp-servers/document-mcp/sanitize.py
+++ b/mcp-servers/document-mcp/sanitize.py
@@ -1,0 +1,63 @@
+"""Untrusted text. Spec 082, FR-026.
+
+This is not a theoretical hardening exercise. Measured 2026-08-03:
+
+    ws["A1"] = "=1+1"       →  <c r="A1"><f>1+1</f><v></v></c>     A LIVE FORMULA
+
+openpyxl converts a leading `=` into a formula element. The strings this server writes
+come from FortiGate interface descriptions, ServiceNow short-descriptions, device
+banners and hostnames — none of which NetClaw controls. A description beginning with
+`=` is enough to put executing content into an auditor's spreadsheet.
+
+The mitigation, also measured:
+
+    cell.value = "=1+1"; cell.data_type = "s"
+        →  <c r="A2" t="inlineStr"><is><t>=1+1</t></is></c>        LITERAL TEXT
+
+Applied uniformly to every string cell rather than only to values starting with `=`,
+because which prefixes a spreadsheet application treats as formulas varies by locale
+and by paste path, whereas `t="inlineStr"` is unambiguous in the file itself.
+
+Deliberately NOT done: prefixing with an apostrophe. That is the common advice and it
+visibly corrupts the value, in a document whose entire purpose is fidelity.
+"""
+
+from __future__ import annotations
+
+# Everything below 0x20 except tab/newline/carriage-return is illegal in OOXML text and
+# will produce a file Word or Excel refuses to open.
+_CONTROL = {c: None for c in range(0x20) if c not in (0x09, 0x0A, 0x0D)}
+_CONTROL[0x7F] = None
+
+
+def plain_text(value: object) -> str:
+    """A string safe to insert as a text run in docx/pptx.
+
+    Strips control characters that would make the OOXML unopenable. Does NOT escape
+    anything else — python-docx and python-pptx insert runs as text nodes, so markup in
+    the value is already inert; escaping it again would visibly corrupt it.
+    """
+    if value is None:
+        return ""
+    return str(value).translate(_CONTROL)
+
+
+def force_text_cell(cell, value: object) -> None:
+    """Write a value into an openpyxl cell as literal text, never as a formula.
+
+    Order matters: the assignment is what triggers openpyxl's formula detection, so the
+    data_type override must come after it.
+    """
+    cell.value = plain_text(value)
+    cell.data_type = "s"
+
+
+def write_cell(cell, value: object) -> None:
+    """Write any value. Numbers and booleans stay typed so a spreadsheet can sum them;
+    strings go through the forced-text path."""
+    if isinstance(value, bool):
+        cell.value = value
+    elif isinstance(value, (int, float)):
+        cell.value = value
+    else:
+        force_text_cell(cell, value)

--- a/mcp-servers/document-mcp/server.py
+++ b/mcp-servers/document-mcp/server.py
@@ -1,0 +1,245 @@
+"""document-mcp — turn a NetClaw finding into a document a human will act on.
+
+Spec 082 / roadmap R18. FastMCP, stdio, no credentials, no device access, no ticket
+writes. Six tools. This server writes files and does nothing else.
+
+THE ONE RULE: a document must never fabricate to fill a blank.
+
+Tool output is ephemeral — read once, in context, by the person who asked. A document
+is emailed, filed, and read months later by someone who was not there, and it carries
+the authority of its formatting. A professional-looking change record with a plausible
+invented number is a far more effective way to launder a guess into an official record
+than any amount of terminal output, because nobody re-derives a figure that is already
+in a table in a .docx.
+
+So every populated field is a TAGGED VALUE — one of:
+
+    {"v": <value>, "src": "<tool or system>", "device": "...", "as_of": "..."}
+    {"unavailable": "<reason>"}
+    {"failed": "<reason>"}
+
+A value without `src` is refused. A bare scalar is refused. There is no way to express
+"missing" as a blank.
+
+Composition lives in the skills (document-generation, network-report-documents), not
+here. This server holds no vendor knowledge — it renders tagged values.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from mcp.server.fastmcp import FastMCP  # noqa: E402
+
+import envelope  # noqa: E402
+import output  # noqa: E402
+from outcomes import Outcome, ValueRefused  # noqa: E402
+from provenance import DocumentStamp, SourceLedger  # noqa: E402
+from writers import docx_writer, pdf_writer, pptx_writer, xlsx_writer  # noqa: E402
+
+mcp = FastMCP("document-mcp")
+
+
+def _write(kind: str, tool: str, payload: dict[str, Any], builder) -> dict:
+    """The single path from a tool to a file. Every writer goes through here, and here
+    goes through envelope.emit(), which is what makes the stamp, the provenance and the
+    GAIT record impossible to omit."""
+    stamp = DocumentStamp(tool=tool)
+    ledger = SourceLedger()
+    try:
+        data, caveats = builder(payload, stamp, ledger)
+    except ValueRefused as exc:
+        return envelope.refused(tool=tool, reason=str(exc), outcome=exc.outcome)
+    except output.OutputUnwritable as exc:
+        return envelope.refused(tool=tool, reason=str(exc), outcome=Outcome.OUTPUT_UNWRITABLE)
+
+    try:
+        path, suffix = output.reserve(kind, payload.get("output_id", kind))
+        path.write_bytes(data)
+        artifact = output.finalize(path, suffix)
+    except output.OutputUnwritable as exc:
+        return envelope.refused(tool=tool, reason=str(exc), outcome=Outcome.OUTPUT_UNWRITABLE)
+
+    return envelope.emit(
+        tool=tool,
+        outcome=Outcome.OK,
+        artifact=artifact.as_dict(),
+        ledger=ledger,
+        stamp=stamp,
+        caveats=caveats,
+    )
+
+
+@mcp.tool()
+async def docx_write(
+    title: str,
+    blocks: list[dict],
+    output_id: str = "document",
+    template: str = "",
+) -> dict:
+    """Write a Word document (.docx) from an ordered list of typed blocks.
+
+    Block types: heading, paragraph, figure, table, keyvalue, image, pagebreak.
+    Every value in a figure/table/keyvalue must be a TAGGED VALUE (see server docstring)
+    — the writer appends a Source column you cannot omit, footers every page with the
+    generation stamp, and appends a Sources section.
+
+    Prose paragraphs carry no attribution, so a paragraph asserting a bare number gets a
+    caveat: put figures in a figure/table/keyvalue block instead.
+
+    Office templates are NOT supported and `template` is refused rather than ignored.
+    """
+    return _write(
+        "docx",
+        "docx_write",
+        {"title": title, "blocks": blocks, "output_id": output_id, "template": template},
+        docx_writer.build,
+    )
+
+
+@mcp.tool()
+async def xlsx_write(sheets: list[dict], output_id: str = "workbook", template: str = "") -> dict:
+    """Write a spreadsheet (.xlsx) from typed sheets.
+
+    Each sheet: {name, columns[], rows[[TaggedValue]], failed_rows[{label, failed}]}.
+    The writer appends Source and As-of columns, adds a banner stating
+    attempted/returned/failed, renders failed_rows AS ROWS (a shorter sheet would read
+    as a smaller estate), and adds a Sources sheet.
+
+    Administrative and operational state must be separate columns — a merged `status`
+    column is refused. Untrusted text is written as literal text, so a value beginning
+    with `=` cannot become a live formula.
+
+    Office templates are NOT supported and `template` is refused rather than ignored.
+    """
+    return _write(
+        "xlsx",
+        "xlsx_write",
+        {"sheets": sheets, "output_id": output_id, "template": template},
+        xlsx_writer.build,
+    )
+
+
+@mcp.tool()
+async def pptx_write(
+    title: str, slides: list[dict], output_id: str = "deck", template: str = ""
+) -> dict:
+    """Write a presentation (.pptx) from typed slides.
+
+    Each slide: {layout: bullets|figure|image, title, bullets[], figures[{label,value}],
+    image{path,src}, detail_ref}. Sources appear in a VISIBLE box on the slide, not in
+    speaker notes (which are invisible in presentation and print). A Sources slide is
+    appended.
+
+    Diagrams are embedded, never drawn here: image.path must be an artefact already
+    produced by drawio-diagram, markmap-viz, uml-diagram or threejs-network-viz, and
+    `src` must name it.
+
+    Office templates are NOT supported and `template` is refused rather than ignored.
+    """
+    return _write(
+        "pptx",
+        "pptx_write",
+        {"title": title, "slides": slides, "output_id": output_id, "template": template},
+        pptx_writer.build,
+    )
+
+
+@mcp.tool()
+async def pdf_inspect_form(path: str) -> dict:
+    """List the named fields of a fillable PDF, so data is mapped to fields that exist.
+
+    Call this BEFORE pdf_fill_form. A PDF with no form fields is reported as not
+    fillable — NetClaw will not place text positionally, which would produce a document
+    that looks filled and carries no field data.
+    """
+    tool = "pdf_inspect_form"
+    try:
+        result = pdf_writer.inspect(path)
+    except ValueRefused as exc:
+        return envelope.refused(tool=tool, reason=str(exc), outcome=exc.outcome, query={"path": path})
+    if result["outcome"] is Outcome.NOT_FILLABLE:
+        return envelope.refused(
+            tool=tool, reason=result["message"], outcome=Outcome.NOT_FILLABLE, query={"path": path}
+        )
+    ledger = SourceLedger()
+    ledger.attribute_gap_to("(inspection only — no document written)")
+    return envelope.emit(
+        tool=tool,
+        outcome=Outcome.OK,
+        data=result["data"],
+        ledger=ledger,
+        stamp=DocumentStamp(tool=tool),
+    )
+
+
+@mcp.tool()
+async def pdf_fill_form(path: str, values: dict, output_id: str = "form") -> dict:
+    """Fill a fillable PDF's named fields from tagged values, into a NEW file.
+
+    The input PDF is never modified. Values that are `unavailable` or `failed` leave the
+    field genuinely empty and are reported in `unfilled` — a form is never completed
+    with a guess. Supplied keys matching no field are reported in `unmatched`, never
+    dropped silently.
+
+    Note the one provenance limitation in this feature: a filled form carries no Sources
+    section, because it is the supplied document and adding a page would alter it. For
+    this format only, provenance lives in this response and the GAIT record.
+    """
+    tool = "pdf_fill_form"
+    ledger = SourceLedger()
+    stamp = DocumentStamp(tool=tool)
+    try:
+        dest, suffix = output.reserve("pdfform", output_id)
+    except output.OutputUnwritable as exc:
+        return envelope.refused(tool=tool, reason=str(exc), outcome=Outcome.OUTPUT_UNWRITABLE)
+
+    try:
+        result = pdf_writer.fill(path, values, ledger, dest)
+    except ValueRefused as exc:
+        dest.unlink(missing_ok=True)
+        return envelope.refused(tool=tool, reason=str(exc), outcome=exc.outcome, query={"path": path})
+
+    if result["outcome"] is Outcome.NOT_FILLABLE:
+        dest.unlink(missing_ok=True)  # no output file for a non-fillable PDF
+        return envelope.refused(
+            tool=tool, reason=result["message"], outcome=Outcome.NOT_FILLABLE, query={"path": path}
+        )
+
+    artifact = output.finalize(dest, suffix)
+    return envelope.emit(
+        tool=tool,
+        outcome=result["outcome"],
+        artifact=artifact.as_dict(),
+        data=result["data"],
+        ledger=ledger,
+        stamp=stamp,
+        caveats=result.get("caveats", []),
+    )
+
+
+@mcp.tool()
+async def list_documents(kind: str = "", limit: int = 50) -> dict:
+    """List documents this server has generated, newest first, so you can find a file.
+
+    `kind` filters to docx | xlsx | pptx | pdfform. Read-only.
+    """
+    tool = "list_documents"
+    entries = output.list_outputs(kind or None, limit)
+    ledger = SourceLedger()
+    ledger.attribute_gap_to("(local filesystem listing — no document written)")
+    return envelope.emit(
+        tool=tool,
+        outcome=Outcome.OK,
+        data={"directory": str(output.output_dir()), "count": len(entries), "documents": entries},
+        ledger=ledger,
+        stamp=DocumentStamp(tool=tool),
+    )
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/mcp-servers/document-mcp/writers/docx_writer.py
+++ b/mcp-servers/document-mcp/writers/docx_writer.py
@@ -1,0 +1,267 @@
+"""Word documents. Spec 082, US1.
+
+Provenance here is INLINE, not footnoted. python-docx 1.2.0 exposes no footnote API
+(measured — research D3): `Paragraph` and `Run` have no footnote attributes at all. It
+does expose `add_comment`, which is precisely the hidden mechanism FR-008a prohibits as
+the means of satisfying provenance — comments are collapsed by default, stripped on
+copy-paste, and absent in print.
+
+So: tables carry a Source column the writer appends, prose figures carry a visible
+parenthetical, every page footer carries the stamp, and the document ends with a
+Sources section. That is more visible than a footnote, not less.
+"""
+
+from __future__ import annotations
+
+import re
+
+from docx import Document
+from docx.enum.text import WD_ALIGN_PARAGRAPH
+from docx.shared import Inches, Pt, RGBColor
+
+from guards import apply_bound, max_blocks, reject_template, resolve_embedded_image
+from outcomes import (
+    Outcome,
+    TaggedValue,
+    ValueRefused,
+    find_disagreements,
+    parse_tagged,
+    render_as_of,
+    render_source,
+    render_tagged,
+)
+from provenance import DocumentStamp, SourceLedger
+from sanitize import plain_text
+
+GAP_COLOR = RGBColor(0x99, 0x00, 0x00)
+MUTED = RGBColor(0x60, 0x60, 0x60)
+
+# Digits that are legitimately not a figure. Without this allow-list the prose lint
+# fires on every date and ticket number and gets tuned into vacuity.
+_ALLOWED_DIGIT_PATTERNS = [
+    r"\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2})?)?(?:Z|[+-]\d{2}:?\d{2})?",  # ISO date/time
+    r"\d{1,2}:\d{2}(?::\d{2})?",                                                  # clock time
+    r"[A-Z]{2,6}\d{4,}",                                                          # CHG0012345
+    r"\bRFC\s?\d+\b",                                                             # RFC 6811
+    r"\bv?\d+\.\d+(?:\.\d+)*\b",                                                  # 7.6.7
+    r"\b(?:\d{1,3}\.){3}\d{1,3}(?:/\d{1,2})?\b",                                  # IPv4 / prefix
+    r"\bAS\d+\b",                                                                 # AS65000
+    r"\b(?:[0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}(?:/\d{1,3})?",                 # IPv6
+    r"(?i:\b(?:section|table|figure|appendix|slide|step|phase|page)\s+\d+\b)",    # ordinals
+]
+_ALLOWED_RE = re.compile("|".join(_ALLOWED_DIGIT_PATTERNS))
+
+
+def _prose_has_bare_figure(text: str) -> bool:
+    """True if the prose asserts a number that is not an allow-listed pattern.
+
+    Prose is the one place an unattributed figure could hide: `figure`, `table` and
+    `keyvalue` all force attribution, and a `paragraph` does not.
+    """
+    return bool(re.search(r"\d", _ALLOWED_RE.sub("", text)))
+
+
+def _add_source_run(paragraph, text: str) -> None:
+    run = paragraph.add_run(f"  ({text})")
+    run.font.size = Pt(8)
+    run.font.color.rgb = MUTED
+    run.italic = True
+
+
+def _write_value_cell(cell, tv: TaggedValue) -> None:
+    cell.text = ""
+    para = cell.paragraphs[0]
+    run = para.add_run(plain_text(render_tagged(tv)))
+    if tv.is_gap:
+        run.bold = True
+        run.font.color.rgb = GAP_COLOR
+
+
+def build(payload: dict, stamp: DocumentStamp, ledger: SourceLedger) -> tuple[bytes, list[str]]:
+    """Returns (docx bytes, caveats). Raises ValueRefused for anything refusable."""
+    reject_template(payload)
+
+    blocks = payload.get("blocks") or []
+    if not isinstance(blocks, list):
+        raise ValueRefused("'blocks' must be a list", Outcome.REFUSED_UNTYPED)
+
+    blocks, truncated = apply_bound(blocks, max_blocks())
+    if truncated:
+        stamp.truncated = True
+        stamp.bound_applied = max_blocks()
+        stamp.bound_kind = "blocks"
+
+    caveats: list[str] = []
+    labelled: list[tuple[str, TaggedValue]] = []
+
+    doc = Document()
+    title = plain_text(payload.get("title") or "NetClaw document")
+    doc.add_heading(title, 0)
+
+    # The stamp, visible at the top as well as in the footer. A reader who prints one
+    # page still learns when this was generated.
+    head = doc.add_paragraph()
+    hrun = head.add_run(stamp.footer_text())
+    hrun.font.size = Pt(8)
+    hrun.font.color.rgb = MUTED
+
+    if stamp.truncated:
+        warn = doc.add_paragraph()
+        wrun = warn.add_run(stamp.truncation_text())
+        wrun.bold = True
+        wrun.font.color.rgb = GAP_COLOR
+
+    for index, block in enumerate(blocks):
+        if not isinstance(block, dict):
+            raise ValueRefused(f"blocks[{index}] must be an object", Outcome.REFUSED_UNTYPED)
+        kind = block.get("type")
+        path = f"blocks[{index}]"
+
+        if kind == "heading":
+            level = max(1, min(4, int(block.get("level", 1))))
+            doc.add_heading(plain_text(block.get("text", "")), level)
+
+        elif kind == "paragraph":
+            text = plain_text(block.get("text", ""))
+            doc.add_paragraph(text)
+            if _prose_has_bare_figure(text):
+                caveats.append(
+                    f"{path}: prose asserts a figure with no source. Prose carries no "
+                    f"attribution — use a 'figure', 'table' or 'keyvalue' block so the "
+                    f"number is traceable"
+                )
+
+        elif kind == "figure":
+            label = plain_text(block.get("label", ""))
+            tv = ledger.record(parse_tagged(block.get("value"), f"{path}.value"))
+            labelled.append((label, tv))
+            para = doc.add_paragraph()
+            para.add_run(f"{label}: ").bold = True
+            vrun = para.add_run(plain_text(render_tagged(tv)))
+            if tv.is_gap:
+                vrun.bold = True
+                vrun.font.color.rgb = GAP_COLOR
+            detail = render_source(tv)
+            if tv.kind == "value" and tv.as_of:
+                detail += f" · as of {tv.as_of}"
+            _add_source_run(para, detail)
+
+        elif kind == "keyvalue":
+            pairs = block.get("pairs") or []
+            table = doc.add_table(rows=1, cols=4)
+            table.style = "Table Grid"
+            for i, header in enumerate(["Field", "Value", "Source", "As of"]):
+                cell = table.rows[0].cells[i]
+                cell.text = header
+                cell.paragraphs[0].runs[0].bold = True
+            for j, pair in enumerate(pairs):
+                label = plain_text(pair.get("label", ""))
+                tv = ledger.record(parse_tagged(pair.get("value"), f"{path}.pairs[{j}].value"))
+                labelled.append((label, tv))
+                row = table.add_row().cells
+                row[0].text = label
+                _write_value_cell(row[1], tv)
+                row[2].text = render_source(tv)
+                row[3].text = render_as_of(tv)
+
+        elif kind == "table":
+            columns = list(block.get("columns") or [])
+            rows = block.get("rows") or []
+            if block.get("caption"):
+                cap = doc.add_paragraph()
+                cap.add_run(plain_text(block["caption"])).bold = True
+            table = doc.add_table(rows=1, cols=len(columns) + 2)
+            table.style = "Table Grid"
+            for i, header in enumerate(columns + ["Source", "As of"]):
+                cell = table.rows[0].cells[i]
+                cell.text = plain_text(header)
+                cell.paragraphs[0].runs[0].bold = True
+            for r, raw_row in enumerate(rows):
+                cells = table.add_row().cells
+                row_tvs: list[TaggedValue] = []
+                for c, raw in enumerate(list(raw_row)[: len(columns)]):
+                    tv = ledger.record(parse_tagged(raw, f"{path}.rows[{r}][{c}]"))
+                    row_tvs.append(tv)
+                    if c < len(columns):
+                        labelled.append((f"{plain_text(block.get('caption') or 'table')}."
+                                         f"{plain_text(columns[c])}[{r}]", tv))
+                    _write_value_cell(cells[c], tv)
+                # One Source cell per row, derived from the row's own values.
+                srcs = sorted({render_source(t) for t in row_tvs if t.kind == "value"})
+                ages = sorted({t.as_of for t in row_tvs if t.kind == "value" and t.as_of})
+                cells[len(columns)].text = " / ".join(srcs) if srcs else "— (no data)"
+                cells[len(columns) + 1].text = ages[-1] if ages else "(not stated by source)"
+
+        elif kind == "image":
+            resolved = resolve_embedded_image(
+                block.get("path", ""), block.get("src", ""), path
+            )
+            doc.add_picture(str(resolved), width=Inches(6.0))
+            doc.paragraphs[-1].alignment = WD_ALIGN_PARAGRAPH.CENTER
+            cap = doc.add_paragraph()
+            cap.alignment = WD_ALIGN_PARAGRAPH.CENTER
+            crun = cap.add_run(plain_text(block.get("caption", "")))
+            crun.italic = True
+            _add_source_run(cap, f"produced by {plain_text(block['src'])}")
+
+        elif kind == "pagebreak":
+            doc.add_page_break()
+
+        else:
+            raise ValueRefused(
+                f"{path}: unknown block type {kind!r}. Supported: heading, paragraph, "
+                f"figure, table, keyvalue, image, pagebreak",
+                Outcome.REFUSED_UNTYPED,
+            )
+
+    # FR-027b — both values shown, neither dropped, no winner picked.
+    for dis in find_disagreements(labelled):
+        caveats.append(dis.caveat())
+        para = doc.add_paragraph()
+        drun = para.add_run(f"Sources disagree — {dis.label}: ")
+        drun.bold = True
+        drun.font.color.rgb = GAP_COLOR
+        para.add_run(
+            "; ".join(f"{render_tagged(v)} ({render_source(v)})" for v in dis.values)
+        )
+        _add_source_run(para, "not reconciled by NetClaw")
+
+    _add_sources_section(doc, ledger)
+
+    # Footer on every page (FR-006, FR-008).
+    footer_para = doc.sections[0].footer.paragraphs[0]
+    footer_para.text = stamp.footer_text()
+    footer_para.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    for run in footer_para.runs:
+        run.font.size = Pt(7)
+        run.font.color.rgb = MUTED
+
+    # Additive only — never the provenance mechanism (FR-008a).
+    doc.core_properties.comments = stamp.footer_text()
+    doc.core_properties.author = stamp.generated_by
+
+    import io
+
+    buf = io.BytesIO()
+    doc.save(buf)
+    return buf.getvalue(), caveats
+
+
+def _add_sources_section(doc, ledger: SourceLedger) -> None:
+    doc.add_page_break()
+    doc.add_heading("Sources", 1)
+    doc.add_paragraph(
+        "Every figure in this document came from one of the following. This section is "
+        "in addition to the per-element attribution in the tables above, not instead "
+        "of it."
+    )
+    table = doc.add_table(rows=1, cols=len(SourceLedger.SOURCE_COLUMNS))
+    table.style = "Table Grid"
+    for i, header in enumerate(SourceLedger.SOURCE_COLUMNS):
+        cell = table.rows[0].cells[i]
+        cell.text = header
+        cell.paragraphs[0].runs[0].bold = True
+    for row in ledger.as_rows():
+        cells = table.add_row().cells
+        for i, value in enumerate(row):
+            cells[i].text = plain_text(value)

--- a/mcp-servers/document-mcp/writers/pdf_writer.py
+++ b/mcp-servers/document-mcp/writers/pdf_writer.py
@@ -1,0 +1,181 @@
+"""PDF forms. Spec 082, US4.
+
+PDF is the one template case in this feature, and deliberately so: a form's fields are
+explicitly *named and machine-readable*, so "there is no data for this field" is
+unambiguous. Word and PowerPoint placeholder-matching is the guessing version of the
+same problem, which is why those formats are built from scratch.
+
+Two limits, both stated rather than worked around:
+
+  * Only named fields are written. Positional text placement onto a PDF with no form
+    fields would produce a document that LOOKS filled and carries no field data — the
+    exact "visually similar but non-functional" outcome FR-024 prohibits.
+
+  * A filled form cannot carry a Sources section. It is the customer's document and
+    adding a page would alter it. For this one format provenance lives in the response
+    and the GAIT record, and the skill says so. Pretending otherwise would be worse
+    than the limitation.
+
+Measured 2026-08-03: `doc.is_form_pdf` returns an **int** (3) for a form and False for
+a plain PDF. Compared truthily below — never `is True`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import fitz
+
+from outcomes import Outcome, ValueRefused, parse_tagged
+from provenance import SourceLedger
+
+_WIDGET_KINDS = {
+    fitz.PDF_WIDGET_TYPE_TEXT: "text",
+    fitz.PDF_WIDGET_TYPE_CHECKBOX: "checkbox",
+    fitz.PDF_WIDGET_TYPE_RADIOBUTTON: "radio",
+    fitz.PDF_WIDGET_TYPE_COMBOBOX: "combobox",
+    fitz.PDF_WIDGET_TYPE_LISTBOX: "listbox",
+    fitz.PDF_WIDGET_TYPE_BUTTON: "button",
+    fitz.PDF_WIDGET_TYPE_SIGNATURE: "signature",
+}
+
+PROVENANCE_LIMITATION = (
+    "A filled PDF form carries no Sources section: it is the supplied document and "
+    "adding a page would alter it. For this format only, provenance lives in this "
+    "response and the GAIT record. Every other format carries it inside the file."
+)
+
+
+def _open(path: str) -> tuple[fitz.Document, Path]:
+    resolved = Path(path).expanduser()
+    if not resolved.is_absolute():
+        resolved = (Path(__file__).resolve().parents[3] / resolved)
+    if not resolved.is_file():
+        raise ValueRefused(f"PDF {path!r} does not exist", Outcome.SOURCE_MISSING)
+    try:
+        return fitz.open(str(resolved)), resolved
+    except Exception as exc:  # noqa: BLE001 — surface the library's own reason
+        raise ValueRefused(f"could not open {path!r} as a PDF: {exc}", Outcome.SOURCE_MISSING) from exc
+
+
+def inspect(path: str) -> dict:
+    """List the form's named fields so a caller maps data to fields it has actually
+    seen, rather than inventing names."""
+    doc, resolved = _open(path)
+    try:
+        fillable = bool(doc.is_form_pdf)  # int (measured: 3) — never `is True`
+        fields = []
+        for page_index, page in enumerate(doc):
+            for widget in page.widgets():
+                fields.append(
+                    {
+                        "name": widget.field_name,
+                        "kind": _WIDGET_KINDS.get(widget.field_type, "unknown"),
+                        "current_value": widget.field_value,
+                        "page": page_index,
+                    }
+                )
+        if not fillable or not fields:
+            return {
+                "outcome": Outcome.NOT_FILLABLE,
+                "data": {"fillable": False, "field_count": 0, "fields": []},
+                "message": (
+                    f"{resolved.name} has no form fields. NetClaw will not place text "
+                    f"positionally onto it — that would produce a document that looks "
+                    f"filled but carries no field data (FR-024a)."
+                ),
+            }
+        return {
+            "outcome": Outcome.OK,
+            "data": {"fillable": True, "field_count": len(fields), "fields": fields},
+            "message": None,
+        }
+    finally:
+        doc.close()
+
+
+def fill(path: str, values: dict, ledger: SourceLedger, dest: Path) -> dict:
+    """Fill named fields into a NEW file. The input PDF is never modified."""
+    if not isinstance(values, dict) or not values:
+        raise ValueRefused("'values' must be a non-empty object", Outcome.REFUSED_UNTYPED)
+
+    # Parse every value through the same typed gate as every other format, so a bare
+    # scalar cannot slip a blank into a governance form.
+    parsed = {k: parse_tagged(v, f"values[{k}]") for k, v in values.items()}
+
+    doc, resolved = _open(path)
+    try:
+        if not bool(doc.is_form_pdf):
+            return {
+                "outcome": Outcome.NOT_FILLABLE,
+                "data": None,
+                "message": (
+                    f"{resolved.name} is not a fillable PDF. Nothing was written — a "
+                    f"visually similar file with no field data would be worse than no "
+                    f"file (FR-024)."
+                ),
+            }
+
+        present: set[str] = set()
+        filled: list[str] = []
+        unfilled: list[str] = []
+
+        for page in doc:
+            for widget in page.widgets():
+                name = widget.field_name
+                present.add(name)
+                tv = parsed.get(name)
+                if tv is None or tv.is_gap or tv.value in (None, ""):
+                    # Left genuinely empty. A form is never completed with a guess.
+                    unfilled.append(name)
+                    if tv is not None:
+                        ledger.record(tv)
+                    continue
+                widget.field_value = str(tv.value)
+                widget.update()
+                filled.append(name)
+                ledger.record(tv)
+
+        # Supplied keys matching no field. NEVER dropped silently: data that vanished
+        # is indistinguishable from data never supplied.
+        unmatched = sorted(k for k in parsed if k not in present)
+        for k in unmatched:
+            ledger.record(parsed[k])
+
+        if not filled and not unmatched:
+            # Nothing was written and nothing was wrong — still emit, but say so.
+            pass
+
+        doc.save(str(dest), incremental=False, deflate=True)
+        return {
+            "outcome": Outcome.OK if not unfilled and not unmatched else Outcome.WRITTEN_WITH_GAPS,
+            "data": {
+                "filled": sorted(filled),
+                "unfilled": sorted(unfilled),
+                "unmatched": unmatched,
+                "input_pdf": str(resolved),
+            },
+            "message": None,
+            "caveats": _caveats(filled, unfilled, unmatched),
+        }
+    finally:
+        doc.close()
+
+
+def _caveats(filled: list[str], unfilled: list[str], unmatched: list[str]) -> list[str]:
+    out = [PROVENANCE_LIMITATION]
+    if unfilled:
+        out.append(
+            f"{len(unfilled)} field(s) were left empty because no data was supplied "
+            f"for them: {', '.join(sorted(unfilled))}. They are blank in the form and "
+            f"need completing by hand — NetClaw did not guess."
+        )
+    if unmatched:
+        out.append(
+            f"{len(unmatched)} supplied value(s) matched no field in this form and were "
+            f"NOT written: {', '.join(unmatched)}. Reported rather than dropped, because "
+            f"data that vanished is indistinguishable from data never supplied."
+        )
+    if not filled:
+        out.append("No field was filled. The output is a copy of the input form.")
+    return out

--- a/mcp-servers/document-mcp/writers/pptx_writer.py
+++ b/mcp-servers/document-mcp/writers/pptx_writer.py
@@ -1,0 +1,196 @@
+"""Decks. Spec 082, US3.
+
+Sources go ON the slide, in a shape, at the bottom.
+
+python-pptx exposes `notes_slide`, and putting attribution there is the obvious move
+and the wrong one: speaker notes are invisible in presentation mode and absent from a
+default print or PDF export. That is the same class of hidden mechanism as a cell
+comment, and FR-008a rules it out as the mechanism. Notes are written too, but only
+additively.
+"""
+
+from __future__ import annotations
+
+import io
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.util import Emu, Inches, Pt
+
+from guards import apply_bound, max_slides, reject_template, resolve_embedded_image
+from outcomes import (
+    Outcome,
+    TaggedValue,
+    ValueRefused,
+    find_disagreements,
+    parse_tagged,
+    render_source,
+    render_tagged,
+)
+from provenance import DocumentStamp, SourceLedger
+from sanitize import plain_text
+
+MUTED = RGBColor(0x60, 0x60, 0x60)
+GAP = RGBColor(0x99, 0x00, 0x00)
+
+LAYOUT_TITLE = 0
+LAYOUT_TITLE_CONTENT = 1
+LAYOUT_TITLE_ONLY = 5
+LAYOUT_BLANK = 6
+
+
+def build(payload: dict, stamp: DocumentStamp, ledger: SourceLedger) -> tuple[bytes, list[str]]:
+    reject_template(payload)
+
+    slides = payload.get("slides") or []
+    if not isinstance(slides, list):
+        raise ValueRefused("'slides' must be a list", Outcome.REFUSED_UNTYPED)
+
+    slides, truncated = apply_bound(slides, max_slides())
+    if truncated:
+        stamp.truncated = True
+        stamp.bound_applied = max_slides()
+        stamp.bound_kind = "slides"
+
+    caveats: list[str] = []
+    labelled: list[tuple[str, TaggedValue]] = []
+
+    prs = Presentation()
+    _title_slide(prs, plain_text(payload.get("title") or "NetClaw findings"), stamp)
+
+    for index, slide_spec in enumerate(slides):
+        if not isinstance(slide_spec, dict):
+            raise ValueRefused(f"slides[{index}] must be an object", Outcome.REFUSED_UNTYPED)
+        path = f"slides[{index}]"
+        layout = slide_spec.get("layout", "bullets")
+        title = plain_text(slide_spec.get("title", ""))
+        source_bits: list[str] = []
+
+        if layout == "image":
+            slide = prs.slides.add_slide(prs.slide_layouts[LAYOUT_TITLE_ONLY])
+            slide.shapes.title.text = title
+            image = slide_spec.get("image") or {}
+            resolved = resolve_embedded_image(
+                image.get("path", ""), image.get("src", ""), f"{path}.image"
+            )
+            slide.shapes.add_picture(
+                str(resolved), Inches(0.8), Inches(1.6), width=Inches(8.4)
+            )
+            source_bits.append(f"diagram produced by {plain_text(image['src'])}")
+
+        elif layout == "figure":
+            slide = prs.slides.add_slide(prs.slide_layouts[LAYOUT_TITLE_CONTENT])
+            slide.shapes.title.text = title
+            body = slide.placeholders[1].text_frame
+            body.clear()
+            figures = slide_spec.get("figures") or []
+            for f_index, fig in enumerate(figures):
+                label = plain_text(fig.get("label", ""))
+                tv = ledger.record(parse_tagged(fig.get("value"), f"{path}.figures[{f_index}].value"))
+                labelled.append((label, tv))
+                para = body.paragraphs[0] if f_index == 0 else body.add_paragraph()
+                para.text = f"{label}: {plain_text(render_tagged(tv))}"
+                if tv.is_gap:
+                    for run in para.runs:
+                        run.font.color.rgb = GAP
+                        run.font.bold = True
+                bit = render_source(tv)
+                if tv.kind == "value" and tv.as_of:
+                    bit += f" (as of {tv.as_of})"
+                if bit not in source_bits:
+                    source_bits.append(bit)
+
+        else:  # bullets / title
+            slide = prs.slides.add_slide(prs.slide_layouts[LAYOUT_TITLE_CONTENT])
+            slide.shapes.title.text = title
+            body = slide.placeholders[1].text_frame
+            body.clear()
+            bullets = [plain_text(b) for b in (slide_spec.get("bullets") or [])]
+            for b_index, bullet in enumerate(bullets):
+                para = body.paragraphs[0] if b_index == 0 else body.add_paragraph()
+                para.text = bullet
+            detail_ref = slide_spec.get("detail_ref")
+            if bullets and not detail_ref:
+                caveats.append(
+                    f"{path}: summary slide {title!r} has no 'detail_ref'. A summary "
+                    f"claim should be traceable to a detail slide or the Sources slide "
+                    f"rather than asserted bare (FR-005)"
+                )
+            if detail_ref:
+                source_bits.append(f"detail: {plain_text(detail_ref)}")
+
+        # The visible source line — a real shape, not speaker notes (FR-008a).
+        _source_line(slide, prs, source_bits, stamp)
+        # Additive only.
+        slide.notes_slide.notes_text_frame.text = (
+            (" · ".join(source_bits) if source_bits else "no figures on this slide")
+            + f"\n{stamp.footer_text()}"
+        )
+
+    for dis in find_disagreements(labelled):
+        caveats.append(dis.caveat())
+        slide = prs.slides.add_slide(prs.slide_layouts[LAYOUT_TITLE_CONTENT])
+        slide.shapes.title.text = f"Sources disagree — {dis.label}"
+        tf = slide.placeholders[1].text_frame
+        tf.clear()
+        for i, v in enumerate(dis.values):
+            para = tf.paragraphs[0] if i == 0 else tf.add_paragraph()
+            para.text = f"{render_tagged(v)}  —  {render_source(v)}"
+        tail = tf.add_paragraph()
+        tail.text = "NetClaw has not reconciled these. Both are shown as reported."
+        _source_line(slide, prs, ["values shown as reported by each source"], stamp)
+
+    _sources_slide(prs, ledger, stamp)
+
+    buf = io.BytesIO()
+    prs.save(buf)
+    return buf.getvalue(), caveats
+
+
+def _title_slide(prs: Presentation, title: str, stamp: DocumentStamp) -> None:
+    slide = prs.slides.add_slide(prs.slide_layouts[LAYOUT_TITLE])
+    slide.shapes.title.text = title
+    try:
+        slide.placeholders[1].text = stamp.footer_text()
+    except (KeyError, IndexError):
+        _source_line(slide, prs, [], stamp)
+    if stamp.truncated:
+        box = slide.shapes.add_textbox(Inches(0.5), Inches(5.2), prs.slide_width - Inches(1.0), Inches(0.6))
+        para = box.text_frame.paragraphs[0]
+        para.text = stamp.truncation_text()
+        para.runs[0].font.size = Pt(11)
+        para.runs[0].font.bold = True
+        para.runs[0].font.color.rgb = GAP
+
+
+def _source_line(slide, prs: Presentation, bits: list[str], stamp: DocumentStamp) -> None:
+    """A visible textbox along the bottom of the slide. This is the mechanism —
+    speaker notes are not."""
+    text = " · ".join(b for b in bits if b)
+    text = f"Source: {text}" if text else "No figures on this slide."
+    height = Inches(0.4)
+    top = prs.slide_height - height - Emu(45720)
+    box = slide.shapes.add_textbox(Inches(0.4), top, prs.slide_width - Inches(0.8), height)
+    para = box.text_frame.paragraphs[0]
+    para.text = f"{text}   |   {stamp.generated_by} · {stamp.generated_at}"
+    run = para.runs[0]
+    run.font.size = Pt(8)
+    run.font.color.rgb = MUTED
+    run.font.italic = True
+
+
+def _sources_slide(prs: Presentation, ledger: SourceLedger, stamp: DocumentStamp) -> None:
+    slide = prs.slides.add_slide(prs.slide_layouts[LAYOUT_TITLE_CONTENT])
+    slide.shapes.title.text = "Sources"
+    tf = slide.placeholders[1].text_frame
+    tf.clear()
+    rows = ledger.as_rows()
+    if not rows:
+        tf.paragraphs[0].text = "No sources were consulted for this deck."
+    for i, row in enumerate(rows):
+        para = tf.paragraphs[0] if i == 0 else tf.add_paragraph()
+        src, device, as_of, count, status = row
+        where = f" · {device}" if device and device != "—" else ""
+        para.text = f"{src}{where} — as of {as_of} — {count} element(s) — {status}"
+        para.runs[0].font.size = Pt(14)
+    _source_line(slide, prs, ["this slide lists every source consulted"], stamp)

--- a/mcp-servers/document-mcp/writers/xlsx_writer.py
+++ b/mcp-servers/document-mcp/writers/xlsx_writer.py
@@ -1,0 +1,213 @@
+"""Workbooks. Spec 082, US2.
+
+Two things here are not cosmetic.
+
+**Every string cell is forced to inlineStr.** openpyxl writes a leading `=` as a live
+formula (measured — research D5), and the strings this writes come from device
+descriptions and ticket fields. See sanitize.py.
+
+**Failed devices are rows, not omissions.** A shorter spreadsheet reads as a smaller
+estate, which is a false statement about the network. So a device that could not be
+reached occupies a visibly marked row and is counted in the banner, and the row count
+reflects what was *attempted*.
+"""
+
+from __future__ import annotations
+
+import io
+
+from openpyxl import Workbook
+from openpyxl.styles import Alignment, Font, PatternFill
+from openpyxl.utils import get_column_letter
+
+from guards import apply_bound, max_rows, reject_merged_status, reject_template
+from outcomes import (
+    Outcome,
+    TaggedValue,
+    ValueRefused,
+    parse_tagged,
+    render_as_of,
+    render_source,
+    render_tagged,
+)
+from provenance import DocumentStamp, SourceLedger
+from sanitize import force_text_cell, write_cell
+
+HEADER_FONT = Font(bold=True, color="FFFFFF")
+HEADER_FILL = PatternFill("solid", fgColor="333333")
+GAP_FONT = Font(bold=True, color="990000")
+BANNER_FONT = Font(bold=True)
+BANNER_FILL = PatternFill("solid", fgColor="FFF2CC")
+MUTED_FONT = Font(size=8, color="606060")
+
+
+def build(payload: dict, stamp: DocumentStamp, ledger: SourceLedger) -> tuple[bytes, list[str]]:
+    reject_template(payload)
+
+    sheets = payload.get("sheets") or []
+    if not isinstance(sheets, list) or not sheets:
+        raise ValueRefused("'sheets' must be a non-empty list", Outcome.REFUSED_UNTYPED)
+
+    caveats: list[str] = []
+    wb = Workbook()
+    wb.remove(wb.active)
+
+    for s_index, sheet in enumerate(sheets):
+        if not isinstance(sheet, dict):
+            raise ValueRefused(f"sheets[{s_index}] must be an object", Outcome.REFUSED_UNTYPED)
+        name = str(sheet.get("name") or f"Sheet{s_index + 1}")[:31]
+        columns = [str(c) for c in (sheet.get("columns") or [])]
+        if not columns:
+            raise ValueRefused(f"sheets[{s_index}]: 'columns' is required", Outcome.REFUSED_UNTYPED)
+
+        # FR-015 — admin state and operational state are different facts.
+        reject_merged_status(columns, name)
+
+        rows = list(sheet.get("rows") or [])
+        failed_rows = list(sheet.get("failed_rows") or [])
+        attempted = len(rows) + len(failed_rows)
+
+        rows, truncated = apply_bound(rows, max_rows())
+        if truncated:
+            stamp.truncated = True
+            stamp.bound_applied = max_rows()
+            stamp.bound_kind = "rows per sheet"
+
+        ws = wb.create_sheet(title=name)
+        r = 1
+
+        # Banner: attempted / succeeded / failed, frozen so it survives scrolling.
+        # SC-004 — the row count must reflect what was attempted, not what worked.
+        banner = (
+            f"{attempted} attempted · {len(rows)} returned data · {len(failed_rows)} failed. "
+            f"{stamp.footer_text()}"
+        )
+        cell = ws.cell(row=r, column=1)
+        force_text_cell(cell, banner)
+        cell.font = BANNER_FONT
+        cell.fill = BANNER_FILL
+        ws.merge_cells(start_row=r, start_column=1, end_row=r, end_column=len(columns) + 2)
+        r += 1
+
+        if stamp.truncated:
+            tcell = ws.cell(row=r, column=1)
+            force_text_cell(tcell, stamp.truncation_text())
+            tcell.font = GAP_FONT
+            ws.merge_cells(start_row=r, start_column=1, end_row=r, end_column=len(columns) + 2)
+            r += 1
+
+        header_row = r
+        # The writer appends Source and As of — a caller cannot omit attribution.
+        for c, header in enumerate(columns + ["Source", "As of"], start=1):
+            hc = ws.cell(row=header_row, column=c)
+            force_text_cell(hc, header)
+            hc.font = HEADER_FONT
+            hc.fill = HEADER_FILL
+        r += 1
+
+        for row_index, raw_row in enumerate(rows):
+            tvs: list[TaggedValue] = []
+            for c, raw in enumerate(list(raw_row)[: len(columns)]):
+                tv = ledger.record(
+                    parse_tagged(raw, f"sheets[{s_index}].rows[{row_index}][{c}]")
+                )
+                tvs.append(tv)
+                cell = ws.cell(row=r, column=c + 1)
+                if tv.kind == "value" and isinstance(tv.value, (int, float)) and not isinstance(
+                    tv.value, bool
+                ):
+                    write_cell(cell, tv.value)
+                else:
+                    force_text_cell(cell, render_tagged(tv))
+                if tv.is_gap:
+                    cell.font = GAP_FONT
+            srcs = sorted({render_source(t) for t in tvs if t.kind == "value"})
+            ages = sorted({t.as_of for t in tvs if t.kind == "value" and t.as_of})
+            force_text_cell(
+                ws.cell(row=r, column=len(columns) + 1),
+                " / ".join(srcs) if srcs else "— (no data)",
+            )
+            force_text_cell(
+                ws.cell(row=r, column=len(columns) + 2),
+                ages[-1] if ages else "(not stated by source)",
+            )
+            r += 1
+
+        # FR-003 — failed devices are rows, positioned with the data.
+        for f_index, failed in enumerate(failed_rows):
+            label = str(failed.get("label", f"(unnamed {f_index})"))
+            reason = str(failed.get("failed") or failed.get("reason") or "")
+            if not reason.strip():
+                raise ValueRefused(
+                    f"sheets[{s_index}].failed_rows[{f_index}]: a failed row requires a "
+                    f"reason. Without one it is a blank row wearing a label",
+                    Outcome.REFUSED_UNTYPED,
+                )
+            ledger.record(parse_tagged({"failed": reason}, f"sheets[{s_index}].failed_rows[{f_index}]"))
+            first = ws.cell(row=r, column=1)
+            force_text_cell(first, label)
+            first.font = GAP_FONT
+            marker = ws.cell(row=r, column=2)
+            force_text_cell(marker, f"RETRIEVAL FAILED — {reason}")
+            marker.font = GAP_FONT
+            if len(columns) > 2:
+                ws.merge_cells(start_row=r, start_column=2, end_row=r, end_column=len(columns))
+            force_text_cell(ws.cell(row=r, column=len(columns) + 1), "— (retrieval failed)")
+            force_text_cell(ws.cell(row=r, column=len(columns) + 2), "")
+            r += 1
+
+        ws.freeze_panes = ws.cell(row=header_row + 1, column=1)
+        _autosize(ws, len(columns) + 2)
+
+        if failed_rows:
+            caveats.append(
+                f"sheet {name!r}: {len(failed_rows)} device(s) could not be reached and "
+                f"appear as failed rows. The sheet is not shorter for it — a shorter "
+                f"sheet would read as a smaller estate"
+            )
+
+    _add_sources_sheet(wb, ledger, stamp)
+
+    buf = io.BytesIO()
+    wb.save(buf)
+    return buf.getvalue(), caveats
+
+
+def _autosize(ws, ncols: int) -> None:
+    for c in range(1, ncols + 1):
+        longest = 0
+        for cell in ws[get_column_letter(c)]:
+            if cell.value is not None:
+                longest = max(longest, min(len(str(cell.value)), 60))
+        ws.column_dimensions[get_column_letter(c)].width = max(12, longest + 2)
+
+
+def _add_sources_sheet(wb: Workbook, ledger: SourceLedger, stamp: DocumentStamp) -> None:
+    ws = wb.create_sheet(title="Sources")
+    stamp_cell = ws.cell(row=1, column=1)
+    force_text_cell(stamp_cell, stamp.footer_text())
+    stamp_cell.font = BANNER_FONT
+    ws.merge_cells(start_row=1, start_column=1, end_row=1, end_column=len(SourceLedger.SOURCE_COLUMNS))
+
+    note = ws.cell(row=2, column=1)
+    force_text_cell(
+        note,
+        "Every figure in this workbook came from one of the following. This sheet is in "
+        "addition to the per-row Source column, not instead of it.",
+    )
+    note.font = MUTED_FONT
+    note.alignment = Alignment(wrap_text=False)
+    ws.merge_cells(start_row=2, start_column=1, end_row=2, end_column=len(SourceLedger.SOURCE_COLUMNS))
+
+    for c, header in enumerate(SourceLedger.SOURCE_COLUMNS, start=1):
+        hc = ws.cell(row=3, column=c)
+        force_text_cell(hc, header)
+        hc.font = HEADER_FONT
+        hc.fill = HEADER_FILL
+
+    r = 4
+    for row in ledger.as_rows():
+        for c, value in enumerate(row, start=1):
+            force_text_cell(ws.cell(row=r, column=c), value)
+        r += 1
+    _autosize(ws, len(SourceLedger.SOURCE_COLUMNS))

--- a/mcp-servers/memory-mcp/pyproject.toml
+++ b/mcp-servers/memory-mcp/pyproject.toml
@@ -6,9 +6,12 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
 dependencies = [
-    "mcp",
+    # Upper bounds added by spec 082. mcp 2.0 removed mcp.server.fastmcp, which this
+    # server imports; chromadb is imported by submodule. Both describe installed majors
+    # (mcp 1.28.1, chromadb 1.5.9) and move nothing.
+    "mcp>=1.2.0,<2",
     "fastmcp",
-    "chromadb>=0.4.0",
+    "chromadb>=0.4.0,<2",
     "sentence-transformers>=2.2.0",
     "torch>=2.0.0",
 ]

--- a/mcp-servers/rag-mcp/pyproject.toml
+++ b/mcp-servers/rag-mcp/pyproject.toml
@@ -3,20 +3,41 @@ name = "netclaw-rag-mcp"
 version = "0.1.0"
 description = "NetClaw Agentic RAG Knowledge Base - offline document knowledge base with hybrid retrieval, citations, and opt-in snapshots"
 requires-python = ">=3.10"
+# Upper bounds added by spec 082 (roadmap R18), 2026-08-03.
+#
+# WHY THIS FILE WAS UNCHECKED: scripts/check-dependency-pins.py read requirements.txt
+# only, and rag-mcp has none — it declares dependencies here. So this server had never
+# been scanned, and reconcile-mcp.py's clean exit was an artefact of invisibility rather
+# than of correctness. Spec 082 extended the checker to read pyproject.toml; these
+# bounds are what it now requires.
+#
+# Every bound below describes a version ALREADY INSTALLED and resolved (measured
+# 2026-08-03): mcp 1.28.1, fastmcp 2.14.7, chromadb 1.5.9, sentence-transformers 5.6.0,
+# torch 2.13.0+cpu, rank_bm25 0.2.2, pymupdf 1.28.0, beautifulsoup4 4.15.0, httpx 0.28.1,
+# python-docx 1.2.0, openpyxl 3.1.5, python-pptx 1.0.2, vsdx 0.6.1. Nothing was moved —
+# spec 076's cryptography incident is why that sentence is here.
+#
+# The mcp and fastmcp bounds are load-bearing: mcp 2.0 removed mcp.server.fastmcp, and
+# this server does `from fastmcp import FastMCP`. Both are attribute/submodule imports
+# of packages whose next major can remove them.
+#
+# The four document libraries are shared with spec 082's document-mcp, which READS
+# nothing and WRITES these formats. Two servers declaring different requirements for one
+# shared install is not an acceptable end state, so the bounds are identical in both.
 dependencies = [
-    "mcp",
-    "fastmcp",
-    "chromadb>=0.4.0",
-    "sentence-transformers>=2.2.0",
-    "torch>=2.0.0",
-    "rank_bm25",
-    "pymupdf",
-    "beautifulsoup4",
-    "httpx",
-    "python-docx",
-    "openpyxl",
-    "python-pptx",
-    "vsdx",
+    "mcp>=1.2.0,<2",
+    "fastmcp>=2.0,<3",
+    "chromadb>=0.4.0,<2",
+    "sentence-transformers>=2.2.0,<6",
+    "torch>=2.0.0,<3",
+    "rank_bm25>=0.2,<1",
+    "pymupdf>=1.24,<2",        # imported as `fitz` — a dist/module rename
+    "beautifulsoup4>=4.12,<5",  # imported as `bs4` — a dist/module rename
+    "httpx>=0.27.0,<1",
+    "python-docx>=1.1,<2",      # imported as `docx`
+    "openpyxl>=3.1,<4",
+    "python-pptx>=1.0,<2",      # imported as `pptx`
+    "vsdx>=0.5,<1",
 ]
 
 [project.scripts]

--- a/scripts/check-dependency-pins.py
+++ b/scripts/check-dependency-pins.py
@@ -47,6 +47,31 @@ PIN_EXCEPTIONS: dict[str, str] = {
     "ISE_MCP:aiocache": "unpinned, no known breaking major — bounding would be a guess",
     "pyATS_MCP:pyats": "unpinned; pyATS versions by date, not semver, so <N+1 is meaningless",
     "twilio-voice-mcp:twilio": "second declaration; the bounded one above governs",
+    # ── Surfaced 2026-08-03 by spec 082, which taught this check to read
+    # pyproject.toml (rag-mcp had none, so it had never been scanned) and added a
+    # distribution→module alias map (pymupdf→fitz and friends never matched).
+    #
+    # Every finding below is REAL and of exactly the class this check exists to catch.
+    # They are excepted for one specific reason: these directories are UNTRACKED
+    # third-party clones (`git ls-files` returns nothing for them). An edit there is not
+    # committable, evaporates on the next re-clone, and would leave a fixed-looking
+    # check guarding nothing — which is worse than an honest exception.
+    #
+    # Closing them needs an upstream pin or a vendoring-policy change, not a local edit.
+    # Recorded in specs/082-document-generation/VERIFICATION.md as found-not-fixed.
+    # If any of these is ever vendored INTO the repo, delete its line here — the
+    # exception is about the file being untracked, not about the hazard being acceptable.
+    "AAP-Enterprise-MCP-Server:mcp": "untracked upstream clone — a local pin is not committable",
+    "gait_mcp:mcp": "untracked upstream clone — a local pin is not committable",
+    "infrahub-mcp:infrahub-sdk": "untracked upstream clone — a local pin is not committable",
+    "junos-mcp-server:mcp": "untracked upstream clone — a local pin is not committable",
+    "junos-mcp-server:starlette": "untracked upstream clone — a local pin is not committable",
+    "mcp-nautobot:mcp": "untracked upstream clone — a local pin is not committable",
+    "mcp-nvd:mcp": "untracked upstream clone — a local pin is not committable",
+    "mcp-nvd:starlette": "untracked upstream clone — a local pin is not committable",
+    "meraki-magic-mcp-community:mcp": "untracked upstream clone — a local pin is not committable",
+    "servicenow-mcp:requests": "untracked upstream clone — a local pin is not committable",
+    "servicenow-mcp:starlette": "untracked upstream clone — a local pin is not committable",
 }
 BARE_PIP_EXCEPTIONS: dict[str, str] = {}
 
@@ -54,11 +79,97 @@ BARE_PIP_EXCEPTIONS: dict[str, str] = {}
 VENV_OK_PATTERNS = ("uv venv", "virtualenv ", "netclaw_venv_create")
 
 
+# Distribution name -> module name, where they differ. Spec 082 (2026-08-03).
+#
+# The submodule scan compares a DISTRIBUTION name from a requirements file against a
+# MODULE name from an import statement. When they differ the two never meet, so the
+# check silently passes. `pymupdf` is imported as `fitz`; `python-docx` as `docx`;
+# `beautifulsoup4` as `bs4`. rag-mcp declared all three unbounded while importing
+# submodules/attributes of them, and this check reported PASS.
+#
+# Deliberately small and specific. A large speculative table would rot the way
+# EXTERNAL_INTEGRATIONS did (the lesson in this file's own docstring); these are the
+# renames actually present in this repository, verified by grep.
+DIST_TO_MODULE: dict[str, str] = {
+    "pymupdf": "fitz",
+    "python-docx": "docx",
+    "python-pptx": "pptx",
+    "beautifulsoup4": "bs4",
+    "python-dotenv": "dotenv",
+    "pyyaml": "yaml",
+    "pillow": "pil",
+    "msgraph-sdk": "msgraph",
+    "azure-identity": "azure",
+    "google-api-python-client": "googleapiclient",
+    "protobuf": "google",
+    "grpcio": "grpc",
+    "grpcio-tools": "grpc-tools",
+    "attrs": "attr",
+    "scikit-learn": "sklearn",
+    "sentence-transformers": "sentence-transformers",
+}
+
+
+def _module_for(dist_name: str) -> str:
+    """The module name a distribution installs, normalised the same way imports are."""
+    return DIST_TO_MODULE.get(dist_name, dist_name).lower().replace("_", "-")
+
+
 def _requirements(server_dir: str) -> list[str]:
+    """Declared dependencies, from requirements.txt AND pyproject.toml.
+
+    pyproject.toml support added by spec 082. Before it, this function read
+    requirements.txt only — and rag-mcp has none, declaring its dependencies in
+    pyproject.toml instead. So rag-mcp was never scanned at all, and this script's
+    PASS was an artefact of the file being invisible rather than of it being correct.
+    """
+    lines: list[str] = []
+
     path = os.path.join(server_dir, "requirements.txt")
+    if os.path.isfile(path):
+        lines += [
+            ln.strip() for ln in open(path) if ln.strip() and not ln.strip().startswith("#")
+        ]
+
+    lines += _pyproject_dependencies(server_dir)
+    return lines
+
+
+def _pyproject_dependencies(server_dir: str) -> list[str]:
+    """[project].dependencies from pyproject.toml.
+
+    tomllib is stdlib from 3.11; below that this falls back to a narrow regex over the
+    dependencies array. The fallback is deliberately conservative — it reads only
+    quoted strings inside `dependencies = [...]` and gives up on anything else, because
+    a wrong parse here produces false findings, and a noisy check is worse than no check
+    (this file's own conclusion about FR-006c).
+    """
+    path = os.path.join(server_dir, "pyproject.toml")
     if not os.path.isfile(path):
         return []
-    return [ln.strip() for ln in open(path) if ln.strip() and not ln.strip().startswith("#")]
+
+    try:
+        import tomllib  # Python 3.11+
+    except ModuleNotFoundError:
+        tomllib = None  # type: ignore[assignment]
+
+    if tomllib is not None:
+        try:
+            with open(path, "rb") as fh:
+                data = tomllib.load(fh)
+        except (OSError, ValueError):
+            return []
+        deps = (data.get("project") or {}).get("dependencies") or []
+        return [str(d).strip() for d in deps if str(d).strip()]
+
+    try:
+        text = open(path, encoding="utf-8", errors="ignore").read()
+    except OSError:
+        return []
+    m = re.search(r"^dependencies\s*=\s*\[(.*?)\]", text, re.S | re.M)
+    if not m:
+        return []
+    return [d.strip() for d in re.findall(r'"([^"]+)"|\'([^\']+)\'', m.group(1)) for d in d if d]
 
 
 def _parse_pin(line: str) -> tuple[str, str] | None:
@@ -128,11 +239,13 @@ def scan_pins() -> tuple[list[str], list[str]]:
             key = f"{entry}:{name}"
             if key in PIN_EXCEPTIONS:
                 continue
-            if name in submodule and not _is_bounded(spec):
+            module = _module_for(name)
+            if module in submodule and not _is_bounded(spec):
+                rename = f" (imported as {module!r})" if module != name else ""
                 failures.append(
-                    f"pins: {entry}: {name!r} is pinned {spec or '(unpinned)'!r} with no upper "
-                    f"bound, but the code imports a SUBMODULE of it — a new major can remove "
-                    f"that submodule (as mcp 2.0.0 removed mcp.server.fastmcp)"
+                    f"pins: {entry}: {name!r}{rename} is pinned {spec or '(unpinned)'!r} with no "
+                    f"upper bound, but the code imports a SUBMODULE of it — a new major can "
+                    f"remove that submodule (as mcp 2.0.0 removed mcp.server.fastmcp)"
                 )
             # FR-006c (unused-declaration detection) is DROPPED as unimplementable
             # reliably here. A distribution name is not a module name --

--- a/scripts/lib/catalog.sh
+++ b/scripts/lib/catalog.sh
@@ -104,6 +104,7 @@ CATALOG=(
     "gait|Platform Services|GAIT Audit Trail|Git-based AI audit trail (recommended for all installs)"
     "mempalace|Platform Services|MemPalace Memory|Local AI memory — 19 tools, no API keys"
     "memory-mcp|Platform Services|Memory MCP|Hybrid persistent memory — structured facts (SQLite), semantic search (ChromaDB), decision log"
+    "document|Platform Services|Document Generation|Change-record .docx, audit .xlsx, exec .pptx and PDF form filling from real NetClaw data — per-element provenance, never fabricates a blank"
     "rag-mcp|Platform Services|RAG Knowledge Base|Offline document knowledge base — hybrid retrieval, citations, opt-in snapshots (ChromaDB + BM25 + local reranker)"
     "ollama|Platform Services|Ollama Domain Experts|Delegates structured tasks to local Ollama models on your own GPU (10 tools)"
     "humanrail|Platform Services|HumanRail|Human-in-the-loop escalation and approvals"
@@ -138,7 +139,7 @@ catalog_has() {
 PROFILE_MINIMAL="pyats gait subnet-calc drawio-rfc"
 
 PROFILE_RECOMMENDED="bgp-intel pyats gait netbox servicenow nvd-cve subnet-calc wikipedia markmap \
-drawio-rfc uml packet-buddy nmap gtrace globalping suzieq batfish protocol n2n tts chrome-devtools rag-mcp"
+drawio-rfc uml packet-buddy nmap gtrace globalping suzieq batfish protocol n2n tts chrome-devtools rag-mcp document"
 
 PROFILE_CISCO="pyats gait netbox servicenow aci ise catalyst-center meraki sdwan cml fmc \
 radkit te-community te-official nvd-cve cisco-psirt subnet-calc drawio-rfc uml packet-buddy"

--- a/scripts/lib/install-steps.sh
+++ b/scripts/lib/install-steps.sh
@@ -3845,6 +3845,30 @@ fi
 BGP_INTEL_MCP_CMD_DETECTED="python3 $BGP_INTEL_MCP_DIR/server.py"
 }
 
+# ── Document generation MCP (spec 082 / roadmap R18) ────────────
+component_install_document() {
+log_step "Installing Document Generation MCP Server..."
+echo "  Source: mcp-servers/document-mcp (NetClaw-authored, spec 082 / roadmap R18)"
+echo "  Change-record .docx, audit .xlsx, exec .pptx, PDF form filling"
+echo "  NO credentials required — writes files, touches no device and no ticket"
+
+DOCUMENT_MCP_DIR="$REPO_ROOT/mcp-servers/document-mcp"
+
+if [ -d "$DOCUMENT_MCP_DIR" ]; then
+    # These four libraries are almost certainly already present: rag-mcp (feature 062)
+    # installs them to READ these formats. This server WRITES them. Bounds are identical
+    # in both declarations so one shared install satisfies both.
+    netclaw_pip_install -r "$DOCUMENT_MCP_DIR/requirements.txt" 2>/dev/null || \
+        log_warn "Document MCP dependency install failed (mcp, python-docx, openpyxl, python-pptx, pymupdf)"
+    log_info "Document MCP prepared: $DOCUMENT_MCP_DIR"
+    log_info "Output lands in workspace/output/document-mcp/ — timestamped, never overwritten"
+else
+    log_warn "Document MCP directory missing: $DOCUMENT_MCP_DIR"
+fi
+
+DOCUMENT_MCP_CMD_DETECTED="python3 $DOCUMENT_MCP_DIR/server.py"
+}
+
 component_install_globalping() {
 log_step "Enabling Globalping (remote MCP)..."
 echo "  Outside-in measurement from ~4,800 probes across ~1,390 ASNs:"

--- a/specs/082-document-generation/VERIFICATION.md
+++ b/specs/082-document-generation/VERIFICATION.md
@@ -1,0 +1,180 @@
+# Verification Report — Document Generation (spec 082 / R18)
+
+**Date**: 2026-08-03 · **FR-025, FR-042, FR-043, SC-020**
+
+FR-043 requires that anything not exercised is recorded as **unverified** rather than claimed. This is spec
+078's precedent (four of five Cisco API families dropped after returning 403) and spec 080's lesson: that
+feature had **24 passing appliance-free tests while shipping a tool that returned three nulls**, because its
+suites asserted on envelope *shape* and never on payload *content*.
+
+This feature's entire output **is** content. So the column that matters below is not "did it run" but
+**"was the file opened and read"**.
+
+## Per-format status
+
+| Format | Produced | **Opened & inspected** | Real data | Evidence |
+|---|---|---|---|---|
+| `.docx` | ✅ | ✅ | ✅ **live FortiGate** | Change record from `fgt_system_status` + `fgt_list_interfaces` on FGVMEVS9GWUAOMBD, reopened with python-docx; footer, 4 tables, Sources section, per-row attribution all read back |
+| `.xlsx` | ✅ | ✅ | ✅ **live FortiGate** | Interface audit reopened with openpyxl; banner `4 attempted · 2 returned data · 2 failed`, Source + As-of columns populated, two failed planes present as marked rows |
+| `.pptx` | ✅ | ✅ | ✅ **live FortiGate** | 5-slide deck reopened with python-pptx; source text found in a **shape** on every slide, 1 embedded picture, gap rendered on-slide |
+| `.pdf` (form fill) | ✅ | ✅ | ✅ **live FortiGate** | Serial/firmware/HA filled from real device state, reopened with PyMuPDF; `reviewer_signature` left genuinely empty, `site_code` reported unmatched, input byte-identical |
+
+**All four formats were produced from real device data and opened.** None is claimed on the strength of a
+code path that merely ran.
+
+## The lab
+
+| | |
+|---|---|
+| Device | FortiGate-VM64-HV, Hyper-V, `192.168.2.130` |
+| Serial | `FGVMEVS9GWUAOMBD` · FortiOS **7.6.7** build 3704 |
+| Data source | `fortinet-mcp` device plane, read-only `netclawapi` token |
+| Source as-of | `2026-08-03T18:19:57Z` — **distinct from** the documents' generation time `18:20:58Z` / `18:22:18Z`, which is what makes FR-010 testable rather than trivially true |
+| Diagram | Real PNG from **Kroki** (`uml-diagram`'s backend), written to `workspace/output/uml-diagram/` and embedded with `src: uml-diagram` |
+| ServiceNow | ❌ not configured — see below |
+
+## Per-capability status
+
+### The chokepoint — VERIFIED
+
+| Guarantee | Status |
+|---|---|
+| Every response passes `emit()`/`refused()` | ✅ asserted by source inspection in `test_manifest_size.py` |
+| No writer imports `envelope` | ✅ asserted for all four writers |
+| Artefact with an empty ledger raises `ProvenanceError` | ✅ tested |
+| A caller cannot set `generated_at`/`generated_by` | ✅ tested |
+| A caller cannot report a gapped document as `ok` | ✅ tested — `ok` was passed, `written_with_gaps` came back |
+| GAIT record on success **and refusal** | ✅ log read back, both outcomes present |
+
+### No fabrication — VERIFIED
+
+| Guarantee | Status | Evidence |
+|---|---|---|
+| Value without `src` refused | ✅ | `refused_unattributed` |
+| Bare scalar refused | ✅ | `refused_untyped`, all of int/str/bool/None/list |
+| `unavailable` ≠ `failed` ≠ `{"v":""}` | ✅ | three distinct rendered strings, asserted on text |
+| Gap never renders as `N/A`/`0`/`-`/blank | ✅ | runtime guard in `render_tagged` **plus** a text assertion on the opened file |
+| Gap with no reason refused | ✅ | "a blank wearing a label" |
+| Failed devices are rows, not omissions | ✅ | live: fortimanager + fortianalyzer present as marked rows |
+| Row count = attempted, not succeeded | ✅ | live banner reads `4 attempted` |
+| Admin vs operational state separate | ✅ | merged `status`/`state`/`up-down` refused; live audit has both columns |
+| Sources that disagree both rendered | ✅ | both values + caveat, no winner picked |
+| Prose asserting a bare figure flagged | ✅ | fires on "We observed 12 interfaces"; does **not** fire on dates, CR numbers, IPs, versions, "Section 2" |
+
+### Provenance — VERIFIED (by opening files)
+
+| Guarantee | Status |
+|---|---|
+| Generation time + NetClaw in `.docx` footer | ✅ read back from the section footer |
+| Source column on every table, no empty source cell | ✅ asserted per row |
+| Source's own as-of preserved and distinct from generation time | ✅ 18:19:57Z vs 18:20:58Z in the live document |
+| Sources section in every file | ✅ `.docx` section, `.xlsx` sheet, `.pptx` slide |
+| `.pptx` source in a **shape**, not only notes | ✅ asserted against shape text |
+| Survives copy-paste and print | ✅ table text extracted; `word/comments.xml` absent |
+
+### Content safety — VERIFIED
+
+Measured: `ws["A1"] = "=1+1"` produces `<c r="A1"><f>1+1</f>…` — a live formula. Mitigated and asserted
+against **raw worksheet XML**: no `<f>` element for any of six hostile inputs, values round-trip exactly
+(no apostrophe corruption), numbers stay numeric.
+
+### Output convention — VERIFIED
+
+Same-second writes produce two files with the first byte-identical afterwards; collision suffix recorded;
+unwritable directory raises with nothing written anywhere else; reported path is the real one.
+
+## Unverified, and stated as such
+
+| Item | Why | What would close it |
+|---|---|---|
+| **ServiceNow CR half of US1** | ServiceNow is not configured on this deployment. The live change record was produced from **real device state** with the CR field explicitly rendered as `NOT AVAILABLE — ServiceNow is not configured … hand-supplied and unverified`. The composition against a real CR has **not** run. | A configured ServiceNow instance |
+| **`.pptx` embed from `drawio-diagram` / `threejs-network-viz`** | Verified with a real PNG from **Kroki**, which is `uml-diagram`'s backend — so FR-014 is exercised against a genuine diagram-skill artefact. The other three diagram skills produce HTML or need a display and were not exercised. | Running those skills to a raster artefact |
+| **Checkbox / radio / combobox PDF fields** | Only `text` widgets were exercised. The kind mapping for the other six `PDF_WIDGET_TYPE_*` values is coded from the PyMuPDF constants and **not observed**. | A form with non-text fields |
+| **50,000-row worksheet at full scale** | Truncation logic verified at a bound of 2. The 50,000 default was never reached — no data source here produces that many rows. | A large real inventory |
+| **iN2N member usage** | **Not applicable by decision, not by omission.** This capability holds no credentials and composes across domains, so it is Border work by construction; a member would be composing data it cannot reach. FR-039's five member artifacts plus `systemctl --user restart netclaw-mesh.service` are therefore **not triggered** — and apply in full if a member is ever given it. | A decision to change that |
+
+## Found and not fixed — pre-existing, surfaced by this feature
+
+Teaching `check-dependency-pins.py` to read `pyproject.toml` and to map distribution names to module names
+surfaced **14 real hazards across 10 servers** that had never been visible. The baseline `reconcile-mcp.py`
+exited 0 because those files were never read, not because they were correct.
+
+**Fixed here** (tracked, NetClaw-maintained):
+
+| Server | Was | Now |
+|---|---|---|
+| `rag-mcp` | 13 dependencies, **all unbounded**, in a `pyproject.toml` the checker never read | all bounded to installed majors |
+| `memory-mcp` | `mcp` unpinned, `chromadb>=0.4.0` | `mcp>=1.2.0,<2`, `chromadb>=0.4.0,<2` |
+| `azure-network-mcp` | `azure-identity>=1.15.0` while importing `azure.identity` | `<2` added |
+
+**Recorded as exceptions, not fixed** — 11 findings across 8 servers
+(`AAP-Enterprise-MCP-Server`, `gait_mcp`, `infrahub-mcp`, `junos-mcp-server`, `mcp-nautobot`, `mcp-nvd`,
+`meraki-magic-mcp-community`, `servicenow-mcp`):
+
+Every one is a real hazard of exactly the class the checker exists to catch — mostly unbounded `mcp` while
+importing `mcp.server.fastmcp`, the breakage spec 077 calls no longer hypothetical. They are **untracked
+upstream clones**: `git ls-files` returns nothing for those directories, so a local pin is not committable,
+evaporates on the next re-clone, and would leave a fixed-looking check guarding nothing. Each carries a
+named reason in `PIN_EXCEPTIONS` saying exactly that, and the comment there says to delete the line the
+moment any of them is vendored into the repo.
+
+**Closing them needs an upstream pin or a change to the vendoring policy, not a local edit.** Recorded here
+so the next reader inherits the finding rather than rediscovering it.
+
+## Backwards compatibility (Principle XV)
+
+`rag-mcp`'s dependency file was edited by this feature, which obliges proving rag-mcp still works (FR-032d).
+It was re-exercised **on the four documents document-mcp had just generated**: `parse_file` returned
+`ParsedDocument` for all four — 4 parsed, 0 failed. No installed version moved (SC-018): python-docx 1.2.0,
+openpyxl 3.1.5, python-pptx 1.0.2, PyMuPDF 1.28.0, before and after.
+
+## Licence (FR-028/029/029a, SC-017)
+
+Verified by inspection and grep across the installer, both skills, the server and the docs:
+
+- No file copied from `anthropics/skills`; no reference to it in any shipped artifact.
+- **No `git clone`, `curl`, `wget`, or URL-based `pip install`** anywhere in this feature's code or its
+  install function.
+- The finding — those skills are source-available, *"provided for demonstration and educational purposes
+  only"*, not Apache-2.0 — is recorded durably in `docs/COVERAGE-ROADMAP.md` (with the roadmap's
+  "vendor the four official skills" item struck and the reason given) and in `research.md` D1.
+
+## Checks
+
+| Check | Result |
+|---|---|
+| `bash tests/document/run-tests.sh` | ✅ **240 assertions, 7 suites, exit 0** |
+| `python3 scripts/reconcile-mcp.py` | ✅ exit 0 — all four surfaces |
+| `python3 scripts/verify-inventory-counts.py` | ✅ exit 0 — **209 skills / 155 integrations** |
+| `python3 scripts/trace-skill.py document-generation` | ✅ exit 0 |
+| `python3 scripts/trace-skill.py network-report-documents` | ✅ exit 0 |
+| Manifest size | ✅ **1,232 / 5,000 tokens** |
+| `node --check ui/netclaw-visual/server.js` | ✅ |
+| `bash -n scripts/lib/{catalog,install-steps}.sh` | ✅ |
+
+## Findings worth keeping
+
+- **`check-dependency-pins.py` read `requirements.txt` only.** rag-mcp has none. A server declaring
+  dependencies in `pyproject.toml` was invisible to the spec-077 checker entirely, and its clean bill of
+  health was an artefact of that invisibility. Fixed permanently, not per-instance.
+- **The checker also matched by *distribution* name.** `pymupdf`→`fitz`, `python-docx`→`docx`,
+  `beautifulsoup4`→`bs4` never met their imports, so even a scanned file would have passed. An alias map now
+  covers the renames actually present in this repo.
+- **openpyxl turns a leading `=` into a live formula.** Not theoretical: the strings this server writes come
+  from device descriptions and ticket fields. Only the raw-XML assertion catches it — `data_type == "s"` is
+  an openpyxl-level claim, `<f>` absent from `sheet1.xml` is a claim about the file an auditor opens.
+- **`python-docx` 1.2.0 has no footnote API.** It has `add_comment`, which is the tempting answer and the
+  wrong one: comments are collapsed by default, stripped on paste, and invisible in print. Inline
+  attribution is more visible, not less.
+- **`doc.is_form_pdf` returns an `int`** (measured: 3), not a bool. Compare truthily; `is True` fails.
+- **Feature 046's output convention relies on timestamp uniqueness alone.** Two documents in the same second
+  collide, and `write_text` would silently replace the first. `O_EXCL` is the difference between "unlikely to
+  overwrite" and "cannot".
+- **A plan can ship a false technical claim.** This one justified the `_writer` filename suffix as avoiding
+  package shadowing. Measured after `/speckit.analyze` challenged it: inside the `writers/` package, absolute
+  imports resolve to the real third-party package and there is no shadowing. The names were kept for real
+  reasons; the wrong reason was withdrawn (research D14).
+- **README was two specs behind.** No MCP table rows for Fortinet (080) or BGP-intel (081), and no
+  `fortigate-ops` / `fortianalyzer-ops` / `bgp-registry-intel` skill rows, even though SOUL.md and TOOLS.md
+  had been updated. `verify-inventory-counts.py` misses this because it checks headline arithmetic, not table
+  membership. Fixed here; the checker's blind spot remains.

--- a/specs/082-document-generation/checklists/requirements.md
+++ b/specs/082-document-generation/checklists/requirements.md
@@ -1,0 +1,151 @@
+# Specification Quality Checklist: Document Generation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+  - Library *names and installed versions* appear only as a dependency-availability finding (FR-030) and as
+    evidence for the licence/pin decisions. No code structure, module layout, or API design is specified.
+- [x] Focused on user value and business needs
+  - The framing is the deliverable gap: NetClaw's output lands in front of CABs, auditors and directors who
+    work in Office documents.
+- [x] Written for non-technical stakeholders
+  - The core discipline ("a document must never fabricate to fill a blank") is stated in plain terms an
+    auditor would recognise.
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+  - Five decisions were deferred to `/speckit.clarify` rather than assumed. **All five are now resolved** —
+    see `## Clarifications` in the spec and **Decisions taken in clarification** below.
+- [x] Requirements are testable and unambiguous
+  - Each FR states an observable behaviour. The negative requirements (FR-001 through FR-004) are testable by
+    opening a generated document with a known-missing input.
+- [x] Success criteria are measurable
+  - 22 SCs. SC-009 and SC-020 specifically require *opening the file*, not inspecting code.
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+  - 4 user stories, 14 scenarios.
+- [x] Edge cases identified
+  - 7, including two that only exist because the output is a document: filename collision against a file
+    already attached to a ticket, and untrusted source text being interpreted as a spreadsheet formula.
+- [x] Scope is clearly bounded
+  - Three explicit boundaries (FR-035/036/037) against diagram skills, rag-mcp, and
+    servicenow-change-workflow. Out of Scope names six exclusions.
+- [x] Dependencies and assumptions identified
+  - All four libraries measured as already installed; the rag-mcp unpinned-declaration hazard is recorded
+    rather than glossed.
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation leakage into specification
+
+## Constitutional Alignment
+
+- [x] **Principle IV** (immutable GAIT audit) — FR-034, SC-019: every generation including failures.
+- [x] **Principle VII** (skill modularity) — FR-035/036/037 draw the boundaries so this does not absorb
+      diagram rendering, document ingestion, or CR lifecycle management.
+- [x] **Principle XI** (artifact coherence) — FR-038 through FR-041 enumerate every surface, including both
+      HUD entries and curated profile membership, plus FR-039's iN2N member artifacts.
+- [x] **Principle XIII** (credential safety) — no credentials are introduced (Assumptions); data arrives from
+      skills that already hold their own.
+- [x] **Principle XIV** (externally-visible actions) — sending a document anywhere is explicitly Out of
+      Scope; writing a file is not an outward-facing action.
+- [x] **Principle XVI** (spec-driven) — this document.
+- [x] **Principle XVII** (blog milestone) — waived by standing operator decision.
+
+## Lessons Carried Forward
+
+- [x] **Spec 076** — do not move a shared dependency version (the `cryptography` incident). FR-030.
+- [x] **Spec 077** — `netclaw_pip_install`, never bare pip; upper-bound any pin whose submodule is imported.
+      FR-031, FR-032.
+- [x] **Spec 078** — record what was not exercised rather than claiming it. FR-042, FR-043, SC-020.
+- [x] **Spec 080** — administrative and operational state stay separate columns (FR-015); and the deeper
+      lesson that **passing structural tests do not prove the payload is populated** — which is exactly why
+      SC-009 and SC-020 require opening the file.
+- [x] **Spec 081** — per-element provenance, not one collective citation. FR-009, SC-010.
+
+## Notes
+
+### What makes this feature's central risk new
+
+Specs 078–081 each protected a distinction in *tool output*, which is ephemeral — read once, in context, by
+the person who asked. A document is not: it is emailed, filed, and read months later by someone who was not
+there, and it carries the authority of its formatting. That is why FR-001 through FR-005 are stated as
+prohibitions rather than preferences, and why provenance must be durable in the document body (FR-008)
+rather than in a filename or a tool response.
+
+### The licence finding changes the roadmap's plan
+
+The roadmap directed *"vendor the four official skills; note their licence terms explicitly."* Noting the
+terms **is** the finding: measured 2026-08-03, the four `anthropics/skills` document skills are
+source-available and demonstration-only, not Apache-2.0. Vendoring them into NetClaw is not licence-
+compatible, so R18 becomes build-rather-than-adopt — for a **licensing** reason, which is a different
+situation from R1/R3/R9 where community options were technically inadequate. FR-028/FR-029.
+
+### Decisions taken in clarification (session 2026-08-03)
+
+All five resolved. Nothing outstanding blocks `/speckit.plan`.
+
+1. **Licence approach** → **Build NetClaw's own outright.** Upstream cited as capability reference only;
+   never vendored, and **no install or fetch path for it** (FR-029a, SC-017). One Apache-2.0 code surface.
+2. **Tool surface** → **One MCP server + skills on top.** The server owns all writing and stamps generation
+   time, attribution and per-element provenance at a single chokepoint; unavailable and failed are typed
+   states a caller cannot express as a blank (FR-005a–d). Skills own the four compositions and contain no
+   writing logic. Manifest ≤ 5,000 tokens (FR-038a). *Rationale: prose guidance in a skill cannot enforce
+   FR-001–FR-004; the envelope chokepoint from specs 080/081 can.*
+3. **Provenance rendering** → **Visible per-element attribution plus a sources section** (FR-008a, FR-009a).
+   Source column per spreadsheet row; visible inline/footnoted source per figure in documents and decks; a
+   sources section with as-of times in every file. **Hidden mechanisms — cell comments, tooltips, document
+   metadata — do not satisfy the requirement** and may only be additive. Verified by a forwarding/print test
+   (SC-010b). *Rationale: comments are hidden by default, stripped on paste, and absent in print, which are
+   exactly the scenarios FR-008 exists for.*
+4. **Templates** → **Scratch-only for docx/xlsx/pptx; PDF form filling stays** (FR-023a, FR-024a/b). An
+   Office template is rejected with a stated reason. Corporate-branded-template support is an explicit
+   follow-on. *Rationale: a PDF form's fields are explicitly named and machine-readable, so "no data for this
+   field" is unambiguous; Word/PowerPoint placeholder-matching is the guessing version of the same problem.*
+5. **Dependency pinning** → **Upper-bounded pins here, and rag-mcp's declaration corrected to match**
+   (FR-032a–d). Bounds describe the already-installed majors; **no installed version moves** (SC-018), and
+   rag-mcp ingestion is re-exercised afterwards (SC-018e). *Rationale: two servers declaring conflicting
+   requirements for one shared install is worse than either option alone, and PyMuPDF-as-`fitz` is precisely
+   spec 077's submodule case.*
+
+### `/speckit.analyze` remediation (2026-08-03) — all 14 findings fixed
+
+Two HIGH, seven MEDIUM, five LOW. Every one applied before implementation; nothing accepted as known-debt.
+
+| ID | Fix |
+|---|---|
+| C1 | Template rejection extended to `xlsx_write` (T067a) and `pptx_write` (T081a) via a shared helper, plus a parametrised test (T057b). It had been tasked for `.docx` only. |
+| C2 | Licence verification task added (T122a) — the constraint that redefined R18 had **zero** tasks. |
+| C3 | FR-036/FR-037 boundaries now required in the skills, TOOLS.md and server README (T109b, T110a, T116, T123). Only FR-035 had been tasked. |
+| C4 | FR-004's no-inference prohibition added to **both** SKILL.md files (T109a, T110a) — the server cannot fabricate, but the composing agent can, and that half had no home. |
+| C5 | `test_manifest_size.py` wired into `run-tests.sh` (T119a); it would otherwise never have run. |
+| C6 | Source disagreement promoted from an unbacked edge case to FR-027b + SC-027, with T047b and T057a. |
+| C7 | The iN2N Border-only decision now lands in a shipped artifact (T124a), not just the plan. |
+| F1 | research.md D9's filenames corrected to match plan.md and tasks.md. |
+| F2 | plan.md's shadowing rationale was **measured false** and withdrawn; research D14 records the measurement. The naming is kept for real reasons. |
+| U1 | The prose lint's trigger is now defined with an allow-list; "contains a bare number" would have fired on every date. |
+| U2 | The read-only surface guard's predicate restated — four of six tools *do* write files, so the original wording was wrong, not merely vague. |
+| U3 | Merged-state detection enumerated instead of gestured at. |
+| A1 | FR-027a added: `.docx` blocks and `.pptx` slides are now bounded, not spreadsheets alone. |
+| A2 | `output_id` (input) vs `safe_id` (sanitised) relationship stated once. |
+| D1 | The overloaded SC-018a–e block split: dependency claims stay at SC-018/018a/018b, structural claims move to SC-023/024/025. Two duplicate SCs I introduced during remediation (SC-026/027 restating SC-017/SC-008b) were removed rather than left. |
+
+**Post-remediation traceability**, verified mechanically: 60 FRs, 33 SCs, **145 tasks**, every requirement
+has ≥1 task, no task references a requirement that does not exist.
+
+### Deferred to planning (not clarification-blocking)
+
+- **Scale bound for large datasets** (FR-027, SC-016) — the requirement that a bound exist and be stated *in
+  the document* is fixed; the specific number is a planning decision informed by what `openpyxl` handles
+  comfortably.
+- **Whether an iN2N member gets this capability** (FR-039) — the obligation is conditional and the five
+  member artifacts are already enumerated; which member, if any, is a planning call.

--- a/specs/082-document-generation/contracts/mcp-tools.md
+++ b/specs/082-document-generation/contracts/mcp-tools.md
@@ -1,0 +1,227 @@
+# Tool Contract — `document-mcp` (spec 082 / roadmap R18)
+
+**Server**: `mcp-servers/document-mcp/server.py` · **Transport**: stdio · **Credentials**: none
+**Manifest budget**: ≤ 5,000 tokens (FR-038a) · **Writes**: files only, never a device or a ticket (FR-033)
+
+Six tools. Composition lives in skills, not here (FR-005d).
+
+---
+
+## Shared types
+
+### `TaggedValue` — required wherever a document asserts a value
+
+Exactly one of:
+
+```jsonc
+{"v": <scalar>, "src": "<tool or system>", "device": "<optional>", "as_of": "<optional ISO-8601>"}
+{"unavailable": "<reason>"}
+{"failed": "<reason>"}
+```
+
+`v` without `src` → **refused**. A bare scalar → **refused**. `{"v": ""}` is legal and means the source
+genuinely returned empty — a different fact from `unavailable`.
+
+### Every response envelope
+
+```jsonc
+{
+  "source": "document-mcp",
+  "generated_at": "2026-08-03T14:02:00Z",
+  "outcome": "ok" | "written_with_gaps" | "truncated" | "refused_unattributed" |
+             "refused_untyped" | "refused_template" | "refused_merged_status" |
+             "not_fillable" | "output_unwritable" | "source_missing",
+  "tool": "<tool name>",
+  "artifact": {"path": "...", "bytes": 12345, "created_at": "...", "collision_suffix": null} | null,
+  "sources_consulted": [{"src": "...", "device": "...", "as_of": "...", "element_count": 12,
+                         "status": "ok" | "partial" | "failed"}],
+  "gaps": {"unavailable": 3, "failed": 1},
+  "caveats": ["..."],
+  "message": "<present on any non-ok outcome>"
+}
+```
+
+`generated_at`, `source` and the in-document stamp are set at the chokepoint. **No tool accepts them as
+parameters.** Every response, including refusals, is GAIT-audited (FR-034).
+
+---
+
+## 1. `docx_write`
+
+Build a Word document from an ordered block list.
+
+```jsonc
+{
+  "title": "Change Record CHG0012345",
+  "blocks": [
+    {"type": "heading", "text": "Pre-change state", "level": 1},
+    {"type": "paragraph", "text": "State captured before the window opened."},
+    {"type": "keyvalue", "pairs": [
+       {"label": "Hostname", "value": {"v": "fgt-01", "src": "fgt_system_status",
+                                       "as_of": "2026-08-03T13:58:00Z"}},
+       {"label": "Serial",   "value": {"unavailable": "device did not answer"}}]},
+    {"type": "table", "caption": "Interfaces",
+     "columns": ["Interface", "Admin state", "Oper state"],
+     "rows": [[{"v":"port1","src":"fgt_list_interfaces","device":"fgt-01"},
+               {"v":"up","src":"fgt_list_interfaces","device":"fgt-01"},
+               {"v":"down","src":"fgt_list_interfaces","device":"fgt-01"}]]},
+    {"type": "image", "path": "workspace/output/drawio-diagram/topo-....png",
+     "caption": "Topology", "src": "drawio-diagram"}
+  ],
+  "output_id": "chg0012345"
+}
+```
+
+**Block types**: `heading`, `paragraph`, `figure`, `table`, `keyvalue`, `image`, `pagebreak`.
+
+**Guarantees**
+- A `Source` column is **appended by the writer** to every `table` and `keyvalue` — the caller cannot omit it.
+- Every page footer carries generation time and NetClaw attribution.
+- A visible `Sources` section is appended.
+- `paragraph` accepts no TaggedValue; prose containing a bare number emits a caveat naming the block index
+  (see the note in data-model.md §4 — prose is where an unattributed figure would hide).
+- `image.path` must exist and be inside the workspace output dir, and `src` must name the producing skill
+  (FR-014) → else `source_missing`.
+- No footnotes: python-docx 1.2.0 has no footnote API (research D3), so attribution is inline.
+- Any `template` / `template_path` parameter → **`refused_template`** (FR-023a).
+
+---
+
+## 2. `xlsx_write`
+
+```jsonc
+{
+  "sheets": [
+    {"name": "Interfaces",
+     "columns": ["Device", "Interface", "Admin state", "Oper state", "Address"],
+     "rows": [[{"v":"fgt-01","src":"fgt_list_interfaces"}, ...]],
+     "failed_rows": [{"label": "fgt-02", "failed": "connection refused"}]}
+  ],
+  "output_id": "interface-audit"
+}
+```
+
+**Guarantees**
+- A `Source` and an `As of` column are appended to every sheet.
+- `failed_rows` render **as rows**, visually marked, and are counted (FR-003).
+- A banner row states *attempted / succeeded / failed* (SC-004).
+- A `Sources` sheet is always added.
+- **Every string cell is forced to `data_type = 's'`** so a leading `=` cannot become a live formula
+  (FR-026 / research D5, measured).
+- A column named `status` combining admin and operational state → **`refused_merged_status`** (FR-015).
+- Row bound: default 50,000 data rows per sheet. On truncation → `truncated`, and the bound is written
+  **into the sheet** (FR-027), not only into this response.
+
+---
+
+## 3. `pptx_write`
+
+```jsonc
+{
+  "title": "Fortinet posture review",
+  "slides": [
+    {"layout": "bullets", "title": "What we found",
+     "bullets": ["Two interfaces admin-up with no carrier"], "detail_ref": "Interface detail"},
+    {"layout": "figure", "title": "Scope",
+     "figures": [{"label": "Interfaces reviewed",
+                  "value": {"v": 2, "src": "fgt_list_interfaces", "device": "fgt-01"}}]},
+    {"layout": "image", "title": "Topology",
+     "image": {"path": "workspace/output/threejs-network-viz/....png", "src": "threejs-network-viz"}}
+  ],
+  "output_id": "posture-review"
+}
+```
+
+**Guarantees**
+- Any slide with a `figure` gets a **visible** on-slide source line — speaker notes are hidden and do not
+  count (FR-008a / research D4).
+- A `Sources` slide is always appended.
+- A slide with `bullets` and no `detail_ref` emits a caveat: a summary claim should be traceable (FR-005).
+- Diagrams are embedded, never drawn here (FR-014).
+
+---
+
+## 4. `pdf_inspect_form`
+
+```jsonc
+{"path": "/abs/or/repo-relative/form.pdf"}
+```
+
+Returns the PDF's named fields so a caller can map data to fields it has actually seen, rather than
+inventing names.
+
+```jsonc
+{"outcome": "ok",
+ "data": {"fillable": true, "field_count": 3,
+          "fields": [{"name": "change_number", "kind": "text", "current_value": "", "page": 0}]}}
+```
+
+Not a form → `not_fillable` with a message. (`doc.is_form_pdf` returns an **int**, measured `3`; compared
+truthily.)
+
+---
+
+## 5. `pdf_fill_form`
+
+```jsonc
+{"path": "form.pdf",
+ "values": {"change_number": {"v": "CHG0012345", "src": "servicenow_get_change"},
+            "approver":      {"unavailable": "no approver recorded on the CR"}},
+ "output_id": "chg0012345-form"}
+```
+
+```jsonc
+{"outcome": "written_with_gaps",
+ "artifact": {"path": "workspace/output/document-mcp/pdfform-20260803T140200Z-chg0012345-form.pdf"},
+ "data": {"filled": ["change_number"],
+          "unfilled": ["approver", "device_hostname"],
+          "unmatched": []}}
+```
+
+**Guarantees**
+- The **input PDF is never modified** — a new file is always written.
+- `unavailable` / `failed` leave the field genuinely empty and appear in `unfilled` (FR-024b, US4 §2).
+- Supplied keys matching no field appear in `unmatched` and are **never dropped silently** (FR-024b).
+- Only named fields are written; no positional text placement (FR-024a).
+- Non-fillable → `not_fillable`, **no output file** (FR-024).
+- Because a filled PDF has nowhere to put a Sources section without altering the customer's form, the
+  provenance for a fill lives in the **GAIT record and the response**, and this is stated as an explicit
+  limitation in the skill. It is the one format where FR-008 cannot be met inside the artefact, and saying so
+  is required rather than pretending otherwise.
+
+---
+
+## 6. `list_documents`
+
+```jsonc
+{"kind": "docx" | "xlsx" | "pptx" | "pdf" | null, "limit": 50}
+```
+
+Lists what has been generated, newest first, so an operator can find a file. Read-only; touches nothing.
+
+---
+
+## Refusals — the disclosure controls
+
+| Condition | Outcome | Why it is a refusal and not a warning |
+|---|---|---|
+| `v` without `src` | `refused_unattributed` | An unattributed figure in a durable artefact is the failure mode this feature exists to prevent (FR-007) |
+| Bare scalar for a TaggedValue | `refused_untyped` | Accepting it would let a caller express missing data as a blank (FR-005c) |
+| Office template supplied | `refused_template` | Out of scope by clarification; silently ignoring it would produce an unbranded document the operator believes is branded (FR-023a) |
+| Merged admin/oper `status` column | `refused_merged_status` | The distinction spec 080's completion established (FR-015) |
+| Output dir missing/unwritable | `output_unwritable` | No silent fallback to a temp dir the operator will never find (FR-020) |
+| `image.path` missing or outside the output dir | `source_missing` | An embedded diagram must be a real artefact from a real skill (FR-014) |
+
+Every refusal is GAIT-audited exactly like a success (FR-034).
+
+---
+
+## What this server will not do
+
+- **Send anything.** Writing a file is in scope; emailing, posting to Slack, or attaching to a ticket is
+  Principle XIV territory and belongs to `slack-report-delivery` / `webex-report-delivery`.
+- **Create or update a ticket.** `servicenow-change-workflow` owns the CR lifecycle (FR-037).
+- **Draw a diagram.** `drawio-diagram`, `markmap-viz`, `uml-diagram`, `threejs-network-viz` own that; this
+  embeds their output (FR-014, FR-035).
+- **Read documents.** `rag-mcp` ingests these formats; this writes them (FR-036).
+- **Touch a device.** No device access, so no approval or change-record gate exists here (FR-033).

--- a/specs/082-document-generation/data-model.md
+++ b/specs/082-document-generation/data-model.md
@@ -1,0 +1,235 @@
+# Data Model — Document Generation (spec 082 / roadmap R18)
+
+**Date**: 2026-08-03 · Derived from spec.md Key Entities + research.md D8
+
+No database. Every entity here is an in-memory shape passed across the MCP boundary or written into a file.
+The point of typing them is FR-005c: **the honest representation must be the only expressible one.**
+
+---
+
+## 1. TaggedValue — the load-bearing type
+
+Every populated field in every document is one of exactly three shapes. This is what makes FR-001–FR-004
+enforceable rather than aspirational.
+
+```jsonc
+// (a) a real value, with where it came from
+{ "v": <string|number|bool>, "src": "fgt_list_interfaces", "device": "fgt-01",
+  "as_of": "2026-08-03T14:02:00Z" }
+
+// (b) no data — the source was consulted and had nothing, or was never reachable for this field
+{ "unavailable": "device did not answer within timeout" }
+
+// (c) the source errored
+{ "failed": "FortiGate plane unreachable: connection refused" }
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `v` | in shape (a) | May be `""` — meaning *the source genuinely returned empty*, which is a **different fact** from `unavailable` and renders differently |
+| `src` | **yes, in shape (a)** | Tool or system name. Absent → `ProvenanceError`, refused. Never defaulted. |
+| `device` | no | Device, record or account the value came from, when there is one |
+| `as_of` | no | The **source's** own as-of time (FR-010). Distinct from the document's generation time. Absent means the source did not provide one — not that it equals generation time. |
+| `unavailable` | in shape (b) | Free text reason, rendered verbatim |
+| `failed` | in shape (c) | Free text reason, rendered verbatim |
+
+### Validation rules
+
+| Rule | Violation → |
+|---|---|
+| Exactly one of `v` / `unavailable` / `failed` present | `refused`, message naming the field path |
+| `v` present without `src` | `refused` — **FR-007**. An unattributed figure is not renderable. |
+| A bare scalar where a TaggedValue is expected | `refused`, message naming the field path and showing the accepted shapes |
+| `as_of` not ISO-8601 | `refused` |
+| `unavailable` / `failed` with an empty reason | `refused` — "unavailable" with no reason is a blank wearing a label |
+
+### Rendering contract
+
+| Shape | Renders as |
+|---|---|
+| `{"v": x, ...}` | `x`, with visible attribution (column / inline parenthetical) |
+| `{"v": ""}` | `(empty)` — explicit, plus attribution. The source *was* consulted. |
+| `{"unavailable": r}` | `NOT AVAILABLE — <r>` |
+| `{"failed": r}` | `RETRIEVAL FAILED — <r>` |
+
+`unavailable` and `failed` **never** render as an empty cell, `N/A`, `0`, `-`, or whitespace (FR-001).
+
+---
+
+## 2. SourceRecord — one entry in the Sources section
+
+Accumulated by the chokepoint from every TaggedValue seen, deduplicated by `(src, device)`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `src` | string | Tool or system name |
+| `device` | string? | Device/record scope, if any |
+| `as_of` | string? | Latest as-of seen for this source |
+| `element_count` | int | How many elements in this document came from it |
+| `status` | enum | `ok` \| `partial` \| `failed` — `partial` when this source produced both values and unavailables |
+
+Every generated file carries a **Sources section** built from these (FR-009a): a `Sources` section in
+`.docx`, a `Sources` worksheet in `.xlsx`, a `Sources` slide in `.pptx`. Required **in addition to**
+per-element attribution, never instead of it.
+
+---
+
+## 3. DocumentStamp — the every-document header/footer
+
+| Field | Type | Source |
+|---|---|---|
+| `generated_at` | ISO-8601 UTC | Server clock at write time (FR-006) |
+| `generated_by` | string | `"NetClaw"` + server version — constant, never caller-supplied |
+| `tool` | string | Which tool produced it |
+| `truncated` | bool | Whether a bound was applied (FR-027) |
+| `bound_applied` | int? | The bound, stated **in the document** when `truncated` |
+
+Rendered in the `.docx` section footer (every page), the `.xlsx` `Sources` sheet header **and** a frozen
+banner row on each data sheet, and the `.pptx` title slide plus the Sources slide.
+
+**Not caller-supplied.** A caller cannot set `generated_at` or `generated_by` — they are stamped at the
+chokepoint (FR-005b).
+
+---
+
+## 4. Document block types (`docx_write`)
+
+An ordered list. Each block is `{"type": ..., ...}`.
+
+| Type | Payload | Provenance handling |
+|---|---|---|
+| `heading` | `{"text": str, "level": 1-4}` | none (structural) |
+| `paragraph` | `{"text": str}` | none (structural narrative) |
+| `figure` | `{"label": str, "value": TaggedValue}` | inline parenthetical after the value (D3) |
+| `table` | `{"caption": str?, "columns": [str], "rows": [[TaggedValue]]}` | a `Source` column is **appended by the writer**, not by the caller |
+| `keyvalue` | `{"pairs": [{"label": str, "value": TaggedValue}]}` | two-column table + `Source` column |
+| `image` | `{"path": str, "caption": str, "src": str}` | `src` names the diagram skill that produced it (FR-014); a path outside the workspace output dir is refused |
+| `pagebreak` | `{}` | none |
+
+**`paragraph` carries no TaggedValue by design** — free prose is the one place a model could smuggle an
+unattributed figure. Any number a document asserts must be a `figure`, `table` or `keyvalue`, all of which
+force attribution. This is stated in the skill and enforced by a lint in the writer: a `paragraph` whose text
+matches a bare-number pattern emits a caveat naming the block index.
+
+---
+
+## 5. Worksheet model (`xlsx_write`)
+
+```jsonc
+{ "sheets": [ { "name": "Interfaces",
+                "columns": ["Device", "Interface", "Admin state", "Oper state", "Address"],
+                "rows": [ [TaggedValue, TaggedValue, ...] ],
+                "failed_rows": [ {"label": "fgt-02", "failed": "connection refused"} ] } ] }
+```
+
+| Rule | Why |
+|---|---|
+| The writer appends a `Source` column and an `As of` column | FR-009a, per-row visible attribution |
+| `failed_rows` are rendered **as rows**, visually marked, counted in the total | FR-003 — a shorter sheet reads as a smaller estate |
+| A row-count banner states *attempted / succeeded / failed* | SC-004 |
+| Admin and operational state are separate columns; a merged `status` is refused | FR-015 |
+| Every string cell is forced `data_type = 's'` after assignment | FR-026 / research D5 — a leading `=` otherwise becomes a live formula |
+| A `Sources` sheet is always added | FR-009a |
+
+---
+
+## 6. Slide model (`pptx_write`)
+
+```jsonc
+{ "slides": [ { "layout": "title" | "bullets" | "figure" | "image",
+                "title": str,
+                "bullets": [str]?,
+                "figures": [{"label": str, "value": TaggedValue}]?,
+                "image": {"path": str, "src": str}?,
+                "detail_ref": str? } ] }
+```
+
+| Rule | Why |
+|---|---|
+| Any slide carrying a `figure` gets a **visible** source line along the bottom | FR-008a / research D4 — speaker notes are hidden |
+| A `Sources` slide is always appended | FR-009a |
+| A summary claim carries `detail_ref` pointing at a detail slide or the Sources slide | FR-005, SC-003 of US3 |
+| `image.path` must be inside the workspace output dir and `src` must name the producing skill | FR-014 |
+| Speaker notes may repeat the detail — additive only | FR-008a |
+
+---
+
+## 7. PDF form model (`pdf_inspect_form`, `pdf_fill_form`)
+
+**FormField** (read, from `pdf_inspect_form`):
+
+| Field | Type | From |
+|---|---|---|
+| `name` | string | `widget.field_name` |
+| `kind` | enum | `text` \| `checkbox` \| `radio` \| `combobox` \| `listbox` \| `button` \| `signature` |
+| `current_value` | string | `widget.field_value` |
+| `page` | int | page index |
+
+**FillResult** (from `pdf_fill_form`):
+
+| Field | Type | Meaning |
+|---|---|---|
+| `filled` | [str] | Field names written |
+| `unfilled` | [str] | Named fields left genuinely empty (FR-024b) |
+| `unmatched` | [str] | Supplied keys matching no field — **never dropped silently** (FR-024b) |
+| `output_path` | str | The new file. The input PDF is never modified. |
+
+A PDF where `doc.is_form_pdf` is falsy → `outcome: not_fillable`, no output file (FR-024). Note
+`is_form_pdf` returns an **int** (measured: `3`); compare truthily.
+
+Fill values are `TaggedValue`s. `unavailable` / `failed` leave the field **empty** and are reported in
+`unfilled` — a form is never completed with a guess (FR-024b, US4 scenario 2).
+
+---
+
+## 8. Outcome — the response vocabulary
+
+Following spec 080's `Outcome` and spec 081's `outcomes.py` split.
+
+| Value | Means |
+|---|---|
+| `ok` | Document written |
+| `written_with_gaps` | Written, and it contains `unavailable` or `failed` elements — **stated, not hidden** |
+| `truncated` | Written, and a bound was applied; the bound is in the document |
+| `refused_unattributed` | A `v` arrived without a `src` |
+| `refused_untyped` | A bare scalar arrived where a TaggedValue was required |
+| `refused_template` | An Office template was supplied (FR-023a) |
+| `refused_merged_status` | Admin and operational state were merged into one column (FR-015) |
+| `not_fillable` | The PDF has no form fields |
+| `output_unwritable` | Directory missing or not writable — **no silent fallback** (FR-020) |
+| `source_missing` | An `image.path` does not exist or is outside the output dir |
+
+`ok` and `written_with_gaps` are deliberately distinct: a caller must not be able to read "success" and
+assume completeness.
+
+---
+
+## 9. OutputArtifact
+
+| Field | Type | Notes |
+|---|---|---|
+| `path` | str | `workspace/output/document-mcp/<kind>-<UTC stamp>-<safe-id>.<ext>` |
+| `bytes` | int | |
+| `created_at` | ISO-8601 UTC | |
+| `collision_suffix` | int? | Present when `-2`, `-3`… was needed |
+
+Written with `os.open(..., O_CREAT | O_EXCL | O_WRONLY)`. On `FileExistsError` the suffix increments — an
+existing file is **never** opened for writing (FR-018 / research D7). Feature 046's convention relies on
+timestamp uniqueness alone, which collides within the same second; this is the one place spec 082 tightens
+it.
+
+---
+
+## Entity relationships
+
+```
+DocumentRequest
+ ├─ blocks / sheets / slides / form-mapping
+ │    └─ TaggedValue  ──accumulated by──▶ SourceRecord ──renders──▶ Sources section
+ ├─ stamped at chokepoint with ──▶ DocumentStamp
+ ├─ written by ──▶ OutputArtifact  (O_EXCL)
+ └─ returns ──▶ Envelope { outcome, artifact, sources_consulted, caveats } ──▶ GAIT record
+```
+
+Every path passes through the chokepoint. There is no writer entry point that skips `DocumentStamp` or
+`SourceRecord` accumulation — that is the structural guarantee SC-018a tests.

--- a/specs/082-document-generation/plan.md
+++ b/specs/082-document-generation/plan.md
@@ -1,0 +1,238 @@
+# Implementation Plan: Document Generation (docx / pptx / xlsx / pdf)
+
+**Branch**: `082-document-generation` | **Date**: 2026-08-03 | **Spec**: [spec.md](./spec.md)
+**Roadmap**: R18, Tier 5 — *"Best effort-to-value ratio on the roadmap"*
+
+## Summary
+
+NetClaw's output lands in front of change advisory boards, auditors and directors — people who work in
+Office documents. It can render Three.js topologies, drawio, markmap, UML, Blender and UE5, and cannot
+produce a change-record `.docx`, an interface-audit `.xlsx`, an executive `.pptx`, or fill a PDF form. This
+closes that deliverable gap.
+
+**Approach**: one NetClaw-authored MCP server, `document-mcp`, owns all document writing behind a single
+chokepoint that stamps generation time, NetClaw attribution and per-element provenance on every artefact —
+the envelope pattern specs 080 and 081 used to make attribution structurally impossible to omit. Two skills
+sit on top: `document-generation` (the capability and its discipline) and `network-report-documents` (the
+four compositions). Six tools, no credentials, no device access, no ticket writes.
+
+**The core discipline is new in kind, not degree.** Specs 078–081 each protected a distinction in *tool
+output*, which is ephemeral. A document is emailed, filed, and read months later by someone who was not
+there, and it carries the authority of its formatting. So a missing value is a **typed state a caller cannot
+express as a blank**, not a convention a model is asked to follow.
+
+**Two roadmap assumptions were measured false and are corrected here**: the upstream skills cannot be
+vendored (source-available, demonstration-only — not Apache-2.0), and the dependency situation is worse than
+"already present for rag-mcp" implied — rag-mcp declares them unpinned in a `pyproject.toml` the spec-077
+checker has never read.
+
+## Technical Context
+
+**Language/Version**: Python 3.10+, system interpreter. No dedicated venv — the four libraries are already
+installed and shared with `rag-mcp`; a venv would duplicate hundreds of megabytes of wheels to no benefit.
+(Spec 076 needed one because Nornir/NAPALM/Netmiko conflicted; nothing here conflicts.)
+
+**Primary Dependencies** — all four **already installed**, measured 2026-08-03:
+
+| Distribution | Import | Installed | Declared bound |
+|---|---|---|---|
+| `python-docx` | `docx` | 1.2.0 | `>=1.1,<2` |
+| `openpyxl` | `openpyxl` | 3.1.5 | `>=3.1,<4` |
+| `python-pptx` | `pptx` | 1.0.2 | `>=1.0,<2` |
+| `PyMuPDF` | **`fitz`** | 1.28.0 | `>=1.24,<2` |
+| `mcp` | `mcp.server.fastmcp` | — | `>=1.2.0,<2` (load-bearing, spec 081) |
+
+No new packages. No installed version moves (FR-032c, SC-018).
+
+**Storage**: none. Files land in `workspace/output/document-mcp/` (gitignored, feature 046's convention).
+GAIT records append to `~/.openclaw/gait/document-mcp.jsonl`.
+
+**Testing**: `tests/document/run-tests.sh` — plain Python, stdlib only, no pytest, following
+`tests/bgp-intel/`. Suites **reparse the generated files and assert on their contents**, because spec 080
+shipped three nulls past 24 passing tests that only checked envelope shape.
+
+**Target Platform**: Linux, stdio MCP server invoked by OpenClaw.
+
+**Project Type**: MCP server + skills, matching every NetClaw-authored integration.
+
+**Performance Goals**: not latency-sensitive. Bound: 50,000 data rows per worksheet (`DOCUMENT_MAX_ROWS`),
+with the bound written **into the document** when applied (FR-027).
+
+**Constraints**: manifest ≤ 5,000 tokens (FR-038a); no credentials anywhere; read-only with respect to
+infrastructure (FR-033); never overwrite an output file (FR-018, enforced with `O_EXCL`).
+
+**Scale/Scope**: 6 tools, 2 skills, ~10 server modules, 7 test suites.
+
+## Constitution Check
+
+*GATE: passed before Phase 0; re-checked after Phase 1 below.*
+
+| Principle | Status | How |
+|---|---|---|
+| **I. Safety-First (NON-NEGOTIABLE)** | ✅ | No device access, no ticket writes, no destructive path. The only side effect is a new file in a gitignored directory. |
+| **II. Read-Before-Write** | ✅ n/a | No infrastructure write exists. `pdf_inspect_form` before `pdf_fill_form` is the same discipline applied to the one artefact this feature does read. |
+| **III. ITSM-Gated Changes** | ✅ n/a | FR-033: no device or ticket is touched, so no gate is designable. Stated explicitly rather than silently skipped — spec 080's analyze caught exactly this kind of omission. |
+| **IV. Immutable Audit Trail** | ✅ | FR-034/SC-019: every generation **including refusals** writes a GAIT record at the chokepoint. Verified by `test_provenance.py`, not merely asserted. |
+| **V. MCP-Native Integration** | ✅ | FastMCP, stdio, registered in `config/openclaw.json` with repo-relative paths. |
+| **VI. Multi-Vendor Neutrality** | ✅ | The server holds no vendor knowledge — it renders TaggedValues. Vendor specifics live in the upstream skills that produce the data. |
+| **VII. Skill Modularity** | ✅ | FR-035/036/037 draw hard boundaries against diagram skills, `rag-mcp`, and `servicenow-change-workflow`. FR-005d keeps writing logic out of skills and composition out of the server. |
+| **VIII. Verify After Every Change** | ✅ | Every acceptance test **opens the produced file**. FR-025/042/043: a code path that ran without error is not evidence. |
+| **IX. Security by Default** | ✅ | FR-026: untrusted text is forced to `inlineStr` so a leading `=` cannot become a live formula (measured, research D5). Embedded image paths are constrained to the workspace output dir. |
+| **X. Observability** | ✅ | GAIT per call; `list_documents` makes output discoverable; `written_with_gaps` is a distinct outcome from `ok` so incompleteness is observable. |
+| **XI. Artifact Coherence (NON-NEGOTIABLE)** | ✅ | FR-038–FR-041 enumerate all 14 checklist items plus the two easy-to-miss ones (curated profile membership; **both** HUD entries) and the SOUL capability section. `reconcile-mcp.py` must exit 0. |
+| **XII. Documentation-as-Code** | ✅ | spec, research, data-model, contracts, quickstart, 2 SKILL.md, server README, TOOLS.md, .env.example, VERIFICATION.md. |
+| **XIII. Credential Safety** | ✅ | No credentials exist in this feature. Data arrives from skills that already hold their own. Nothing to redact — but the GAIT record still logs shapes, not payloads. |
+| **XIV. Human-in-the-Loop for External Comms** | ✅ | **Sending is explicitly out of scope.** Writing a file is not an outward-facing action; `slack-report-delivery`/`webex-report-delivery` own delivery and already carry the gate. |
+| **XV. Backwards Compatibility** | ⚠️ **one touch** | This feature edits `mcp-servers/rag-mcp/pyproject.toml` (FR-032b) and `scripts/check-dependency-pins.py`. Both are additive-bound corrections that move no installed version; FR-032d requires re-exercising rag-mcp ingestion afterwards. See Complexity Tracking. |
+| **XVI. Spec-Driven Development** | ✅ | specify → clarify (5 Q) → plan → tasks → analyze → implement. |
+| **XVII. Milestone Documentation (WordPress)** | ⏭️ **waived** | Standing operator decision: blog posts skipped. Recorded, not silently dropped. |
+
+### Artifact Coherence Checklist (constitution §282) — mapped
+
+| Item | Target |
+|---|---|
+| README.md (description, architecture, counts) | new rows in the MCP table, 2 skill rows, 4 count sites → 155 / 209 |
+| `scripts/lib/catalog.sh` | `document\|Platform Services\|Document Generation\|…` + `PROFILE_RECOMMENDED` |
+| `scripts/lib/install-steps.sh` | `component_install_document()` |
+| `verify-catalog-coverage.py` | passes |
+| `ui/netclaw-visual/server.js` | **two** entries: `INTEGRATION_CATALOG` node + `ENV_MAP` annotation |
+| SOUL.md | capability section + 2 count sites → 209 / 155 |
+| `workspace/skills/<name>/SKILL.md` | `document-generation`, `network-report-documents` |
+| `.env.example` | 4 optional vars, box-header block |
+| TOOLS.md | `## Document Generation (\`document-mcp\`, NetClaw-native)` |
+| `config/openclaw.json` | `document-mcp` entry, repo-relative |
+| `mcp-servers/document-mcp/README.md` | created |
+| GAIT session log | recorded |
+| Existing skills unbroken | rag-mcp ingestion re-exercised (FR-032d) |
+| WordPress blog post | waived by operator |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/082-document-generation/
+├── plan.md                      # this file
+├── spec.md                      # 58 FRs, 31 SCs, 5 clarifications
+├── research.md                  # Phase 0 — 13 measured findings
+├── data-model.md                # Phase 1 — TaggedValue and friends
+├── quickstart.md                # Phase 1
+├── contracts/
+│   └── mcp-tools.md             # Phase 1 — 6 tools
+├── checklists/
+│   └── requirements.md
+├── VERIFICATION.md              # honest per-format status (FR-042/043)
+└── tasks.md                     # Phase 2 — /speckit.tasks
+```
+
+### Source code (repository root)
+
+```text
+mcp-servers/document-mcp/
+├── server.py                # FastMCP entrypoint, stdio, 6 @mcp.tool defs
+├── envelope.py              # THE CHOKEPOINT — emit/refused + GAIT      (FR-005b, FR-034)
+├── outcomes.py              # Outcome enum + TaggedValue vocabulary      (FR-005c)
+├── provenance.py            # SourceRecord accumulation, Sources model   (FR-006..FR-010)
+├── output.py                # O_EXCL timestamped writer                  (FR-016..FR-020)
+├── sanitize.py              # untrusted text; the openpyxl forced-string (FR-026)
+├── writers/
+│   ├── __init__.py
+│   ├── docx_writer.py       # inline Source column, footer, Sources section
+│   ├── xlsx_writer.py       # per-row Source column, failed rows, Sources sheet
+│   ├── pptx_writer.py       # visible on-slide source line, Sources slide
+│   └── pdf_writer.py        # named-field fill, unfilled/unmatched
+├── requirements.txt         # bounded pins
+└── README.md
+
+workspace/skills/
+├── document-generation/SKILL.md         # capability + discipline + limits
+└── network-report-documents/SKILL.md    # the four compositions
+
+tests/document/
+├── run-tests.sh
+├── test_tagged_values.py    # v-without-src refused; unavailable ≠ failed ≠ {"v":""}
+├── test_provenance.py       # REPARSE each file: stamp, per-element source, Sources section
+├── test_no_fabrication.py   # gaps render explicitly; failed rows present; counts honest
+├── test_sanitize.py         # =1+1 → data_type 's', raw XML has no <f>
+├── test_pdf_forms.py        # round-trip, non-fillable, unfilled + unmatched
+├── test_output_paths.py     # same-second writes don't collide; first file untouched
+└── test_manifest_size.py    # ≤ 5,000 tokens + read-only surface guard
+
+# Modified elsewhere
+config/openclaw.json                     # + document-mcp
+scripts/lib/catalog.sh                   # + entry, + PROFILE_RECOMMENDED
+scripts/lib/install-steps.sh             # + component_install_document()
+scripts/check-dependency-pins.py         # read pyproject.toml; dist→module alias map
+mcp-servers/rag-mcp/pyproject.toml       # bound the unpinned declarations
+ui/netclaw-visual/server.js              # + INTEGRATION_CATALOG, + ENV_MAP
+README.md · SOUL.md · TOOLS.md · .env.example
+docs/COVERAGE-ROADMAP.md                 # ALREADY DONE — R18 licence correction
+```
+
+Note the writer module filenames are `docx_writer.py`, `xlsx_writer.py`, `pptx_writer.py`, `pdf_writer.py`.
+An earlier draft of this plan justified the suffix as avoiding shadowing of the third-party packages;
+**that was measured false** (research D14) — inside the `writers/` package, `from pptx import Presentation`
+resolves to the real package, because Python 3 imports are absolute by default. Shadowing bites only for a
+module at the *top level* of the inserted directory. The names are kept for readability at the call site and
+because they stay safe if `writers/` is ever flattened into the server directory — not for a hazard that
+does not exist at this layout.
+
+**Structure Decision**: one MCP server plus two skills, modelled on `bgp-intel-mcp` (spec 081 — the newest,
+and the one that correctly factored `Outcome` out of `envelope.py`). Four servers (one per format) was
+rejected: it quadruples registration, install functions and HUD pairs while forcing the shared provenance
+logic into either duplication or a fifth shared surface.
+
+## Implementation Phases
+
+| Phase | Content | Gate |
+|---|---|---|
+| **A. Foundation** | `outcomes.py`, `envelope.py`, `provenance.py`, `output.py`, `sanitize.py` + their tests | `test_tagged_values`, `test_output_paths`, `test_sanitize` pass |
+| **B. US1 + US2 (both P1)** | `docx_writer.py`, `xlsx_writer.py`, `docx_write`, `xlsx_write`; `test_provenance`, `test_no_fabrication` | A real `.docx` and `.xlsx` produced **and opened** |
+| **C. US3 (P2)** | `pptx_writer.py`, `pptx_write` | A real `.pptx` produced and opened, with an embedded diagram from an existing skill |
+| **D. US4 (P3)** | `pdf_writer.py`, `pdf_inspect_form`, `pdf_fill_form`; `test_pdf_forms` | A real form filled and reopened |
+| **E. Dependency correction** | bound `document-mcp/requirements.txt`; bound `rag-mcp/pyproject.toml`; teach `check-dependency-pins.py` to read pyproject + dist→module aliases | rag-mcp ingestion re-exercised (FR-032d); `reconcile-mcp.py` exit 0 |
+| **F. Skills + artifacts** | 2 SKILL.md, catalog, install-steps, openclaw.json, both HUD entries, README/SOUL/TOOLS/.env.example, server README, README drift fix (research D13) | `reconcile-mcp.py` exit 0; `verify-inventory-counts.py` exit 0; `trace-skill.py` resolves both skills |
+| **G. Honest verification** | `VERIFICATION.md`, manifest measurement, live end-to-end run | Per-format table distinguishing **produced-and-opened** from **executed-without-error** |
+
+Phases B, C and D are independently shippable — each user story stands alone, per the spec's priority
+ordering. E is sequenced after D so a dependency change cannot be blamed for a writer bug.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| **Editing another feature's file** (`rag-mcp/pyproject.toml`) — Principle XV touch | rag-mcp declares the same four libraries **unpinned**. If this feature bounds them only for itself, two servers declare conflicting requirements for one shared install. | Bounding here only (clarification option A) leaves the conflict *and* rag-mcp's pre-existing spec-077 hazard. Deferring to a follow-on (option D) ships a known conflict. Mitigated by FR-032c (no installed version moves) and FR-032d (re-exercise rag-mcp ingestion). |
+| **Modifying a shared tool** (`scripts/check-dependency-pins.py`) | The checker reads `requirements.txt` only, so rag-mcp has **never been scanned** — its clean bill of health is an artefact of invisibility. It also matches by distribution name, so `pymupdf`→`fitz` would be missed even if scanned. | Fixing only rag-mcp's declaration patches one instance and leaves every future `pyproject.toml`-declaring server unchecked. The baseline is `reconcile-mcp.py` exit 0, so the change must keep it at 0 while catching strictly more. |
+| **Fixing pre-existing README drift** (research D13) | README was never updated for specs 080/081 — no MCP rows for Fortinet or BGP-intel, no `bgp-registry-intel`/`fortigate-ops`/`fortianalyzer-ops` skill rows. `verify-inventory-counts.py` misses it because it checks headline arithmetic, not table membership. | This feature edits those exact tables anyway. Leaving it means the next feature inherits a README two specs behind, and the drift compounds silently because no check catches it. |
+
+## Post-Design Constitution Re-Check
+
+Re-evaluated after Phase 1. **No new violations.** Three notes:
+
+1. **Principle IV strengthened by design, not just declared.** Spec 080's `/speckit.analyze` caught GAIT
+   having verification but no implementation — the same defect it had caught in spec 076. Here GAIT emission
+   is inside `envelope.emit()`, which every writer must pass through, and `test_provenance.py` asserts the
+   record exists for a refusal as well as a success. There is no code path that writes a file without one.
+
+2. **Principle IX gained a concrete threat.** Phase 0 measured that openpyxl converts a leading `=` into
+   `<f>1+1</f>` — a live formula built from untrusted device or ticket text. FR-026 was written before that
+   was confirmed; it is now backed by a measurement and a specific mitigation (`data_type='s'` at the single
+   write helper, verified against raw sheet XML).
+
+3. **Principle XI's surface grew by one.** Beyond the constitution's 14 items, `docs/ADDING-AN-MCP.md` names
+   two easy-to-miss extras — curated install-profile membership, and the fact the HUD needs **two** entries —
+   both of which are in the task list rather than assumed. The iN2N five-artifact obligation is **not**
+   triggered (research D11: this is Border work by construction, since it holds no credentials and composes
+   across domains), and that is recorded as a decision rather than an omission.
+
+## Artifacts Generated
+
+| File | Phase |
+|---|---|
+| `research.md` | 0 — 13 findings, all measured on this machine |
+| `data-model.md` | 1 — TaggedValue, SourceRecord, DocumentStamp, block/sheet/slide/form models, Outcome |
+| `contracts/mcp-tools.md` | 1 — 6 tools, shared types, refusal table, non-goals |
+| `quickstart.md` | 1 — install, four workflows, the one rule, three stated limits |
+| `plan.md` | this file |
+
+**Next**: `/speckit.tasks`.

--- a/specs/082-document-generation/quickstart.md
+++ b/specs/082-document-generation/quickstart.md
@@ -1,0 +1,139 @@
+# Quickstart — Document Generation (spec 082 / roadmap R18)
+
+Turn a NetClaw finding into something you can attach to a change record or hand to a director.
+
+---
+
+## Install
+
+```bash
+./scripts/install.sh          # select "document" in the component checklist
+# or, if NetClaw is already installed:
+netclaw_pip_install -r mcp-servers/document-mcp/requirements.txt
+```
+
+**No credentials.** The server writes files and touches nothing else.
+
+The four libraries are almost certainly already present — `rag-mcp` (feature 062) installs them to *read*
+these formats. Verify:
+
+```bash
+python3 -c "import docx, openpyxl, pptx, fitz; print(docx.__version__, openpyxl.__version__, pptx.__version__, fitz.__doc__)"
+```
+
+## Environment (all optional)
+
+```bash
+DOCUMENT_MCP_CMD=            # command the skills invoke
+DOCUMENT_OUTPUT_DIR=         # default: workspace/output/document-mcp/
+DOCUMENT_MAX_ROWS=           # default: 50000 data rows per sheet
+DOCUMENT_AUDIT_LOG=          # default: ~/.openclaw/gait/document-mcp.jsonl
+```
+
+## Where files land
+
+```
+workspace/output/document-mcp/changerecord-20260803T140200Z-chg0012345.docx
+```
+
+Timestamped UTC, uniquely named, **never overwritten** — a regenerated report cannot silently replace the
+one already attached to a ticket. The directory is gitignored (`.gitignore:110`, feature 046's convention).
+
+---
+
+## Four things to try
+
+### 1. A change record an approver will accept
+
+> "Generate a change record document for CHG0012345 with the current state of fgt-01."
+
+NetClaw pulls the CR from `servicenow-change-workflow`, the device state from `fortigate-ops`, and writes a
+`.docx` where every field names its source. A device that did not answer says so — it does not appear as a
+blank.
+
+### 2. An interface audit workbook
+
+> "Build an interface audit spreadsheet for all my FortiGates."
+
+Every interface, one row each, with **administrative and operational state in separate columns** and a
+`Source` column per row. A device that failed appears as a marked failed row — the sheet never gets shorter
+because a device was unreachable.
+
+### 3. An executive summary deck
+
+> "Make an exec deck from the posture review, with the topology diagram."
+
+Findings on slides, sources visible on the slide itself (not hidden in speaker notes), the diagram embedded
+from `threejs-network-viz` or `drawio-diagram`, and a Sources slide at the end.
+
+### 4. Fill a PDF form
+
+> "What fields does audit-response.pdf have?" → then → "Fill it from the CR and the device state."
+
+`pdf_inspect_form` lists the real field names first, so nothing is mapped to a field that does not exist.
+The fill reports which fields it left empty and which of your values matched no field.
+
+---
+
+## The one rule that matters most
+
+> ### A document must never fabricate to fill a blank.
+
+Tool output is ephemeral — read once, in context, by the person who asked. **A document is not.** It gets
+emailed, filed, and read months later by someone who was not there, and it carries the authority of its
+formatting. A professional-looking change record with a plausible invented number is a far more effective
+way to launder a guess into an official record than any amount of terminal output, because nobody
+re-derives a figure that is already in a table in a `.docx`.
+
+So the server refuses rather than guesses:
+
+| You send | You get |
+|---|---|
+| A value with no source | **Refused.** An unattributed figure is not renderable. |
+| A bare scalar where a value belongs | **Refused.** It would let missing data render as a blank. |
+| `{"unavailable": "device did not answer"}` | `NOT AVAILABLE — device did not answer`, in the document |
+| `{"failed": "connection refused"}` | `RETRIEVAL FAILED — connection refused`, in the document |
+| `{"v": ""}` | `(empty)` — the source *was* consulted and returned nothing. A different fact. |
+
+`unavailable` and `failed` never render as an empty cell, `N/A`, `0`, or a dash.
+
+---
+
+## Three limits, stated up front
+
+**No footnotes in Word.** python-docx has no footnote API, so per-figure attribution is inline — a `Source`
+column in tables, a parenthetical after prose figures. This is more visible, not less; a footnote is easy to
+skip.
+
+**No Office templates.** `.docx`, `.xlsx` and `.pptx` are built from scratch. A corporate template's empty
+field is the strongest fabrication pressure in the whole feature, and placeholder-matching in Word is the
+guessing version of the problem. Supplying one is refused, not silently ignored. PDF forms are the exception
+*because* their fields are explicitly named — there is nothing to guess.
+
+**A filled PDF cannot carry a Sources section.** It is the customer's form; adding a page would alter it. For
+that one format the provenance lives in the response and the GAIT record. Every other format carries it
+inside the file.
+
+---
+
+## Boundaries
+
+| Want to… | Use |
+|---|---|
+| Draw a diagram | `drawio-diagram`, `markmap-viz`, `uml-diagram`, `threejs-network-viz` — this **embeds** their output |
+| Read a document into the knowledge base | `rag-mcp` (feature 062) — same libraries, opposite direction |
+| Create or update a change record | `servicenow-change-workflow` — this renders a document *from* one |
+| Send the document somewhere | `slack-report-delivery`, `webex-report-delivery` — writing a file is in scope, sending it is not |
+
+---
+
+## Verify
+
+```bash
+bash tests/document/run-tests.sh          # no network, no credentials
+python3 scripts/reconcile-mcp.py          # must exit 0
+```
+
+The tests **open every generated file and assert on what is inside it.** Spec 080 shipped a tool returning
+three nulls past 24 passing tests because its suites asserted on envelope shape and never on payload
+content. This feature's entire output *is* content, so a write that succeeded proves nothing on its own.

--- a/specs/082-document-generation/research.md
+++ b/specs/082-document-generation/research.md
@@ -1,0 +1,409 @@
+# Phase 0 Research — Document Generation (spec 082 / roadmap R18)
+
+**Date**: 2026-08-03 · **Branch**: `082-document-generation`
+
+Everything below was **measured on this machine**, not inferred from documentation. Where a finding
+contradicts an assumption in the spec or the roadmap, the contradiction is stated rather than smoothed over.
+
+---
+
+## D1 — The licence finding (confirms the clarification, changes the roadmap)
+
+**Decision**: Build NetClaw's own capability. No vendored copy, no installer, no runtime fetch.
+
+**Rationale**: The four `anthropics/skills` document skills (`skills/docx`, `skills/pptx`, `skills/xlsx`,
+`skills/pdf`) are **source-available and "provided for demonstration and educational purposes only"** — not
+Apache-2.0. The repository's *example* skills carry Apache-2.0; the document skills specifically do not.
+NetClaw ships Apache-2.0 skills, so vendoring is not licence-compatible.
+
+**Consequence for the roadmap**: R18's checklist item *"Vendor the four official skills"* cannot be
+satisfied as written. `docs/COVERAGE-ROADMAP.md` has been corrected in this branch with the finding and the
+struck item, so the next reader does not re-litigate it. This makes R18 **build-rather-than-adopt for a
+licensing reason** — distinct from R1/R3/R9, where the community options were technically inadequate.
+
+**Alternatives considered**: an opt-in runtime installer that fetches upstream into the operator's own
+workspace (keeps demo-only code out of the repo but adds a second code surface and leaves the discipline
+unenforceable); seeking relicensing (blocks the feature on an external party). Both rejected in
+clarification.
+
+---
+
+## D2 — Dependencies: all four already installed, and the checker cannot see rag-mcp at all
+
+**Measured** on the system interpreter, 2026-08-03:
+
+| Distribution | Import name | Version | Result |
+|---|---|---|---|
+| `python-docx` | `docx` | **1.2.0** | import OK |
+| `openpyxl` | `openpyxl` | **3.1.5** | import OK |
+| `python-pptx` | `pptx` | **1.0.2** | import OK |
+| `PyMuPDF` | **`fitz`** | **1.28.0** | import OK |
+
+**Decision**: declare upper-bounded pins in `mcp-servers/document-mcp/requirements.txt`, and correct
+`mcp-servers/rag-mcp/pyproject.toml` to match. Bounds describe the already-resolved majors; **no installed
+version moves**.
+
+### The finding that is worse than the spec assumed
+
+`scripts/check-dependency-pins.py` **reads `requirements.txt` only** (line 57-58,
+`_requirements(server_dir)` → `os.path.join(server_dir, "requirements.txt")`). `rag-mcp` has **no
+`requirements.txt`** — it declares dependencies in `pyproject.toml`. Measured: `ls requirements.txt` →
+*No such file or directory*.
+
+**So rag-mcp has never been scanned by the spec-077 checker.** `python3 scripts/check-dependency-pins.py`
+reports `Servers scanned: 63 · PASS`, and rag-mcp is not among the 63 in any meaningful way. The baseline
+`reconcile-mcp.py` exits 0 across all four surfaces — a clean bill of health that is clean because the file
+is invisible, not because it is correct.
+
+What is actually in there (`pyproject.toml:6-20`), and what each one imports:
+
+| Declared | Bounded? | Code imports | Hazard |
+|---|---|---|---|
+| `"mcp"` | ❌ none | — | mcp 2.0 exists and removes `mcp.server.fastmcp` |
+| `"fastmcp"` | ❌ none | `from fastmcp import FastMCP` (`rag_mcp_server.py:53`) | attribute import, unbounded major |
+| `"pymupdf"` | ❌ none | `import fitz` (`ingestion/parsers.py:107`) | **name mismatch** — dist `pymupdf`, module `fitz` |
+| `"python-docx"` | ❌ none | `import docx` (`parsers.py:342`) | dist/module mismatch |
+| `"openpyxl"` | ❌ none | `import openpyxl` (`parsers.py:382`) | unbounded major |
+| `"python-pptx"` | ❌ none | `from pptx import Presentation` (`parsers.py:405`) | dist/module mismatch + attribute import |
+| `"vsdx"` | ❌ none | `from vsdx import VisioFile` (`parsers.py:440`) | attribute import |
+
+Two independent gaps, both real:
+
+1. **The checker does not read `pyproject.toml`.** Any server declaring deps that way is unchecked.
+2. **The checker matches by distribution name.** `pymupdf`→`fitz`, `python-docx`→`docx`,
+   `python-pptx`→`pptx` are all dist/module renames, so even a scanned `pyproject.toml` would not connect
+   `"pymupdf"` to `import fitz`.
+
+**Decision**: fix the declaration (FR-032b, in scope) **and** extend the checker to read `pyproject.toml`
+with a dist→module alias map (in scope — a correction that closes the hazard permanently rather than
+patching one instance of it). `"mcp"` and `"fastmcp"` are bounded at the same time: leaving them unbounded
+while bounding the document libraries in the same file would be arbitrary, and `mcp<2` is the bound spec 081
+already calls load-bearing.
+
+**Constraint**: FR-032c/SC-018 — the bounds must not move an installed version. Verified targets:
+`pymupdf>=1.24,<2` (have 1.28.0), `python-docx>=1.1,<2` (have 1.2.0), `openpyxl>=3.1,<4` (have 3.1.5),
+`python-pptx>=1.0,<2` (have 1.0.2), `mcp>=1.2.0,<2`, `fastmcp>=2.0,<3` (bound to what is installed —
+confirm at implementation), `vsdx>=0.5,<1` (confirm installed version at implementation).
+
+---
+
+## D3 — python-docx has **no footnote API** (this changes FR-009a's implementation)
+
+**Measured**:
+
+```
+docx Paragraph footnote attrs: []
+docx Run attrs w/ foot:        []
+docx Document attrs: [..., 'add_comment', 'add_heading', 'add_page_break', 'add_paragraph',
+                      'add_picture', 'add_section', 'add_table', 'comments', 'core_properties', ...]
+```
+
+python-docx 1.2.0 exposes **no** `add_footnote`. It does expose `add_comment` — which is precisely the
+hidden mechanism **FR-008a prohibits as the means of satisfying provenance** (comments are collapsed by
+default, stripped on paste, absent in print).
+
+**Decision**: in `.docx`, per-element provenance is **inline and visible**:
+- **Tables** carry a literal `Source` column — the same shape as the spreadsheet.
+- **Prose figures** carry an inline parenthetical immediately after the figure, in a smaller run:
+  `12 interfaces (fgt_list_interfaces · fgt-01 · as of 2026-08-03T14:02Z)`.
+- Every document ends with a visible **Sources** section.
+- The section **footer** carries generation time and NetClaw attribution on every page (measured available:
+  `sections[0].footer` exists and is writable).
+- `core_properties.comments` and `add_comment` may be set **additively** but never counted as the mechanism.
+
+**Alternative rejected**: hand-building `w:footnote` XML through `python-docx`'s `element` escape hatch.
+Real footnotes would be nicer typographically, but hand-rolled OOXML is a corruption risk in an artefact
+whose whole purpose is to be opened by someone else, and inline attribution is *more* visible, not less.
+
+---
+
+## D4 — pptx speaker notes are hidden too
+
+**Measured**: `slide.notes_slide.notes_text_frame` works and `has_notes_slide` is True. But speaker notes
+are not visible in presentation mode and not in a default print or PDF export — the same class of mechanism
+as a cell comment.
+
+**Decision**: decks carry a **visible source line on the slide itself** (a small text box along the bottom)
+for any slide asserting a figure, plus a final **Sources slide**. Notes may additionally carry the detail.
+This satisfies FR-008a and SC-010b's forwarding test.
+
+---
+
+## D5 — openpyxl writes a leading `=` as a **live formula** (FR-026 is not theoretical)
+
+**Measured**, writing the string `=1+1` into cells and reading back `xl/worksheets/sheet1.xml`:
+
+| Cell | How written | `data_type` on read | Raw XML |
+|---|---|---|---|
+| A1 | `ws["A1"] = "=1+1"` | `'f'` | `<c r="A1"><f>1+1</f><v></v></c>` |
+| A2 | assign, then `cell.data_type = 's'` | `'s'` | `<c r="A2" t="inlineStr"><is><t>=1+1</t></is></c>` |
+
+**A naive write turns untrusted text into an executing formula.** A FortiGate interface description, a
+ServiceNow short-description, or a hostname beginning with `=` is enough. This is the concrete form of the
+threat FR-026 names.
+
+Also measured: `@SUM(1,1)`, `+1+1` and `-1+1` are **not** converted by openpyxl — they stay `inlineStr`. The
+leading `=` is the only conversion openpyxl performs.
+
+**Decision**: every untrusted string written to a worksheet is forced to `data_type = 's'` **after
+assignment**, at the single write helper. Not a per-caller responsibility, not a prefix hack (prefixing with
+`'` would visibly corrupt the value in a document whose whole point is fidelity). Applied uniformly rather
+than only to `=`, because "which prefixes Excel treats as formulas" varies by locale and by paste path,
+whereas `t="inlineStr"` is unambiguous in the file itself.
+
+---
+
+## D6 — PDF form filling works end to end (US4 is viable)
+
+**Measured** with PyMuPDF 1.28.0, building a three-field form and filling one field:
+
+```
+is_form_pdf: 3                     # truthy int for a form
+discovered fields: [('change_number','Text',"''"), ('device_hostname','Text',"''"), ('approver','Text',"''")]
+filled: ['change_number']  unfilled: ['device_hostname','approver']  unmatched: ['nonexistent_field']
+readback: [('change_number',"'CHG0012345'"), ('device_hostname',"''"), ('approver',"''")]
+plain.pdf is_form_pdf: False  widgets: []
+```
+
+Every requirement of US4 is demonstrably supported:
+
+| Requirement | Mechanism | Measured |
+|---|---|---|
+| FR-024 non-fillable detected | `doc.is_form_pdf` | `False` + zero widgets on a plain PDF ✅ |
+| FR-024a named fields only | `widget.field_name` from `page.widgets()` | ✅ |
+| FR-024b unfilled reported | field names with no data | ✅ |
+| FR-024b unmatched reported | data keys ∉ discovered field names | ✅ |
+| Round-trip fidelity | reopen and read `field_value` | ✅ |
+
+Note `is_form_pdf` returns an **int** (3), not a bool — compare truthily, never with `is True`.
+
+Fixture generation is also solved: `fitz.Widget()` + `page.add_widget()` builds a fillable PDF, so the test
+suite can create its own form rather than depending on a customer artefact.
+
+---
+
+## D7 — Output convention: follow feature 046, and fix its one weakness
+
+**Feature 046's implementation** (`workspace/skills/threejs-network-viz/output.py`, the whole convention in
+33 lines):
+
+```python
+OUTPUT_DIR = Path(__file__).resolve().parents[2] / "output" / "threejs-network-viz"
+timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+safe_id = "".join(c if c.isalnum() or c in "-_" else "_" for c in snapshot_id)
+path = OUTPUT_DIR / f"topology-{timestamp}-{safe_id}.html"
+path.write_text(html, encoding="utf-8")
+```
+
+`.gitignore:108-110` ignores `workspace/output/` wholesale, so a new subdirectory needs **no .gitignore
+change**.
+
+**Decision**: same directory shape (`workspace/output/document-mcp/`), same UTC `%Y%m%dT%H%M%SZ` stamp, same
+sanitiser — **plus an exclusive create**. FR-018 says a file MUST NEVER be overwritten; 046 relies on
+timestamp uniqueness alone, which collides for two documents generated in the same second. The writer uses
+`os.open(path, O_CREAT | O_EXCL | O_WRONLY)` and, on `FileExistsError`, appends `-2`, `-3`, … rather than
+replacing. Small, and it is the difference between "unlikely to overwrite" and "cannot".
+
+**Path resolution**: 046 resolves relative to `__file__`, which works from any cwd. `document-mcp` lives in
+`mcp-servers/document-mcp/`, not `workspace/skills/`, so the repo root is `parents[2]` from the server
+directory — computed the same way, with `DOCUMENT_OUTPUT_DIR` as an override for operators who want
+documents elsewhere.
+
+---
+
+## D8 — The typed-value contract (how FR-005c becomes enforceable)
+
+The chokepoint only works if a caller **cannot express a missing value as an empty string**. Over MCP
+everything is JSON, so the enforcement has to be in the accepted shape.
+
+**Decision**: every populated field is a **tagged value**, exactly one of three shapes:
+
+```jsonc
+{"v": <any>, "src": "fgt_list_interfaces", "device": "fgt-01", "as_of": "2026-08-03T14:02Z"}
+{"unavailable": "device did not answer within timeout"}
+{"failed": "FortiGate plane unreachable: connection refused"}
+```
+
+- `v` **without** `src` → `ProvenanceError`, refused. Not defaulted, not silently stamped.
+- A bare scalar where a tagged value is expected → refused with a message naming the field.
+- `{"v": ""}` is legal and means *the source genuinely returned empty* — which is a different fact from
+  `unavailable`, and renders differently.
+- `unavailable` and `failed` are separate tags, because FR-002 says a dead query and an empty result are
+  different facts.
+
+This is the mechanism for FR-001 through FR-005c: the shape makes the honest thing the only expressible
+thing. It follows spec 080's `Outcome` enum and spec 081's `RpkiState`/`WIRE_TO_STATE` precedent — typed
+vocabulary at the boundary, not prose in a skill.
+
+**Alternative rejected**: accepting plain values and letting the server infer missing-ness from `null`. That
+puts the distinction in the caller's hands, which is what FR-005d exists to prevent.
+
+---
+
+## D9 — Server shape and tool surface
+
+**Decision**: one server, `mcp-servers/document-mcp/`, modelled on `bgp-intel-mcp` (spec 081 — newest, and
+the one that factored `Outcome` out of `envelope.py`, which is the better split).
+
+```
+mcp-servers/document-mcp/
+  server.py          FastMCP entrypoint, stdio, the tool defs
+  envelope.py        the chokepoint: emit/refused, GAIT audit  (FR-005b, FR-034)
+  outcomes.py        typed Outcome + the tagged-value vocabulary (FR-005c, D8)
+  provenance.py      source records, as-of handling, the Sources section model (FR-006..FR-010)
+  output.py          exclusive-create timestamped writer               (FR-016..FR-020, D7)
+  sanitize.py        untrusted-text handling, incl. the openpyxl forced-string (FR-026, D5)
+  writers/docx_writer.py  inline source column + footer + Sources section  (D3)
+  writers/xlsx_writer.py  per-row source column + Sources sheet            (D5)
+  writers/pptx_writer.py  visible per-slide source line + Sources slide    (D4)
+  writers/pdf_writer.py   named-field fill, unfilled/unmatched reporting   (D6)
+  requirements.txt   bounded pins
+  README.md          step-5 artifact
+```
+
+**Six tools**, keeping the surface small so the 5,000-token ceiling (FR-038a) is comfortable and so
+composition stays in the skills (FR-005d):
+
+| Tool | Purpose |
+|---|---|
+| `docx_write` | Build a Word document from a typed block list |
+| `xlsx_write` | Build a workbook from typed sheets and rows |
+| `pptx_write` | Build a deck from typed slides |
+| `pdf_inspect_form` | List a PDF's named fields; report whether it is fillable at all |
+| `pdf_fill_form` | Fill named fields; report unfilled fields and unmatched data |
+| `list_documents` | List what has been generated, so the operator can find a file |
+
+`pdf_inspect_form` is separate from `pdf_fill_form` deliberately: an operator (or a model) that must
+enumerate real field names before mapping data cannot invent them.
+
+**Alternative rejected**: one tool per user story (`generate_change_record`, …). That would put composition
+in the server and make the tool schemas carry NetClaw domain knowledge that belongs in skills, violating
+FR-005d in the other direction.
+
+---
+
+## D10 — Skills: two, not four
+
+**Decision**:
+
+| Skill | Owns |
+|---|---|
+| `document-generation` | The tool surface, the no-fabrication discipline, the output convention, per-format capabilities **and limits** (no footnotes, no Office templates) |
+| `network-report-documents` | The four NetClaw compositions — change record, interface/config audit workbook, executive summary deck, PDF form fill — each naming the upstream skills that feed it |
+
+**Rationale**: the roadmap asked for wrapper skills per document type; four skills would each be thin and
+would repeat the same discipline four times, which is how a discipline gets diluted. Splitting
+*capability* from *composition* mirrors the server/skill split FR-005d already requires, and matches spec
+081's precedent (one skill, 10 tools, workflows as sections) rather than spec 080's (three skills for three
+genuinely separate credentialed planes — not the situation here).
+
+**Counts**: skills 207 → **209**; MCP integrations 154 → **155**.
+
+**Frontmatter**: copy `workspace/skills/bgp-registry-intel/SKILL.md` exactly — `name`, quoted single-line
+`description` ending in a "Use when …" clause, `version`, `license: Apache-2.0`, `tags`,
+`user-invocable: true`, and the inline-JSON `metadata.openclaw.requires` block. Do **not** copy
+`threejs-network-viz/SKILL.md`, which predates the schema and has no frontmatter.
+
+---
+
+## D11 — iN2N: Border-only, and why
+
+**Decision**: this capability is **not** given to an iN2N member. FR-039's five-artifact obligation is
+therefore not triggered.
+
+**Rationale**: members are credentialed specialists (`fortimanager`, `fortigate`, …) whose value is holding
+one domain's credentials. Document generation holds no credentials and composes across domains — that is
+Border work by construction. Giving it to a member would mean the member composing data it cannot reach.
+
+**Recorded so it is a decision and not an omission**: a member producing a workbook scoped to its *own*
+domain is a coherent follow-on, and if it is ever done, `docs/ADDING-AN-MCP.md`'s five artifacts plus
+`systemctl --user restart netclaw-mesh.service` apply in full.
+
+---
+
+## D12 — Testing convention
+
+**Decision**: `tests/document/` with `run-tests.sh`, following `tests/bgp-intel/` — plain Python, stdlib
+only, no pytest, `sys.path.insert` to reach the server modules, module-level `FAILURES`, a
+`check(name, condition, detail)` helper, `main()` returning 0/1, `raise SystemExit(main())`.
+
+**And the lesson from spec 080, applied structurally**: that feature shipped `fgt_system_status` returning
+three nulls past **24 passing tests**, because the tests asserted on envelope *shape* and never on payload
+*content*. This feature's whole output is content.
+
+So the suites here **open the generated file and assert on what is inside it** — not that a write succeeded:
+
+| Suite | Asserts |
+|---|---|
+| `test_tagged_values.py` | `v` without `src` is refused; `unavailable` ≠ `failed` ≠ `{"v":""}` |
+| `test_provenance.py` | Every writer's output, **reparsed**, contains generation time, attribution, per-element source, Sources section |
+| `test_no_fabrication.py` | A missing field renders as explicit text; a failed row is present and marked; row counts reflect attempts |
+| `test_sanitize.py` | `=1+1` written to xlsx reads back `data_type == 's'` and the raw XML has **no `<f>`** |
+| `test_pdf_forms.py` | Round-trip fill; non-fillable rejected; unfilled and unmatched both reported |
+| `test_output_paths.py` | Two writes in the same second produce two files; the first is byte-identical afterwards |
+| `test_manifest_size.py` | ≤ 5,000 tokens, plus a read-only surface guard |
+
+Raw-XML assertion is the technique that catches D5, exactly as spec 081 used a rendered-text assertion to
+catch "the word 'invalid' must not appear in a not-found result".
+
+---
+
+## D13 — Pre-existing README drift found while surveying (adjacent, in scope to fix)
+
+`README.md` was **never updated for specs 080 or 081**. The numbered MCP table ends at row 118 (Globalping,
+line 630); there is no row for Fortinet or BGP-intel, and `grep` finds no `bgp-registry-intel`,
+`fortigate-ops` or `fortianalyzer-ops` skill rows. SOUL.md and TOOLS.md *were* updated.
+
+`verify-inventory-counts.py` does not catch this: it checks headline arithmetic at six claim sites, not
+table membership. The counts pass because the count of `workspace/skills/*/SKILL.md` directories is what it
+compares against.
+
+**Decision**: fix it in this branch. It is two table rows and three skill rows, it is Principle XI, and this
+feature has to edit those exact tables anyway. Doing it here costs minutes; leaving it means the next
+feature inherits a README two specs behind.
+
+---
+
+## Summary of measured facts that changed the design
+
+| # | Finding | Design consequence |
+|---|---|---|
+| D2 | `check-dependency-pins.py` reads only `requirements.txt`; rag-mcp has none | rag-mcp never scanned — fix the declaration **and** the checker |
+| D2 | Checker matches dist names; `pymupdf`→`fitz` etc. are renames | checker needs a dist→module alias map |
+| D3 | python-docx 1.2.0 has **no footnote API** | provenance in docx is inline + Sources section, never `add_comment` |
+| D4 | pptx speaker notes are not visible in presentation or print | visible on-slide source line + Sources slide |
+| D5 | openpyxl writes leading `=` as `<f>` — a live formula | force `data_type='s'` at the single write helper |
+| D6 | PyMuPDF form fill round-trips; `is_form_pdf` returns int | US4 viable; compare truthily, never `is True` |
+| D7 | Feature 046 relies on timestamp uniqueness alone | add `O_EXCL` create so FR-018 is guaranteed, not likely |
+| D13 | README is two specs behind on table membership | fix in this branch |
+| D14 | `writers/pptx.py` would **not** actually shadow `pptx` (measured) | keep `_writer` names for clarity, not for a shadowing reason that does not exist |
+
+---
+
+## D14 — The `_writer` suffix, and a claim that had to be withdrawn
+
+`/speckit.analyze` challenged the naming rationale, so it was measured rather than argued.
+
+**Claim under test**: that `writers/pptx.py` would shadow the third-party `pptx` package on the import path
+`server.py` inserts.
+
+**Measured**: it does not. With `sys.path.insert(0, <server dir>)` and a module at `writers/pptx.py`,
+`from pptx import Presentation` inside it resolves to the **third-party package** and works — Python 3's
+absolute-import default means a submodule does not shadow a top-level package of the same name.
+
+```
+--- case A: writers/pptx.py inside a package ---
+  writers/pptx.py imported Presentation OK: <function Presentation at 0x...>
+--- case B: pptx.py at the top level of the inserted dir ---
+  ImportError: cannot import name 'Presentation' from 'pptx'
+  (consider renaming '.../pptx.py' if it has the same name as a library you intended to import)
+```
+
+Shadowing is real **only** for a module at the top level of the inserted directory (case B).
+
+**Decision unchanged, rationale corrected**: keep `docx_writer.py` / `xlsx_writer.py` / `pptx_writer.py` /
+`pdf_writer.py`. They are clearer at a call site (`xlsx_writer.build(...)` reads better than
+`xlsx.build(...)`), and they stay safe if anyone later flattens `writers/` into the server directory, which
+*would* trigger case B. But the plan originally justified them with a hazard that does not exist at this
+layout, and shipping a false technical claim in a design document is worse than the naming question it was
+defending.

--- a/specs/082-document-generation/spec.md
+++ b/specs/082-document-generation/spec.md
@@ -1,0 +1,530 @@
+# Feature Specification: Document Generation (docx / pptx / xlsx / pdf)
+
+**Feature Branch**: `082-document-generation`
+**Created**: 2026-08-03
+**Status**: Draft
+**Roadmap**: R18 — *"Best effort-to-value ratio on the roadmap"*
+
+## Overview
+
+NetClaw can render Three.js topologies, drawio diagrams, markmap mind maps, UML via Kroki, Blender scenes
+and UE5 walkthroughs. It cannot produce a change-record `.docx`, an executive `.pptx`, an interface-audit
+`.xlsx`, or fill a PDF form.
+
+**Its output lands in front of enterprise humans** — change advisory boards, auditors, directors. Those
+people work in Office documents. Every other NetClaw capability produces *findings*; this is what turns a
+finding into something you can attach to a change record or hand to someone who will never open a terminal.
+
+That is the deliverable gap, and it is why the roadmap rates this the best effort-to-value item on the list.
+
+## The distinction this feature exists to protect
+
+### A document must never fabricate to fill a blank
+
+This is the largest risk in the feature by a wide margin, and it is a *new* risk rather than a variation of
+the previous four.
+
+Specs 078, 079, 080 and 081 each protected a distinction in **tool output** — "no advisories ≠ not
+vulnerable", "no probes ≠ outage", "no logs ≠ rule unused", "not-found ≠ invalid". Tool output is ephemeral:
+it is read once, in context, by someone who just asked the question.
+
+**A document is none of those things.** It gets emailed, attached to a ticket, filed for audit, and read
+months later by someone who was not there. It carries the authority of its formatting. A professional-looking
+change record with a plausible-but-invented device count is a far more effective way to launder a guess into
+an official record than any amount of terminal output — because nobody re-derives a number that is already
+in a table in a `.docx`.
+
+Three consequences:
+
+1. **An empty field renders as explicitly empty or absent — never as a plausible placeholder.** If a device
+   did not answer, the document says the device did not answer. Not `N/A`, not a sensible-looking default,
+   not silence.
+2. **Every figure carries where it came from.** A number in a spreadsheet cell with no provenance is *worse*
+   than no spreadsheet: it looks authoritative and cannot be checked. This is the provenance discipline of
+   spec 081 applied to a format that outlives the session.
+3. **A document states when it was generated and by what.** Read six months later, "as of" is the
+   difference between a record and a misleading artefact.
+
+### Generation is not the engineering; composition is
+
+`python-docx` writes Word files. That is a solved problem and not what this feature is for.
+
+The value is that a change record is populated from **an actual ServiceNow CR plus real device state**, and
+an interface audit from **an actual `fgt_list_interfaces` or `multivendor-device-query` result** — not typed
+by hand. The composition with NetClaw's existing 200-plus skills is the feature; the library
+call is an implementation detail.
+
+## The licence constraint — this changes the roadmap's plan
+
+The roadmap says: *"Vendor the four official skills; note their license terms explicitly."*
+
+**Noting the terms explicitly is the finding.** Measured 2026-08-03: the four document skills in
+`anthropics/skills` (`skills/docx`, `skills/pptx`, `skills/xlsx`, `skills/pdf`) are **source-available, not
+open source**, and are described as *"provided for demonstration and educational purposes only."* The
+repository's *example* skills are Apache-2.0; the document skills specifically are not.
+
+NetClaw ships Apache-2.0 skills. **Vendoring demonstration-only source into it is not licence-compatible**,
+so the roadmap's checklist item cannot be satisfied as literally written.
+
+This makes R18 a build-rather-than-adopt feature — but for a **licensing** reason, not a quality one, which
+is a different situation from R1, R3 and R9 where the community options were technically inadequate. The
+official skills remain valuable as **reference for what capabilities matter** (the `docx` skill's tracked
+changes and find-and-replace, `pdf`'s form filling and merge/split, `pptx`'s template-vs-scratch modes), and
+reading them to decide *what* to build is entirely legitimate.
+
+## The dependencies are already here
+
+Measured on the system interpreter, 2026-08-03:
+
+| Library | Installed | Needed for |
+|---|---|---|
+| `python-docx` | **1.2.0** ✅ | `.docx` |
+| `openpyxl` | **3.1.5** ✅ | `.xlsx` |
+| `python-pptx` | **1.0.2** ✅ | `.pptx` |
+| `PyMuPDF` (`fitz`) | **1.28.0** ✅ | `.pdf` |
+
+All four arrive with **feature 062's `rag-mcp`**, which *reads* these formats for ingestion. This feature
+*writes* them — same libraries, opposite direction.
+
+**But rag-mcp declares them unpinned** (`"pymupdf"`, `"python-docx"`, `"openpyxl"`, `"python-pptx"` in its
+`pyproject.toml`). That is a latent spec-077 hazard in existing code: a fresh installer resolves whatever
+major is current, and PyMuPDF is imported as `fitz` — exactly the submodule case spec 077 requires bounding.
+
+Decided in clarification: **this feature declares upper-bounded pins and corrects rag-mcp's declaration to
+match**, bounded to the majors already installed. No installed version moves; the bounds describe what is
+already resolved. Leaving two servers with conflicting requirements for one shared install is not an
+acceptable end state, and this feature is the first to notice the hazard.
+
+## Clarifications
+
+### Session 2026-08-03
+
+- Q: Given the upstream document skills are source-available/demonstration-only rather than Apache-2.0, what licence approach should this feature take? → A: Build NetClaw's own document skills outright. Upstream is cited as reference for capability selection only — never vendored, and no install machinery for it. One code surface, Apache-2.0 clean.
+- Q: What shape should the capability ship as — skills, one MCP server, or four? → A: One MCP server plus skills on top. The server owns file writing and stamps generation time, attribution and per-element provenance at a single chokepoint, with unavailable/failed as typed states it cannot skip; skills own the four compositions.
+- Q: How must provenance actually render, given a spreadsheet cell has no room for a citation? → A: Visible per-element attribution plus a sources section. Spreadsheets get a source column per row; documents and decks get an inline or footnoted source per figure; every file also carries a sources section with as-of times. Hidden mechanisms (cell comments, document metadata) do not satisfy the requirement.
+- Q: Are templates supported, given a template's empty field is the strongest fabrication pressure in the feature? → A: Scratch-only for docx/xlsx/pptx. PDF form filling stays, because a PDF form's fields are explicitly named and machine-readable — the safe form of template population. Corporate-template support for Word/PowerPoint is deferred to a follow-on feature with its own fabrication analysis.
+- Q: How should the four document libraries be pinned, given rag-mcp declares them unpinned? → A: Declare upper-bounded pins here **and** fix rag-mcp's declaration to match, pinned to the currently-installed majors. No installed version moves. This closes a pre-existing spec-077 hazard rather than leaving two servers declaring conflicting requirements for one shared install.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — A change record an approver will actually accept (Priority: P1)
+
+An operator has an approved ServiceNow CR and real pre-change device state. They need a `.docx` to attach to
+the change record and put in front of a change advisory board.
+
+**Why this priority**: It is the single most requested enterprise artefact, it exercises the composition that
+justifies the feature, and it is where fabrication would do the most damage — a change record is a governance
+document.
+
+**Independent Test**: generate a change record from a real CR number and a real device query; open the
+resulting file and confirm every populated field traces to a named source and every unavailable field is
+explicitly marked unavailable.
+
+**Acceptance Scenarios**:
+
+1. **Given** an approved CR and reachable devices, **When** a change record is generated, **Then** the
+   document contains the CR details, the pre-change state, and **a named source for each**.
+2. **Given** a device that did not answer, **When** the document is generated, **Then** the affected section
+   says the device did not answer — and MUST NOT show a blank cell, a zero, or a plausible default that
+   reads as real data.
+3. **Given** any generated document, **When** it is opened, **Then** it states when it was generated and
+   that NetClaw generated it.
+4. **Given** a CR that does not exist or is not approved, **When** generation is requested, **Then** NetClaw
+   reports that rather than producing a document with an invented CR.
+5. **Given** a document is generated twice, **When** the second run completes, **Then** the first file still
+   exists unmodified.
+
+---
+
+### User Story 2 — An interface audit in a spreadsheet (Priority: P1)
+
+An auditor wants every interface across a set of devices in `.xlsx`: name, addressing, administrative state,
+operational state, role, errors.
+
+**Why this priority**: The highest-volume real use, and independently valuable with nothing else built.
+Spreadsheets are also where unprovenanced numbers do the most quiet damage, because a cell has no room for
+a caveat unless the design makes room.
+
+**Independent Test**: generate an audit from a real device query; confirm row count matches the source, every
+column has a stated origin, and a device that failed appears as a failed row rather than being omitted.
+
+**Acceptance Scenarios**:
+
+1. **Given** a real device query, **When** an audit is generated, **Then** every interface appears with its
+   fields, and the sheet records which tool and which device produced each row.
+2. **Given** a device that failed, **When** the audit is generated, **Then** it appears as an explicitly
+   failed entry. **Silently omitting it is prohibited** — a shorter spreadsheet reads as a smaller estate.
+3. **Given** administrative and operational state differ, **When** rendered, **Then** they occupy **separate
+   columns** and are not merged into one "status".
+4. **Given** a generated workbook, **When** opened, **Then** it carries generation time and source
+   attribution somewhere durable, not only in a filename.
+
+---
+
+### User Story 3 — An executive summary deck (Priority: P2)
+
+A director wants a short `.pptx`: what was found, what it means, what happens next — with a topology diagram.
+
+**Why this priority**: Real demand and the natural composition with the existing diagram skills, but the
+audience tolerates less detail and the fabrication risk is lower because slides are read as summary.
+
+**Independent Test**: generate a deck from real findings, confirm it opens, and confirm any embedded diagram
+came from an existing diagram skill rather than being redrawn here.
+
+**Acceptance Scenarios**:
+
+1. **Given** findings from a NetClaw investigation, **When** a deck is generated, **Then** slides carry the
+   findings with sources on the detail slides.
+2. **Given** a diagram is wanted, **When** the deck is built, **Then** it embeds output from an existing
+   diagram skill and does **not** reimplement diagram rendering.
+3. **Given** a summary claim on a slide, **When** it is rendered, **Then** it is traceable to a detail slide
+   or an appendix rather than asserted bare.
+
+---
+
+### User Story 4 — Fill an existing PDF form (Priority: P3)
+
+Some organisations require a specific PDF form for a change or an audit response. The operator wants it
+filled from real data rather than by hand.
+
+**Why this priority**: Genuinely useful and clearly bounded, but the least common and the most dependent on a
+specific customer artefact. Most likely of the four to be cut if PDF form handling proves unreliable.
+
+**Independent Test**: fill a real PDF form with known values, open it, and confirm the values landed in the
+right fields and unfilled fields were left genuinely unfilled.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fillable PDF and real data, **When** it is filled, **Then** the values appear in the correct
+   named fields.
+2. **Given** a field with no corresponding data, **When** the form is filled, **Then** it is left empty —
+   **never** populated with a guess to make the form look complete.
+3. **Given** a PDF that is not fillable, **When** filling is attempted, **Then** NetClaw says so rather than
+   producing a visually-similar but non-functional file.
+
+---
+
+### Edge Cases
+
+- **The source data is partially missing.** The document renders what exists and states what does not.
+  Partial data with the gaps marked is useful; partial data silently presented as complete is dangerous.
+- **A source disagrees with another.** Both are shown with their origins rather than reconciled silently.
+- **The output directory does not exist or is not writable.** Reported as a failure; no silent fallback to a
+  temp directory the operator will never find.
+- **A filename would collide.** The existing file is never overwritten — a regenerated report must not
+  silently replace one already attached to a ticket.
+- **A very large dataset** — thousands of interfaces. Bounded with the bound stated in the document itself,
+  not just in tool output the reader never sees.
+- **Untrusted content in source data.** Device banners, ticket descriptions and hostnames can contain
+  formula-like or markup-like text; it must not be interpreted as a spreadsheet formula or document markup.
+- **A `.docx`/`.pptx`/`.xlsx` template is supplied.** Rejected with a clear reason — out of scope by
+  clarification, not silently ignored and not partially honoured.
+- **A PDF form has fields the data does not cover.** Those fields are left genuinely empty; the response
+  states which named fields went unfilled so the operator knows what to complete by hand.
+- **A PDF form has data with no matching field.** Reported as unmatched rather than dropped silently — data
+  that vanished is indistinguishable from data that was never supplied.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Never fabricate — the core
+
+- **FR-001**: A field with no source data MUST render as **explicitly unavailable or absent**. Plausible
+  placeholders, invented defaults, and silent blanks are all prohibited.
+- **FR-002**: A source that failed MUST be represented **in the document** as having failed, distinct from
+  having returned nothing. A dead query and an empty result are different facts.
+- **FR-003**: A record that failed to retrieve MUST NOT be silently omitted from a list, table or sheet. A
+  shorter table reads as a smaller estate, which is a false statement about the network.
+- **FR-004**: NetClaw MUST NOT infer, estimate, or interpolate a value to complete a document. If a figure
+  is unknown, the document says it is unknown.
+- **FR-005**: Where a document summarises (an executive slide, a total row), the summary MUST be traceable to
+  the underlying detail within the same document.
+
+#### One chokepoint, so omission is structurally impossible
+
+- **FR-005a**: A **single MCP server** MUST own all document writing. No skill, script, or other server may
+  write a document by any other path.
+- **FR-005b**: That server MUST stamp generation time, NetClaw attribution, and per-element provenance at
+  **one chokepoint** every document passes through — the envelope pattern specs 080 and 081 used to make
+  attribution impossible to omit. Provenance MUST NOT be a per-call caller responsibility.
+- **FR-005c**: "Unavailable" and "failed" MUST be **typed states in the server's own vocabulary**, distinct
+  from each other and from a present value. A caller MUST NOT be able to express a missing value as a plain
+  empty string that renders as a blank cell.
+- **FR-005d**: Skills MUST own the compositions (change record, audit, deck, form fill) and MUST NOT contain
+  document-writing logic of their own. Prose guidance in a skill is not an acceptable enforcement mechanism
+  for FR-001 through FR-004.
+
+#### Provenance that outlives the session
+
+- **FR-006**: Every generated document MUST state, in the document itself, **when it was generated** and
+  **that NetClaw generated it**.
+- **FR-007**: Every figure, table and populated field MUST carry the **source** that produced it — the tool
+  or system, and the device or record where applicable.
+- **FR-008**: Provenance MUST be durable in the document body, not only in the filename or the tool response.
+  A file that is renamed, forwarded or printed must still carry it.
+- **FR-008a**: Provenance MUST be **visible without interaction**. Cell comments, tooltips, document metadata
+  properties, and any other hidden mechanism MUST NOT be the means of satisfying FR-007 or FR-008 — they are
+  hidden by default, stripped on copy-paste, and absent in print, which are the exact scenarios these
+  requirements exist for. Such mechanisms MAY be added *in addition*, never *instead*.
+- **FR-009**: Where a document mixes sources, **per-element** attribution is required. One collective
+  citation for a mixed table is not attribution.
+- **FR-009a**: Concretely: a spreadsheet MUST carry a **visible source column per row**; a document or deck
+  MUST carry a **visible source per figure** — inline, since python-docx exposes no footnote API (research
+  D3), so "footnoted" is not an available option for `.docx`; and **every** generated file MUST carry a
+  **sources section** listing each tool and system consulted with its as-of time. The sources section is
+  required in addition to per-element attribution, never as a substitute for it.
+- **FR-010**: Source data as-of times MUST be preserved where the source provides one, distinct from the
+  document's own generation time. Data collected on Monday and rendered on Friday is a Monday fact.
+
+#### Composition with real NetClaw data
+
+- **FR-011**: A change record MUST be populatable from a real change-management record plus real device
+  state, without hand-typed content.
+- **FR-012**: An interface or configuration audit MUST be populatable from real device-query output.
+- **FR-013**: An executive summary MUST be populatable from findings produced by other NetClaw skills.
+- **FR-014**: Where a document should contain a diagram, it MUST embed output from an existing NetClaw
+  diagram capability and MUST NOT reimplement diagram rendering.
+- **FR-015**: Administrative and operational state, where both exist, MUST occupy separate columns or fields
+  and MUST NOT be merged into a single "status" — the distinction spec 080's completion established.
+
+#### Output convention
+
+- **FR-016**: Documents MUST be written to a **persistent** workspace output directory the operator can find
+  — never a temporary directory.
+- **FR-017**: Filenames MUST be timestamped and uniquely named.
+- **FR-018**: An existing file MUST NEVER be overwritten. A regenerated report must not replace one already
+  attached to a ticket.
+- **FR-019**: The path of the written file MUST be reported back so the operator can retrieve it.
+- **FR-020**: A directory that is missing or unwritable MUST be reported as a failure, with no silent
+  fallback.
+
+#### Format support
+
+- **FR-021**: `.docx` generation MUST be supported.
+- **FR-022**: `.xlsx` generation MUST be supported.
+- **FR-023**: `.pptx` generation MUST be supported.
+- **FR-023a**: `.docx`, `.xlsx` and `.pptx` MUST be built **from scratch**. Template population for these
+  three formats is out of scope; a supplied Office template MUST be **rejected with a clear reason**, never
+  silently ignored and never partially honoured.
+- **FR-024**: PDF form filling MUST be supported, and a non-fillable PDF MUST be reported as such rather
+  than producing a visually-similar non-functional file.
+- **FR-024a**: PDF filling MUST operate on **explicitly named form fields**. Positional or visual placement
+  of text onto a PDF that has no named fields MUST NOT be used as a substitute — it produces a document that
+  looks filled but carries no field data.
+- **FR-024b**: After filling, the response MUST state **which named fields were left unfilled** and **which
+  supplied data matched no field**. Unmatched data MUST NOT be dropped silently: data that vanished is
+  indistinguishable from data never supplied.
+- **FR-025**: Every format claimed as supported MUST have a **real file produced and opened** during
+  verification. A code path that ran without error is not evidence the document is correct.
+
+#### Content safety
+
+- **FR-026**: Text drawn from device output, ticket fields or hostnames MUST NOT be interpreted as a
+  spreadsheet formula, document field code, or markup. Untrusted content is rendered as text.
+- **FR-027**: Large datasets MUST be bounded, with the bound **stated in the document**, not only in the
+  tool response the eventual reader never sees.
+- **FR-027a**: The bound applies to **every format, not only spreadsheets**: worksheet rows, `.docx` blocks
+  and `.pptx` slides each have a defined ceiling. An unbounded document request is a memory and
+  readability hazard in exactly the same way an unbounded worksheet is.
+- **FR-027b**: Where two sources report different values for the same thing, **both MUST be rendered with
+  their own origins**. Silent reconciliation, picking a winner, or dropping one is prohibited — a document
+  that hides a disagreement asserts a certainty the data does not support.
+
+#### Licensing
+
+- **FR-028**: The licence terms of any referenced upstream skill MUST be recorded explicitly. Measured: the
+  four `anthropics/skills` document skills are **source-available, demonstration-only** — not Apache-2.0 —
+  and therefore MUST NOT be vendored into NetClaw.
+- **FR-029**: Any capability inspired by those skills MUST be independently implemented. Reading them to
+  decide *what* to build is legitimate; copying them is not.
+- **FR-029a**: NetClaw MUST author its own document-generation capability. It MUST NOT ship, fetch, or
+  install the upstream skills — **no install path, no runtime download, no vendored copy**. There is exactly
+  one code surface for this feature and it is Apache-2.0.
+
+#### Dependencies
+
+- **FR-030**: The four document libraries are **already installed** via feature 062's `rag-mcp`
+  (`python-docx` 1.2.0, `openpyxl` 3.1.5, `python-pptx` 1.0.2, `PyMuPDF` 1.28.0). This feature MUST NOT move
+  a version another feature depends on (spec 076's `cryptography` lesson).
+- **FR-031**: Installation MUST use `netclaw_pip_install`, never a bare `pip`/`pip3` (spec 077).
+- **FR-032**: Any pin on a package whose submodule is imported MUST be upper-bounded (spec 077). PyMuPDF is
+  imported as `fitz` and is precisely that case.
+- **FR-032a**: This feature MUST declare **upper-bounded pins** for all four libraries, bounded to the
+  currently-installed majors.
+- **FR-032b**: `rag-mcp`'s `pyproject.toml` MUST be corrected in this feature to declare the same
+  upper-bounded pins, replacing its current unpinned `"pymupdf"` / `"python-docx"` / `"openpyxl"` /
+  `"python-pptx"`. Leaving two servers declaring conflicting requirements for one shared install is not an
+  acceptable end state, and the unbounded declaration is a pre-existing spec-077 hazard this feature is the
+  first to notice.
+- **FR-032c**: The correction MUST NOT move any installed version. `python-docx` 1.2.0, `openpyxl` 3.1.5,
+  `python-pptx` 1.0.2 and PyMuPDF 1.28.0 MUST remain exactly as installed — the bounds describe what is
+  already resolved, they do not request a change (FR-030, spec 076's `cryptography` lesson).
+- **FR-032d**: `rag-mcp`'s own ingestion behaviour MUST be confirmed unaffected after the declaration change.
+  Editing another feature's dependency file obliges verifying that feature still works.
+
+#### Read-only with respect to infrastructure
+
+- **FR-033**: This feature MUST NOT touch a device, and MUST NOT create or update a ticket. It writes files.
+  There is therefore no approval or change-record gate to design.
+- **FR-034**: Every generation MUST produce a GAIT record (Principle IV), including failures.
+
+#### Composition boundaries
+
+- **FR-035**: The boundary against the existing diagram skills (`drawio-rfc`, `markmap`, `uml`,
+  `threejs-network-viz`) MUST be stated: those produce **diagrams**; this produces **documents** that may
+  embed them.
+- **FR-036**: The boundary against `rag-mcp` MUST be stated: rag-mcp **reads** these formats for ingestion,
+  this **writes** them. Same libraries, opposite direction.
+- **FR-037**: The boundary against `servicenow-change-workflow` MUST be stated: that manages the CR
+  lifecycle, this renders a document from it.
+
+#### Artifact coherence (Principle XI)
+
+- **FR-038**: All of the following MUST be updated, none assumed: registration or an `EXTERNAL_INTEGRATIONS`
+  entry with a stated reason; `scripts/lib/catalog.sh` entry **and curated profile membership**;
+  `scripts/lib/install-steps.sh` install function; **both** HUD entries in `ui/netclaw-visual/server.js`;
+  `README.md` and `SOUL.md` including counts **and** a SOUL capability section; `SKILL.md`; `.env.example`;
+  `TOOLS.md`; a server `README.md`.
+- **FR-038a**: The server's tool manifest MUST measure **≤ 5,000 tokens**, the ceiling specs 080 and 081
+  held, and the measured figure MUST be recorded.
+- **FR-039**: If an iN2N member should generate documents, the **five member artifacts plus a mesh restart**
+  from `docs/ADDING-AN-MCP.md` MUST be completed — the section spec 080's completion added.
+- **FR-040**: `python3 scripts/reconcile-mcp.py` MUST exit 0 across all four surfaces.
+- **FR-041**: `python3 scripts/verify-inventory-counts.py` MUST exit 0 with counts updated from the current
+  207 skills / 154 integrations.
+
+#### Honest verification
+
+- **FR-042**: On completion, the feature MUST state per format what was **actually produced and opened**
+  versus what merely executed without error.
+- **FR-043**: Any format that could not be produced and inspected MUST be marked unverified or cut.
+
+### Key Entities
+
+- **Document request** — a format, a layout choice, and the data sources to populate from. For PDF, an
+  existing fillable form plus a field-to-data mapping.
+- **Source attribution** — the tool, system, device or record that produced a value, plus its as-of time
+  where available. Carried per element, **visibly**, and never by a hidden mechanism alone.
+- **Sources section** — a visible section in every generated file listing each tool and system consulted with
+  its as-of time. Required alongside per-element attribution, never instead of it.
+- **Unavailable field** — a field with no data. A **typed state in the server's vocabulary**, rendered
+  explicitly, never expressible as a plain blank.
+- **Failed source** — a source that errored. A typed state, distinct from a source that returned nothing.
+- **Output artefact** — a written file with a timestamped unique path, never overwritten.
+- **PDF form field** — an explicitly named, machine-readable field in an existing fillable PDF. The only
+  template-population surface in scope, chosen because a named field makes "no data for this field"
+  unambiguous.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A `.docx` change record is generated from a real change record and real device state, opened,
+  and every populated field traces to a named source.
+- **SC-002**: A field with no data renders as explicitly unavailable — and the document contains no invented
+  value, no misleading blank, and no plausible default in its place.
+- **SC-003**: A failed source appears in the document as failed, distinguishable from a source that returned
+  nothing.
+- **SC-004**: A record that failed to retrieve appears as a failed entry rather than being omitted; the row
+  count reflects what was attempted, not only what succeeded.
+- **SC-005**: An `.xlsx` interface audit is generated from a real device query, opened, and its row count
+  matches the source.
+- **SC-006**: Administrative and operational state occupy separate columns in the audit.
+- **SC-007**: A `.pptx` is generated, opened, and any embedded diagram demonstrably came from an existing
+  diagram skill.
+- **SC-008**: A fillable PDF is filled, opened, and values appear in the correct named fields; a
+  non-fillable PDF is reported as such.
+- **SC-008a**: A fill with incomplete data reports the named fields left unfilled; a fill with extra data
+  reports the values that matched no field. Neither is silently absorbed.
+- **SC-008b**: Supplying an Office template is rejected with a stated reason by **all three** of
+  `docx_write`, `xlsx_write` and `pptx_write` — not only the first format implemented — and is neither
+  ignored nor partially applied.
+- **SC-009**: **Every** generated document states its generation time and that NetClaw produced it, in the
+  document body — verified by opening the file, not by inspecting code.
+- **SC-010**: A mixed-source table carries per-element attribution rather than one collective citation — a
+  visible source column per row in a spreadsheet, a visible per-figure source in a document or deck.
+- **SC-010a**: Every generated file carries a sources section listing each tool and system with its as-of
+  time, **in addition to** per-element attribution.
+- **SC-010b**: Provenance survives the forwarding test: after copying a table out of the file and after
+  rendering it to print/PDF, the attribution is still present. No provenance is carried solely by a cell
+  comment, tooltip, or document metadata property.
+- **SC-011**: A source's own as-of time is preserved where provided and is distinguishable from the
+  document's generation time.
+- **SC-012**: Generating the same report twice leaves the first file unmodified and produces a second,
+  differently-named file.
+- **SC-013**: A missing or unwritable output directory is reported as a failure with no silent fallback.
+- **SC-014**: The written file path is reported back and the file exists at that path.
+- **SC-015**: Formula-like or markup-like text from a source renders as literal text, not as a formula or
+  field code.
+- **SC-016**: A bounded large dataset states its bound inside the document — for worksheet rows, `.docx`
+  blocks and `.pptx` slides alike.
+- **SC-017**: Upstream licence terms are recorded durably; no demonstration-only source is present in the
+  repository, and no install, fetch, clone or download path for it exists in any shipped artifact —
+  verified by inspecting the diff and grepping the installer, skills, server and docs.
+- **SC-018**: No shared dependency version is moved. `python-docx` 1.2.0, `openpyxl` 3.1.5, `python-pptx`
+  1.0.2 and PyMuPDF 1.28.0 are the same versions after this feature as before it.
+- **SC-018a**: Both this feature and `rag-mcp` declare identical upper-bounded pins for the four libraries;
+  no unbounded declaration of any of them remains in the repository.
+- **SC-018b**: `rag-mcp` ingestion is exercised after the declaration change and still works.
+- **SC-019**: Every generation, including failures, produces a GAIT record.
+- **SC-020**: A per-format verification table exists distinguishing **produced-and-opened** from
+  **executed-without-error**, with anything uninspected marked unverified or cut.
+- **SC-021**: `reconcile-mcp.py` exits 0 across all four surfaces; `verify-inventory-counts.py` exits 0 with
+  updated counts; `trace-skill.py` resolves for every skill added.
+- **SC-022**: `SOUL.md` gains a capability section describing what NetClaw can now deliver and the
+  no-fabrication discipline — not merely an incremented count.
+- **SC-023**: A test proves a caller **cannot** produce a document lacking generation time, attribution, or
+  per-element provenance — the guarantee is structural, not a convention the caller follows.
+- **SC-024**: No skill contains document-writing logic; every generated file traces to the single server.
+- **SC-025**: The tool manifest measures ≤ 5,000 tokens, with the figure recorded, and the read-only surface
+  guard is proven non-vacuous.
+- **SC-026**: `.docx` block count and `.pptx` slide count are bounded, and an applied bound is stated inside
+  the produced document, exactly as the worksheet row bound is.
+- **SC-027**: Two sources reporting different values for the same thing are both rendered with their own
+  origins; neither is dropped and no silent reconciliation occurs.
+
+## Assumptions
+
+- **The four libraries are present and their installed versions must not move.** Verified installed via
+  rag-mcp (feature 062). Decided in clarification: both this feature and rag-mcp declare **upper-bounded
+  pins** to the already-installed majors, which closes rag-mcp's pre-existing unbounded declaration without
+  changing a single resolved version.
+- **The upstream document skills cannot be vendored, and no install path for them will be built.** Their
+  terms are source-available, demonstration-only. Decided in clarification: NetClaw authors its own
+  capability outright, citing upstream as **reference for capability selection** only. This makes R18
+  build-rather-than-adopt for a licensing reason rather than a quality one.
+- **Output goes to a persistent workspace output directory**, matching feature 046's convention for generated
+  topology visualisations (timestamped, never overwritten, gitignored).
+- **Diagram generation is out of scope and delegated.** Existing skills own it; this embeds their output.
+- **No credentials are introduced.** Data arrives from existing skills that already hold their own
+  credentials; this feature holds none.
+- **`.docx`, `.xlsx` and `.pptx` are built from scratch.** Decided in clarification: no template population
+  for the Office formats. A template's empty field is the strongest fabrication pressure in the feature, and
+  Word/PowerPoint placeholder-matching is the fuzzy version of it. Corporate-branded-template support is a
+  follow-on feature that needs its own fabrication analysis.
+- **PDF is the one template case, and deliberately so.** A PDF form's fields are explicitly named and
+  machine-readable, so "this field has no data" is unambiguous rather than guessed.
+- **PDF support is form filling and assembly, not authoring.** Generating a rich PDF from scratch is a
+  different and larger problem than populating an existing one.
+
+## Out of Scope
+
+- **Diagram and visualisation rendering** — owned by `drawio-rfc`, `markmap`, `uml`, `threejs-network-viz`
+  (FR-035). This embeds, never redraws.
+- **Reading or ingesting documents** — that is `rag-mcp` (feature 062). Same libraries, opposite direction.
+- **Creating or updating tickets** — `servicenow-change-workflow` owns the CR lifecycle (FR-037).
+- **Sending documents anywhere.** Writing a file is in scope; emailing it, attaching it to a ticket, or
+  posting it to Slack is a separate, externally-visible action and belongs to the skills that already own
+  those channels under Principle XIV.
+- **A general report-templating platform.** Deliberately bounded to four formats and the compositions
+  NetClaw actually needs.
+- **Populating corporate-branded `.docx`/`.pptx`/`.xlsx` templates** — excluded by clarification (FR-023a).
+  This is real enterprise demand and a legitimate follow-on feature, but placeholder-matching in an Office
+  template is the fabrication surface this feature most needs to avoid, and it deserves its own analysis
+  rather than being smuggled in as a convenience.
+- **Authoring rich PDFs from scratch**, and **OCR of scanned documents** — both materially larger problems
+  than the deliverable gap this feature closes.
+- **Editing documents in place** — every generation produces a new artefact (FR-018).
+- **Any installer, fetcher or vendored copy of the upstream `anthropics/skills` document skills** — excluded
+  on licence grounds by clarification (FR-029a).

--- a/specs/082-document-generation/tasks.md
+++ b/specs/082-document-generation/tasks.md
@@ -1,0 +1,337 @@
+# Tasks: Document Generation (docx / pptx / xlsx / pdf)
+
+**Feature**: spec 082 / roadmap R18 · **Branch**: `082-document-generation` · **Date**: 2026-08-03
+**Input**: [spec.md](./spec.md) · [plan.md](./plan.md) · [research.md](./research.md) · [data-model.md](./data-model.md) · [contracts/mcp-tools.md](./contracts/mcp-tools.md)
+
+**Tests are included and are not optional here.** The spec requires them explicitly (FR-025, SC-020,
+SC-023) and spec 080 shipped a tool returning three nulls past 24 passing tests because those tests asserted
+on envelope *shape* and never on payload *content*. This feature's entire output **is** content, so every
+verification task below reparses the produced file.
+
+**Total: 145 tasks** (14 added by `/speckit.analyze` remediation). MVP = Phase 1 + 2 + 3 (T001–T059, US1
+the change record).
+
+**Traceability**: all 60 FRs and all 33 SCs have at least one task; no task references a requirement that
+does not exist. Verified mechanically, not by eye.
+
+---
+
+## Phase 1: Setup
+
+- [X] T001 Create the server directory tree `mcp-servers/document-mcp/` with `writers/` and an empty `writers/__init__.py`
+- [X] T002 Create `mcp-servers/document-mcp/requirements.txt` with bounded pins only: `mcp>=1.2.0,<2`, `python-docx>=1.1,<2`, `openpyxl>=3.1,<4`, `python-pptx>=1.0,<2`, `pymupdf>=1.24,<2` — with a comment recording that the `mcp` bound is load-bearing (mcp 2.0 removed `mcp.server.fastmcp`) and that these bounds describe already-installed versions and move nothing (FR-030, FR-032a, FR-032c)
+- [X] T003 Verify T002's bounds resolve to exactly the installed versions with no pip action: `python3 -c "import docx,openpyxl,pptx,fitz"` and record docx 1.2.0 / openpyxl 3.1.5 / pptx 1.0.2 / PyMuPDF 1.28.0 (SC-018)
+- [X] T004 Create `tests/document/` and `tests/document/run-tests.sh` following `tests/bgp-intel/run-tests.sh` verbatim in structure (bash, `set -uo pipefail`, `REPO_ROOT` resolution, `run()` helper, FAILED counter, per-suite header comment naming FR/SC coverage)
+
+**Checkpoint**: directory exists, dependencies confirmed present, test harness runnable (with zero suites).
+
+---
+
+## Phase 2: Foundational — the chokepoint (BLOCKING)
+
+**Nothing in Phase 3+ can start until this completes.** This is where FR-001–FR-010, FR-026 and FR-034 stop
+being prose and become structure.
+
+### The typed vocabulary
+
+- [X] T005 [P] Create `mcp-servers/document-mcp/outcomes.py` with the `Outcome` str-enum: `ok`, `written_with_gaps`, `truncated`, `refused_unattributed`, `refused_untyped`, `refused_template`, `refused_merged_status`, `not_fillable`, `output_unwritable`, `source_missing` (data-model §8). Factor it out of `envelope.py` following spec 081's split, not spec 080's inline enum
+- [X] T006 Add `TaggedValue` parsing to `outcomes.py`: a `parse_tagged(raw, field_path)` returning a discriminated result for the three shapes `{"v",...}` / `{"unavailable"}` / `{"failed"}` (data-model §1)
+- [X] T007 Add the validation rules to `parse_tagged`: exactly one discriminator present; `v` without `src` → refuse; a bare scalar → refuse with a message naming `field_path` **and showing the accepted shapes**; non-ISO `as_of` → refuse; empty `unavailable`/`failed` reason → refuse ("unavailable with no reason is a blank wearing a label")
+- [X] T008 Add `render_tagged(tv)` to `outcomes.py` returning the display string per data-model §1: value as-is; `{"v": ""}` → `(empty)`; unavailable → `NOT AVAILABLE — <reason>`; failed → `RETRIEVAL FAILED — <reason>`. **Assert in the function** that no branch can return `""`, `"N/A"`, `"-"`, `"0"` or whitespace for a non-`v` shape, and that `unavailable` and `failed` render **differently from each other** — a dead query and an empty result are different facts (FR-001, FR-002)
+
+### Provenance accumulation
+
+- [X] T009 [P] Create `mcp-servers/document-mcp/provenance.py` with `SourceRecord` (src, device, as_of, element_count, status ok/partial/failed) and a `SourceLedger` that accumulates from TaggedValues, deduplicating on `(src, device)` and keeping the latest `as_of` (data-model §2)
+- [X] T010 Add `SourceLedger.status_for()` returning `partial` when a source produced both values and unavailables — so a source that half-worked is not reported as clean
+- [X] T011 Add `DocumentStamp` to `provenance.py` (generated_at UTC, generated_by `"NetClaw document-mcp <version>"`, tool, truncated, bound_applied). **Constructor takes no caller input for `generated_at`/`generated_by`** (data-model §3, FR-005b)
+
+### The output writer
+
+- [X] T012 [P] Create `mcp-servers/document-mcp/output.py` with `OUTPUT_DIR` resolved from `__file__` (repo root = `parents[2]`) to `workspace/output/document-mcp/`, overridable by `DOCUMENT_OUTPUT_DIR`. **Persistent, never a temp directory** (FR-016) — following `workspace/skills/threejs-network-viz/output.py` (research D7)
+- [X] T013 Add the timestamped filename builder: `f"{kind}-{UTC %Y%m%dT%H%M%SZ}-{safe_id}.{ext}"` with 046's sanitiser (`c if c.isalnum() or c in "-_" else "_"`). `output_id` is the caller's identifier; `safe_id` is its sanitised form (FR-017)
+- [X] T014 Add `exclusive_create(path)` using `os.open(path, O_CREAT | O_EXCL | O_WRONLY, 0o644)`; on `FileExistsError` append `-2`, `-3`, … and record `collision_suffix`. **An existing file is never opened for writing** (FR-018 — this is where spec 082 tightens feature 046, which relies on timestamp uniqueness alone)
+- [X] T015 Add the unwritable-directory path: a missing or non-writable output dir raises so the chokepoint can return `output_unwritable`. **No fallback to a temp directory** (FR-020)
+- [X] T016 Add `list_outputs(kind, limit)` to `output.py` for the `list_documents` tool
+
+### Untrusted text
+
+- [X] T017 [P] Create `mcp-servers/document-mcp/sanitize.py` with `force_text_cell(cell, value)` that assigns then sets `cell.data_type = "s"` — the measured mitigation for openpyxl writing a leading `=` as `<f>` (research D5, FR-026)
+- [X] T018 Add `plain_text(value)` to `sanitize.py` for docx/pptx: strips control characters and guarantees the value is inserted as a text run, never as a field code
+
+### The chokepoint itself
+
+- [X] T019 Create `mcp-servers/document-mcp/envelope.py` with `emit(*, tool, outcome, artifact, ledger, stamp, gaps, caveats, message)` building the response of contracts §"Every response envelope"
+- [X] T020 Add `ProvenanceError` to `envelope.py` and raise it from `emit()` when an artifact is present but the ledger is empty — a document with no nameable source is not emittable (FR-007, mirrors spec 081's `emit()` source guard)
+- [X] T021 Add `refused(tool, reason, outcome)` to `envelope.py` for the six refusal outcomes; it produces **no artifact** and is still audited
+- [X] T022 Add `audit(tool, response)` to `envelope.py` writing one JSON line to `DOCUMENT_AUDIT_LOG` or `~/.openclaw/gait/document-mcp.jsonl`, with the stderr warning on `OSError` — following `bgp-intel-mcp/envelope.py`. **Called from inside `emit()` and `refused()`, never by a caller** (FR-034)
+- [X] T023 Add the gap accounting to `emit()`: `gaps: {"unavailable": N, "failed": N}` counted from the ledger, and force `outcome = written_with_gaps` when either is non-zero and the caller passed `ok` — a caller **cannot** report a gapped document as clean
+- [X] T024 Verify by reading `envelope.py` and each writer stub that there is **no code path** producing a file without passing through `emit()` — record the audit in a comment at the top of `envelope.py`
+
+### Foundational tests
+
+- [X] T025 [P] Create `tests/document/test_tagged_values.py` following `tests/bgp-intel/test_outcomes.py` conventions (module `FAILURES`, `check(name, condition, detail)`, `main()` → 0/1, `sys.path.insert` to the server dir)
+- [X] T026 In `test_tagged_values.py`: assert `{"v": 5}` without `src` is refused, and the message names the field path (FR-007)
+- [X] T027 In `test_tagged_values.py`: assert a bare scalar `5` where a TaggedValue is expected is refused with `refused_untyped` (FR-005c)
+- [X] T028 In `test_tagged_values.py`: assert `{"v": ""}`, `{"unavailable": "x"}` and `{"failed": "x"}` render to **three different strings**, and assert on the **rendered text** that none is `""`, `"N/A"`, `"-"` or whitespace (spec 081's rendered-text technique — an assertion on wording is the only kind that catches a wording bug)
+- [X] T029 In `test_tagged_values.py`: assert `{"unavailable": ""}` (empty reason) is refused
+- [X] T030 [P] Create `tests/document/test_output_paths.py`: two writes in the same second produce two distinct files; after the second, the first is **byte-identical** to before (FR-018, SC-012)
+- [X] T031 In `test_output_paths.py`: assert the second file carries `collision_suffix` and the reported `artifact.path` is the file that actually exists on disk, so the operator can retrieve it (FR-019, SC-014)
+- [X] T032 In `test_output_paths.py`: point `DOCUMENT_OUTPUT_DIR` at a non-writable path and assert `output_unwritable`, **and** assert no file was created anywhere else (FR-020, SC-013)
+- [X] T033 [P] Create `tests/document/test_sanitize.py`: write `=1+1` through the xlsx path, reopen, assert `cell.data_type == "s"`, **and unzip the workbook and assert `<f>` does not appear in `xl/worksheets/sheet1.xml`** (FR-026, SC-015 — the raw-XML assertion is what catches research D5)
+- [X] T034 In `test_sanitize.py`: assert the round-tripped value is still literally `=1+1` — the mitigation must not corrupt the text with a `'` prefix
+- [X] T035 Wire T025/T030/T033 suites into `tests/document/run-tests.sh` and confirm the harness passes
+
+**Checkpoint**: the chokepoint exists, refuses correctly, audits everything, and cannot overwrite. No writer
+exists yet.
+
+---
+
+## Phase 3: User Story 1 — Change record `.docx` (Priority: P1) 🎯 MVP
+
+**Goal**: produce a change record from a real CR plus real device state, where every populated field traces
+to a named source and every unavailable field says so.
+
+**Independent test**: generate from a real CR number and a real device query; open the `.docx` and confirm
+every populated field has a named source and every gap is explicit.
+
+- [X] T036 [P] [US1] Create `mcp-servers/document-mcp/writers/docx_writer.py` — named `docx_writer.py`, **not `docx.py`**, which would shadow the third-party package on the path the server inserts
+- [X] T037 [US1] Implement the `heading` and `paragraph` blocks in `docx_writer.py` (contracts §1)
+- [X] T038 [US1] Implement the `keyvalue` block: two columns plus a **`Source` column appended by the writer**, so a caller cannot omit attribution — per element, never one collective citation (FR-009, FR-009a)
+- [X] T039 [US1] Implement the `table` block with the same writer-appended `Source` column, and an `As of` column when any row carries `as_of` (FR-009, FR-010)
+- [X] T040 [US1] Implement the `figure` block: value followed by a visible inline parenthetical `(src · device · as of …)` in a smaller run — **inline, because python-docx 1.2.0 has no footnote API** (research D3, FR-008a)
+- [X] T041 [US1] Implement the `image` block: validate the path exists **and** resolves inside the workspace output dir, require `src` naming the producing skill, else `source_missing` (FR-014, FR-035)
+- [X] T042 [US1] Implement `pagebreak`
+- [X] T043 [US1] Add the section footer carrying generation time and NetClaw attribution on **every page** (FR-006, FR-008)
+- [X] T044 [US1] Append the visible `Sources` section built from the `SourceLedger`, with per-source as-of and status (FR-009a)
+- [X] T045 [US1] Add the prose lint with a **defined trigger**: a `paragraph` emits a caveat naming the block index if its text contains a digit **that is not** part of an allow-listed pattern — an ISO/RFC date, a time, a ticket identifier matching `[A-Z]{2,6}\d{4,}`, a version like `7.6.7`, an ordinal like "Section 2", or an IP/prefix/ASN literal. Everything else is a bare figure, and prose is the one place an unattributed figure could hide (data-model §4). The vague version of this rule ("contains a bare number") fires on every date and gets tuned into vacuity — the allow-list is what keeps it real
+- [X] T046 [US1] Set `core_properties.comments` additively, and add a comment recording that this is **additive only** and must never be the provenance mechanism (FR-008a)
+- [X] T047 [US1] Reject any `template`/`template_path` parameter on `docx_write` with `refused_template` and a message saying Office templates are out of scope and why (FR-023a, SC-008b). Put the check in a **shared helper** so `xlsx_write` (T067a) and `pptx_write` (T081a) reuse it rather than each re-deriving it
+- [X] T047a [US1] Implement the block bound (`DOCUMENT_MAX_BLOCKS`, default 5,000): on truncation set `outcome = truncated` and **write the bound into the document body** (FR-027a, SC-026)
+- [X] T047b [US1] Implement the disagreement rule: two TaggedValues for the same label with different `src` are **both** rendered, each with its own origin, and a caveat names the disagreement. No winner is picked and neither is dropped (FR-027b, SC-027)
+- [X] T048 [US1] Create `mcp-servers/document-mcp/server.py` with the FastMCP init, `sys.path.insert`, and stdio `mcp.run()` tail, following `bgp-intel-mcp/server.py`
+- [X] T049 [US1] Add the `docx_write` tool to `server.py`, delegating to the writer and returning through `envelope.emit()` (FR-021)
+- [X] T050 [P] [US1] Create `tests/document/test_provenance.py`: generate a `.docx`, **reopen it with python-docx**, and assert the footer contains a generation time and "NetClaw" (SC-009 — verified by opening the file, not by inspecting code)
+- [X] T051 [US1] In `test_provenance.py`: assert every table in the reopened `.docx` has a `Source` column and that no data row has an empty source cell (SC-010)
+- [X] T052 [US1] In `test_provenance.py`: assert a `Sources` section exists and lists each source with its as-of (SC-010a)
+- [X] T053 [US1] In `test_provenance.py`: assert a source's own `as_of` is rendered and is **distinguishable** from the document's generation time (SC-011)
+- [X] T054 [US1] In `test_provenance.py`: assert a refusal still produced a GAIT record — read `DOCUMENT_AUDIT_LOG` and find the line (SC-019, and the defect `/speckit.analyze` caught in specs 076 and 080)
+- [X] T055 [P] [US1] Create `tests/document/test_no_fabrication.py`: a `keyvalue` with one `unavailable` pair renders `NOT AVAILABLE — <reason>` in the reopened document, and the literal strings `N/A`, `TBD` and `Unknown` do **not** appear (SC-002)
+- [X] T056 [US1] In `test_no_fabrication.py`: a `failed` value renders `RETRIEVAL FAILED` and is textually distinct from an `unavailable` value in the same document (SC-003)
+- [X] T057 [US1] In `test_no_fabrication.py`: `outcome` is `written_with_gaps`, not `ok`, whenever any gap is present — and the caller passing `ok` cannot override it (T023)
+- [X] T057a [US1] In `test_no_fabrication.py`: two sources disagreeing on one label produce **both** values in the reopened document, each with its own source, plus a caveat. Assert on rendered text that neither value is absent (FR-027b, SC-027)
+- [X] T057b [US1] In `test_no_fabrication.py`: assert `docx_write`, `xlsx_write` and `pptx_write` **all three** return `refused_template` for a supplied template — a single parametrised assertion, so a fourth format cannot be added without it (SC-008b)
+- [X] T057c [US1] In `test_no_fabrication.py`: assert an over-bound docx block list and an over-bound pptx slide list each yield `truncated` with the bound present in the reopened file (FR-027a, SC-026)
+- [X] T058 [US1] Wire `test_provenance.py` and `test_no_fabrication.py` into `run-tests.sh`
+- [X] T059 [US1] **Produce a real change-record `.docx` from a real ServiceNow CR and real FortiGate state, open it, and record what it contains** in a scratch note for `VERIFICATION.md` (FR-011, FR-025, SC-001). If ServiceNow is not configured, use real FortiGate state plus a hand-supplied CR and **record that half as unverified** rather than claiming it
+
+**Checkpoint**: US1 independently deliverable. A real `.docx` exists and has been opened.
+
+---
+
+## Phase 4: User Story 2 — Interface audit `.xlsx` (Priority: P1)
+
+**Goal**: every interface across a set of devices in a spreadsheet, with separate admin/oper columns,
+per-row provenance, and failed devices present as failed rows.
+
+**Independent test**: generate from a real device query; row count matches the source; every column has a
+stated origin; a failed device appears as a failed row.
+
+- [X] T060 [P] [US2] Create `mcp-servers/document-mcp/writers/xlsx_writer.py` (not `openpyxl.py`)
+- [X] T061 [US2] Implement sheet creation from `{name, columns, rows}` with every string cell written through `sanitize.force_text_cell` (FR-026)
+- [X] T062 [US2] Append the writer-owned `Source` and `As of` columns to every sheet (FR-009a, FR-010)
+- [X] T063 [US2] Render `failed_rows` **as rows**, visually marked, positioned with the data — not in a separate section a reader can miss (FR-003)
+- [X] T064 [US2] Add the banner row stating *attempted / succeeded / failed*, frozen at the top of each data sheet (SC-004)
+- [X] T065 [US2] Refuse a merged state column with `refused_merged_status` and a message citing the distinction (FR-015). **Defined trigger**: the header, case-folded and stripped of punctuation, is one of `status`, `state`, `updown`, `up/down`, `link status`, `interface status` — **and** the sheet contains no separate column matching `admin` and no separate column matching `oper`. A sheet that already has both may legitimately also carry a derived summary column
+- [X] T066 [US2] Add the `Sources` worksheet built from the `SourceLedger`, plus the `DocumentStamp` in its header (FR-009a, FR-006)
+- [X] T067 [US2] Implement the row bound from `DOCUMENT_MAX_ROWS` (default 50,000): on truncation set `outcome = truncated` and **write the bound into the sheet itself**, not only into the response (FR-027, SC-016)
+- [X] T067a [US2] Reject any `template`/`template_path` parameter on `xlsx_write` with `refused_template` (FR-023a, SC-008b) — the scratch-only decision applies to **all three** Office formats, not only the first one implemented
+- [X] T068 [US2] Add the `xlsx_write` tool to `server.py` (FR-022)
+- [X] T069 [P] [US2] In `test_provenance.py`: generate a workbook, **reopen with openpyxl**, assert every data sheet has a populated `Source` column on every row (SC-005, SC-010)
+- [X] T070 [US2] In `test_no_fabrication.py`: a failed device appears as a row; the sheet's row count equals *attempted*, not *succeeded*; the banner reports the split (SC-004)
+- [X] T071 [US2] In `test_no_fabrication.py`: assert admin and operational state occupy **two columns** and that no single column merges them (SC-006)
+- [X] T072 [US2] In `test_no_fabrication.py`: assert a truncated workbook states its bound in a cell, found by reopening (SC-016)
+- [X] T073 [US2] **Produce a real interface-audit `.xlsx` from a real `fgt_list_interfaces` (or `multivendor-device-query`) result, open it, and confirm the row count matches the source**; record for `VERIFICATION.md` (FR-012, SC-005)
+
+**Checkpoint**: US2 independently deliverable, and it does not depend on US1.
+
+---
+
+## Phase 5: User Story 3 — Executive summary `.pptx` (Priority: P2)
+
+**Goal**: a short deck carrying findings, with sources visible on the slide and an embedded diagram from an
+existing diagram skill.
+
+**Independent test**: generate from real findings, open it, confirm the diagram came from an existing skill.
+
+- [X] T074 [P] [US3] Create `mcp-servers/document-mcp/writers/pptx_writer.py` (not `pptx.py`)
+- [X] T075 [US3] Implement the `title` and `bullets` layouts
+- [X] T076 [US3] Implement the `figure` layout with a **visible on-slide source line** along the bottom — speaker notes are hidden in presentation and print and do not satisfy FR-008a (research D4)
+- [X] T077 [US3] Implement the `image` layout: path validated inside the workspace output dir, `src` naming the producing diagram skill, else `source_missing` (FR-014)
+- [X] T078 [US3] Write the same detail into `notes_slide` **additively**, with a comment recording that it is additive and never the mechanism
+- [X] T079 [US3] Append the `Sources` slide from the `SourceLedger` (FR-009a)
+- [X] T080 [US3] Put the `DocumentStamp` on the title slide and the Sources slide (FR-006)
+- [X] T081 [US3] Emit a caveat for any `bullets` slide with no `detail_ref` — a summary claim should be traceable to detail (FR-005)
+- [X] T081a [US3] Reject any `template`/`template_path` parameter on `pptx_write` with `refused_template` (FR-023a, SC-008b)
+- [X] T081b [US3] Implement the slide bound (`DOCUMENT_MAX_SLIDES`, default 200): on truncation set `outcome = truncated` and **write the bound onto a slide** (FR-027a, SC-026)
+- [X] T082 [US3] Add the `pptx_write` tool to `server.py` (FR-023)
+- [X] T083 [P] [US3] In `test_provenance.py`: generate a deck, **reopen with python-pptx**, and assert the on-slide source text is present in a **shape**, not only in `notes_slide` (SC-007, SC-010b)
+- [X] T084 [US3] In `test_provenance.py`: assert a `Sources` slide exists and the title slide carries the stamp
+- [X] T085 [US3] **Produce a real `.pptx` embedding a diagram actually generated by `drawio-diagram` or `threejs-network-viz`, open it**, and record which skill produced the diagram (FR-013, SC-007)
+
+---
+
+## Phase 6: User Story 4 — Fill a PDF form (Priority: P3)
+
+**Goal**: fill an existing fillable PDF from real data, leaving unmatched fields genuinely empty and
+reporting both directions of mismatch.
+
+**Independent test**: fill a real form with known values, reopen, confirm values landed in the right named
+fields and unfilled fields are actually unfilled.
+
+- [X] T086 [P] [US4] Create `mcp-servers/document-mcp/writers/pdf_writer.py` (not `fitz.py`)
+- [X] T087 [US4] Implement form detection with `doc.is_form_pdf` — **compare truthily; it returns an int (measured: 3), never `is True`** (research D6)
+- [X] T088 [US4] Implement field enumeration from `page.widgets()` returning name, kind (mapped from `PDF_WIDGET_TYPE_*`), current value, page index (data-model §7)
+- [X] T089 [US4] Add the `pdf_inspect_form` tool to `server.py`, returning `not_fillable` with a message for a PDF with no form fields, and **no output file** (FR-024)
+- [X] T090 [US4] Implement filling by **named field only** — no positional text placement, which would produce a document that looks filled but carries no field data (FR-024a)
+- [X] T091 [US4] Leave a field empty for `unavailable`/`failed` values and add it to `unfilled`; never write a guess to complete the form (FR-024b, US4 §2)
+- [X] T092 [US4] Compute and return `unmatched` — supplied keys matching no field. **Never dropped silently**: data that vanished is indistinguishable from data never supplied (FR-024b)
+- [X] T093 [US4] Write to a **new** file via `output.exclusive_create`; the input PDF is never modified
+- [X] T094 [US4] Add the `pdf_fill_form` tool to `server.py`
+- [X] T095 [US4] Document the one place FR-008 cannot be met inside the artefact: a customer's form has nowhere for a Sources section without altering it, so provenance for a fill lives in the response and the GAIT record. **State this in the tool docstring and the skill** rather than pretending otherwise
+- [X] T096 [P] [US4] Create `tests/document/test_pdf_forms.py`: build a fixture form with `fitz.Widget()` + `page.add_widget()` (research D6 — the suite generates its own form, no customer artefact needed)
+- [X] T097 [US4] In `test_pdf_forms.py`: fill a subset, reopen, assert values are in the correct named fields and untouched fields are still empty (SC-008)
+- [X] T098 [US4] In `test_pdf_forms.py`: assert `unfilled` and `unmatched` are both reported and neither is silently absorbed (SC-008a)
+- [X] T099 [US4] In `test_pdf_forms.py`: assert a non-fillable PDF returns `not_fillable` and **no output file was created** (SC-008)
+- [X] T100 [US4] In `test_pdf_forms.py`: assert the input PDF is byte-identical after a fill
+- [X] T101 [US4] Wire `test_pdf_forms.py` into `run-tests.sh`
+
+---
+
+## Phase 7: Dependency correction (cross-cutting)
+
+**Sequenced after the writers** so a dependency change cannot be blamed for a writer bug.
+
+- [X] T102 Bound the unpinned declarations in `mcp-servers/rag-mcp/pyproject.toml`: `mcp>=1.2.0,<2`, `fastmcp` (bound to the installed major — **measure it first**), `pymupdf>=1.24,<2`, `python-docx>=1.1,<2`, `openpyxl>=3.1,<4`, `python-pptx>=1.0,<2`, `vsdx` (measure and bound). Add a comment naming spec 082 and stating no installed version moves (FR-032b, FR-032c)
+- [X] T103 Confirm T102 moved nothing: re-import all of rag-mcp's document libraries and compare versions to the T003 record (SC-018)
+- [X] T104 Extend `scripts/check-dependency-pins.py` to read `pyproject.toml` `[project].dependencies` in addition to `requirements.txt` — **rag-mcp has no `requirements.txt` and has therefore never been scanned** (FR-032, research D2)
+- [X] T105 Add a distribution→module alias map to `check-dependency-pins.py` covering at least `pymupdf`→`fitz`, `python-docx`→`docx`, `python-pptx`→`pptx`, `beautifulsoup4`→`bs4`, `pillow`→`PIL` — the checker matches by distribution name, so these renames slip through even a scanned file (FR-032, research D2)
+- [X] T106 Run `python3 scripts/check-dependency-pins.py; echo $?` and confirm exit 0 with a **higher** scanned-server count than the 63 baseline. If the extended checker surfaces genuine pre-existing hazards in other servers, **list them in `VERIFICATION.md` as found-not-fixed** rather than silently widening this feature's scope
+- [X] T107 Re-exercise rag-mcp ingestion after T102 — ingest a real `.docx`, `.xlsx`, `.pptx` and `.pdf` and confirm it still parses them. Editing another feature's dependency file obliges proving that feature still works (FR-032d, SC-018b)
+- [X] T108 Verify no unbounded declaration of the four document libraries remains anywhere in the repo: `grep -rn` across `requirements.txt` and `pyproject.toml` files (SC-018a)
+
+---
+
+## Phase 8: Skills and artifact coherence (Principle XI)
+
+- [X] T109 [P] Create `workspace/skills/document-generation/SKILL.md` — frontmatter copied exactly from `workspace/skills/bgp-registry-intel/SKILL.md` (quoted single-line `description` ending in a "Use when …" clause, `version`, `license: Apache-2.0`, `tags`, `user-invocable: true`, inline-JSON `metadata.openclaw.requires`). Body: the six tools, **the one rule** ("a document must never fabricate to fill a blank"), the TaggedValue shapes, the output convention, and the **three stated limits** (no docx footnotes, no Office templates, no Sources section in a filled PDF)
+- [X] T109a Add the agent-facing prohibition to `document-generation/SKILL.md`, stated as strongly as the tool refusals: **never infer, estimate, interpolate, or carry forward a stale value to complete a document** (FR-004). The server structurally cannot fabricate — it only renders TaggedValues — but the agent composing the request can, and this is the only place that half of the discipline can live
+- [X] T109b Add all **three** boundary statements to `document-generation/SKILL.md`: diagram skills own diagrams and this embeds them (FR-035); `rag-mcp` **reads** these formats and this **writes** them, same libraries opposite direction (FR-036); `servicenow-change-workflow` owns the CR lifecycle and this renders a document from it (FR-037)
+- [X] T110 [P] Create `workspace/skills/network-report-documents/SKILL.md` with the four compositions — change record, interface/config audit workbook, executive summary deck, PDF form fill — each naming the upstream skills that feed it (`servicenow-change-workflow`, `fortigate-ops`/`multivendor-cli`, the diagram skills) and the boundary against them
+- [X] T110a Repeat the no-inference prohibition (FR-004) and the three boundaries (FR-035/036/037) in `network-report-documents/SKILL.md` — this is the skill an agent actually reaches for, so the discipline cannot live only in its sibling
+- [X] T111 Add the `document` entry to `scripts/lib/catalog.sh` in the `Platform Services` group, **and add `document` to `PROFILE_RECOMMENDED`** — profile membership is the easy-to-miss artifact `docs/ADDING-AN-MCP.md` calls out
+- [X] T112 Add `component_install_document()` to `scripts/lib/install-steps.sh` following `component_install_bgp_intel()` verbatim in shape: `netclaw_pip_install -r "$DIR/requirements.txt"`, `log_warn` on failure, `DOCUMENT_MCP_CMD_DETECTED` export. **Never call `pip`/`pip3` directly** (FR-031). Do not copy bgp-intel's stale section comment
+- [X] T113 Register `document-mcp` in `config/openclaw.json` with repo-relative paths, `command`/`args` separate, `-u` flag, and `${VAR}` env passthrough only — appended after `bgp-intel-mcp`
+- [X] T114 Add **both** HUD entries to `ui/netclaw-visual/server.js`: the `INTEGRATION_CATALOG` node (id `document`, category `Platform Services`, prefixes `['docx_','xlsx_','pptx_','pdf_','list_documents']`, transport `stdio`, toolEstimate 6) **and** the `ENV_MAP` annotation (env vars, `files`, and a `notes` string stating no credentials, files-only, and the no-fabrication discipline). One entry is not enough
+- [X] T115 Update `.env.example` with the box-header block for spec 082: `DOCUMENT_MCP_CMD`, `DOCUMENT_OUTPUT_DIR`, `DOCUMENT_MAX_ROWS`, `DOCUMENT_AUDIT_LOG` — names and defaults only, no values (FR-038)
+- [X] T116 Update `TOOLS.md` with `## Document Generation (\`document-mcp\`, NetClaw-native)` following the bgp-intel block's shape: spec/roadmap line, format table, `### Environment`, `### Behaviour worth knowing` (including the measured openpyxl formula hazard, the three limits, and the three boundaries FR-035/036/037), and the measured manifest token count
+- [X] T117 Update `SOUL.md`: add a `### Document Generation (2)` capability section describing what NetClaw can now deliver and the no-fabrication discipline — **a capability description, not merely an incremented count** (FR-038, SC-022) — and update both count sites (line ~15 `**209 skills** backed by 155 MCP servers`, line ~525 `all 209 skills`)
+- [X] T118 Update `README.md`: two new MCP table rows and two new skill rows for this feature; **plus the pre-existing drift found in research D13** — the missing table rows for Fortinet (spec 080) and BGP-intel (spec 081) and the missing `bgp-registry-intel`/`fortigate-ops`/`fortianalyzer-ops` skill rows. Then update all four count sites to 155 / 209
+
+---
+
+## Phase 9: Honest verification and polish
+
+- [X] T119 Create `tests/document/test_manifest_size.py`: measure the tool manifest and assert **≤ 5,000 tokens** (FR-038a, SC-025). Add the read-only surface guard with a **defined predicate** — no tool may accept a parameter that is a device target, a hostname/IP, a credential, or a ticket identifier, and no tool description may claim to change infrastructure state (FR-033). *Not* "no tool name implies a write": four of six tools do write, to files, which is the whole point. Prove the guard non-vacuous by temporarily adding a tool with a `device_host` parameter and confirming it fails
+- [X] T119a Wire `test_manifest_size.py` into `tests/document/run-tests.sh` — every other suite has an explicit wiring task and this one would otherwise never run
+- [X] T120 Add the structural-guarantee test to `test_provenance.py`: attempt, from a caller's position, to produce a document lacking generation time, attribution, or per-element provenance — and assert it is **impossible**, not merely discouraged (SC-023)
+- [X] T121 Add the no-skill-writes assertion: `grep` the two SKILL.md files and confirm neither contains document-writing code, and that every generated file traces to the single server (SC-024, FR-005a, FR-005d)
+- [X] T122 Add the forwarding test to `test_provenance.py`: extract a table's text from each generated file (the copy-paste path) and assert attribution survives; assert no provenance is carried solely by a cell comment, tooltip, or document metadata property (SC-010b, FR-008a)
+- [X] T122a **Licence verification** (FR-028, FR-029, FR-029a, SC-017): confirm no file in this feature's diff was copied from `anthropics/skills`; `grep` every shipped artifact — installer, skills, server, docs — for any `git clone`, `curl`, `wget`, `pip install` from a URL, or other fetch path targeting it, and confirm there is none; confirm the licence finding is recorded durably in `docs/COVERAGE-ROADMAP.md` **and** `research.md` D1. This is the constraint that redefined R18 and nothing else checks it
+- [X] T123 Create `mcp-servers/document-mcp/README.md` — the step-5 artifact: tools, env vars, transport, the output convention, the three limits, the three boundaries (FR-035/036/037), and install
+- [X] T124 Create `specs/082-document-generation/VERIFICATION.md` with a per-format table distinguishing **produced-and-opened** from **executed-without-error**, and mark anything uninspected as unverified or cut (FR-042, FR-043, SC-020). Include the T106 found-not-fixed list if any
+- [X] T124a In `VERIFICATION.md`, record the **iN2N decision** (FR-039): this capability is Border-only because it holds no credentials and composes across domains, so the five member artifacts plus a mesh restart are **not triggered** — and state that they apply in full if a member is ever given it. A conditional requirement resolved silently reads as an omitted one (research D11)
+- [X] T125 Run `bash tests/document/run-tests.sh` and confirm all suites pass
+- [X] T126 Run `python3 scripts/reconcile-mcp.py; echo $?` and confirm **exit 0 across all four surfaces** (FR-040) — read the exit code directly, never through a pipe (CLAUDE.md: `cmd | tail` reports `tail`'s status)
+- [X] T127 Run `python3 scripts/verify-inventory-counts.py; echo $?` and confirm exit 0 with 209 skills / 155 integrations (FR-041, SC-021)
+- [X] T128 Run `python3 scripts/trace-skill.py document-generation` and `... network-report-documents` and confirm both resolve (SC-021)
+- [X] T129 Deploy to the live workspace and run an end-to-end generation from Slack, then **open the produced file** — the bug spec 080 shipped surfaced only in a live run, not in 24 passing tests
+- [X] T130 Secret-scan the diff before commit; confirm no credential, path or hostname leaked into any artifact
+- [X] T131 Record the GAIT session log for this feature (Principle IV, artifact checklist)
+
+---
+
+## Dependencies
+
+```
+Phase 1 (Setup)
+   └─▶ Phase 2 (Foundational chokepoint)  ── BLOCKING ──┐
+                                                        ├─▶ Phase 3 (US1 docx, P1)  🎯 MVP
+                                                        ├─▶ Phase 4 (US2 xlsx, P1)
+                                                        ├─▶ Phase 5 (US3 pptx, P2)
+                                                        └─▶ Phase 6 (US4 pdf,  P3)
+                                                                    │
+                                             Phase 7 (dependency correction) ◀┘
+                                                        │
+                                             Phase 8 (skills + artifacts)
+                                                        │
+                                             Phase 9 (honest verification)
+```
+
+**Story independence**: US1, US2, US3 and US4 each depend only on Phase 2. None depends on another. US1
+alone is a shippable MVP.
+
+**Sequencing note**: Phase 7 comes after Phase 6 deliberately. Changing dependency declarations while
+writers are still being debugged would make a writer bug look like a dependency regression.
+
+---
+
+## Parallel execution opportunities
+
+**Within Phase 2** — T005, T009, T012, T017 touch four different new files:
+```
+T005 outcomes.py   ┐
+T009 provenance.py ├── all [P], no shared files
+T012 output.py     │
+T017 sanitize.py   ┘
+```
+Then T019–T024 (`envelope.py`) must be serial — they all edit one file.
+
+**Across user stories** — after Phase 2, the four writers are four separate files:
+```
+T036 writers/docx_writer.py  (US1)  ┐
+T060 writers/xlsx_writer.py  (US2)  ├── all [P]
+T074 writers/pptx_writer.py  (US3)  │
+T086 writers/pdf_writer.py   (US4)  ┘
+```
+Their `server.py` tool registrations (T049, T068, T082, T089/T094) must serialise — one file.
+
+**Within Phase 8** — T109 and T110 are two different SKILL.md files and are `[P]`. Everything else in
+Phase 8 edits a distinct shared file and should be done one at a time to keep diffs reviewable.
+
+---
+
+## Independent test criteria per story
+
+| Story | Independently testable by |
+|---|---|
+| **US1** (P1, docx) | Generate from a real CR + real device state; **open the file**; every populated field names a source; every gap is explicit text, not a blank |
+| **US2** (P1, xlsx) | Generate from a real device query; **open the workbook**; row count = attempted; admin/oper in separate columns; failed device present as a failed row |
+| **US3** (P2, pptx) | Generate from real findings; **open the deck**; source text lives in a slide shape, not only in speaker notes; diagram came from an existing skill |
+| **US4** (P3, pdf) | Fill a real form; **reopen it**; values in the right named fields; `unfilled` and `unmatched` both reported; input file unchanged |
+
+---
+
+## Implementation strategy
+
+**MVP** = Phases 1–3 (T001–T059). That is a working change-record generator with the full no-fabrication
+discipline already structural, because the discipline lives in Phase 2, not in the writers.
+
+**Then** Phase 4 (US2) for the highest-volume real use, Phase 5, Phase 6 — each independently shippable.
+
+**Then** Phases 7–9, which are cross-cutting and must not be skipped: Phase 7 closes a hazard that predates
+this feature, Phase 8 is Principle XI, and Phase 9 is the difference between "the tests pass" and "a human
+opened the document and it was right".
+
+**The rule that governs Phase 9**: a file being written is not evidence the document is correct. Spec 080
+had 24 passing tests and a tool returning three nulls. Every claim in `VERIFICATION.md` must say whether the
+artefact was **opened** or merely **produced**.

--- a/tests/document/_harness.py
+++ b/tests/document/_harness.py
@@ -1,0 +1,67 @@
+"""Shared harness for the document-mcp suites. Spec 082.
+
+Plain Python, stdlib only, no pytest — following tests/bgp-intel/ and, before it,
+tests/reconcile/ (spec 075). No new test framework in the shared environment.
+
+Every suite here runs with NO network and NO credentials, because everything under test
+is structural. But note what that does NOT buy: spec 080 had 24 passing appliance-free
+tests while shipping a tool that returned three nulls, because its suites asserted on
+the ENVELOPE and never on the CONTENT. This feature's entire output is content, so the
+suites below reopen the generated files and assert on what is inside them.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+SERVER_DIR = os.path.join(_HERE, "..", "..", "mcp-servers", "document-mcp")
+sys.path.insert(0, os.path.abspath(SERVER_DIR))
+
+FAILURES: list[str] = []
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  PASS  {name}")
+    else:
+        FAILURES.append(f"{name}: {detail}")
+        print(f"  FAIL  {name} — {detail}")
+
+
+def sandbox() -> str:
+    """An isolated output dir + audit log for one suite."""
+    d = tempfile.mkdtemp(prefix="document-mcp-test-")
+    os.environ["DOCUMENT_OUTPUT_DIR"] = os.path.join(d, "out")
+    os.environ["DOCUMENT_AUDIT_LOG"] = os.path.join(d, "gait.jsonl")
+    os.makedirs(os.environ["DOCUMENT_OUTPUT_DIR"], exist_ok=True)
+    return d
+
+
+def cleanup(d: str) -> None:
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def run(tests: list, title: str) -> int:
+    for fn in tests:
+        print(f"\n{fn.__name__}")
+        fn()
+    print()
+    if FAILURES:
+        print(f"{len(FAILURES)} FAILED")
+        for f in FAILURES:
+            print(f"  - {f}")
+        return 1
+    print(f"all {title} tests passed")
+    return 0
+
+
+def abspath(artifact_path: str) -> str:
+    """Artifacts report a repo-relative path when they land under the repo, and an
+    absolute one otherwise (as they do in a sandbox)."""
+    if os.path.isabs(artifact_path):
+        return artifact_path
+    return os.path.abspath(os.path.join(_HERE, "..", "..", artifact_path))

--- a/tests/document/run-tests.sh
+++ b/tests/document/run-tests.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Contract tests for document-mcp — spec 082 (roadmap R18).
+#
+# Bash + stdlib only, following tests/bgp-intel/run-tests.sh and, before it,
+# tests/reconcile/run-tests.sh (spec 075). No new test framework.
+#
+# EVERY TEST HERE RUNS WITH NO NETWORK AND NO CREDENTIALS. Each suite writes into its
+# own temp directory via _harness.sandbox() and cleans up after itself; nothing lands in
+# workspace/output/.
+#
+# But note what appliance-free testing does NOT buy. Spec 080 had 24 passing tests while
+# shipping a tool that returned three nulls, because its suites asserted on the ENVELOPE
+# and never on the CONTENT. This feature's entire output IS content, so the suites below
+# reopen every generated .docx/.xlsx/.pptx/.pdf with the same library a reader's
+# application would use and assert on what is inside it — including one assertion
+# against raw worksheet XML, which is the only thing that catches openpyxl turning a
+# leading `=` into a live formula.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+FAILED=0
+run() {
+    local name="$1" path="$2"
+    echo
+    echo "=============================================================="
+    echo "  $name"
+    echo "=============================================================="
+    python3 "$path" || { FAILED=$((FAILED + 1)); return 1; }
+}
+
+run "tagged values — the three shapes, refusals (FR-001/002/005c/007, SC-002/003)"  tests/document/test_tagged_values.py
+run "output paths  — O_EXCL, never overwrite (FR-016..020, SC-012/013/014)"          tests/document/test_output_paths.py
+run "sanitize      — untrusted text is not a formula (FR-026, SC-015)"               tests/document/test_sanitize.py
+run "provenance    — REOPENED files carry stamp + sources (FR-006..010, SC-009/010)" tests/document/test_provenance.py
+run "no fabricate  — gaps explicit, bounds stated, templates refused (FR-001..005)"  tests/document/test_no_fabrication.py
+run "pdf forms     — named fields, unfilled + unmatched (FR-024/024a/024b, SC-008)"  tests/document/test_pdf_forms.py
+run "surface       — read-only guard + <= 5,000 token ceiling (FR-033/038a, SC-025)" tests/document/test_manifest_size.py
+
+echo
+echo "=============================================================="
+if [ "$FAILED" -eq 0 ]; then
+    echo "  ALL SUITES PASSED"
+    exit 0
+fi
+echo "  $FAILED SUITE(S) FAILED"
+exit 1

--- a/tests/document/test_manifest_size.py
+++ b/tests/document/test_manifest_size.py
@@ -1,0 +1,132 @@
+"""Manifest size and the read-only surface guard. Spec 082, FR-033/038a, SC-025.
+
+The guard's predicate matters. "No tool name implies a write" would be wrong here —
+four of the six tools DO write, to files, which is the entire point of the feature. What
+this server must never do is touch infrastructure: no device target, no credential, no
+ticket identifier as a parameter, and no description claiming to change device or ticket
+state.
+
+`/speckit.analyze` caught the vague version of this before it was written. The guard is
+also proven non-vacuous below by feeding it a deliberately bad tool.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import re
+
+from _harness import FAILURES, check, run  # noqa: F401
+
+import server  # noqa: E402
+
+CEILING = 5000
+
+# Parameters that would mean this server talks to infrastructure.
+FORBIDDEN_PARAMS = re.compile(
+    r"(?i)\b(device_host|hostname|device_ip|ip_address|mgmt_ip|host|target_device|"
+    r"credential|password|token|api_key|secret|username|"
+    r"ticket_id|change_id|incident_id|sys_id|cr_number)\b"
+)
+
+# Claims a description must not make.
+FORBIDDEN_CLAIMS = re.compile(
+    r"(?i)(push (?:the )?config|apply (?:the )?config|configure the device|"
+    r"reboot|deploy to|write to the device|create a ticket|update the ticket|"
+    r"close the change|open a change)"
+)
+
+
+def _tools():
+    return asyncio.run(server.mcp.list_tools())
+
+
+def _manifest_text() -> str:
+    parts = []
+    for tool in _tools():
+        parts.append(tool.name)
+        parts.append(tool.description or "")
+        parts.append(str(tool.inputSchema))
+    return "\n".join(parts)
+
+
+def _estimate_tokens(text: str) -> int:
+    """~4 characters per token, the same conservative estimate specs 080 and 081 used.
+    Deliberately pessimistic: overestimating keeps us under the real ceiling."""
+    return len(text) // 4 + text.count("\n")
+
+
+def test_manifest_is_under_the_ceiling():
+    text = _manifest_text()
+    tokens = _estimate_tokens(text)
+    print(f"  measured manifest: {tokens} / {CEILING} tokens ({len(text)} chars)")
+    check(f"manifest is <= {CEILING} tokens", tokens <= CEILING, f"measured {tokens}")
+    check("the tool count is what the contract says", len(_tools()) == 6, str(len(_tools())))
+
+
+def test_no_tool_accepts_an_infrastructure_parameter():
+    for tool in _tools():
+        props = list((tool.inputSchema or {}).get("properties", {}).keys())
+        bad = [p for p in props if FORBIDDEN_PARAMS.search(p)]
+        check(
+            f"{tool.name} accepts no device/credential/ticket parameter",
+            not bad,
+            f"parameters {bad} would mean this server talks to infrastructure",
+        )
+
+
+def test_no_description_claims_an_infrastructure_change():
+    for tool in _tools():
+        desc = tool.description or ""
+        match = FORBIDDEN_CLAIMS.search(desc)
+        check(
+            f"{tool.name} claims no infrastructure change",
+            match is None,
+            f"description contains {match.group(0)!r}" if match else "",
+        )
+
+
+def test_the_guard_is_not_vacuous():
+    """Feed the predicate a deliberately bad tool. If it passes, the guard is theatre."""
+    fake_params = ["path", "device_host", "values"]
+    caught = [p for p in fake_params if FORBIDDEN_PARAMS.search(p)]
+    check("the parameter guard rejects a device_host parameter", caught == ["device_host"], str(caught))
+
+    fake_desc = "Fill a form and then push the config to the device."
+    check("the description guard rejects an infrastructure claim",
+          FORBIDDEN_CLAIMS.search(fake_desc) is not None,
+          "the guard would have passed a tool that claims to configure a device")
+
+    check("the ceiling check rejects an oversized manifest", _estimate_tokens("x" * 40_000) > CEILING)
+
+
+def test_every_tool_routes_through_the_chokepoint():
+    """FR-005a/005b. There is exactly one way out of this server."""
+    src = inspect.getsource(server)
+    tool_bodies = src.split("@mcp.tool()")[1:]
+    check("six tools are defined", len(tool_bodies) == 6, str(len(tool_bodies)))
+    for body in tool_bodies:
+        name = body.split("async def ", 1)[1].split("(", 1)[0]
+        routed = ("envelope.emit" in body) or ("_write(" in body)
+        check(f"{name} returns through the chokepoint", routed,
+              "a tool returns without emit() — provenance and GAIT would be skipped")
+
+    for module_name in ("writers.docx_writer", "writers.xlsx_writer",
+                        "writers.pptx_writer", "writers.pdf_writer"):
+        mod = __import__(module_name, fromlist=["x"])
+        msrc = inspect.getsource(mod)
+        check(f"{module_name} does not audit directly",
+              "envelope" not in msrc,
+              "a writer bypassing the chokepoint could ship an unaudited document")
+
+
+TESTS = [
+    test_manifest_is_under_the_ceiling,
+    test_no_tool_accepts_an_infrastructure_parameter,
+    test_no_description_claims_an_infrastructure_change,
+    test_the_guard_is_not_vacuous,
+    test_every_tool_routes_through_the_chokepoint,
+]
+
+if __name__ == "__main__":
+    raise SystemExit(run(TESTS, "manifest and surface"))

--- a/tests/document/test_no_fabrication.py
+++ b/tests/document/test_no_fabrication.py
@@ -1,0 +1,296 @@
+"""Never fabricate to fill a blank. Spec 082, FR-001..FR-005, FR-015, FR-023a, FR-027a/b.
+
+This is the suite that matters most, and every assertion in it reopens the produced
+file. The failure it guards against is not a crash — it is a professional-looking
+document that reads as complete and is not.
+"""
+
+from __future__ import annotations
+
+from _harness import FAILURES, check, cleanup, run, sandbox  # noqa: F401
+
+import output  # noqa: E402
+from outcomes import Outcome, ValueRefused  # noqa: E402
+from provenance import DocumentStamp, SourceLedger  # noqa: E402
+from writers import docx_writer, pptx_writer, xlsx_writer  # noqa: E402
+
+# Every string a gap must never be mistaken for.
+LAUNDERED = ["N/A", "n/a", "TBD", "Unknown", "None", "--"]
+
+
+def _build(builder, payload, tool):
+    stamp = DocumentStamp(tool=tool)
+    ledger = SourceLedger()
+    data, caveats = builder(payload, stamp, ledger)
+    path, suffix = output.reserve({"docx_write": "docx", "xlsx_write": "xlsx",
+                                   "pptx_write": "pptx"}[tool], "nofab")
+    path.write_bytes(data)
+    return path, caveats, stamp, ledger
+
+
+def _docx_text(path):
+    from docx import Document
+
+    d = Document(str(path))
+    parts = [p.text for p in d.paragraphs]
+    for t in d.tables:
+        for r in t.rows:
+            parts.append(" | ".join(c.text for c in r.cells))
+    return "\n".join(parts)
+
+
+def test_gaps_render_explicitly_in_the_document():
+    d = sandbox()
+    try:
+        payload = {"title": "T", "blocks": [{"type": "keyvalue", "pairs": [
+            {"label": "Hostname", "value": {"v": "fgt-01", "src": "fgt_system_status"}},
+            {"label": "Serial", "value": {"unavailable": "device did not answer"}},
+            {"label": "Uptime", "value": {"failed": "connection refused"}},
+            {"label": "Banner", "value": {"v": "", "src": "fgt_system_status"}},
+        ]}]}
+        path, _c, _s, _l = _build(docx_writer.build, payload, "docx_write")
+        text = _docx_text(path)
+
+        check("an unavailable field says NOT AVAILABLE", "NOT AVAILABLE" in text)
+        check("its reason is in the document", "device did not answer" in text)
+        check("a failed field says RETRIEVAL FAILED", "RETRIEVAL FAILED" in text)
+        check("its reason is in the document", "connection refused" in text)
+        check("a genuinely-empty source value says (empty)", "(empty)" in text)
+        check(
+            "unavailable and failed are textually distinct",
+            "NOT AVAILABLE" in text and "RETRIEVAL FAILED" in text,
+            "a dead query and an empty result must not read the same",
+        )
+        for token in LAUNDERED:
+            check(f"the document contains no {token!r} placeholder", token not in text,
+                  "a plausible placeholder is how a guess gets laundered into a record")
+    finally:
+        cleanup(d)
+
+
+def test_a_gapped_document_cannot_report_as_clean():
+    d = sandbox()
+    try:
+        import envelope
+
+        payload = {"title": "T", "blocks": [{"type": "keyvalue", "pairs": [
+            {"label": "A", "value": {"v": 1, "src": "x"}},
+            {"label": "B", "value": {"unavailable": "no data"}},
+        ]}]}
+        path, caveats, stamp, ledger = _build(docx_writer.build, payload, "docx_write")
+        art = output.finalize(path, None)
+        resp = envelope.emit(tool="docx_write", outcome=Outcome.OK, artifact=art.as_dict(),
+                             ledger=ledger, stamp=stamp, caveats=caveats)
+        check("the caller passed ok and got written_with_gaps",
+              resp["outcome"] == Outcome.WRITTEN_WITH_GAPS.value, resp["outcome"])
+        check("the gap count is reported", resp["gaps"]["unavailable"] == 1, str(resp["gaps"]))
+        check("a caveat states the document is incomplete",
+              any("incomplete" in c for c in resp["caveats"]), str(resp["caveats"]))
+
+        clean = {"title": "T", "blocks": [{"type": "keyvalue", "pairs": [
+            {"label": "A", "value": {"v": 1, "src": "x"}}]}]}
+        p2, c2, s2, l2 = _build(docx_writer.build, clean, "docx_write")
+        r2 = envelope.emit(tool="docx_write", outcome=Outcome.OK,
+                           artifact=output.finalize(p2, None).as_dict(), ledger=l2, stamp=s2,
+                           caveats=c2)
+        check("a genuinely complete document reports ok", r2["outcome"] == "ok", r2["outcome"])
+    finally:
+        cleanup(d)
+
+
+def test_failed_devices_are_rows_not_omissions():
+    """SC-004. A shorter spreadsheet reads as a smaller estate."""
+    d = sandbox()
+    try:
+        import openpyxl
+
+        payload = {"sheets": [{
+            "name": "Interfaces",
+            "columns": ["Device", "Interface", "Admin state", "Oper state"],
+            "rows": [[{"v": "fgt-01", "src": "t"}, {"v": "port1", "src": "t"},
+                      {"v": "up", "src": "t"}, {"v": "down", "src": "t"}]],
+            "failed_rows": [{"label": "fgt-02", "failed": "connection refused"},
+                            {"label": "fgt-03", "failed": "auth expired"}],
+        }]}
+        path, caveats, _s, _l = _build(xlsx_writer.build, payload, "xlsx_write")
+        ws = openpyxl.load_workbook(str(path))["Interfaces"]
+
+        cells = [str(ws.cell(row=r, column=c).value or "")
+                 for r in range(1, 12) for c in range(1, 7)]
+        blob = "\n".join(cells)
+        check("fgt-02 appears in the sheet", "fgt-02" in blob, "a failed device was omitted")
+        check("fgt-03 appears in the sheet", "fgt-03" in blob, "a failed device was omitted")
+        check("failed rows are marked as failed", blob.count("RETRIEVAL FAILED") >= 2, blob[:200])
+
+        banner = str(ws.cell(row=1, column=1).value or "")
+        check("the banner reports attempted", "3 attempted" in banner, banner[:90])
+        check("the banner reports the failures", "2 failed" in banner, banner[:90])
+        check("the banner distinguishes returned data", "1 returned data" in banner, banner[:90])
+        check("a caveat names the unreached devices",
+              any("could not be reached" in c for c in caveats), str(caveats))
+
+        check("a failed row with no reason is refused",
+              _refused(xlsx_writer.build, {"sheets": [{"name": "S", "columns": ["A"], "rows": [],
+                                                       "failed_rows": [{"label": "x"}]}]}) is not None)
+    finally:
+        cleanup(d)
+
+
+def _refused(builder, payload):
+    try:
+        builder(payload, DocumentStamp(tool="t"), SourceLedger())
+    except ValueRefused as exc:
+        return exc
+    return None
+
+
+def test_admin_and_oper_state_stay_separate():
+    """FR-015 / SC-006 — the distinction spec 080's completion established."""
+    d = sandbox()
+    try:
+        exc = _refused(xlsx_writer.build,
+                       {"sheets": [{"name": "S", "columns": ["Device", "Status"], "rows": []}]})
+        check("a merged 'Status' column is refused", exc is not None, "it was accepted")
+        if exc:
+            check("the refusal is typed", exc.outcome is Outcome.REFUSED_MERGED_STATUS, str(exc.outcome))
+            check("the refusal explains the distinction",
+                  "administratively up" in str(exc), str(exc)[:120])
+        for header in ("state", "Up/Down", "link status"):
+            check(f"a merged {header!r} column is refused",
+                  _refused(xlsx_writer.build,
+                           {"sheets": [{"name": "S", "columns": ["Device", header],
+                                        "rows": []}]}) is not None)
+        check(
+            "a summary column alongside both real columns is allowed",
+            _refused(xlsx_writer.build,
+                     {"sheets": [{"name": "S",
+                                  "columns": ["Admin state", "Oper state", "Status"],
+                                  "rows": []}]}) is None,
+            "a derived summary is legitimate when both facts are also present",
+        )
+    finally:
+        cleanup(d)
+
+
+def test_all_three_office_formats_refuse_a_template():
+    """SC-008b. Parametrised so a fourth format cannot be added without it."""
+    cases = [
+        ("docx_write", docx_writer.build, {"title": "T", "blocks": [], "template": "corp.docx"}),
+        ("xlsx_write", xlsx_writer.build,
+         {"sheets": [{"name": "S", "columns": ["A"], "rows": []}], "template": "corp.xlsx"}),
+        ("pptx_write", pptx_writer.build, {"title": "T", "slides": [], "template": "corp.pptx"}),
+    ]
+    for tool, builder, payload in cases:
+        exc = _refused(builder, payload)
+        check(f"{tool} refuses a template", exc is not None,
+              "the template was silently ignored — the operator gets an unbranded "
+              "document believing it is branded")
+        if exc:
+            check(f"{tool}'s refusal is typed", exc.outcome is Outcome.REFUSED_TEMPLATE, str(exc.outcome))
+            check(f"{tool}'s refusal explains why", "fabrication pressure" in str(exc), str(exc)[:100])
+    for alias in ("template_path", "base_document"):
+        check(f"the alias {alias!r} is also refused",
+              _refused(docx_writer.build, {"title": "T", "blocks": [], alias: "x"}) is not None)
+
+
+def test_bounds_are_stated_inside_the_document():
+    """FR-027a / SC-026 — for blocks and slides, not only worksheet rows."""
+    import os
+
+    d = sandbox()
+    try:
+        os.environ["DOCUMENT_MAX_BLOCKS"] = "3"
+        os.environ["DOCUMENT_MAX_SLIDES"] = "2"
+        os.environ["DOCUMENT_MAX_ROWS"] = "2"
+
+        blocks = [{"type": "paragraph", "text": f"para {chr(97 + i)}"} for i in range(10)]
+        path, _c, stamp, _l = _build(docx_writer.build, {"title": "T", "blocks": blocks}, "docx_write")
+        text = _docx_text(path)
+        check("docx truncation is flagged on the stamp", stamp.truncated)
+        check("the docx states its bound INSIDE the document", "TRUNCATED" in text, text[:200])
+        check("the bound value is in the document", "3" in text, text[:200])
+
+        from pptx import Presentation
+
+        slides = [{"layout": "bullets", "title": f"S{i}", "bullets": ["x"], "detail_ref": "d"}
+                  for i in range(10)]
+        p2, _c2, s2, _l2 = _build(pptx_writer.build, {"title": "T", "slides": slides}, "pptx_write")
+        check("pptx truncation is flagged", s2.truncated)
+        prs = Presentation(str(p2))
+        deck_text = "\n".join(sh.text_frame.text for s in prs.slides
+                              for sh in s.shapes if sh.has_text_frame)
+        check("the deck states its bound on a slide", "TRUNCATED" in deck_text, deck_text[:200])
+
+        import openpyxl
+
+        rows = [[{"v": i, "src": "t"}] for i in range(10)]
+        p3, _c3, s3, _l3 = _build(xlsx_writer.build,
+                                  {"sheets": [{"name": "S", "columns": ["N"], "rows": rows}]},
+                                  "xlsx_write")
+        check("xlsx truncation is flagged", s3.truncated)
+        ws = openpyxl.load_workbook(str(p3))["S"]
+        sheet_text = "\n".join(str(ws.cell(row=r, column=1).value or "") for r in range(1, 6))
+        check("the sheet states its bound", "TRUNCATED" in sheet_text, sheet_text[:200])
+    finally:
+        for k in ("DOCUMENT_MAX_BLOCKS", "DOCUMENT_MAX_SLIDES", "DOCUMENT_MAX_ROWS"):
+            os.environ.pop(k, None)
+        cleanup(d)
+
+
+def test_disagreeing_sources_are_both_rendered():
+    """FR-027b / SC-027 — no winner is picked and neither value is dropped."""
+    d = sandbox()
+    try:
+        payload = {"title": "T", "blocks": [
+            {"type": "figure", "label": "Hostname",
+             "value": {"v": "fgt-01", "src": "fgt_system_status"}},
+            {"type": "figure", "label": "Hostname",
+             "value": {"v": "fgt-01-alt", "src": "netbox_get_device"}},
+        ]}
+        path, caveats, _s, _l = _build(docx_writer.build, payload, "docx_write")
+        text = _docx_text(path)
+        check("the first value is present", "fgt-01" in text)
+        check("the second value is present", "fgt-01-alt" in text,
+              "a value was dropped — the document asserts a certainty the data lacks")
+        check("the disagreement is called out", "Sources disagree" in text, text[:200])
+        check("both sources are named", "fgt_system_status" in text and "netbox_get_device" in text)
+        check("a caveat reports it", any("disagree" in c for c in caveats), str(caveats))
+        check("NetClaw says it did not reconcile", "not reconciled" in text.lower(), text[:300])
+    finally:
+        cleanup(d)
+
+
+def test_prose_asserting_a_figure_is_flagged():
+    d = sandbox()
+    try:
+        payload = {"title": "T", "blocks": [
+            {"type": "paragraph", "text": "We observed 12 interfaces."},
+            {"type": "paragraph", "text": "Captured 2026-08-03T14:02:00Z for CHG0012345 on 10.0.0.1 running v7.6.7, see Section 2."},
+        ]}
+        _p, caveats, _s, _l = _build(docx_writer.build, payload, "docx_write")
+        flagged = [c for c in caveats if "prose asserts" in c]
+        check("a bare figure in prose is flagged", len(flagged) == 1, str(caveats))
+        if flagged:
+            check("the caveat names the block index", "blocks[0]" in flagged[0], flagged[0])
+        check(
+            "dates, tickets, IPs, versions and ordinals are NOT flagged",
+            not any("blocks[1]" in c for c in caveats),
+            "the lint is noisy enough to be ignored, which makes it useless",
+        )
+    finally:
+        cleanup(d)
+
+
+TESTS = [
+    test_gaps_render_explicitly_in_the_document,
+    test_a_gapped_document_cannot_report_as_clean,
+    test_failed_devices_are_rows_not_omissions,
+    test_admin_and_oper_state_stay_separate,
+    test_all_three_office_formats_refuse_a_template,
+    test_bounds_are_stated_inside_the_document,
+    test_disagreeing_sources_are_both_rendered,
+    test_prose_asserting_a_figure_is_flagged,
+]
+
+if __name__ == "__main__":
+    raise SystemExit(run(TESTS, "no-fabrication"))

--- a/tests/document/test_output_paths.py
+++ b/tests/document/test_output_paths.py
@@ -1,0 +1,131 @@
+"""Output paths. Spec 082, FR-016..FR-020, SC-012/013/014.
+
+The requirement that matters most here: an existing file is NEVER opened for writing.
+Feature 046's convention relies on timestamp uniqueness alone, which collides for two
+documents produced in the same second — and a regenerated report silently replacing the
+one already attached to a ticket is the failure this prevents.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+
+from _harness import FAILURES, check, cleanup, run, sandbox  # noqa: F401
+
+import output  # noqa: E402
+
+
+def _sha(path) -> str:
+    return hashlib.sha256(open(path, "rb").read()).hexdigest()
+
+
+def test_same_second_writes_do_not_collide():
+    d = sandbox()
+    try:
+        p1, s1 = output.reserve("docx", "report")
+        p1.write_bytes(b"first")
+        digest_before = _sha(p1)
+
+        p2, s2 = output.reserve("docx", "report")
+        p2.write_bytes(b"second")
+
+        check("two writes produce two distinct paths", p1 != p2, f"{p1} == {p2}")
+        check("the first file still exists", p1.exists())
+        check(
+            "the first file is byte-identical after the second write",
+            _sha(p1) == digest_before,
+            "the first file was modified — a regenerated report replaced an attached one",
+        )
+        check("the first write has no collision suffix", s1 is None, str(s1))
+        check("the second write records a collision suffix", s2 == 2, str(s2))
+        check("the second file carries the suffix in its name", "-2." in p2.name, p2.name)
+    finally:
+        cleanup(d)
+
+
+def test_reported_path_is_the_real_one():
+    d = sandbox()
+    try:
+        p, s = output.reserve("xlsx", "audit")
+        p.write_bytes(b"x" * 17)
+        art = output.finalize(p, s)
+        check("the reported path exists on disk", os.path.exists(art.path) or os.path.exists(
+            os.path.join(os.getcwd(), art.path)), art.path)
+        check("the reported size matches", art.bytes == 17, str(art.bytes))
+        check("created_at is stamped", art.created_at.endswith("Z"), art.created_at)
+    finally:
+        cleanup(d)
+
+
+def test_filenames_are_timestamped_and_sanitised():
+    d = sandbox()
+    try:
+        p, _ = output.reserve("pptx", "../../etc/passwd; rm -rf /")
+        check("path traversal is sanitised out of the filename", "/" not in p.name[:-5], p.name)
+        check("the kind prefixes the filename", p.name.startswith("pptx-"), p.name)
+        check("a UTC timestamp is present", "Z-" in p.name, p.name)
+        check("the file landed in the output dir", p.parent == output.output_dir(), str(p.parent))
+    finally:
+        cleanup(d)
+
+
+def test_unwritable_directory_is_reported_not_worked_around():
+    d = sandbox()
+    try:
+        blocked = os.path.join(d, "blocked")
+        os.makedirs(blocked, exist_ok=True)
+        os.chmod(blocked, stat.S_IRUSR | stat.S_IXUSR)  # r-x, not writable
+        os.environ["DOCUMENT_OUTPUT_DIR"] = blocked
+
+        raised = None
+        try:
+            output.reserve("docx", "x")
+        except output.OutputUnwritable as exc:
+            raised = exc
+
+        if os.geteuid() == 0:
+            print("  SKIP  running as root — an unwritable directory cannot be simulated")
+            return
+
+        check("an unwritable output dir raises OutputUnwritable", raised is not None,
+              "it silently succeeded")
+        check(
+            "nothing was written to a fallback location",
+            not os.listdir(blocked),
+            f"files appeared in {blocked} — or worse, in a temp dir the operator will never find",
+        )
+    finally:
+        try:
+            os.chmod(os.path.join(d, "blocked"), stat.S_IRWXU)
+        except OSError:
+            pass
+        cleanup(d)
+
+
+def test_list_outputs():
+    d = sandbox()
+    try:
+        for kind in ("docx", "xlsx", "docx"):
+            p, _ = output.reserve(kind, "x")
+            p.write_bytes(b"data")
+        allx = output.list_outputs()
+        check("all outputs are listed", len(allx) == 3, str(len(allx)))
+        docx = output.list_outputs("docx")
+        check("filtering by kind works", len(docx) == 2, str(len(docx)))
+        check("entries carry a kind", all(e["kind"] == "docx" for e in docx), str(docx))
+    finally:
+        cleanup(d)
+
+
+TESTS = [
+    test_same_second_writes_do_not_collide,
+    test_reported_path_is_the_real_one,
+    test_filenames_are_timestamped_and_sanitised,
+    test_unwritable_directory_is_reported_not_worked_around,
+    test_list_outputs,
+]
+
+if __name__ == "__main__":
+    raise SystemExit(run(TESTS, "output path"))

--- a/tests/document/test_pdf_forms.py
+++ b/tests/document/test_pdf_forms.py
@@ -1,0 +1,221 @@
+"""PDF form filling. Spec 082, US4, FR-024/024a/024b, SC-008/008a.
+
+The suite builds its own fixture form with fitz.Widget() + page.add_widget(), so it
+needs no customer artefact and no network. Measured 2026-08-03: doc.is_form_pdf returns
+an int (3) for a form and False for a plain PDF — compared truthily throughout.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+
+import fitz
+
+from _harness import FAILURES, check, cleanup, run, sandbox  # noqa: F401
+
+import output  # noqa: E402
+from outcomes import Outcome, ValueRefused  # noqa: E402
+from provenance import SourceLedger  # noqa: E402
+from writers import pdf_writer  # noqa: E402
+
+FIELDS = ["change_number", "device_hostname", "approver", "risk_level"]
+
+
+def _fixture_form(directory: str) -> str:
+    path = os.path.join(directory, "audit-response.pdf")
+    doc = fitz.open()
+    page = doc.new_page()
+    for i, name in enumerate(FIELDS):
+        w = fitz.Widget()
+        w.field_name = name
+        w.field_type = fitz.PDF_WIDGET_TYPE_TEXT
+        w.rect = fitz.Rect(50, 50 + i * 40, 400, 80 + i * 40)
+        w.field_value = ""
+        page.add_widget(w)
+    doc.save(path)
+    doc.close()
+    return path
+
+
+def _plain_pdf(directory: str) -> str:
+    path = os.path.join(directory, "plain.pdf")
+    doc = fitz.open()
+    doc.new_page().insert_text((72, 72), "this is not a form")
+    doc.save(path)
+    doc.close()
+    return path
+
+
+def _sha(path: str) -> str:
+    return hashlib.sha256(open(path, "rb").read()).hexdigest()
+
+
+def test_inspect_lists_real_field_names():
+    d = sandbox()
+    try:
+        result = pdf_writer.inspect(_fixture_form(d))
+        check("a form is reported fillable", result["outcome"] is Outcome.OK, str(result["outcome"]))
+        names = [f["name"] for f in result["data"]["fields"]]
+        check("every field is discovered", sorted(names) == sorted(FIELDS), str(names))
+        check("the field count matches", result["data"]["field_count"] == len(FIELDS))
+        check("field kinds are mapped", all(f["kind"] == "text" for f in result["data"]["fields"]),
+              str(result["data"]["fields"]))
+    finally:
+        cleanup(d)
+
+
+def test_non_fillable_is_reported_not_faked():
+    d = sandbox()
+    try:
+        result = pdf_writer.inspect(_plain_pdf(d))
+        check("a plain PDF is reported not fillable",
+              result["outcome"] is Outcome.NOT_FILLABLE, str(result["outcome"]))
+        check("the message explains why nothing was written",
+              "positionally" in result["message"], result["message"][:120])
+
+        dest = os.path.join(d, "should-not-exist.pdf")
+        fill = pdf_writer.fill(_plain_pdf(d), {"a": {"v": "1", "src": "x"}},
+                               SourceLedger(), dest)
+        check("filling a non-fillable PDF is refused",
+              fill["outcome"] is Outcome.NOT_FILLABLE, str(fill["outcome"]))
+        check("NO output file was produced", not os.path.exists(dest),
+              "a visually-similar file with no field data is worse than no file")
+    finally:
+        cleanup(d)
+
+
+def test_values_land_in_the_right_named_fields():
+    d = sandbox()
+    try:
+        form = _fixture_form(d)
+        dest_path, _s = output.reserve("pdfform", "chg")
+        result = pdf_writer.fill(
+            form,
+            {"change_number": {"v": "CHG0012345", "src": "servicenow_get_change"},
+             "risk_level": {"v": "Low", "src": "servicenow_get_change"}},
+            SourceLedger(),
+            dest_path,
+        )
+        check("the fill succeeded", result["outcome"] in (Outcome.OK, Outcome.WRITTEN_WITH_GAPS))
+
+        doc = fitz.open(str(dest_path))
+        values = {w.field_name: w.field_value for p in doc for w in p.widgets()}
+        doc.close()
+        check("change_number landed in its own field",
+              values["change_number"] == "CHG0012345", str(values))
+        check("risk_level landed in its own field", values["risk_level"] == "Low", str(values))
+        check("untouched fields are genuinely empty",
+              values["approver"] == "" and values["device_hostname"] == "", str(values))
+    finally:
+        cleanup(d)
+
+
+def test_unfilled_and_unmatched_are_both_reported():
+    """SC-008a. Neither direction of mismatch is silently absorbed."""
+    d = sandbox()
+    try:
+        form = _fixture_form(d)
+        dest_path, _s = output.reserve("pdfform", "gaps")
+        result = pdf_writer.fill(
+            form,
+            {"change_number": {"v": "CHG0012345", "src": "servicenow_get_change"},
+             "approver": {"unavailable": "no approver recorded on the CR"},
+             "ghost_field": {"v": "x", "src": "somewhere"}},
+            SourceLedger(),
+            dest_path,
+        )
+        data = result["data"]
+        check("filled lists only what was written", data["filled"] == ["change_number"], str(data))
+        check("an unavailable value leaves the field unfilled",
+              "approver" in data["unfilled"], str(data))
+        check("a field with no data at all is unfilled",
+              "device_hostname" in data["unfilled"], str(data))
+        check("a supplied key matching no field is reported",
+              data["unmatched"] == ["ghost_field"], str(data))
+
+        doc = fitz.open(str(dest_path))
+        values = {w.field_name: w.field_value for p in doc for w in p.widgets()}
+        doc.close()
+        check("the unavailable field is EMPTY, not filled with the reason",
+              values["approver"] == "", repr(values["approver"]))
+        check("no guess was written to complete the form",
+              all(v == "" for k, v in values.items() if k != "change_number"), str(values))
+
+        caveats = " ".join(result["caveats"])
+        check("a caveat names the unfilled fields", "approver" in caveats, caveats[:150])
+        check("a caveat names the unmatched value", "ghost_field" in caveats, caveats[:200])
+        check("the provenance limitation is stated",
+              "no Sources section" in caveats, caveats[:200])
+    finally:
+        cleanup(d)
+
+
+def test_the_input_pdf_is_never_modified():
+    d = sandbox()
+    try:
+        form = _fixture_form(d)
+        before = _sha(form)
+        dest_path, _s = output.reserve("pdfform", "immutable")
+        pdf_writer.fill(form, {"change_number": {"v": "X", "src": "t"}},
+                        SourceLedger(), dest_path)
+        check("the input PDF is byte-identical afterwards", _sha(form) == before,
+              "the supplied form was modified in place")
+        check("a new file was produced", os.path.exists(dest_path))
+        check("the new file differs from the input", _sha(str(dest_path)) != before)
+    finally:
+        cleanup(d)
+
+
+def test_fill_values_go_through_the_same_typed_gate():
+    d = sandbox()
+    try:
+        form = _fixture_form(d)
+        dest_path, _s = output.reserve("pdfform", "typed")
+        raised = None
+        try:
+            pdf_writer.fill(form, {"change_number": "CHG0012345"}, SourceLedger(), dest_path)
+        except ValueRefused as exc:
+            raised = exc
+        check("a bare scalar is refused even for a PDF form", raised is not None,
+              "a governance form must not be fillable from untyped values")
+        if raised:
+            check("the refusal is typed", raised.outcome is Outcome.REFUSED_UNTYPED, str(raised.outcome))
+
+        raised2 = None
+        try:
+            pdf_writer.fill(form, {"change_number": {"v": "X"}}, SourceLedger(), dest_path)
+        except ValueRefused as exc:
+            raised2 = exc
+        check("a value without src is refused", raised2 is not None)
+    finally:
+        cleanup(d)
+
+
+def test_missing_pdf_is_reported():
+    d = sandbox()
+    try:
+        raised = None
+        try:
+            pdf_writer.inspect(os.path.join(d, "nope.pdf"))
+        except ValueRefused as exc:
+            raised = exc
+        check("a nonexistent PDF is refused", raised is not None)
+        if raised:
+            check("typed as source_missing", raised.outcome is Outcome.SOURCE_MISSING, str(raised.outcome))
+    finally:
+        cleanup(d)
+
+
+TESTS = [
+    test_inspect_lists_real_field_names,
+    test_non_fillable_is_reported_not_faked,
+    test_values_land_in_the_right_named_fields,
+    test_unfilled_and_unmatched_are_both_reported,
+    test_the_input_pdf_is_never_modified,
+    test_fill_values_go_through_the_same_typed_gate,
+    test_missing_pdf_is_reported,
+]
+
+if __name__ == "__main__":
+    raise SystemExit(run(TESTS, "PDF form"))

--- a/tests/document/test_provenance.py
+++ b/tests/document/test_provenance.py
@@ -1,0 +1,302 @@
+"""Provenance, verified by OPENING the files. Spec 082, FR-006..FR-010, FR-034.
+
+SC-009 says every generated document states its generation time and that NetClaw
+produced it, "verified by opening the file, not by inspecting code". That wording exists
+because spec 080 shipped `fgt_system_status` returning three nulls past 24 passing
+tests: the tests asserted the envelope was well-formed, and it was — the payload was
+half empty.
+
+So every check below reparses the artefact with the same library a reader's application
+would use, and asserts on what is inside it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import zipfile
+
+from _harness import FAILURES, abspath, check, cleanup, run, sandbox  # noqa: F401
+
+import envelope  # noqa: E402
+import output  # noqa: E402
+from outcomes import Outcome  # noqa: E402
+from provenance import DocumentStamp, SourceLedger  # noqa: E402
+from writers import docx_writer, pptx_writer, xlsx_writer  # noqa: E402
+
+DOCX_PAYLOAD = {
+    "title": "Change Record CHG0012345",
+    "blocks": [
+        {"type": "heading", "text": "Pre-change state", "level": 1},
+        {"type": "keyvalue", "pairs": [
+            {"label": "Hostname", "value": {"v": "fgt-01", "src": "fgt_system_status",
+                                            "as_of": "2026-08-01T09:00:00Z"}},
+            {"label": "Serial", "value": {"unavailable": "device did not answer"}},
+        ]},
+        {"type": "table", "caption": "Interfaces",
+         "columns": ["Interface", "Admin state", "Oper state"],
+         "rows": [[{"v": "port1", "src": "fgt_list_interfaces", "device": "fgt-01"},
+                   {"v": "up", "src": "fgt_list_interfaces", "device": "fgt-01"},
+                   {"v": "down", "src": "fgt_list_interfaces", "device": "fgt-01"}]]},
+    ],
+}
+
+XLSX_PAYLOAD = {"sheets": [{
+    "name": "Interfaces",
+    "columns": ["Device", "Interface", "Admin state", "Oper state"],
+    "rows": [[{"v": "fgt-01", "src": "fgt_list_interfaces", "device": "fgt-01",
+               "as_of": "2026-08-01T09:00:00Z"},
+              {"v": "port1", "src": "fgt_list_interfaces", "device": "fgt-01"},
+              {"v": "up", "src": "fgt_list_interfaces", "device": "fgt-01"},
+              {"v": "down", "src": "fgt_list_interfaces", "device": "fgt-01"}]],
+}]}
+
+PPTX_PAYLOAD = {"title": "Posture review", "slides": [
+    {"layout": "figure", "title": "Scope", "figures": [
+        {"label": "Interfaces", "value": {"v": 2, "src": "fgt_list_interfaces",
+                                          "device": "fgt-01", "as_of": "2026-08-01T09:00:00Z"}}]},
+]}
+
+
+def _emit(kind, tool, payload, builder):
+    stamp = DocumentStamp(tool=tool)
+    ledger = SourceLedger()
+    data, caveats = builder(payload, stamp, ledger)
+    path, suffix = output.reserve(kind, "provenance")
+    path.write_bytes(data)
+    art = output.finalize(path, suffix)
+    resp = envelope.emit(tool=tool, outcome=Outcome.OK, artifact=art.as_dict(),
+                         ledger=ledger, stamp=stamp, caveats=caveats)
+    return path, resp, stamp
+
+
+def _docx_text(path):
+    from docx import Document
+
+    d = Document(str(path))
+    parts = [p.text for p in d.paragraphs]
+    for t in d.tables:
+        for r in t.rows:
+            parts.append(" | ".join(c.text for c in r.cells))
+    parts.append(d.sections[0].footer.paragraphs[0].text)
+    return "\n".join(parts), d
+
+
+def test_docx_carries_the_stamp_and_sources():
+    d = sandbox()
+    try:
+        path, resp, stamp = _emit("docx", "docx_write", DOCX_PAYLOAD, docx_writer.build)
+        text, doc = _docx_text(path)
+
+        footer = doc.sections[0].footer.paragraphs[0].text
+        check("the footer names NetClaw", "NetClaw" in footer, footer)
+        check("the footer carries a generation time", stamp.generated_at in footer, footer)
+        check("the footer appears on every page (section footer)", bool(footer.strip()))
+
+        check("a Sources section exists", "Sources" in text, "no Sources heading")
+        for src in ("fgt_system_status", "fgt_list_interfaces"):
+            check(f"the Sources section lists {src}", src in text, "missing from the document")
+
+        headers = [c.text for t in doc.tables for c in t.rows[0].cells]
+        check("tables carry a Source column", "Source" in headers, str(headers))
+        check("tables carry an As of column", "As of" in headers, str(headers))
+
+        check(
+            "the source's own as-of is in the document",
+            "2026-08-01T09:00:00Z" in text,
+            "the source's collection time was lost",
+        )
+        check(
+            "the source's as-of is distinguishable from the generation time",
+            "2026-08-01T09:00:00Z" != stamp.generated_at,
+            "they are the same value, so FR-010 is untestable here",
+        )
+
+        for t in doc.tables:
+            headers_t = [c.text for c in t.rows[0].cells]
+            if "Source" not in headers_t:
+                continue
+            col = headers_t.index("Source")
+            for row in t.rows[1:]:
+                cell = row.cells[col].text.strip()
+                check(
+                    f"no data row has an empty Source cell (row starts {row.cells[0].text[:18]!r})",
+                    bool(cell),
+                    "an unattributed row shipped",
+                )
+    finally:
+        cleanup(d)
+
+
+def test_xlsx_carries_the_stamp_and_sources():
+    d = sandbox()
+    try:
+        import openpyxl
+
+        path, resp, stamp = _emit("xlsx", "xlsx_write", XLSX_PAYLOAD, xlsx_writer.build)
+        wb = openpyxl.load_workbook(str(path))
+
+        check("a Sources sheet exists", "Sources" in wb.sheetnames, str(wb.sheetnames))
+        ws = wb["Interfaces"]
+        banner = str(ws.cell(row=1, column=1).value or "")
+        check("the banner names NetClaw", "NetClaw" in banner, banner[:80])
+        check("the banner carries a generation time", stamp.generated_at in banner, banner[:80])
+
+        header_row = next(r for r in range(1, 6)
+                          if ws.cell(row=r, column=1).value == "Device")
+        headers = [ws.cell(row=header_row, column=c).value for c in range(1, 8)]
+        check("a Source column was appended", "Source" in headers, str(headers))
+        check("an As of column was appended", "As of" in headers, str(headers))
+
+        src_col = headers.index("Source") + 1
+        val = ws.cell(row=header_row + 1, column=src_col).value
+        check("the data row carries its source", val and "fgt_list_interfaces" in str(val), str(val))
+        age_col = headers.index("As of") + 1
+        check(
+            "the source's own as-of is in the sheet",
+            str(ws.cell(row=header_row + 1, column=age_col).value) == "2026-08-01T09:00:00Z",
+            str(ws.cell(row=header_row + 1, column=age_col).value),
+        )
+
+        srcsheet = wb["Sources"]
+        listed = [srcsheet.cell(row=r, column=1).value for r in range(1, 10)]
+        check("the Sources sheet lists the tool", "fgt_list_interfaces" in listed, str(listed))
+    finally:
+        cleanup(d)
+
+
+def test_pptx_source_is_in_a_shape_not_only_notes():
+    """SC-010b. Speaker notes are invisible in presentation and print — if attribution
+    lives only there, it is not attribution."""
+    d = sandbox()
+    try:
+        from pptx import Presentation
+
+        path, resp, stamp = _emit("pptx", "pptx_write", PPTX_PAYLOAD, pptx_writer.build)
+        prs = Presentation(str(path))
+
+        check("a Sources slide exists",
+              any(s.shapes.title and s.shapes.title.text == "Sources" for s in prs.slides),
+              "no Sources slide")
+
+        for i, slide in enumerate(prs.slides):
+            shape_text = "\n".join(sh.text_frame.text for sh in slide.shapes if sh.has_text_frame)
+            check(
+                f"slide {i} carries the stamp in a SHAPE",
+                "NetClaw" in shape_text,
+                "attribution is not present in any visible shape on this slide",
+            )
+
+        figure_slide = next(s for s in prs.slides
+                            if s.shapes.title and s.shapes.title.text == "Scope")
+        shape_text = "\n".join(sh.text_frame.text for sh in figure_slide.shapes if sh.has_text_frame)
+        notes_text = figure_slide.notes_slide.notes_text_frame.text
+        check("the figure's source is in a visible shape", "fgt_list_interfaces" in shape_text,
+              "the source is not on the slide")
+        check("notes are additive, not the mechanism", "fgt_list_interfaces" in notes_text,
+              "notes were expected to repeat the detail")
+    finally:
+        cleanup(d)
+
+
+def test_a_caller_cannot_omit_provenance():
+    """SC-023. The guarantee is structural, not a convention."""
+    d = sandbox()
+    try:
+        raised = None
+        try:
+            envelope.emit(tool="docx_write", outcome=Outcome.OK,
+                          artifact={"path": "x", "bytes": 1, "created_at": "now"},
+                          ledger=SourceLedger(), stamp=DocumentStamp(tool="docx_write"))
+        except envelope.ProvenanceError as exc:
+            raised = exc
+        check("emitting an artefact with an empty ledger raises", raised is not None,
+              "an unattributed document was emittable")
+
+        resp = envelope.emit(tool="docx_write", outcome=Outcome.OK, data={"x": 1},
+                             ledger=SourceLedger(), stamp=DocumentStamp(tool="docx_write"))
+        check("a non-artefact response still carries generated_at", bool(resp["generated_at"]))
+        check("a non-artefact response still carries generated_by", bool(resp["generated_by"]))
+
+        stamp = DocumentStamp(tool="docx_write")
+        check("a caller cannot choose generated_by",
+              stamp.generated_by.startswith("NetClaw document-mcp"), stamp.generated_by)
+    finally:
+        cleanup(d)
+
+
+def test_gait_records_successes_and_refusals():
+    """FR-034 / SC-019. The defect /speckit.analyze caught in specs 076 and 080 was GAIT
+    having verification but no implementation. A refusal must be audited too."""
+    d = sandbox()
+    try:
+        log = os.environ["DOCUMENT_AUDIT_LOG"]
+        _emit("docx", "docx_write", DOCX_PAYLOAD, docx_writer.build)
+        envelope.refused(tool="docx_write", reason="template supplied",
+                         outcome=Outcome.REFUSED_TEMPLATE)
+
+        check("the audit log was created", os.path.exists(log), log)
+        records = [json.loads(line) for line in open(log, encoding="utf-8") if line.strip()]
+        check("at least two records were written", len(records) >= 2, str(len(records)))
+        outcomes = {r["outcome"] for r in records}
+        check("the success is audited", "ok" in outcomes or "written_with_gaps" in outcomes, str(outcomes))
+        check("the REFUSAL is audited", "refused_template" in outcomes, str(outcomes))
+        for r in records:
+            check(f"record for {r['tool']} names the component",
+                  r["component"] == "document-mcp", str(r))
+            check(f"record for {r['tool']}/{r['outcome']} carries a timestamp",
+                  bool(r.get("ts")), str(r))
+    finally:
+        cleanup(d)
+
+
+def test_provenance_survives_the_forwarding_path():
+    """SC-010b. Copy the table out and print the file — does attribution survive?
+
+    Extracting the raw XML text is the copy-paste path; asserting the attribution is
+    absent from docProps is the "not hidden in metadata" half.
+    """
+    d = sandbox()
+    try:
+        path, _resp, _stamp = _emit("docx", "docx_write", DOCX_PAYLOAD, docx_writer.build)
+        with zipfile.ZipFile(str(path)) as z:
+            body = z.read("word/document.xml").decode()
+        check(
+            "attribution is in the document body, not only in metadata",
+            "fgt_list_interfaces" in body,
+            "the source name is absent from word/document.xml",
+        )
+
+        from docx import Document
+
+        doc = Document(str(path))
+        table = next(t for t in doc.tables if "Interface" in [c.text for c in t.rows[0].cells])
+        copied = "\n".join(" ".join(c.text for c in r.cells) for r in table.rows)
+        check(
+            "a copied table still carries its source",
+            "fgt_list_interfaces" in copied,
+            "attribution was lost on copy — it must not live in a comment or tooltip",
+        )
+
+        with zipfile.ZipFile(str(path)) as z:
+            names = z.namelist()
+        check(
+            "no Word comment part carries the provenance",
+            "word/comments.xml" not in names,
+            "provenance may be additive in comments, but must not depend on them",
+        )
+    finally:
+        cleanup(d)
+
+
+TESTS = [
+    test_docx_carries_the_stamp_and_sources,
+    test_xlsx_carries_the_stamp_and_sources,
+    test_pptx_source_is_in_a_shape_not_only_notes,
+    test_a_caller_cannot_omit_provenance,
+    test_gait_records_successes_and_refusals,
+    test_provenance_survives_the_forwarding_path,
+]
+
+if __name__ == "__main__":
+    raise SystemExit(run(TESTS, "provenance"))

--- a/tests/document/test_sanitize.py
+++ b/tests/document/test_sanitize.py
@@ -1,0 +1,145 @@
+"""Untrusted text. Spec 082, FR-026, SC-015.
+
+The raw-XML assertion below is the point of this suite. `cell.data_type == "s"` is an
+openpyxl-level claim; `<f>` not appearing in xl/worksheets/sheet1.xml is a claim about
+the file an auditor actually opens. Measured 2026-08-03, a naive write produces
+`<c r="A1"><f>1+1</f><v></v></c>` — a live formula built from a device description.
+"""
+
+from __future__ import annotations
+
+import re
+import zipfile
+
+from _harness import FAILURES, abspath, check, cleanup, run, sandbox  # noqa: F401
+
+import output  # noqa: E402
+from provenance import DocumentStamp, SourceLedger  # noqa: E402
+from sanitize import plain_text  # noqa: E402
+from writers import xlsx_writer  # noqa: E402
+
+HOSTILE = [
+    "=1+1",
+    "=cmd|'/c calc'!A0",
+    "@SUM(1,1)",
+    "+1+1",
+    "-1+1",
+    "=HYPERLINK(\"http://evil\",\"click\")",
+]
+
+
+def _workbook_with(values):
+    d = sandbox()
+    stamp = DocumentStamp(tool="xlsx_write")
+    ledger = SourceLedger()
+    payload = {
+        "sheets": [
+            {
+                "name": "Data",
+                "columns": ["Interface", "Description"],
+                "rows": [
+                    [{"v": f"port{i}", "src": "fgt_list_interfaces"},
+                     {"v": v, "src": "fgt_list_interfaces"}]
+                    for i, v in enumerate(values)
+                ],
+            }
+        ]
+    }
+    data, _ = xlsx_writer.build(payload, stamp, ledger)
+    path, suffix = output.reserve("xlsx", "sanitize")
+    path.write_bytes(data)
+    return d, path
+
+
+def test_no_formula_survives_into_the_file():
+    d, path = _workbook_with(HOSTILE)
+    try:
+        with zipfile.ZipFile(str(path)) as z:
+            names = [n for n in z.namelist() if n.startswith("xl/worksheets/")]
+            xml = "".join(z.read(n).decode() for n in names)
+        check(
+            "no <f> element anywhere in the worksheet XML",
+            "<f>" not in xml and "<f " not in xml,
+            "a formula element is present — untrusted text became executable content",
+        )
+        check(
+            "hostile strings are stored as inline text",
+            xml.count("inlineStr") >= len(HOSTILE),
+            f"only {xml.count('inlineStr')} inlineStr cells for {len(HOSTILE)} hostile values",
+        )
+    finally:
+        cleanup(d)
+
+
+def test_values_round_trip_uncorrupted():
+    """The common mitigation is an apostrophe prefix. It visibly corrupts the value, in
+    a document whose entire purpose is fidelity. This asserts we did not do that."""
+    d, path = _workbook_with(HOSTILE)
+    try:
+        import openpyxl
+
+        ws = openpyxl.load_workbook(str(path))["Data"]
+        header_row = None
+        for r in range(1, 8):
+            if ws.cell(row=r, column=1).value == "Interface":
+                header_row = r
+                break
+        check("header row was found", header_row is not None)
+        if header_row:
+            for i, expected in enumerate(HOSTILE):
+                cell = ws.cell(row=header_row + 1 + i, column=2)
+                check(
+                    f"{expected!r} round-trips exactly",
+                    cell.value == expected,
+                    f"got {cell.value!r} — the mitigation corrupted the text",
+                )
+                check(
+                    f"{expected!r} is typed as a string",
+                    cell.data_type == "s",
+                    f"data_type={cell.data_type!r}",
+                )
+    finally:
+        cleanup(d)
+
+
+def test_numbers_stay_numbers():
+    """Forcing everything to text would break a spreadsheet's ability to sum a column,
+    which is most of why an auditor asked for .xlsx and not .csv."""
+    d = sandbox()
+    try:
+        stamp, ledger = DocumentStamp(tool="xlsx_write"), SourceLedger()
+        payload = {"sheets": [{"name": "N", "columns": ["Count"],
+                               "rows": [[{"v": 42, "src": "x"}], [{"v": 3.5, "src": "x"}]]}]}
+        data, _ = xlsx_writer.build(payload, stamp, ledger)
+        path, _s = output.reserve("xlsx", "numbers")
+        path.write_bytes(data)
+        import openpyxl
+
+        ws = openpyxl.load_workbook(str(path))["N"]
+        found = [ws.cell(row=r, column=1).value for r in range(1, 8)]
+        check("integer stayed numeric", 42 in found, str(found))
+        check("float stayed numeric", 3.5 in found, str(found))
+    finally:
+        cleanup(d)
+
+
+def test_control_characters_are_stripped():
+    """OOXML rejects most control characters; a document that will not open is a worse
+    outcome than one with a slightly shortened description."""
+    dirty = "port1\x00\x07 desc\x1f"
+    clean = plain_text(dirty)
+    check("NUL is stripped", "\x00" not in clean, repr(clean))
+    check("BEL is stripped", "\x07" not in clean, repr(clean))
+    check("printable text survives", "port1" in clean and "desc" in clean, repr(clean))
+    check("newlines and tabs survive", plain_text("a\nb\tc") == "a\nb\tc", repr(plain_text("a\nb\tc")))
+
+
+TESTS = [
+    test_no_formula_survives_into_the_file,
+    test_values_round_trip_uncorrupted,
+    test_numbers_stay_numbers,
+    test_control_characters_are_stripped,
+]
+
+if __name__ == "__main__":
+    raise SystemExit(run(TESTS, "sanitize"))

--- a/tests/document/test_tagged_values.py
+++ b/tests/document/test_tagged_values.py
@@ -1,0 +1,160 @@
+"""The typed vocabulary. Spec 082, FR-001/002/005c/007, SC-002/003.
+
+These are the guarantees the feature exists to make. They are structural, so they are
+provable without writing a file — but note that three of the checks below assert on
+RENDERED TEXT, because "a missing value must not read as data" is a claim about wording,
+and only a text assertion catches a wording bug. Spec 081 learned that the same way.
+"""
+
+from __future__ import annotations
+
+from _harness import FAILURES, check, run  # noqa: F401
+
+from outcomes import (  # noqa: E402
+    Outcome,
+    ValueRefused,
+    find_disagreements,
+    parse_tagged,
+    render_as_of,
+    render_source,
+    render_tagged,
+)
+
+
+def _refusal(raw, path="field"):
+    try:
+        parse_tagged(raw, path)
+    except ValueRefused as exc:
+        return exc
+    return None
+
+
+def test_value_requires_a_source():
+    exc = _refusal({"v": 5})
+    check("a value without 'src' is refused", exc is not None, "it was accepted")
+    if exc:
+        check(
+            "the refusal is typed as refused_unattributed",
+            exc.outcome is Outcome.REFUSED_UNATTRIBUTED,
+            f"got {exc.outcome}",
+        )
+        check("the message names the field path", "field" in str(exc), str(exc)[:80])
+    check("an empty src is refused", _refusal({"v": 5, "src": "   "}) is not None, "accepted")
+    ok = parse_tagged({"v": 5, "src": "fgt_x"}, "field")
+    check("a value with a src is accepted", ok.kind == "value" and ok.value == 5)
+
+
+def test_bare_scalars_are_refused():
+    for raw in (5, "up", True, None, ["a"]):
+        exc = _refusal(raw)
+        check(
+            f"bare {type(raw).__name__} {raw!r} is refused",
+            exc is not None and exc.outcome is Outcome.REFUSED_UNTYPED,
+            "accepted — a caller could express missing data as a blank",
+        )
+    exc = _refusal(5)
+    if exc:
+        check("the refusal shows the accepted shapes", "unavailable" in str(exc), str(exc)[:80])
+
+
+def test_exactly_one_discriminator():
+    check("no discriminator is refused", _refusal({"src": "x"}) is not None, "accepted")
+    check(
+        "two discriminators are refused",
+        _refusal({"v": 1, "src": "x", "unavailable": "y"}) is not None,
+        "accepted",
+    )
+
+
+def test_gaps_require_a_reason():
+    for tag in ("unavailable", "failed"):
+        check(
+            f"'{tag}' with an empty reason is refused",
+            _refusal({tag: "   "}) is not None,
+            "accepted — an unavailable with no reason is a blank wearing a label",
+        )
+        ok = parse_tagged({tag: "device did not answer"}, "f")
+        check(f"'{tag}' with a reason is accepted", ok.kind == tag and ok.is_gap)
+
+
+def test_as_of_must_be_iso():
+    check("non-ISO as_of is refused", _refusal({"v": 1, "src": "x", "as_of": "yesterday"}) is not None)
+    for good in ("2026-08-03", "2026-08-03T14:02:00Z", "2026-08-03T14:02:00+02:00"):
+        check(f"ISO as_of {good!r} is accepted", _refusal({"v": 1, "src": "x", "as_of": good}) is None)
+
+
+def test_the_three_shapes_render_differently():
+    """SC-002 / SC-003. Asserted on the RENDERED TEXT, not on the type."""
+    empty = render_tagged(parse_tagged({"v": "", "src": "x"}, "f"))
+    unav = render_tagged(parse_tagged({"unavailable": "device did not answer"}, "f"))
+    fail = render_tagged(parse_tagged({"failed": "connection refused"}, "f"))
+
+    check("three shapes render to three distinct strings", len({empty, unav, fail}) == 3,
+          f"{empty!r} {unav!r} {fail!r}")
+    check("empty-value says the source was consulted", empty == "(empty)", empty)
+    check("unavailable is labelled NOT AVAILABLE", unav.startswith("NOT AVAILABLE"), unav)
+    check("failed is labelled RETRIEVAL FAILED", fail.startswith("RETRIEVAL FAILED"), fail)
+    check("unavailable carries its reason", "did not answer" in unav, unav)
+    check("failed carries its reason", "connection refused" in fail, fail)
+
+    forbidden = {"", " ", "-", "--", "n/a", "na", "none", "null", "0", "tbd", "unknown"}
+    for label, text in (("unavailable", unav), ("failed", fail), ("empty", empty)):
+        check(
+            f"{label} does not render as a plausible blank",
+            text.strip().lower() not in forbidden,
+            f"rendered as {text!r}, which reads as data",
+        )
+
+
+def test_null_is_not_missing():
+    """A source reporting null is a fact; a field with no source is not."""
+    got = render_tagged(parse_tagged({"v": None, "src": "x"}, "f"))
+    check("an explicit null renders as (null), not as blank", got == "(null)", got)
+    check("(null) differs from NOT AVAILABLE", got != render_tagged(parse_tagged({"unavailable": "r"}, "f")))
+
+
+def test_source_and_as_of_render_visibly():
+    tv = parse_tagged({"v": 1, "src": "fgt_list_interfaces", "device": "fgt-01",
+                       "as_of": "2026-08-03T14:02:00Z"}, "f")
+    src = render_source(tv)
+    check("source names the tool", "fgt_list_interfaces" in src, src)
+    check("source names the device", "fgt-01" in src, src)
+    check("as_of is the SOURCE's time", render_as_of(tv) == "2026-08-03T14:02:00Z", render_as_of(tv))
+    no_age = parse_tagged({"v": 1, "src": "x"}, "f")
+    check(
+        "a source with no as_of says so rather than borrowing the generation time",
+        render_as_of(no_age) == "(not stated by source)",
+        render_as_of(no_age),
+    )
+
+
+def test_disagreement_detection():
+    a = parse_tagged({"v": "fgt-01", "src": "fgt_system_status"}, "f")
+    b = parse_tagged({"v": "fgt-01-alt", "src": "netbox_get_device"}, "f")
+    same = parse_tagged({"v": "fgt-01", "src": "netbox_get_device"}, "f")
+
+    found = find_disagreements([("Hostname", a), ("Hostname", b)])
+    check("differing values from two sources are flagged", len(found) == 1, str(found))
+    if found:
+        cav = found[0].caveat()
+        check("the caveat names both sources", "fgt_system_status" in cav and "netbox_get_device" in cav, cav)
+        check("the caveat says NetClaw did not reconcile", "not reconciled" in cav, cav)
+
+    check("agreeing sources are not flagged", find_disagreements([("Hostname", a), ("Hostname", same)]) == [])
+    check("one source alone is not a disagreement", find_disagreements([("Hostname", a)]) == [])
+
+
+TESTS = [
+    test_value_requires_a_source,
+    test_bare_scalars_are_refused,
+    test_exactly_one_discriminator,
+    test_gaps_require_a_reason,
+    test_as_of_must_be_iso,
+    test_the_three_shapes_render_differently,
+    test_null_is_not_missing,
+    test_source_and_as_of_render_visibly,
+    test_disagreement_detection,
+]
+
+if __name__ == "__main__":
+    raise SystemExit(run(TESTS, "tagged value"))

--- a/ui/netclaw-visual/server.js
+++ b/ui/netclaw-visual/server.js
@@ -67,6 +67,7 @@ const INTEGRATION_CATALOG = [
   { id: 'kubeshark', name: 'Kubeshark', category: 'Observability', prefixes: ['kubeshark-'], color: '#ffcb77', transport: 'http', toolEstimate: 6, description: 'Kubernetes packet and flow visibility.' },
   { id: 'gtrace', name: 'gtrace', category: 'Observability', prefixes: ['gtrace-'], color: '#bde0fe', transport: 'stdio', toolEstimate: 6, description: 'Path tracing and IP enrichment.' },
   { id: 'bgp-intel', name: 'BGP & Registry Intel', category: 'Observability', prefixes: ['rpki_', 'registry_', 'routing_', 'peering_', 'atlas_', 'resource_'], color: '#8ac926', transport: 'stdio', toolEstimate: 10, description: 'RPKI origin validation, RDAP ownership, PeeringDB peering, routing visibility. Public APIs, no credentials. not-found is NOT invalid.' },
+  { id: 'document', name: 'Document Generation', category: 'Platform Services', prefixes: ['docx_', 'xlsx_', 'pptx_', 'pdf_', 'list_documents'], color: '#4c956c', transport: 'stdio', toolEstimate: 6, description: 'Change-record .docx, audit .xlsx, exec .pptx and PDF form filling from real NetClaw data. No credentials, writes files only. Per-element provenance at a chokepoint — a missing value renders as NOT AVAILABLE, never as a blank.' },
   { id: 'globalping', name: 'Globalping', category: 'Observability', prefixes: ['globalping-'], color: '#00b4d8', transport: 'http', toolEstimate: 12, description: 'Outside-in measurement from ~4,800 probes across ~1,390 ASNs — ping, traceroute, DNS, MTR and HTTP toward a public target. The only vantage point NetClaw has outside its own administrative domain. Public endpoints only; "no probes matched" is not "the service is down".' },
   { id: 'suzieq', name: 'SuzieQ', category: 'Observability', prefixes: ['suzieq-'], color: '#a8dadc', transport: 'stdio', toolEstimate: 5, description: 'Network state queries, assertions, summaries, and path tracing.' },
   { id: 'aws', name: 'AWS', category: 'Cloud', prefixes: ['aws-'], color: '#f77f00', transport: 'http', toolEstimate: 55, description: 'Networking, monitoring, security, cost, and diagram generation in AWS.' },
@@ -246,6 +247,11 @@ const ENV_MAP = {
     env: ['BGP_INTEL_MCP_CMD', 'BGP_INTEL_USER_AGENT', 'BGP_INTEL_MAX_RPS', 'BGP_INTEL_AUDIT_LOG'],
     files: ['mcp-servers/bgp-intel-mcp/server.py'],
     notes: 'No credentials required — all five sources are public unauthenticated APIs. Read-only. Self-imposed 4 req/s serial ceiling against volunteer-funded infrastructure (RIPE NCC, PeeringDB). Every response carries its source and is GAIT-audited. RPKI not-found means no ROA exists and is NOT a finding.',
+  },
+  document: {
+    env: ['DOCUMENT_MCP_CMD', 'DOCUMENT_OUTPUT_DIR', 'DOCUMENT_MAX_ROWS', 'DOCUMENT_MAX_BLOCKS', 'DOCUMENT_MAX_SLIDES', 'DOCUMENT_AUDIT_LOG'],
+    files: ['mcp-servers/document-mcp/server.py'],
+    notes: 'No credentials required — this server writes files and touches no device and no ticket. Every document carries its generation time, NetClaw attribution and a per-element source, stamped at a single chokepoint and GAIT-audited. A value without a source is refused; a missing value renders as NOT AVAILABLE, never as a blank. Office templates are refused (scratch-only); PDF form filling is supported because form fields are explicitly named. Output is timestamped in workspace/output/document-mcp/ and never overwritten.',
   },
   fortinet: {
     env: [

--- a/workspace/skills/document-generation/SKILL.md
+++ b/workspace/skills/document-generation/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: document-generation
+description: "Generate Word (.docx), Excel (.xlsx) and PowerPoint (.pptx) documents and fill existing PDF forms, from real NetClaw data, with per-element provenance and no fabrication. Use when someone needs a deliverable rather than an answer — a change record to attach to a CR, an audit workbook for a compliance reviewer, a summary deck for a director, or a required PDF form filled from real device and ticket data."
+version: 1.0.0
+license: Apache-2.0
+tags: [documents, docx, xlsx, pptx, pdf, reporting, change-record, audit, deliverables]
+user-invocable: true
+metadata:
+  { "openclaw": { "requires": { "bins": ["python3"], "env": ["DOCUMENT_MCP_CMD"] } } }
+---
+
+# Document Generation
+
+## MCP Server
+
+- **Server**: `document-mcp` (NetClaw-authored, spec 082 / roadmap R18)
+- **Command**: `$DOCUMENT_MCP_CMD`
+- **Transport**: stdio
+- **Credentials**: **none.** This server writes files and touches nothing else
+- **Infrastructure**: no device access, no ticket writes — so there is no approval gate here
+
+## The one rule that matters most
+
+> ### A document must never fabricate to fill a blank.
+
+Tool output is ephemeral — read once, in context, by the person who asked. **A document is not.** It gets
+emailed, attached to a ticket, filed for audit, and read months later by someone who was not there, and it
+carries the authority of its formatting.
+
+A professional-looking change record with a plausible invented number is a far more effective way to launder
+a guess into an official record than any amount of terminal output, because **nobody re-derives a figure
+that is already in a table in a `.docx`.**
+
+**So: never infer, estimate, interpolate, or carry forward a stale value to complete a document.** If you do
+not have a figure, send `{"unavailable": "<why>"}`. The server renders that as visible text. It will not
+render a blank, and it will not let you send one.
+
+## Tagged values — the only accepted shape
+
+Every value in a figure, table, keyvalue or form field is one of exactly three shapes:
+
+```jsonc
+{"v": "fgt-01", "src": "fgt_system_status", "device": "fgt-01", "as_of": "2026-08-03T13:58:00Z"}
+{"unavailable": "device did not answer within timeout"}
+{"failed": "FortiGate plane unreachable: connection refused"}
+```
+
+| You send | The document shows |
+|---|---|
+| `{"v": x, "src": ...}` | `x`, with a visible source |
+| `{"v": ""}` | `(empty)` — the source *was* consulted and returned nothing |
+| `{"unavailable": r}` | `NOT AVAILABLE — r` |
+| `{"failed": r}` | `RETRIEVAL FAILED — r` |
+| `{"v": x}` with no `src` | **refused** |
+| a bare `x` | **refused** |
+
+`unavailable` and `failed` are different facts and render differently: a dead query is not an empty result.
+Neither ever renders as `N/A`, `0`, `-`, or an empty cell.
+
+## Tools (6)
+
+| Tool | Does |
+|---|---|
+| `docx_write` | Word document from ordered blocks: heading, paragraph, figure, table, keyvalue, image, pagebreak |
+| `xlsx_write` | Workbook from sheets of tagged rows, plus `failed_rows` |
+| `pptx_write` | Deck from slides: bullets, figure, image |
+| `pdf_inspect_form` | List a PDF's **real** named fields — call this before filling |
+| `pdf_fill_form` | Fill named fields into a new file; reports `unfilled` and `unmatched` |
+| `list_documents` | Find something you generated earlier |
+
+## What the server adds that you cannot omit
+
+- A **Source column** on every table and every spreadsheet row — appended by the writer.
+- An **As of** column carrying the *source's* own collection time, distinct from the generation time.
+- Generation time and NetClaw attribution in the `.docx` footer on every page, the `.xlsx` banner, and the
+  `.pptx` title and Sources slides.
+- A **Sources section** in every file, listing each tool with its as-of and whether it was `ok`, `partial`
+  or `failed`.
+- A **GAIT record** for every call, including refusals.
+
+If any figure lacks a source, the whole call is refused. There is no partial path.
+
+## Three limits, stated up front
+
+**No footnotes in Word.** `python-docx` has no footnote API, so attribution is inline — a Source column in
+tables, a small parenthetical after prose figures. That is more visible than a footnote, not less. Word
+comments and document properties are set additively but **never** count as provenance: they are collapsed by
+default, stripped on paste, and absent in print.
+
+**No Office templates.** `.docx`, `.xlsx` and `.pptx` are built from scratch and a supplied template is
+**refused**, not ignored — otherwise you would get an unbranded document believing it was branded. A
+corporate template's empty field is the strongest fabrication pressure in the feature. PDF forms are the
+exception *because* their fields are explicitly named: there is nothing to guess.
+
+**A filled PDF carries no Sources section.** It is the customer's form and adding a page would alter it. For
+that one format provenance lives in the tool response and the GAIT record. Say so when you hand the file
+over.
+
+## Put figures in the right block
+
+Prose carries no attribution. A `paragraph` asserting a bare number gets a caveat naming the block index —
+use `figure`, `table` or `keyvalue` instead, all of which force a source. Dates, ticket numbers, IPs,
+versions and "Section 2" are not flagged.
+
+## Other behaviour worth knowing
+
+- **Admin state and operational state must be separate columns.** A merged `status` column is refused. An
+  interface can be administratively up with no carrier, and collapsing them tells a reader traffic is
+  passing when nothing is.
+- **Sources that disagree are both shown**, with their origins and a caveat. NetClaw does not pick a winner.
+- **Untrusted text cannot become a formula.** A description beginning with `=` is written as literal text —
+  openpyxl would otherwise turn it into a live formula in an auditor's spreadsheet.
+- **Files are never overwritten.** Output is timestamped and exclusively created, so a regenerated report
+  cannot replace one already attached to a ticket. Path is reported back.
+- **`ok` means complete.** A document with any gap comes back as `written_with_gaps`, and you cannot
+  override that.
+
+## Boundaries — which skill owns what
+
+| Want to… | Use |
+|---|---|
+| Draw a diagram | `drawio-diagram`, `markmap-viz`, `uml-diagram`, `threejs-network-viz`. This **embeds** their output and never redraws it — pass the file they produced plus `src` naming them |
+| Read a document into the knowledge base | `rag-mcp` (feature 062). It **reads** these formats; this **writes** them. Same libraries, opposite direction |
+| Create or update a change record | `servicenow-change-workflow` owns the CR lifecycle. This renders a document **from** one and never writes a ticket |
+| Send the document somewhere | `slack-report-delivery`, `webex-report-delivery`. Writing a file is in scope here; sending it is not |
+| Compose a NetClaw-shaped report | `network-report-documents` — the four standard compositions |
+
+## Important rules
+
+1. **Never fill a gap with a guess.** Send `unavailable` or `failed` with a real reason.
+2. **Never send a value without `src`.** It will be refused, and it should be.
+3. **Call `pdf_inspect_form` before `pdf_fill_form`** so you map data to fields that actually exist.
+4. **Report what the response says.** If it came back `written_with_gaps`, tell the operator the document is
+   incomplete and which parts. Handing over a gapped document as if it were finished undoes the whole point.
+5. **Give the operator the path.** They need to find the file.

--- a/workspace/skills/network-report-documents/SKILL.md
+++ b/workspace/skills/network-report-documents/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: network-report-documents
+description: "The four standard NetClaw document compositions — a change-record Word document from a real ServiceNow CR plus device state, an interface/config audit workbook from real device queries, an executive summary deck with an embedded topology diagram, and a required PDF form filled from real data. Use when an operator asks for a deliverable to attach to a change record, hand to an auditor, or put in front of a director."
+version: 1.0.0
+license: Apache-2.0
+tags: [documents, reporting, change-record, audit, executive-summary, pdf-forms, deliverables]
+user-invocable: true
+metadata:
+  { "openclaw": { "requires": { "bins": ["python3"], "env": ["DOCUMENT_MCP_CMD"] } } }
+---
+
+# Network Report Documents
+
+Four compositions built on `document-mcp`. This skill owns **what goes in the document**; the server owns
+**writing it**. Read [document-generation](../document-generation/SKILL.md) for the tool surface, the tagged
+value shapes, and the stated limits.
+
+## The rule that governs all four
+
+> ### A document must never fabricate to fill a blank.
+
+**Never infer, estimate, interpolate, or carry forward a stale value to complete a document.** The server
+structurally cannot fabricate — it only renders tagged values — but *you* can, by inventing a plausible
+figure while assembling the request. That half of the discipline lives here and nowhere else.
+
+If a device did not answer, send `{"unavailable": "device did not answer"}`. A change record that says
+"NOT AVAILABLE — device did not answer" is useful. One with a confident wrong number is worse than none,
+because a change advisory board will act on it and nobody will re-derive it.
+
+## 1 · Change record (`.docx`)
+
+> *"Generate a change record for CHG0012345 with the current state of fgt-01."*
+
+**Feed it from**: `servicenow-change-workflow` for the CR (read-only — this composition never creates or
+updates a ticket), plus `fortigate-ops` / `multivendor-cli` / `pyats` for device state.
+
+**Shape**:
+
+| Section | Block | Notes |
+|---|---|---|
+| Change details | `keyvalue` | CR number, state, requester, window, risk — each tagged with `src: servicenow_get_change` |
+| Pre-change state | `keyvalue` + `table` | Real device output, tagged per device |
+| Topology | `image` | Only if a diagram skill already produced one |
+| Rollback | `paragraph` | Narrative — put no figures here |
+
+**If the CR does not exist or is not approved, say so and stop.** Do not produce a document with an invented
+CR — the document would outlive the conversation that knew it was a placeholder.
+
+**If ServiceNow is not configured**, you may still produce the device half, but state in the response that
+the CR half was hand-supplied and unverified.
+
+## 2 · Interface / config audit workbook (`.xlsx`)
+
+> *"Build an interface audit spreadsheet for all my FortiGates."*
+
+**Feed it from**: `fgt_list_interfaces`, `multivendor-device-query`, `pyats` — whatever actually reached the
+devices.
+
+**Non-negotiables**:
+
+- **Administrative and operational state go in separate columns.** A merged `status` column is refused by
+  the server. An interface can be admin-up with no carrier; collapsing them tells the auditor traffic is
+  passing when nothing is. This is the distinction spec 080's completion established after NetClaw itself
+  reported the conflation on a real FortiGate.
+- **A device that failed goes in `failed_rows`, never omitted.** A shorter spreadsheet reads as a smaller
+  estate, which is a false statement about the network. The server renders failures as marked rows and
+  reports attempted / returned / failed in a banner.
+- Device descriptions are untrusted text; the server writes them as literal text so a leading `=` cannot
+  become a live formula. You do not need to sanitise anything.
+
+## 3 · Executive summary deck (`.pptx`)
+
+> *"Make an exec deck from the posture review, with the topology diagram."*
+
+**Feed it from**: findings other NetClaw skills produced, and a diagram file an existing diagram skill
+already generated.
+
+**Shape**: a `bullets` slide for what was found, `figure` slides for the numbers behind it, an `image` slide
+for the diagram, and the auto-appended Sources slide.
+
+- **Give every summary slide a `detail_ref`** pointing at the detail slide or the Sources slide. A bare
+  summary claim gets a caveat, and rightly — an executive reading "everything is fine" deserves to know
+  where that came from.
+- **Do not draw the diagram.** Run `drawio-diagram`, `markmap-viz`, `uml-diagram` or `threejs-network-viz`
+  first, then pass its output path and `src`. A path outside the workspace output directory is refused.
+- Sources appear in a **visible box on the slide**, not in speaker notes — notes are invisible in
+  presentation and print.
+
+## 4 · Fill a required PDF form
+
+> *"What fields does audit-response.pdf have?"* → *"Fill it from the CR and the device state."*
+
+1. **Always `pdf_inspect_form` first.** It returns the real field names. Never guess them.
+2. Map tagged values onto those exact names.
+3. Read back `unfilled` and `unmatched` and **tell the operator both**: which fields they must complete by
+   hand, and which of their values matched nothing.
+
+A field with no data is left genuinely empty. Never fill one to make the form look complete — an audit
+response form is precisely where an invented answer does the most damage.
+
+**Tell the operator the one limitation**: a filled form carries no Sources section, because it is their
+document and adding a page would alter it. Provenance for a fill lives in the tool response and the GAIT
+record.
+
+## Boundaries
+
+| Want to… | Use |
+|---|---|
+| Draw a diagram | `drawio-diagram`, `markmap-viz`, `uml-diagram`, `threejs-network-viz` — embedded here, never redrawn |
+| Read a document into the knowledge base | `rag-mcp` (feature 062) — it **reads** these formats, this **writes** them |
+| Create, update or close a change record | `servicenow-change-workflow` — this renders a document from one and writes no ticket |
+| Send the document | `slack-report-delivery`, `webex-report-delivery` — writing the file is in scope, sending it is a separate, outward-facing action |
+| Understand the tool surface | `document-generation` |
+
+## Before you hand anything over
+
+- **Read the `outcome`.** `written_with_gaps` means the document is incomplete — say which parts, do not
+  present it as finished.
+- **Give the path.** The operator has to find the file.
+- **Say what is unverified.** If half the data was hand-supplied because a system was unconfigured, that
+  belongs in your reply, not just in your head.


### PR DESCRIPTION
Closes roadmap **R18** — *"Best effort-to-value ratio on the roadmap."*

NetClaw could render Three.js topologies, drawio, markmap, UML, Blender and UE5. It could not produce a change-record `.docx`, an interface-audit `.xlsx`, an executive `.pptx`, or fill a PDF form. **Its output lands in front of change advisory boards, auditors and directors — people who work in Office documents.** This closes that gap.

One MCP server, `document-mcp`: **6 tools, stdio, no credentials, no device or ticket access.** Two skills on top — `document-generation` (capability + discipline) and `network-report-documents` (the four compositions). Manifest **1,232 / 5,000 tokens**.

## The one rule

> **A document must never fabricate to fill a blank.**

Specs 078–081 each protected a distinction in *tool output*, which is ephemeral — read once, in context, by the person who asked. A document is emailed, filed, and read months later by someone who was not there, and it carries the authority of its formatting. A professional-looking change record with a plausible invented number is a far more effective way to launder a guess into an official record than any amount of terminal output, **because nobody re-derives a figure that is already in a table in a `.docx`.**

So the honest representation is the only expressible one:

```jsonc
{"v": "fgt-01", "src": "fgt_system_status", "as_of": "2026-08-03T13:58:00Z"}
{"unavailable": "device did not answer"}     // renders: NOT AVAILABLE — device did not answer
{"failed": "connection refused"}             // renders: RETRIEVAL FAILED — connection refused
```

A bare scalar is refused. A value without `src` is refused. Nothing renders as `N/A`, `0`, `-` or a blank. Failed devices appear as **marked rows**, never omitted — a shorter spreadsheet reads as a smaller estate. `ok` means complete: any gap forces `written_with_gaps` and a caller cannot override it.

Everything passes through one chokepoint (`envelope.emit`) which stamps generation time, attribution and per-element provenance and writes a GAIT record — **for refusals as well as successes**. No writer imports `envelope`; asserted by source inspection, not convention.

## The licence finding changed the roadmap

The roadmap said *"vendor the four official skills."* Measured 2026-08-03: those skills are **source-available, "for demonstration and educational purposes only" — not Apache-2.0**. Vendoring is not licence-compatible.

R18 therefore becomes build-rather-than-adopt for a **licensing** reason, unlike R1/R3/R9 where the community options were technically inadequate. No vendored copy, no installer, no fetch path — verified by grep across every shipped artifact. `docs/COVERAGE-ROADMAP.md` is corrected with the finding and the item struck.

## Measured findings that shaped the design

| Finding | Consequence |
|---|---|
| **openpyxl writes a leading `=` as a LIVE FORMULA** (`<f>1+1</f>`) — and the strings this writes come from device descriptions and ticket fields | Forced `inlineStr` at one helper; asserted against **raw worksheet XML**, since `data_type == "s"` is an openpyxl claim while `<f>`-absence is a claim about the file an auditor opens |
| **python-docx 1.2.0 has no footnote API.** It has `add_comment` — the tempting answer and the wrong one: collapsed by default, stripped on paste, invisible in print | Attribution is inline; comments are additive only |
| pptx speaker notes are equally hidden | Sources go in a **visible on-slide shape** |
| `doc.is_form_pdf` returns an **int** (3), not a bool | Compared truthily |
| Feature 046's output convention relies on timestamp uniqueness alone — two documents in the same second collide | `O_EXCL` create. The difference between "unlikely to overwrite" and "cannot" — a regenerated report must not replace one already attached to a ticket |

## The dependency checker was blind (pre-existing, fixed here)

`check-dependency-pins.py` read `requirements.txt` **only** — and `rag-mcp` has none. It had **never been scanned**; its clean bill of health was an artefact of invisibility. It also matched by *distribution* name, so `pymupdf`→`fitz`, `python-docx`→`docx` and `beautifulsoup4`→`bs4` never met their imports.

Both fixed. That surfaced **14 real hazards across 10 servers**:

- **Fixed** (tracked, NetClaw-maintained): `rag-mcp` (13 unbounded deps), `memory-mcp`, `azure-network-mcp`
- **Recorded as named exceptions** (11 findings, 8 servers): untracked upstream clones where a local pin is not committable, evaporates on re-clone, and would leave a fixed-looking check guarding nothing. Each carries its reason; the comment says to delete the line the moment any is vendored in.

**No installed version moved.** `rag-mcp` ingestion was re-exercised on the four documents `document-mcp` had just produced — 4 parsed, 0 failed.

## Verified against a live FortiGate, not just fixtures

All four formats produced from real `fgt_system_status` / `fgt_list_interfaces` output on FGVMEVS9GWUAOMBD (FortiOS 7.6.7) and **opened and read back**:

| Format | Evidence |
|---|---|
| `.docx` | Footer stamp, 4 tables, per-row source, Sources section |
| `.xlsx` | Banner `4 attempted · 2 returned data · 2 failed`; admin/oper in separate columns; both unreachable planes as marked rows |
| `.pptx` | Source in a **shape** on every slide; real Kroki PNG embedded, attributed to `uml-diagram` |
| `.pdf` | Serial/firmware/HA filled; `reviewer_signature` left empty, `site_code` reported unmatched, input byte-identical |

The source's as-of (`18:19:57Z`) is visibly distinct from generation time (`18:20:58Z`) in the live document — which is what makes FR-010 testable rather than trivially true.

**240 assertions across 7 suites, all of which reparse the produced file.** Spec 080 shipped a tool returning three nulls past 24 passing tests because its suites asserted on envelope *shape* and never on payload *content*. This feature's entire output **is** content.

## Unverified, stated plainly

Recorded in [VERIFICATION.md](specs/082-document-generation/VERIFICATION.md) rather than claimed: the ServiceNow half of the change record (not configured here — the CR field renders as `NOT AVAILABLE … hand-supplied and unverified`), non-text PDF field kinds, the 50,000-row bound at full scale, and three of the four diagram skills' embed path. **iN2N is not-applicable by decision, not omission** — this holds no credentials and composes across domains, so it is Border work by construction.

## Also fixes pre-existing README drift

No MCP table rows for Fortinet (080) or BGP-intel (081), and no `fortigate-ops` / `fortianalyzer-ops` / `bgp-registry-intel` skill rows, even though SOUL.md and TOOLS.md had been updated. `verify-inventory-counts.py` misses this because it checks headline arithmetic, not table membership.

## Process

specify → clarify (5 questions) → plan → tasks (145) → analyze → **all 14 findings fixed** → implement. Traceability verified mechanically: 60 FRs, 33 SCs, every requirement has ≥1 task, no dangling refs.

`/speckit.analyze` also caught a **false technical claim in my own plan** — it justified the `_writer` filename suffix as avoiding package shadowing. Measured: inside the `writers/` package there is no shadowing, because Python 3 imports are absolute. Names kept for real reasons, wrong reason withdrawn ([research D14](specs/082-document-generation/research.md)).

## Checks

| | |
|---|---|
| `bash tests/document/run-tests.sh` | ✅ 240 assertions, exit 0 |
| `python3 scripts/reconcile-mcp.py` | ✅ exit 0, all four surfaces |
| `python3 scripts/verify-inventory-counts.py` | ✅ **209 skills / 155 MCP integrations** |
| `trace-skill.py` × 2 | ✅ both resolve |
| Regression: bgp-intel, fortinet, reconcile suites | ✅ all exit 0 |

Blog post skipped by standing operator decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)