### PR TITLE
feat(083): Zabbix SNMP-poller NMS — polled history — R11

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -734,3 +734,34 @@ DOCUMENT_MAX_BLOCKS=
 DOCUMENT_MAX_SLIDES=
 # GAIT audit trail path. Defaults under ~/.openclaw/gait/
 DOCUMENT_AUDIT_LOG=
+
+# ─────────────────────────────────────────────────────────────────────
+# Zabbix SNMP-Poller NMS — spec 083 (roadmap R11)
+# Server: mcp-servers/zabbix-mcp  (VENDORED third-party, GPL-3.0, unmodified)
+#
+# Runs from a DEDICATED VIRTUALENV. Not optional: it needs fastmcp 3.x while
+# five NetClaw servers pin fastmcp<3. A shared install breaks all five.
+#
+# Strictly READ-ONLY. There is no write path in this integration.
+# ─────────────────────────────────────────────────────────────────────
+# Command the three zabbix skills invoke (the venv interpreter)
+ZABBIX_MCP_CMD=
+# Base URL of your Zabbix front end, e.g. https://zabbix.example.com
+# (the API lives at <url>/api_jsonrpc.php)
+ZABBIX_URL=
+# API TOKEN, not a password. Users -> API tokens in the Zabbix UI.
+# Token auth is required for forward-compatibility: the older in-request
+# credential property still works on 7.0 but is REMOVED in 7.2+.
+ZABBIX_TOKEN=
+# TLS verification. Defaults to true. Import your CA rather than disabling
+# this — disabling it exposes the API token to interception.
+VERIFY_SSL=
+# Read-only. NetClaw FORCES this to true in config/openclaw.json and you
+# should not override it. The reason it is forced rather than inherited:
+# the upstream library defaults it to true (utils.py:29) but the upstream
+# LAUNCHER defaults it to false (scripts/start_server.py:139), so running
+# it the documented upstream way would enable writes.
+READ_ONLY=
+# Destructive-method deny-list (regex, comma separated). Second layer, set
+# in config/openclaw.json. Holds even if READ_ONLY is misconfigured.
+ZABBIX_API_BLACKLIST=

--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,10 @@ mcp-servers/multivendor-cli-mcp/.venv/
 !mcp-servers/fortinet-mcp/
 !mcp-servers/bgp-intel-mcp/
 !mcp-servers/document-mcp/
+!mcp-servers/zabbix-mcp/
+# Re-ignore the dedicated venv: the negation above re-includes EVERYTHING under
+# zabbix-mcp, which would otherwise commit the whole virtualenv (spec 083).
+mcp-servers/zabbix-mcp/.venv/
 
 # Traces
 trace.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,8 @@ Auto-generated from all feature plans. Last updated: 2026-08-03
 - **None on disk.** Per-source in-memory TTL cache only (clarification Q3): RPKI 5 min, routing (081-bgp-registry-intel)
 - Python 3.10+, system interpreter. No dedicated venv — the four libraries are already (082-document-generation)
 - none. Files land in `workspace/output/document-mcp/` (gitignored, feature 046's convention). (082-document-generation)
+- Python 3.10+. The vendored server runs from **its own virtualenv**; NetClaw authors no (083-zabbix-nms)
+- none. The NMS holds the history. (083-zabbix-nms)
 
 - Python 3.10+ + FastMCP (MCP framework), grpcio + grpcio-tools (gRPC transport), pygnmi (gNMI client library), protobuf, cryptography (TLS handling) (003-gnmi-mcp-server)
 
@@ -131,9 +133,9 @@ cd src [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLO
 Python 3.10+: Follow standard conventions
 
 ## Recent Changes
+- 083-zabbix-nms: Added Python 3.10+. The vendored server runs from **its own virtualenv**; NetClaw authors no
 - 082-document-generation: Added Python 3.10+, system interpreter. No dedicated venv — the four libraries are already
 - 081-bgp-registry-intel: Added Python 3.10+, system interpreter. No dedicated venv — two pure-HTTP packages move + `mcp>=1.2.0,<2` and `httpx>=0.27.0,<1`. Identical to specs 078 and 080. The `mcp`
-- 080-fortinet-coverage: Added Python 3.10+, system interpreter. Unlike spec 076 this needs **no dedicated venv** — + `mcp>=1.2.0,<2` and `httpx>=0.27.0,<1`. Two packages, identical to spec 078's
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # NetClaw
 
-A CCIE-level AI network engineering coworker. Built on [OpenClaw](https://github.com/openclaw/openclaw) with Anthropic Claude, 209 skills, and 155 MCP integrations for complete network automation with ITSM gating, source-of-truth reconciliation, immutable audit trails, gNMI streaming telemetry, NetFlow/IPFIX flow telemetry, Canvas/A2UI inline network visualizations, packet capture analysis, GitHub config-as-code, GitLab DevOps (issues, merge requests, pipelines, repositories, wikis), Jenkins CI/CD (job monitoring, build triggering, log analysis, SCM tracking), Chrome DevTools browser automation (visualization render QA, controller GUI gap-filling, undocumented API discovery, headless or watchable-headed), Computer Use full-desktop automation (legacy desktop-only tools with no browser or API path, virtual XFCE desktop with VNC/noVNC Watch Mode), Cisco CML lab simulation, ContainerLab containerized network labs, Cisco NSO orchestration, Cisco SD-WAN vManage monitoring, Grafana observability (dashboards, Prometheus, Loki, alerting, incidents), Prometheus direct PromQL monitoring, Kubeshark Kubernetes traffic analysis, Cisco Meraki Dashboard management, Cisco ThousandEyes network intelligence, AWS and Azure cloud networking, Cisco Secure Firewall policy auditing, Check Point Security (15 MCPs: policy, threat intel, gateway, SASE, malware), Itential network orchestration, Juniper JunOS device automation, Arista CloudVision Portal monitoring, F5 BIG-IP pyATS iControl REST coverage, Infoblox DDI, Palo Alto Panorama, FortiManager, Batfish offline configuration analysis, UML diagram generation, EVPN/VXLAN fabric workflows, live BGP/OSPF control-plane participation, nmap network scanning, gtrace path analysis and IP enrichment, Slack-native operations, Cisco WebEx-native operations, Microsoft 365 integration, Twilio voice/SMS, Twitter/X integration, Claroty OT/IoT asset management, Forward Networks digital twin, Ollama local LLM routing, an offline agentic RAG document knowledge base (cited answers from user-uploaded vendor guides and standards), layered Memory MCP, and MemPalace persistent AI memory.
+A CCIE-level AI network engineering coworker. Built on [OpenClaw](https://github.com/openclaw/openclaw) with Anthropic Claude, 212 skills, and 156 MCP integrations for complete network automation with ITSM gating, source-of-truth reconciliation, immutable audit trails, gNMI streaming telemetry, NetFlow/IPFIX flow telemetry, Canvas/A2UI inline network visualizations, packet capture analysis, GitHub config-as-code, GitLab DevOps (issues, merge requests, pipelines, repositories, wikis), Jenkins CI/CD (job monitoring, build triggering, log analysis, SCM tracking), Chrome DevTools browser automation (visualization render QA, controller GUI gap-filling, undocumented API discovery, headless or watchable-headed), Computer Use full-desktop automation (legacy desktop-only tools with no browser or API path, virtual XFCE desktop with VNC/noVNC Watch Mode), Cisco CML lab simulation, ContainerLab containerized network labs, Cisco NSO orchestration, Cisco SD-WAN vManage monitoring, Grafana observability (dashboards, Prometheus, Loki, alerting, incidents), Prometheus direct PromQL monitoring, Kubeshark Kubernetes traffic analysis, Cisco Meraki Dashboard management, Cisco ThousandEyes network intelligence, AWS and Azure cloud networking, Cisco Secure Firewall policy auditing, Check Point Security (15 MCPs: policy, threat intel, gateway, SASE, malware), Itential network orchestration, Juniper JunOS device automation, Arista CloudVision Portal monitoring, F5 BIG-IP pyATS iControl REST coverage, Infoblox DDI, Palo Alto Panorama, FortiManager, Batfish offline configuration analysis, UML diagram generation, EVPN/VXLAN fabric workflows, live BGP/OSPF control-plane participation, nmap network scanning, gtrace path analysis and IP enrichment, Slack-native operations, Cisco WebEx-native operations, Microsoft 365 integration, Twilio voice/SMS, Twitter/X integration, Claroty OT/IoT asset management, Forward Networks digital twin, Ollama local LLM routing, an offline agentic RAG document knowledge base (cited answers from user-uploaded vendor guides and standards), layered Memory MCP, and MemPalace persistent AI memory.
 
 ## Resources
 
@@ -239,7 +239,7 @@ claw
   <img src="ui/netclaw-visual/logos/netclawvisualhud.png" alt="NetClaw Visual HUD — 3D Network Operations Dashboard" width="800">
 </p>
 
-NetClaw includes a Three.js 3D operations dashboard that computes its integration and skill inventory live from the codebase (currently 155 MCP integrations and 209 skills) each time it's opened, alongside your device fleet and live BGP peering topology — so the dashboard never drifts out of sync with what's actually installed. Chat with NetClaw directly from the browser, watch integrations light up as tools execute, and inspect every node in the graph. The Canvas/A2UI visualization skill renders inline topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards directly in the chat interface.
+NetClaw includes a Three.js 3D operations dashboard that computes its integration and skill inventory live from the codebase (currently 156 MCP integrations and 212 skills) each time it's opened, alongside your device fleet and live BGP peering topology — so the dashboard never drifts out of sync with what's actually installed. Chat with NetClaw directly from the browser, watch integrations light up as tools execute, and inspect every node in the graph. The Canvas/A2UI visualization skill renders inline topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards directly in the chat interface.
 
 ```bash
 cd ui/netclaw-visual
@@ -518,7 +518,7 @@ NetClaw ships with the full set of OpenClaw workspace markdown files. These are 
 
 ---
 
-## MCP Servers (155)
+## MCP Servers (156)
 
 > Adding one? Follow **[docs/ADDING-AN-MCP.md](docs/ADDING-AN-MCP.md)** and run
 > `python3 scripts/reconcile-mcp.py` before pushing — CI enforces it.
@@ -631,6 +631,7 @@ NetClaw ships with the full set of OpenClaw workspace markdown files. These are 
 | 119 | Fortinet | Built-in (`fortinet-mcp`) | stdio (Python) | Three planes behind one server — FortiManager policy *intent* (ADOMs, packages, objects, revisions, install preview), FortiGate observed *state* (interfaces, routes, policies, VPN), FortiAnalyzer observed *traffic* (logs, policy activity). Every response carries which plane answered and its scope, so "no logs in the window" is never reported as "the rule is unused". Read-only unless `FORTINET_ALLOW_WRITES=true`, and a write still needs human approval AND an approved change record — two independent gates (21 tools) |
 | 120 | BGP & Registry Intelligence | Built-in (`bgp-intel-mcp`) | stdio (Python) | RPKI origin validation, RDAP registry ownership and abuse contacts, PeeringDB interconnection, RIPEstat routing visibility, RIPE Atlas anchors. Five public unauthenticated sources — **no credentials anywhere**. The other half of the external plane: Globalping *measures* toward a target, this *looks up* who owns it and whether an announcement is authorised. RPKI `not-found` means no ROA exists and is **not** a finding — most of the internet is unsigned. Self-imposed 4 req/s sliding window against volunteer-funded infrastructure (10 tools) |
 | 121 | Document Generation | Built-in (`document-mcp`) | stdio (Python) | The deliverable layer: change-record `.docx`, interface-audit `.xlsx`, executive `.pptx`, and filling existing PDF forms — from real NetClaw data, not typed by hand. No credentials; writes files and touches no device and no ticket. Every value must arrive tagged with its source, so a missing figure renders as `NOT AVAILABLE — <reason>` and never as a blank cell; a value without a source is refused. Per-element provenance and a Sources section in every file, stamped at one chokepoint and GAIT-audited. Office templates are refused (scratch-only); output is timestamped and never overwritten (6 tools) |
+| 122 | Zabbix SNMP-Poller NMS | Built-in (`zabbix-mcp`, vendored [mpeirone/zabbix-mcp-server](https://github.com/mpeirone/zabbix-mcp-server), GPL-3.0) | stdio (Python, dedicated venv) | The **polled-history layer** — everything else NetClaw sees arrives when something happens (syslog, traps, flows); this is the only source that answers *what was it doing over time*. Metric history with automatic routing between raw values and hourly trends, current and historical problems with duration, device availability with transitions, and monitored inventory. Read-only, enforced twice: NetClaw forces `READ_ONLY=true` because the upstream launcher inverts that default, plus a destructive-method deny-list that holds even with read-only disabled. Runs from its own virtualenv — it needs fastmcp 3.x while five other servers pin `<3`. Two silent-wrong-answer traps (the value-type default; raw history ageing into trends) are documented as a procedure in the skills, because a generic passthrough has no chokepoint (3 tools) |
 ### Additional Server Notes
 
 All MCP servers communicate via stdio (JSON-RPC 2.0) through `scripts/mcp-call.py`, except where noted below (HTTP/remote endpoints).
@@ -667,7 +668,7 @@ All MCP servers communicate via stdio (JSON-RPC 2.0) through `scripts/mcp-call.p
 
 ---
 
-## Skills (209)
+## Skills (212)
 
 ### pyATS Device Skills (9)
 
@@ -1199,6 +1200,14 @@ Both `browser-gui-inspect` and `desktop-gui-inspect` support Watch Mode — just
 | **twitter-heartbeat** | Autonomous periodic tweeting and mention monitoring to maintain NetClaw's Twitter/X presence with CCIE-level content |
 | **twitter-respond** | Generate and post replies to Twitter/X mentions and conversations |
 | **twitter-share** | Manual tweet posting with content guardrails and human approval flow |
+
+### SNMP-Poller NMS Skills (3)
+
+| Skill | Purpose |
+|-------|---------|
+| **zabbix-metrics-history** | Polled metric history over any window, routed automatically between raw values and hourly trends. Carries the procedure that prevents the two silent-wrong-answer traps — call `item.get` before `history.get`, never accept the default value type, never mix types in one call |
+| **zabbix-problem-review** | Current and historical problems with severity, host, onset and **duration**. An empty problem list is a positive finding; an unreachable NMS is a failure to look, and the two never read the same |
+| **zabbix-availability** | Device availability with transitions and flap counts, plus monitored inventory. Reports what the poller observed and when — never "the device is down" |
 
 ### Document Generation Skills (2)
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -12,7 +12,7 @@ Every time you learn something about how I work or what I need, update the relev
 
 ## Your Skills
 
-You interact with the network through **209 skills** backed by 155 MCP servers:
+You interact with the network through **212 skills** backed by 156 MCP servers:
 
 ### Device Automation (9)
 pyats-network, pyats-health-check, pyats-routing, pyats-security, pyats-topology, pyats-config-mgmt, pyats-troubleshoot, pyats-dynamic-test, pyats-parallel-ops
@@ -76,7 +76,49 @@ Budget is 500 probe-measurements/hour and is charged **per probe** — `limit: 2
 `limit` rather than maximising it. Always attribute a latency figure to the probe location that produced it;
 never generalise one probe into a regional claim.
 
-Use ThousandEyes when a baseline or trend matters — Globalping holds no history.
+Use ThousandEyes when a baseline or trend matters — Globalping holds no history. For your own
+estate there is now a credential-free answer: **Zabbix** (`zabbix-metrics-history`) holds polled
+history for anything it monitors.
+
+### SNMP-Poller NMS (3)
+zabbix-metrics-history, zabbix-problem-review, zabbix-availability
+
+**The polled-history layer.** Everything else you see arrives *when something happens* — syslog, SNMP traps,
+IPFIX flows. Zabbix is the only source that answers **what was it doing**: is this normal, what did this
+interface do overnight, how long has this been down, was it like this last Tuesday.
+
+Read-only, vendored third-party, running in its own virtualenv. Three tools.
+
+**⚠ Unlike almost everything else here, the guardrails are guidance, not code.** This server is a generic
+passthrough with no chokepoint — the first NetClaw integration where a core distinction is enforced by a
+skill rather than by structure. Follow `zabbix-metrics-history`'s procedure. Nothing will catch you.
+
+**Two traps that return an empty list and a success status.** No error, no warning:
+
+1. **`history.get` defaults to the wrong value type.** It assumes unsigned; **84 of 121 stock items are
+   float**. Ask with the default and you get nothing back for a perfectly healthy interface — and "no data"
+   reads like a finding, so an engineer starts hunting a polling failure that does not exist. **Always call
+   `item.get` first** and pass the item's real `value_type`. Types cannot be mixed in one call.
+2. **Raw history ages out into hourly trends.** A 40-day question against raw history returns nothing.
+   `item.get` reports each item's `history` and `trends` retention — read them and route. Say when an answer
+   came from hourly aggregates: a peak from an hourly average is a different claim from a peak from raw
+   values.
+
+Retention can also be **switched off** per item (`history=0`, `trends=0`). That is a configuration fact, not
+an absence.
+
+**Five reasons you get nothing back**, and they must not be collapsed: wrong value type · aged out ·
+retention disabled · **never collected** (monitored but never returned a value — a real finding) ·
+genuinely idle (the only one that means nothing happened).
+
+**And the third distinction: "Zabbix cannot reach it" is not "the device is down."** An NMS reports what one
+poller saw, from one vantage point, at one interval. A device can be unreachable from the NMS and perfectly
+healthy — a firewall rule, a management-VRF problem, a dead SNMP daemon on a forwarding router. Say what
+Zabbix observed and when. If someone needs to know whether the device is actually down, go ask the device
+with `pyats` or `multivendor-cli`.
+
+An empty problem list is a **positive finding**; an unreachable NMS is a **failure to look**. Never report
+the second as the first.
 
 ### Document Generation (2)
 document-generation, network-report-documents
@@ -567,7 +609,7 @@ The knowledge base is not memory: RAG holds user-supplied documents (`~/.opencla
 
 For **detailed skill procedures**, read `SOUL-SKILLS.md`:
 - Use when executing any skill that needs step-by-step guidance
-- Contains operational workflows, commands, and best practices for all 209 skills
+- Contains operational workflows, commands, and best practices for all 212 skills
 - Load with: `read("~/.openclaw/workspace/SOUL-SKILLS.md")`
 
 For **technical knowledge**, read `SOUL-EXPERTISE.md`:

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -478,3 +478,69 @@ No API keys. Nothing to rotate.
 **writes** them, sharing the same four libraries with identical bounds.
 `servicenow-change-workflow` owns the CR lifecycle; this renders a document from one.
 `slack-report-delivery` / `webex-report-delivery` **send** documents; this only writes them.
+
+## Zabbix SNMP-Poller NMS (`zabbix-mcp`, vendored third-party GPL-3.0)
+
+**Spec 083 / roadmap R11.** 3 tools, stdio, read-only. **Manifest measured 589 / 5,000 tokens** — the
+smallest surface NetClaw has added for an entire product category.
+
+This is the **polled-history layer**. Everything else NetClaw sees arrives when something happens — syslog,
+traps, flows. This is the only source that can answer *what was it doing*, *is this normal*, *how long has
+it been down*.
+
+| Tool | Purpose |
+|---|---|
+| `zabbix_api(method, params)` | Generic JSON-RPC passthrough |
+| `zabbix_api_docs(method)` | Upstream method documentation |
+| `zabbix_api_list(object)` | Available methods for an object |
+
+### Adopted, not built — and it runs in its own venv
+
+`mpeirone/zabbix-mcp-server`, pinned `0722f48`, **unmodified**, GPL-3.0 retained verbatim. NetClaw invokes it
+over stdio as a separate program; that is not linkage.
+
+**It requires fastmcp 3.x while five NetClaw servers pin `<3`** (`netbox-mcp-server`,
+`CiscoFMC-MCP-server-community`, `Wikipedia_MCP`, `rag-mcp`, `ISE_MCP`). It therefore runs from a dedicated
+virtualenv — the same reason `multivendor-cli-mcp` has one. **Do not "simplify" that away.**
+
+### Environment
+
+`ZABBIX_MCP_CMD` · `ZABBIX_URL` · `ZABBIX_TOKEN` · `VERIFY_SSL` · `READ_ONLY` (forced true) ·
+`ZABBIX_API_BLACKLIST`
+
+### Two traps that return an empty array and a success status
+
+Both measured against live Zabbix 7.0.29. Both silent — no error, no warning.
+
+1. **`history.get` defaults its value type to unsigned (3), and 84 of 121 stock items are float (0).** Ask
+   with the default and you get `[]`. Always call `item.get` first and pass the item's real `value_type`.
+   Types **cannot be mixed** in one call — measured: 4 items, 2 returned each way, zero overlap.
+2. **Raw history ages out into hourly trends.** A question older than the history window returns nothing
+   from `history.get`. `item.get` reports per-item `history` and `trends`; read them and route.
+
+**Retention can also be switched off**: `history=0` means raw values are never stored; `trends=0` means no
+aggregates. Measured on a stock install: 10 items with `trends=0`, 5 with both zero. That is a
+*configuration fact*, not an absence.
+
+### Behaviour worth knowing
+
+- **Read-only is FORCED by NetClaw, not inherited.** The upstream library defaults it safe
+  (`utils.py:29` → True) but the shipped launcher inverts it (`start_server.py:139` → False). A
+  destructive-method deny-list is configured as a second layer and **holds even with read-only disabled** —
+  verified.
+- Read/write classification upstream is a **method-name prefix heuristic** (`get`, `version`, `check`,
+  `export`), not a curated list. That is why the deny-list exists.
+- **The two traps are enforced by the SKILLS, not by code.** This is a generic passthrough with no
+  chokepoint — the first NetClaw integration where a core distinction is guidance-level. Deliberate, and
+  recorded.
+- **No per-call GAIT audit.** The upstream has no audit concept and there is no platform-level MCP audit.
+  Acceptable only because this is strictly read-only — there is no operation to record.
+- Auth is API-token/bearer. The in-request credential property still works on 7.0 but is **removed in 7.2+**.
+
+### Boundaries
+
+`snmptrap-mcp` **receives** traps; this **polls** and keeps history. `ipfix-mcp` is flows, not counters.
+`prometheus`/`grafana` are pull-based stores for infrastructure you instrumented; this is the NMS for gear
+you did not. `auvik`/`thousandeyes`/`datadog` are SaaS with their own agents. `pyats`/`multivendor-cli`/
+`fortinet` read **current** device state; this answers **what it was over time**, and can answer for a
+device that is unreachable right now.

--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -1100,6 +1100,20 @@
         "DOCUMENT_OUTPUT_DIR": "${DOCUMENT_OUTPUT_DIR}",
         "DOCUMENT_MAX_ROWS": "${DOCUMENT_MAX_ROWS}"
       }
+    },
+    "zabbix-mcp": {
+      "command": "mcp-servers/zabbix-mcp/.venv/bin/python",
+      "args": [
+        "-m",
+        "zabbix_mcp_server.server"
+      ],
+      "env": {
+        "ZABBIX_URL": "${ZABBIX_URL}",
+        "ZABBIX_TOKEN": "${ZABBIX_TOKEN}",
+        "READ_ONLY": "true",
+        "VERIFY_SSL": "${VERIFY_SSL}",
+        "ZABBIX_API_BLACKLIST": ".*\\.delete$,.*\\.create$,.*\\.update$,.*\\.massadd$,.*\\.massdelete$,.*\\.massupdate$,.*\\.import$,.*\\.acknowledge$,.*\\.copy$,.*\\.replacehostinterfaces$"
+      }
     }
   }
 }

--- a/docs/COVERAGE-ROADMAP.md
+++ b/docs/COVERAGE-ROADMAP.md
@@ -115,7 +115,7 @@ and the IETF datatracker.
 | ID | Title | Spec # | Status |
 |----|-------|--------|--------|
 | **R10** | ntopng — flow analytics platform | — | `NOT STARTED` |
-| **R11** | SNMP-poller NMS (Zabbix / LibreNMS / Netdata) | — | `NOT STARTED` |
+| **R11** | SNMP-poller NMS (Zabbix / LibreNMS / Netdata) | [083](../specs/083-zabbix-nms/spec.md) | `DONE` — **Zabbix only**, adopted not built (3 tools, 589/5,000 tokens). NetClaw's first polled-history source. Runs in a dedicated venv (fastmcp 3.x vs five servers pinning `<3`). Both silent-wrong-answer traps reproduced against live 7.0.29 |
 | **R12** | APM + log platforms (Dynatrace / New Relic / Elastic) | — | `NOT STARTED` |
 | **R13** | NSM / IDS (Zeek / Suricata / Arkime) + packet-buddy audit | — | `NOT STARTED` |
 
@@ -132,7 +132,7 @@ and the IETF datatracker.
 
 | ID | Title | Spec # | Status |
 |----|-------|--------|--------|
-| **R18** | Document generation — docx / pptx / xlsx / pdf | 082 | `IN PROGRESS` |
+| **R18** | Document generation — docx / pptx / xlsx / pdf | [082](../specs/082-document-generation/spec.md) | `DONE` — 6 tools, 2 skills, 1,232/5,000 token manifest, 240 assertions. **All four formats live-verified from a real FortiGate and opened.** Built, not vendored — the upstream skills are demonstration-only, not Apache-2.0. Core discipline: **a document must never fabricate to fill a blank** |
 | **R19** | Google Workspace (official) | — | `NOT STARTED` |
 | **R20** | Notion + Linear (official) | — | `NOT STARTED` |
 | **R21** | GitOps + Azure DevOps (ArgoCD / Flux) | — | `NOT STARTED` |
@@ -533,16 +533,46 @@ flow-analytics platform.
 
 ## R11 — SNMP-poller NMS (Zabbix / LibreNMS / Netdata)
 
-**Status:** `NOT STARTED`
+**Status:** `DONE` — spec [083](../specs/083-zabbix-nms/spec.md)
 
-Prometheus, Grafana, Datadog, Splunk, Auvik, ThousandEyes are covered. There is **no
-SNMP-poller NMS at all** — and Zabbix/LibreNMS are what a large share of enterprises run.
+Prometheus, Grafana, Datadog, Splunk, Auvik, ThousandEyes are covered. There was **no
+SNMP-poller NMS at all** — and therefore no polled history anywhere in NetClaw.
 
 **Checklist**
-- [ ] Pick target(s). Suggested order: Zabbix (largest install base), then LibreNMS
-- [ ] Netdata offers an official Cloud MCP — assess as the low-effort entry point
-- [ ] Observium: assess, likely `DEFERRED`
-- [ ] Skills: interface utilization history, threshold/alert review, device availability
+- [x] Pick target(s) — **Zabbix only.** See the landscape below
+- [x] Netdata assessed → **not in this category** (agent/push, not SNMP-polling). **Correction to this
+      roadmap's earlier claim:** MCP is built into the **free open-source agent** (v2.6.0+,
+      `http://host:19999/mcp`), not only a paid "Cloud MCP". The Cloud endpoint is the paid
+      cross-infrastructure view. That makes Netdata a **separate near-zero-effort item**, not part of R11
+- [x] Observium assessed → **`DEFERRED`.** Its one MCP server (`kdesch5000/observium-mcp`, 10 tools) was
+      created and abandoned on the same day and **bypasses the Observium API entirely**, requiring direct
+      MySQL credentials plus filesystem access to the RRD directory
+- [x] Skills: interface utilization history, threshold/alert review, device availability — delivered as
+      `zabbix-metrics-history`, `zabbix-problem-review`, `zabbix-availability`
+
+**Landscape, measured by cloning and scanning — not read off READMEs**
+
+| Candidate | Tools | Licence | Outcome |
+|---|---|---|---|
+| `mpeirone/zabbix-mcp-server` | **3** (589 tokens) | GPL-3.0 | **adopted, unmodified** |
+| `mhajder/zabbix-mcp` | 53 | MIT | rejected — surface |
+| `mhajder/librenms-mcp` | 111 | MIT | **LibreNMS deferred** — busts the ceiling |
+| `initMAX/zabbix-mcp-server` | 237 | AGPL-3.0 | rejected — surface + copyleft |
+| 2 JS servers | — | one has **no licence** | abandoned 2025 |
+
+> **There is no official Zabbix LLC MCP server.** `mcpservers.org` labels initMAX "Official Zabbix MCP
+> Server" — **that label is wrong**; initMAX is a Zabbix Premium Partner. Zabbix's own AI direction is
+> WebMCP, a browser standard, not an adoptable server.
+
+**Decisions worth not re-litigating**
+- **Adopt, not build** — the first time on this roadmap. The 3-tool passthrough is essentially the design
+  NetClaw would have produced
+- **Dedicated virtualenv, mandatory** — needs fastmcp 3.x while `netbox-mcp-server`,
+  `CiscoFMC-MCP-server-community`, `Wikipedia_MCP`, `rag-mcp` and `ISE_MCP` all pin `<3`
+- **Strictly read-only, no write path.** Adopt-as-is leaves nowhere to insert NetClaw's two gates, so writes
+  were deferred rather than shipped ungated
+- **The distinctions are enforced by SKILL, not structure** — the first NetClaw integration where that is
+  true, and the accepted cost of adopting a generic passthrough
 
 ## R12 — APM + log platforms (Dynatrace / New Relic / Elastic)
 
@@ -647,7 +677,7 @@ files is an excellent analysis substrate for exports.
 
 ## R18 — Document generation (docx / pptx / xlsx / pdf)
 
-**Status:** `IN PROGRESS` — spec `082-document-generation` · **Best effort-to-value ratio on the roadmap**
+**Status:** `DONE` — spec [082](../specs/082-document-generation/spec.md), merged in PR #211 · **Best effort-to-value ratio on the roadmap**
 
 NetClaw can render Three.js topologies, drawio, markmap, UML, Blender and UE5 — but cannot
 produce a change-record `.docx`, an exec `.pptx`, an interface-audit `.xlsx`, or fill a PDF.

--- a/mcp-servers/zabbix-mcp/NOTICE.md
+++ b/mcp-servers/zabbix-mcp/NOTICE.md
@@ -1,0 +1,37 @@
+# Third-Party Notice — `zabbix-mcp-server`
+
+This directory vendors a **third-party program that NetClaw does not own and does not modify**.
+
+| | |
+|---|---|
+| **Upstream** | https://github.com/mpeirone/zabbix-mcp-server |
+| **Pinned revision** | `0722f48` — 2026-05-10, "Feature/v2" |
+| **Licence** | **GNU General Public License v3.0** — see `vendor/zabbix-mcp-server/LICENSE`, retained verbatim |
+| **Relationship to NetClaw** | A separate program, invoked over stdio from its own virtualenv |
+| **Adopted by** | spec 083 / roadmap R11 |
+
+## NetClaw is Apache-2.0; this is GPL-3.0
+
+That difference is deliberate and understood. NetClaw **invokes** this program as a subprocess over the
+Model Context Protocol; it does not link against it, import it, or incorporate its code. Invocation across a
+process boundary is not linkage, so the two licences coexist without either constraining the other.
+
+## Do not modify this tree
+
+The copy under `vendor/` is **byte-identical to upstream at the pinned revision**, and must stay that way.
+
+- A local fork creates a maintenance burden and a licence-obligation question that adopting-as-is exists to
+  avoid.
+- If a change is needed, **it goes upstream.** Two defects found during evaluation are being reported rather
+  than patched locally:
+  1. `scripts/start_server.py:139` defaults `READ_ONLY` to `False`, while `src/.../utils.py:29` defaults it
+     to `True`. The shipped launcher inverts the safe default. NetClaw works around this by **forcing
+     `READ_ONLY=true` in its own configuration** and adding a destructive-method deny-list — see the
+     server README.
+  2. `pyproject.toml` declares `fastmcp>=v3.2.0`, which is not a valid PEP 440 specifier (stray `v`).
+
+## Why it runs in its own virtualenv
+
+It requires **fastmcp 3.x**. Five NetClaw servers pin `fastmcp<3` — `netbox-mcp-server`,
+`CiscoFMC-MCP-server-community`, `Wikipedia_MCP`, `rag-mcp`, `ISE_MCP`. Installing this into the shared
+interpreter would break all five. The virtualenv is not a convenience; removing it is a regression.

--- a/mcp-servers/zabbix-mcp/README.md
+++ b/mcp-servers/zabbix-mcp/README.md
@@ -1,0 +1,95 @@
+# zabbix-mcp — SNMP-poller NMS coverage
+
+**Spec 083 / roadmap R11.** 3 tools, stdio, **strictly read-only**. Manifest measured **589 / 5,000 tokens**.
+
+The polled-history layer. Everything else NetClaw sees arrives *when something happens*; this is the only
+source that answers **what was it doing** — is this normal, what did this interface do overnight, how long
+has this been down.
+
+## Adopted, not authored
+
+See [NOTICE.md](./NOTICE.md). `mpeirone/zabbix-mcp-server`, pinned `0722f48`, **GPL-3.0**, vendored
+unmodified, invoked over stdio as a separate program.
+
+### Why adopt, with the numbers
+
+Measured tool counts, by cloning and scanning — not read off READMEs:
+
+| Candidate | Tools | Licence | State |
+|---|---|---|---|
+| **`mpeirone/zabbix-mcp-server`** ✅ | **3** (589 tokens) | GPL-3.0 | **adopted** |
+| `mhajder/zabbix-mcp` | 53 | MIT | active |
+| `mhajder/librenms-mcp` | 111 | MIT | busts the ceiling |
+| `initMAX/zabbix-mcp-server` | 237 | AGPL-3.0 | active |
+| 2 JavaScript servers | — | one has **no licence** | stale/abandoned |
+
+**There is no official Zabbix LLC MCP server.** `mcpservers.org` labels initMAX "Official Zabbix MCP Server"
+— **that label is wrong**; initMAX is a Zabbix Premium Partner, not Zabbix LLC. Zabbix's own AI direction is
+WebMCP, a browser standard, not a server that can be adopted.
+
+The 3-tool passthrough-plus-self-documentation design is essentially what NetClaw would have built. Adopting
+it avoided rebuilding a solved problem.
+
+## Why it runs in its own virtualenv
+
+**Not optional.** It requires **fastmcp 3.x**; five NetClaw servers pin `fastmcp<3` —
+`netbox-mcp-server`, `CiscoFMC-MCP-server-community`, `Wikipedia_MCP`, `rag-mcp`, `ISE_MCP`. A shared
+install breaks all five. Same class of conflict that gave `multivendor-cli-mcp` its own venv (spec 076's
+`cryptography` incident).
+
+The venv is created with `netclaw_venv_create`/`uv` — **never bare `python3 -m venv`**, which fails on hosts
+without `ensurepip` (measured on this one).
+
+## Read-only, enforced twice
+
+NetClaw **forces `READ_ONLY=true`** in `config/openclaw.json` rather than inheriting it, because the
+upstream defaults disagree with each other:
+
+```
+src/zabbix_mcp_server/utils.py:29   READ_ONLY default True    ← the library
+scripts/start_server.py:139         READ_ONLY default False   ← the shipped launcher
+```
+
+A **destructive-method deny-list** is the second layer, and it was verified to hold **with read-only
+deliberately disabled**:
+
+```
+READ_ONLY=false  host.delete → REFUSED: Blacklist pattern '.*\.delete$' matched
+READ_ONLY=false  host.get    → still allowed (the deny-list is not over-broad)
+```
+
+There is **no write path**. Adding one would require a NetClaw-owned layer carrying human approval, an
+approved change record, *and* per-call audit — not a configuration flag.
+
+## Two limitations, stated plainly
+
+**1. The guarantees are in the skills, not in the code.** This is a generic passthrough with no chokepoint,
+so the two silent-wrong-answer traps below are prevented by `zabbix-metrics-history`'s procedure and nothing
+else. **This is the first NetClaw integration where a core distinction is enforced by guidance rather than
+structure** — a deliberate trade for the smallest surface and upstream maintenance.
+
+**2. No per-call GAIT audit.** The upstream has no audit concept, and there is no platform-level MCP audit.
+Acceptable only because this is strictly read-only: there is no operation to record.
+
+## The two traps
+
+Both measured against live Zabbix 7.0.29. Both return an empty array **and a success status**.
+
+1. **`history.get` defaults its value type to unsigned (3); 84 of 121 stock items are float (0).** Call
+   `item.get` first, pass the real `value_type`. Types cannot be mixed in one call.
+2. **Raw history ages out into hourly trends.** Read per-item `history`/`trends` and route. Retention can
+   also be *disabled* (`history=0`, `trends=0`) — a configuration fact, not an absence.
+
+## Skills
+
+`zabbix-metrics-history` (the procedure lives here) · `zabbix-problem-review` · `zabbix-availability`
+
+## Tests
+
+```bash
+bash tests/zabbix/run-tests.sh                        # static only
+ZABBIX_URL=... ZABBIX_TOKEN=... bash tests/zabbix/run-tests.sh   # + live traps
+```
+
+Static tests prove the skill *says* the right thing. Only the live suite proves following it gives the right
+*answer* — which after adopt-as-is is the only claim that matters.

--- a/mcp-servers/zabbix-mcp/requirements.txt
+++ b/mcp-servers/zabbix-mcp/requirements.txt
@@ -1,0 +1,20 @@
+# Zabbix NMS — spec 083 (roadmap R11)
+#
+# THESE INSTALL INTO A DEDICATED VIRTUALENV, NOT THE SYSTEM INTERPRETER.
+#
+# Why: the vendored upstream requires fastmcp 3.x. Five NetClaw servers pin
+# fastmcp<3 (netbox-mcp-server, CiscoFMC-MCP-server-community, Wikipedia_MCP,
+# rag-mcp, ISE_MCP). Installing this alongside them would break all five —
+# spec 076's cryptography incident, exactly, which is why multivendor-cli-mcp
+# already runs from its own venv too.
+#
+# Do not "simplify" this into the shared interpreter.
+#
+# Measured resolution inside the venv, 2026-08-03:
+#   fastmcp 3.4.5 · mcp 1.29.0 · zabbix_utils 2.0.4 · beautifulsoup4 4.15.0 · requests 2.34.2
+#
+# The dependency set itself is declared by the vendored package's pyproject.toml.
+# Installing the vendored directory pulls them in; this file exists so the
+# installer has a single documented entry point and so the rationale above
+# travels with the code.
+./vendor/zabbix-mcp-server

--- a/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/.gitignore
+++ b/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/.gitignore
@@ -1,0 +1,196 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Abstra
+# Abstra is an AI-powered process automation framework.
+# Ignore directories containing user credentials, local state, and settings.
+# Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  you could uncomment the following to ignore the enitre vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Cursor
+#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
+#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
+#  refer to https://docs.cursor.com/context/ignore-files
+.cursorignore
+.cursorindexingignore
+uv.lock
+opencode.json

--- a/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/CONTRIBUTING.md
+++ b/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/CONTRIBUTING.md
@@ -1,0 +1,199 @@
+# Contributing to Zabbix MCP Server
+
+Thank you for your interest in contributing to the Zabbix MCP Server! This document provides guidelines and information for contributors.
+
+## Code of Conduct
+
+This project adheres to a code of conduct that we expect all contributors to follow. Please be respectful and constructive in all interactions.
+
+## How to Contribute
+
+### Reporting Issues
+
+1. **Search existing issues** first to avoid duplicates
+2. **Use the issue template** when creating new issues
+3. **Provide detailed information** including:
+   - Zabbix version
+   - Python version
+   - Operating system
+   - Steps to reproduce
+   - Expected vs actual behavior
+   - Error messages or logs
+
+### Suggesting Features
+
+1. **Check existing feature requests** to avoid duplicates
+2. **Describe the use case** and why the feature would be valuable
+3. **Provide examples** of how the feature would be used
+4. **Consider implementation complexity** and compatibility
+
+### Contributing Code
+
+#### Prerequisites
+
+- Python 3.10 or higher
+- [uv](https://docs.astral.sh/uv/) package manager
+- Git
+- Access to a Zabbix server for testing
+
+#### Development Setup
+
+1. **Fork the repository** on GitHub
+2. **Clone your fork:**
+   ```bash
+   git clone https://github.com/mpeirone/zabbix-mcp-server.git
+   cd zabbix-mcp-server
+   ```
+3. **Install dependencies:**
+   ```bash
+   uv sync
+   ```
+4. **Set up environment:**
+```bash
+cp config/.env.example .env
+# Configure with your test Zabbix server
+```
+
+#### Making Changes
+
+1. **Create a feature branch:**
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+2. **Make your changes** following the coding standards
+3. **Test your changes:**
+```bash
+uv run python scripts/test_server.py
+```
+4. **Commit your changes:**
+   ```bash
+   git commit -m "Add: brief description of changes"
+   ```
+
+#### Coding Standards
+
+- **Follow PEP 8** Python style guidelines
+- **Use type hints** for function parameters and return values
+- **Write docstrings** for all functions and classes
+- **Keep functions focused** and single-purpose
+- **Use meaningful variable names**
+- **Add comments** for complex logic
+
+#### Code Structure
+
+- **Tool functions** should follow the pattern: `@mcp.tool()` decorator
+- **Error handling** should be comprehensive and user-friendly
+- **Read-only mode** must be respected for write operations
+- **Response formatting** should use `format_response()` helper
+
+#### Example Tool Function
+
+```python
+@mcp.tool()
+def example_get(param1: str, param2: Optional[int] = None) -> str:
+    """Get example data from Zabbix
+    
+    Args:
+        param1: Required parameter description
+        param2: Optional parameter description
+        
+    Returns:
+        JSON string with example data
+        
+    Raises:
+        ValueError: If required parameters are missing
+    """
+    client = get_zabbix_client()
+    params = {"param1": param1}
+    
+    if param2 is not None:
+        params["param2"] = param2
+    
+    result = client.example.get(**params)
+    return format_response(result)
+```
+
+#### Testing
+
+- **Test all new functionality** with a real Zabbix server
+- **Verify read-only mode** works correctly
+- **Test error conditions** and edge cases
+- **Ensure backward compatibility**
+
+#### Documentation
+
+- **Update README.md** if adding new features
+- **Add examples** for new tool functions
+- **Include docstrings** for all new functions
+
+### Pull Request Process
+
+1. **Ensure your branch is up to date:**
+   ```bash
+   git fetch upstream
+   git rebase upstream/main
+   ```
+2. **Push your changes:**
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+3. **Create a pull request** with:
+   - Clear title and description
+   - Reference to related issues
+   - List of changes made
+   - Testing performed
+   - Screenshots if applicable
+
+#### Pull Request Checklist
+
+- [ ] Code follows project style guidelines
+- [ ] All tests pass
+- [ ] Documentation is updated
+- [ ] Commit messages are clear
+- [ ] No merge conflicts
+- [ ] Feature works in both read-only and full modes
+
+## Development Guidelines
+
+### Adding New Zabbix API Methods
+
+1. **Check Zabbix API documentation** for the method
+2. **Follow existing patterns** in the codebase
+3. **Add proper parameter validation**
+4. **Include comprehensive docstrings**
+5. **Test with different parameter combinations**
+
+### Error Handling
+
+- **Use specific exception types** when possible
+- **Provide helpful error messages** to users
+- **Log errors appropriately** for debugging
+- **Handle network timeouts** and connection issues
+
+### Security Considerations
+
+- **Never log sensitive information** (passwords, tokens)
+- **Validate all user inputs**
+- **Respect read-only mode** restrictions
+- **Use secure defaults**
+
+## Release Process
+
+1. **Update version** in `pyproject.toml`
+2. **Create release tag** following semantic versioning
+3. **Update documentation** as needed
+
+## Getting Help
+
+- **GitHub Discussions** for questions and ideas
+- **GitHub Issues** for bugs and feature requests
+- **Code review** for implementation feedback
+
+## Recognition
+
+Contributors will be recognized in:
+- README.md acknowledgments
+- Release notes
+- GitHub contributors list
+
+Thank you for contributing to the Zabbix MCP Server project!

--- a/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/Dockerfile
+++ b/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/Dockerfile
@@ -1,0 +1,46 @@
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    gcc curl\
+    && rm -rf /var/lib/apt/lists/*
+
+
+# Copy application files
+COPY src/ ./src/
+COPY scripts/ ./scripts/
+COPY pyproject.toml .
+
+
+# Create non-root user first
+RUN useradd -m -u 1000 mcpuser
+
+# Install dependencies from root (workspace context)
+ENV UV_COMPILE_BYTECODE=1
+ENV PYTHONOPTIMIZE=1
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+RUN uv sync && chown -R mcpuser:mcpuser /app
+
+USER mcpuser
+
+# Expose MCP port
+EXPOSE 8000
+
+# Run application from root with proper Python path
+ENV PYTHONPATH=/app
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Pre-compile the app code to greatly reduce Python's startup CPU footprint
+RUN python -m compileall -q /app/src/zabbix_mcp_server/ || true
+
+
+ENV ZABBIX_MCP_TRANSPORT=streamable-http
+ENV AUTH_TYPE=no-auth
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 CMD curl -f http://localhost:8000/health || exit 1
+
+# Run the server in HTTP mode
+CMD ["python","scripts/start_server.py"]

--- a/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/LICENSE
+++ b/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/README.md
+++ b/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/README.md
@@ -1,0 +1,242 @@
+# Zabbix MCP Server
+
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![SafeSkill](https://safeskill.dev/api/badge/mpeirone-zabbix-mcp-server)](https://safeskill.dev/scan/mpeirone-zabbix-mcp-server)
+
+
+A lightweight Model Context Protocol (MCP) server that provides **complete access to the entire Zabbix API** through just 3 tools. Compatible with **Zabbix 6.0+**.
+
+<a href="https://glama.ai/mcp/servers/@mpeirone/zabbix-mcp-server">
+<img width="380" height="200" src="https://glama.ai/mcp/servers/@mpeirone/zabbix-mcp-server/badge" alt="zabbix-mcp-server MCP server" />
+</a>
+
+## Why Zabbix MCP Server?
+
+- **Complete API Coverage** - Access every Zabbix API method (100+) through a unified interface
+- **Lightweight Context** - Only 3 tools instead of 50+ individual tools, keeping LLM context minimal
+- **Always Up-to-Date** - Works with current and future Zabbix API methods automatically
+- **Zabbix 6.0+ Compatible** - Supports Zabbix 6.0, 6.4, 7.0, and newer versions
+
+## The 3 Tools
+
+| Tool | Purpose |
+|------|---------|
+| `zabbix_api` | Execute any Zabbix API method |
+| `zabbix_api_docs` | Get documentation for any API method |
+| `zabbix_api_list` | Discover available API objects and methods |
+
+## Quick Start
+
+### Option 1: Claude Code Integration
+
+Add to your Claude Code MCP configuration:
+
+```bash
+claude mcp add zabbix \
+  --env ZABBIX_URL=https://your-zabbix-server.com \
+  --env ZABBIX_TOKEN=your_api_token \
+  -- uvx --from git+https://github.com/mpeirone/zabbix-mcp-server@main zabbix-mcp
+```
+
+### Option 2: Run with uv
+
+```bash
+git clone https://github.com/mpeirone/zabbix-mcp-server.git
+cd zabbix-mcp-server
+uv sync
+
+# Configure environment
+export ZABBIX_URL=https://your-zabbix-server.com
+export ZABBIX_TOKEN=your_api_token
+
+# Start the server
+uv run python scripts/start_server.py
+```
+
+### Test Connection
+
+```bash
+uv run python scripts/test_server.py
+```
+
+## Option 3: Run with docker
+
+```bash
+git clone https://github.com/mpeirone/zabbix-mcp-server.git
+cd zabbix-mcp-server
+
+# Using docker-compose
+docker compose up -d
+
+# Or build manually
+docker build -t zabbix-mcp-server .
+docker run -e ZABBIX_URL=https://zabbix.example.com -e ZABBIX_TOKEN=your_token zabbix-mcp-server
+```
+
+## Environment Variables
+
+### Required
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `ZABBIX_URL` | Zabbix server URL | `https://your-zabbix-server.com` |
+
+### Authentication (choose one)
+
+| Variable | Description |
+|----------|-------------|
+| `ZABBIX_TOKEN` | API token (recommended) |
+| `ZABBIX_USER` + `ZABBIX_PASSWORD` | Username and password |
+
+### Security
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `READ_ONLY` | `false` | Set to `true` to allow only read operations |
+| `VERIFY_SSL` | `true` | Enable/disable SSL verification |
+| `ZABBIX_API_WHITELIST` | `.*` | Comma-separated regex patterns for allowed API methods |
+| `ZABBIX_API_BLACKLIST` | (empty) | Comma-separated regex patterns for blocked API methods |
+| `ZABBIX_SKIP_VERSION_CHECK` | `false` | Skip Zabbix version compatibility check |
+| `ZABBIX_API_TIMEOUT` | `30` | API request timeout in seconds |
+
+### Transport
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ZABBIX_MCP_TRANSPORT` | `stdio` | Transport type: `stdio` or `streamable-http` |
+| `ZABBIX_MCP_HOST` | `127.0.0.1` | HTTP server host (when using `streamable-http`) |
+| `ZABBIX_MCP_PORT` | `8000` | HTTP server port (when using `streamable-http`)|
+| `ZABBIX_MCP_STATELESS_HTTP` | `false` | Stateless HTTP mode |
+| `AUTH_TYPE` | - | Must be `no-auth` for HTTP transport (when using `streamable-http`) |
+
+### Debug
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DEBUG` | `false` | Set to `true` for verbose logging |
+
+## Usage Examples
+
+### Get Hosts
+
+```python
+zabbix_api(method='host.get', params={'output': ['hostid', 'name']})
+```
+
+### Get Problems
+
+```python
+zabbix_api(method='problem.get', params={'output': 'extend', 'recent': True})
+```
+
+### Create Host
+
+```python
+zabbix_api(method='host.create', params={
+    'host': 'server-01',
+    'groups': [{'groupid': '1'}],
+    'interfaces': [{'type': 1, 'main': 1, 'useip': 1, 'ip': '192.168.1.100', 'port': '10050'}]
+})
+```
+
+### Get Method Documentation
+
+```python
+zabbix_api_docs(method='host.create')
+```
+
+### List Available Methods
+
+```python
+zabbix_api_list()              # All objects and methods
+zabbix_api_list(object='host')  # Host methods only
+```
+
+## Security Features
+
+### Read-Only Mode
+
+Set `READ_ONLY=true` to block all write operations:
+
+```bash
+export READ_ONLY=true
+```
+
+Only `get`, `version`, `check`, and `export` operations will be allowed.
+
+### API Method Filtering
+
+Control which API methods can be called using whitelist/blacklist patterns:
+
+```bash
+# Allow only host.* and item.get methods
+export ZABBIX_API_WHITELIST="host\..*,item\.get"
+
+# Block all delete and create operations
+export ZABBIX_API_BLACKLIST=".*\.delete,.*\.create"
+```
+
+Both support comma-separated regex patterns. Blacklist is checked first.
+
+## MCP Client Configuration
+
+### Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "zabbix": {
+      "command": "uvx",
+      "args": ["--from", "git+https://github.com/mpeirone/zabbix-mcp-server@main", "zabbix-mcp"],
+      "env": {
+        "ZABBIX_URL": "https://zabbix.example.com",
+        "ZABBIX_TOKEN": "your_api_token"
+      }
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+### Connection Issues
+
+- Verify `ZABBIX_URL` is accessible
+- Check authentication credentials
+- Ensure Zabbix API is enabled
+
+### Permission Errors
+
+- Verify Zabbix user permissions
+- Check if `READ_ONLY` mode is enabled
+
+### Method Blocked
+
+If you see "Method is not in whitelist" or "Method is blacklisted":
+- Review `ZABBIX_API_WHITELIST` and `ZABBIX_API_BLACKLIST` patterns
+- Ensure your regex patterns match the full method name (e.g., `host.get`)
+
+### Debug Mode
+
+```bash
+export DEBUG=true
+uv run python scripts/start_server.py
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines.
+
+## License
+
+GPLv3 License - see [LICENSE](LICENSE) for details.
+
+## Acknowledgments
+
+- [Zabbix](https://www.zabbix.com/) - Monitoring platform
+- [Model Context Protocol](https://modelcontextprotocol.io/) - Integration standard
+- [FastMCP](https://github.com/PrefectHQ/fastmcp) - MCP framework
+- [python-zabbix-utils](https://github.com/zabbix/python-zabbix-utils) - Official Zabbix Python library

--- a/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/config/.env.example
+++ b/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/config/.env.example
@@ -1,0 +1,58 @@
+# Zabbix MCP Server Configuration
+
+# Required: Zabbix server URL
+ZABBIX_URL=https://zabbix.example.com
+
+# Authentication Method 1: API Token (recommended)
+ZABBIX_TOKEN=<your_api_token>
+
+# Authentication Method 2: Username/Password (alternative to token)
+# ZABBIX_USER=<username>
+# ZABBIX_PASSWORD=<password>
+
+# Optional: Read-only mode (only GET operations allowed)
+# Set to true, 1, or yes to enable read-only mode
+# READ_ONLY=true
+
+# Transport Configuration
+# ZABBIX_MCP_TRANSPORT - Transport type: stdio (default) or streamable-http
+# ZABBIX_MCP_TRANSPORT=stdio
+
+# HTTP Transport Configuration (only used when ZABBIX_MCP_TRANSPORT=streamable-http)
+# ZABBIX_MCP_HOST - Server host (default: 127.0.0.1)
+# ZABBIX_MCP_HOST=127.0.0.1
+# ZABBIX_MCP_PORT - Server port (default: 8000)
+# ZABBIX_MCP_PORT=8000
+# ZABBIX_MCP_STATELESS_HTTP - Stateless mode (default: false)
+# ZABBIX_MCP_STATELESS_HTTP=false
+
+# Authentication type for HTTP transport (required when using streamable-http)
+# AUTH_TYPE - Must be set to 'no-auth' for streamable-http transport
+# AUTH_TYPE=no-auth
+
+# SSL Configuration
+# VERIFY_SSL - Enable/disable SSL certificate verification (default: true)
+# Set to false, 0, or no to disable SSL verification (not recommended for production)
+# VERIFY_SSL=true
+
+# API Timeout
+# ZABBIX_API_TIMEOUT - API request timeout in seconds (default: 30)
+# ZABBIX_API_TIMEOUT=30
+
+# API Method Filtering
+# ZABBIX_API_WHITELIST - Comma-separated regex patterns for allowed API methods
+# Default is '.*' which allows all methods
+# Examples:
+# ZABBIX_API_WHITELIST="host\..*,item\.get,problem\.get"
+# ZABBIX_API_WHITELIST=".*\.get,.*\.export"
+
+# ZABBIX_API_BLACKLIST - Comma-separated regex patterns for blocked API methods
+# Default is empty (no methods blocked)
+# Examples:
+# ZABBIX_API_BLACKLIST=".*\.delete,.*\.create"
+# ZABBIX_API_BLACKLIST="host\.delete,user\.create,.*\.massdelete"
+
+# Version Check
+# ZABBIX_SKIP_VERSION_CHECK - Skip Zabbix version compatibility check (default: false)
+# Set to true, 1, or yes to skip version check
+# ZABBIX_SKIP_VERSION_CHECK=false

--- a/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/config/mcp.json
+++ b/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/config/mcp.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "zabbix": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/mpeirone/zabbix-mcp-server@main",
+        "zabbix-mcp"
+      ],
+      "env": {
+        "ZABBIX_URL": "https://zabbix.example.com",
+        "ZABBIX_TOKEN": "<your_api_token>",
+        "READ_ONLY": "true"
+      }
+    }
+  }
+}

--- a/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/docker-compose.yml
+++ b/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  zabbix-mcp:
+    build: .
+    container_name: zabbix-mcp-server
+    environment:
+      - ZABBIX_URL=${ZABBIX_URL}
+      - ZABBIX_TOKEN=${ZABBIX_TOKEN}
+      - ZABBIX_MCP_HOST=0.0.0.0
+    ports:
+      - "8000:8000"
+    restart: unless-stopped

--- a/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/pyproject.toml
+++ b/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/pyproject.toml
@@ -1,0 +1,46 @@
+[project]
+name = "zabbix-mcp-server"
+version = "2.0.0"
+description = "A comprehensive MCP server for Zabbix integration with unified API tool"
+readme = "README.md"
+license = {text = "GPL-3.0"}
+authors = [
+    {name = "Zabbix MCP Server Contributors"}
+]
+keywords = ["zabbix", "mcp", "monitoring", "api", "server"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: System :: Monitoring",
+    "Topic :: System :: Systems Administration",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    "fastmcp>=v3.2.0",
+    "zabbix_utils>=2.0.4",
+    "python-dotenv>=1.2.2",
+    "bs4>=0.0.2",
+    "requests>=2.33.1"
+]
+requires-python = ">=3.10"
+
+[project.urls]
+Homepage = "https://github.com/mpeirone/zabbix-mcp-server"
+Repository = "https://github.com/mpeirone/zabbix-mcp-server"
+Issues = "https://github.com/mpeirone/zabbix-mcp-server/issues"
+Documentation = "https://github.com/mpeirone/zabbix-mcp-server#readme"
+
+[project.scripts]
+zabbix-mcp = "zabbix_mcp_server:main"
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"

--- a/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/requirements.txt
+++ b/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/requirements.txt
@@ -1,0 +1,5 @@
+fastmcp>=v3.2.0
+zabbix_utils>=2.0.4
+python-dotenv>=1.2.2
+bs4>=0.0.2
+requests>=2.33.1

--- a/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/scripts/start_server.py
+++ b/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/scripts/start_server.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Startup script for Zabbix MCP Server
+
+This script validates the environment configuration and starts the MCP server
+with proper error handling and logging.
+"""
+
+import os
+import sys
+import logging
+from pathlib import Path
+from typing import List
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
+# Add src directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from zabbix_mcp_server.config import parse_bool_env
+
+
+def setup_logging() -> None:
+    """Setup logging configuration."""
+    log_level = logging.DEBUG if parse_bool_env("DEBUG") else logging.INFO
+    logging.basicConfig(
+        level=log_level, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+
+
+def check_environment() -> bool:
+    """Check if required environment variables are set.
+
+    Returns:
+        bool: True if environment is properly configured
+    """
+    logger = logging.getLogger(__name__)
+    required_vars = ["ZABBIX_URL"]
+    missing_vars: List[str] = []
+
+    for var in required_vars:
+        if not os.getenv(var):
+            missing_vars.append(var)
+
+    if missing_vars:
+        logger.error(
+            f"Missing required environment variables: {', '.join(missing_vars)}"
+        )
+        print("Error: Missing required environment variables:")
+        for var in missing_vars:
+            print(f" - {var}")
+        print("\nPlease set these variables or create a .env file")
+        return False
+
+    # Check authentication configuration
+    token = os.getenv("ZABBIX_TOKEN")
+    user = os.getenv("ZABBIX_USER")
+    password = os.getenv("ZABBIX_PASSWORD")
+
+    if not token and not (user and password):
+        logger.error("Authentication not configured")
+        print("Error: Authentication not configured")
+        print("Please set either:")
+        print(" - ZABBIX_TOKEN (recommended)")
+        print(" - Both ZABBIX_USER and ZABBIX_PASSWORD")
+        return False
+
+    # Check transport configuration
+    transport = os.getenv("ZABBIX_MCP_TRANSPORT", "stdio").lower()
+    if transport not in ["stdio", "streamable-http"]:
+        logger.error(f"Invalid ZABBIX_MCP_TRANSPORT: {transport}")
+        print(f"Error: Invalid ZABBIX_MCP_TRANSPORT: {transport}")
+        print("Valid values are: stdio, streamable-http")
+        return False
+
+    if transport == "streamable-http":
+        auth_type = os.getenv("AUTH_TYPE", "").lower()
+        if auth_type != "no-auth":
+            logger.error("AUTH_TYPE must be 'no-auth' for streamable-http transport")
+            print(
+                "Error: AUTH_TYPE must be set to 'no-auth' when using streamable-http transport"
+            )
+            return False
+
+    return True
+
+
+def show_configuration() -> None:
+    """Display current configuration."""
+    logger = logging.getLogger(__name__)
+
+    print("\n" + "=" * 50)
+    print("Zabbix MCP Server Configuration")
+    print("=" * 50)
+
+    # Zabbix URL
+    zabbix_url = os.getenv("ZABBIX_URL", "Not configured")
+    print(f"Zabbix URL: {zabbix_url}")
+    logger.info(f"Zabbix URL: {zabbix_url}")
+
+    # Authentication method
+    if os.getenv("ZABBIX_TOKEN"):
+        auth_method = "API Token"
+        logger.info("Authentication: API Token")
+    elif os.getenv("ZABBIX_USER"):
+        auth_method = f"Username/Password ({os.getenv('ZABBIX_USER')})"
+        logger.info(
+            f"Authentication: Username/Password for user {os.getenv('ZABBIX_USER')}"
+        )
+    else:
+        auth_method = "Not configured"
+        logger.warning("Authentication: Not configured")
+
+    print(f"Authentication: {auth_method}")
+
+    # Transport configuration
+    transport = os.getenv("ZABBIX_MCP_TRANSPORT", "stdio")
+    print(f"Transport: {transport}")
+    logger.info(f"Transport: {transport}")
+
+    if transport == "streamable-http":
+        host = os.getenv("ZABBIX_MCP_HOST", "127.0.0.1")
+        port = os.getenv("ZABBIX_MCP_PORT", "8000")
+        stateless = os.getenv("ZABBIX_MCP_STATELESS_HTTP", "false")
+        auth_type = os.getenv("AUTH_TYPE", "Not set")
+
+        print(f" - Host: {host}")
+        print(f" - Port: {port}")
+        print(f" - Stateless: {stateless}")
+        print(f" - Auth Type: {auth_type}")
+
+        logger.info(
+            f"HTTP Transport - Host: {host}, Port: {port}, Stateless: {stateless}, Auth: {auth_type}"
+        )
+
+    # Read-only mode
+    read_only = parse_bool_env("READ_ONLY", default=False)
+    read_only_str = "Enabled" if read_only else "Disabled"
+    print(f"Read-only mode: {read_only_str}")
+    logger.info(f"Read-only mode: {read_only_str}")
+
+    # SSL verification
+    verify_ssl = parse_bool_env("VERIFY_SSL", default=True)
+    verify_ssl_str = "Enabled" if verify_ssl else "Disabled"
+    print(f"SSL verification: {verify_ssl_str}")
+    logger.info(f"SSL verification: {verify_ssl_str}")
+
+    # Debug mode
+    debug_mode = parse_bool_env("DEBUG", default=False)
+    debug_str = "Enabled" if debug_mode else "Disabled"
+    print(f"Debug mode: {debug_str}")
+    logger.info(f"Debug mode: {debug_str}")
+
+    print("=" * 50)
+    print()
+
+
+def main() -> None:
+    """Main startup function."""
+    # Setup logging first
+    setup_logging()
+    logger = logging.getLogger(__name__)
+
+    print("Starting Zabbix MCP Server...")
+    logger.info("Starting Zabbix MCP Server")
+
+    try:
+        # Check environment configuration
+        if not check_environment():
+            logger.error("Environment validation failed")
+            sys.exit(1)
+
+        # Show configuration
+        show_configuration()
+
+        # Import and run the server
+        logger.info("Importing server module")
+        from zabbix_mcp_server import main as server_main
+
+        logger.info("Starting MCP server")
+        print("🚀 Starting MCP server...")
+        print("Press Ctrl+C to stop")
+        print()
+
+        server_main()
+
+    except ImportError as e:
+        logger.error(f"Import error: {e}")
+        print(f"Error importing server: {e}")
+        print("Please install dependencies: uv sync")
+        sys.exit(1)
+
+    except KeyboardInterrupt:
+        logger.info("Server stopped by user")
+        print("\n👋 Server stopped by user")
+
+    except Exception as e:
+        logger.error(f"Unexpected error: {e}", exc_info=True)
+        print(f"Error starting server: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/scripts/test_server.py
+++ b/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/scripts/test_server.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""
+Test script for Zabbix MCP Server
+
+This script validates the server configuration and tests basic functionality
+to ensure everything is working correctly with the unified zabbix_api tool.
+"""
+
+import os
+import sys
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+from dotenv import load_dotenv
+
+load_dotenv()
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+
+def setup_logging() -> None:
+    """Setup logging configuration."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+
+def test_import() -> bool:
+    """Test if the server module can be imported.
+
+    Returns:
+        bool: True if import successful
+    """
+    try:
+        print("🔍 Testing module import...")
+        from zabbix_mcp_server import get_zabbix_client, is_read_operation, is_read_only
+
+        print("✅ Module import successful")
+        return True
+    except ImportError as e:
+        print(f"❌ Import failed: {e}")
+        print("Please install dependencies: uv sync")
+        return False
+    except Exception as e:
+        print(f"❌ Unexpected import error: {e}")
+        return False
+
+
+def test_environment() -> bool:
+    """Test environment configuration.
+
+    Returns:
+        bool: True if environment is properly configured
+    """
+    print("\n🔍 Testing environment configuration...")
+
+    zabbix_url = os.getenv("ZABBIX_URL")
+    if not zabbix_url:
+        print("❌ ZABBIX_URL not configured")
+        return False
+
+    print(f"✅ ZABBIX_URL: {zabbix_url}")
+
+    token = os.getenv("ZABBIX_TOKEN")
+    user = os.getenv("ZABBIX_USER")
+    password = os.getenv("ZABBIX_PASSWORD")
+
+    if token:
+        print("✅ Authentication: API Token configured")
+    elif user and password:
+        print(f"✅ Authentication: Username/Password configured ({user})")
+    else:
+        print("❌ Authentication not configured")
+        print("Please set either ZABBIX_TOKEN or both ZABBIX_USER and ZABBIX_PASSWORD")
+        return False
+
+    read_only = os.getenv("READ_ONLY", "false").lower() in ("true", "1", "yes")
+    print(f"ℹ️  Read-only mode: {'Enabled' if read_only else 'Disabled'}")
+
+    verify_ssl = os.getenv("VERIFY_SSL", "true").lower() in ("true", "1", "yes")
+    print(f"ℹ️  SSL verification: {'Enabled' if verify_ssl else 'Disabled'}")
+
+    return True
+
+
+def test_connection() -> bool:
+    """Test basic connection to Zabbix.
+
+    Returns:
+        bool: True if connection successful
+    """
+    print("\n🔍 Testing Zabbix connection...")
+
+    try:
+        from zabbix_mcp_server import get_zabbix_client
+
+        client = get_zabbix_client()
+        version_info = client.apiinfo.version()
+
+        print(f"✅ Connected to Zabbix API version: {version_info}")
+        return True
+
+    except ValueError as e:
+        if "environment variable" in str(e).lower():
+            print(f"❌ Configuration error: {e}")
+        else:
+            print(f"❌ Connection failed: {e}")
+        return False
+
+    except Exception as e:
+        print(f"❌ Connection failed: {e}")
+        return False
+
+
+def test_unified_tool() -> bool:
+    """Test the unified zabbix_api tool logic.
+
+    Returns:
+        bool: True if tool logic works correctly
+    """
+    print("\n🔍 Testing unified zabbix_api tool logic...")
+
+    try:
+        from zabbix_mcp_server import get_zabbix_client, is_read_operation
+
+        print(" - Testing is_read_operation function...")
+        # Test read operations (should return True)
+        assert is_read_operation("host.get") == True, (
+            "host.get should be read operation"
+        )
+        assert is_read_operation("item.get") == True, (
+            "item.get should be read operation"
+        )
+        assert is_read_operation("apiinfo.version") == True, (
+            "apiinfo.version should be read operation"
+        )
+        assert is_read_operation("template.get") == True, (
+            "template.get should be read operation"
+        )
+        assert is_read_operation("problem.get") == True, (
+            "problem.get should be read operation"
+        )
+        # Test write operations (should return False)
+        assert is_read_operation("host.create") == False, (
+            "host.create should NOT be read operation"
+        )
+        assert is_read_operation("host.update") == False, (
+            "host.update should NOT be read operation"
+        )
+        assert is_read_operation("host.delete") == False, (
+            "host.delete should NOT be read operation"
+        )
+        assert is_read_operation("host.massadd") == False, (
+            "host.massadd should NOT be read operation"
+        )
+        assert is_read_operation("event.acknowledge") == False, (
+            "event.acknowledge should NOT be read operation"
+        )
+        print(" ✅ Read operation detection working")
+
+        client = get_zabbix_client()
+
+        print(" - Testing apiinfo.version...")
+        version = client.apiinfo.version()
+        print(f" ✅ API version: {version}")
+
+        print(" - Testing hostgroup.get...")
+        groups = client.hostgroup.get(limit=1)
+        if groups:
+            print(f" ✅ Retrieved {len(groups)} host group(s)")
+        else:
+            print(" ⚠️  No host groups found (this might be normal)")
+
+        print(" - Testing host.get...")
+        hosts = client.host.get(limit=1, output=["hostid", "name"])
+        if hosts:
+            print(f" ✅ Retrieved {len(hosts)} host(s)")
+            # Verify only requested fields are returned
+            host_keys = set(hosts[0].keys())
+            expected_keys = {"hostid", "name"}
+            if host_keys == expected_keys:
+                print(f" ✅ Output limited to requested fields: {list(host_keys)}")
+            else:
+                print(f" ⚠️  Expected fields {expected_keys}, got {host_keys}")
+        else:
+            print(" ⚠️  No hosts found (this might be normal)")
+
+        print(" - Testing item.get...")
+        items = client.item.get(limit=1)
+        if items:
+            print(f" ✅ Retrieved {len(items)} item(s)")
+        else:
+            print(" ⚠️  No items found (this might be normal)")
+
+        print(" - Testing template.get...")
+        templates = client.template.get(limit=1)
+        if templates:
+            print(f" ✅ Retrieved {len(templates)} template(s)")
+        else:
+            print(" ⚠️  No templates found (this might be normal)")
+
+        # Test that output='extend' works but returns more fields
+        print(" - Testing output='extend' (should return more fields)...")
+        hosts_extend = client.host.get(limit=1, output="extend")
+        if hosts_extend and len(hosts_extend[0].keys()) > 2:
+            print(
+                f" ✅ output='extend' returns {len(hosts_extend[0].keys())} fields (as expected)"
+            )
+        else:
+            print(" ⚠️  output='extend' returned fewer fields than expected")
+
+        print("✅ Unified tool logic tests successful")
+        return True
+
+    except AssertionError as e:
+        print(f"❌ Assertion failed: {e}")
+        return False
+    except Exception as e:
+        print(f"❌ Unified tool logic tests failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def test_read_only_mode() -> bool:
+    """Test read-only mode functionality.
+
+    Returns:
+        bool: True if read-only mode works correctly
+    """
+    read_only = os.getenv("READ_ONLY", "false").lower() in ("true", "1", "yes")
+
+    if not read_only:
+        print("\n⏭️  Skipping read-only mode test (not enabled)")
+        return True
+
+    print("\n🔍 Testing read-only mode...")
+
+    try:
+        from zabbix_mcp_server import is_read_operation, is_read_only
+
+        print(" - Verifying read-only mode is enabled...")
+        if not is_read_only():
+            print(" ❌ Read-only mode should be enabled")
+            return False
+        print(" ✅ Read-only mode is enabled")
+
+        print(" - Testing read operation detection...")
+        if is_read_operation("hostgroup.create"):
+            print(" ❌ hostgroup.create should NOT be a read operation")
+            return False
+        if not is_read_operation("hostgroup.get"):
+            print(" ❌ hostgroup.get should be a read operation")
+            return False
+        print(" ✅ Read operation detection working correctly")
+
+        print(" - Verifying write operations are blocked...")
+        if not is_read_only() or is_read_operation("hostgroup.create"):
+            print(
+                " ⚠️  Cannot test blocking - read-only not enabled or operation is read"
+            )
+            return True
+
+        print(" ✅ Write operations would be blocked in read-only mode")
+        return True
+
+    except Exception as e:
+        print(f"❌ Unexpected error testing read-only mode: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def test_transport_config() -> bool:
+    """Test transport configuration.
+
+    Returns:
+        bool: True if transport configuration is valid
+    """
+    print("\n🔍 Testing transport configuration...")
+
+    try:
+        from zabbix_mcp_server import get_transport_config
+
+        config = get_transport_config()
+        transport = config["transport"]
+
+        print(f"✅ Transport type: {transport}")
+
+        if transport == "streamable-http":
+            print(f" - Host: {config['host']}")
+            print(f" - Port: {config['port']}")
+            print(f" - Stateless: {config['stateless_http']}")
+
+            auth_type = os.getenv("AUTH_TYPE", "").lower()
+            if auth_type == "no-auth":
+                print(" ✅ AUTH_TYPE correctly set to 'no-auth'")
+            else:
+                print(" ❌ AUTH_TYPE must be set to 'no-auth' for HTTP transport")
+                return False
+        else:
+            print(" ✅ STDIO transport configured correctly")
+
+        return True
+
+    except ValueError as e:
+        print(f"❌ Transport configuration error: {e}")
+        return False
+
+    except Exception as e:
+        print(f"❌ Unexpected error testing transport: {e}")
+        return False
+
+
+def show_summary(tests_passed: int, total_tests: int) -> None:
+    """Show test summary.
+
+    Args:
+        tests_passed: Number of tests that passed
+        total_tests: Total number of tests
+    """
+    print("\n" + "=" * 50)
+    print("TEST SUMMARY")
+    print("=" * 50)
+
+    if tests_passed == total_tests:
+        print(f"🎉 All {total_tests} tests passed!")
+        print("✅ The Zabbix MCP Server is ready to use")
+        print("\nNext steps:")
+        print("1. Configure your MCP client (see MCP_SETUP.md)")
+        print("2. Start the server: uv run python src/zabbix_mcp_server/server.py")
+        print("3. Test with your MCP client")
+        print("\nExample zabbix_api calls:")
+        print(
+            "  - Get hosts: zabbix_api(method='host.get', params={'output': ['hostid', 'name']})"
+        )
+        print(
+            "  - Get items: zabbix_api(method='item.get', params={'hostids': ['10084'], 'output': ['itemid', 'name']})"
+        )
+        print(
+            " - Get problems: zabbix_api(method='problem.get', params={'output': ['eventid', 'name'], 'recent': True})"
+        )
+        print("\n⚠️  AVOID using 'output': 'extend' - it's slow and verbose!")
+        print("💡 Use specific fields instead: {'output': ['field1', 'field2']}")
+
+    else:
+        print(f"❌ {tests_passed}/{total_tests} tests passed")
+        print("Please fix the issues above before using the server")
+
+    print("=" * 50)
+
+
+def main() -> None:
+    """Main test function."""
+    setup_logging()
+
+    print("🧪 Zabbix MCP Server Test Suite")
+    print("=" * 50)
+
+    tests = [
+        ("Module Import", test_import),
+        ("Environment Configuration", test_environment),
+        ("Transport Configuration", test_transport_config),
+        ("Zabbix Connection", test_connection),
+        ("Unified zabbix_api Tool", test_unified_tool),
+        ("Read-Only Mode", test_read_only_mode),
+    ]
+
+    tests_passed = 0
+
+    for test_name, test_func in tests:
+        try:
+            if test_func():
+                tests_passed += 1
+        except KeyboardInterrupt:
+            print("\n\n⏹️  Tests interrupted by user")
+            sys.exit(1)
+        except Exception as e:
+            print(f"❌ Unexpected error in {test_name}: {e}")
+
+    show_summary(tests_passed, len(tests))
+
+    if tests_passed == len(tests):
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/src/zabbix_mcp_server/__init__.py
+++ b/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/src/zabbix_mcp_server/__init__.py
@@ -1,0 +1,26 @@
+"""
+Zabbix MCP Server
+
+A comprehensive Model Context Protocol (MCP) server for Zabbix integration.
+"""
+
+__author__ = "mpeirone"
+__license__ = "GPL-3.0"
+
+from zabbix_mcp_server.server import (
+    get_zabbix_client,
+    is_read_operation,
+    is_read_only,
+    get_transport_config,
+    main,
+    mcp,
+)
+
+__all__ = [
+    "get_zabbix_client",
+    "is_read_operation",
+    "is_read_only",
+    "get_transport_config",
+    "main",
+    "mcp",
+]

--- a/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/src/zabbix_mcp_server/api_docs_scraper.py
+++ b/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/src/zabbix_mcp_server/api_docs_scraper.py
@@ -1,0 +1,314 @@
+"""
+Zabbix API Docs Scraper
+Retrieves description and parameters for a Zabbix method from official docs
+and returns them as structured text readable by an LLM.
+"""
+
+import re
+import requests
+from bs4 import BeautifulSoup
+from dataclasses import dataclass, field
+from .client import get_zabbix_client
+
+
+def _get_docs_base(version: str = "current") -> str:
+    return f"https://www.zabbix.com/documentation/{version}/en/manual/api/reference"
+
+
+def _get_user_agent() -> str:
+    return f"ZabbixMCP/v2 (Documentation Fetcher; +https://github.com/mpeirone/zabbix-mcp-server)"
+
+
+HEADERS = {"User-Agent": _get_user_agent()}
+
+
+_LINK_RE = re.compile(
+    r'/manual/api/reference/([a-z][a-z0-9_]+)/([a-z][a-z0-9_]+)(?=["\s])'
+)
+
+_scrape_cache: dict[str, dict[str, list[str]]] = {}
+
+
+def _resolve_version(version: str = None) -> str:
+    """Resolve Zabbix version from parameter or server.
+
+    Args:
+        version: Optional version string (e.g., "7.0"). If None, uses server version.
+
+    Returns:
+        Resolved version string.
+    """
+    if version is not None:
+        return version
+
+    try:
+        client = get_zabbix_client()
+        server_version = str(getattr(client, "version", None))
+
+        if server_version:
+            parts = server_version.split(".")
+            if len(parts) >= 2:
+                return f"{parts[0]}.{parts[1]}"
+    except Exception:
+        # Fall back to "current" if client initialization fails
+        pass
+
+    return "current"
+
+
+def scrape_zabbix_api(version: str = None, timeout: int = 10) -> dict[str, list[str]]:
+    """Scrape Zabbix API reference and return {resource: [methods]}.
+
+    Args:
+        version: Zabbix version, e.g., "7.0", "6.0". If None, uses server version.
+        timeout: HTTP timeout in seconds
+
+    Returns:
+        {"host": ["create", "delete", "get", ...], "item": [...], ...}
+    """
+    version = _resolve_version(version)
+
+    if version in _scrape_cache:
+        return _scrape_cache[version]
+
+    url = _get_docs_base(version)
+    try:
+        with requests.get(url, headers=HEADERS, timeout=timeout) as response:
+            if response.status_code != 200:
+                raise RuntimeError(f"HTTP {response.status_code} for {url}")
+            response_text = response.text
+    except requests.RequestException as exc:
+        raise RuntimeError(f"Network error: {exc}") from exc
+
+    result: dict[str, list[str]] = {}
+    for resource, method in _LINK_RE.findall(response_text):
+        if method == "object":
+            continue
+        methods = result.setdefault(resource, [])
+        if method not in methods:
+            methods.append(method)
+
+    result = dict(sorted(result.items()))
+    _scrape_cache[version] = result
+    return result
+
+
+@dataclass
+class Parameter:
+    name: str
+    type: str
+    required: bool
+    description: str
+
+
+@dataclass
+class ZabbixMethodDocs:
+    method: str
+    description: str
+    parameters: list[Parameter] = field(default_factory=list)
+    returns: str = ""
+    doc_url: str = ""
+
+
+def _build_url(method: str, version: str = "current") -> str:
+    parts = method.strip().lower().split(".", 1)
+    if len(parts) != 2:
+        raise ValueError(
+            f"Invalid format: '{method}'. Expected 'object.action' (e.g. host.get)"
+        )
+    obj, action = parts
+    base = _get_docs_base(version)
+    return f"{base}/{obj}/{action}"
+
+
+def _parse_description(soup: BeautifulSoup) -> str:
+    h1 = soup.find("h1")
+    if h1:
+        for sibling in h1.find_next_siblings():
+            if sibling.name == "p":
+                text = sibling.get_text(separator=" ", strip=True)
+                if text:
+                    return text
+    for p in soup.find_all("p"):
+        text = p.get_text(separator=" ", strip=True)
+        if len(text) > 40:
+            return text
+    return ""
+
+
+def _clean_description(desc: str) -> str:
+    desc = desc.replace(" .", ".").replace(" ,", ",")
+    if "Possible values:" in desc:
+        parts = desc.split("Possible values:", 1)
+        desc = parts[0].strip()
+        if len(parts) > 1:
+            values = parts[1].strip()
+            desc = f"{desc}\n  Possible values: {values}"
+    return desc
+
+
+def _parse_parameters_table(table: BeautifulSoup) -> list[Parameter]:
+    params = []
+    rows = table.find_all("tr")
+    if not rows:
+        return params
+
+    headers = [th.get_text(strip=True).lower() for th in rows[0].find_all(["th", "td"])]
+    col = {
+        "name": next(
+            (i for i, h in enumerate(headers) if "parameter" in h or "name" in h), 0
+        ),
+        "type": next((i for i, h in enumerate(headers) if "type" in h), 1),
+        "required": next(
+            (i for i, h in enumerate(headers) if "mandatory" in h or "required" in h),
+            None,
+        ),
+        "desc": next((i for i, h in enumerate(headers) if "description" in h), -1),
+    }
+
+    for row in rows[1:]:
+        cells = row.find_all(["td", "th"])
+        if len(cells) < 2:
+            continue
+
+        def cell_text(idx):
+            if idx is None or idx >= len(cells):
+                return ""
+            return cells[idx].get_text(separator=" ", strip=True)
+
+        name = cell_text(col["name"])
+        if not name:
+            continue
+
+        ptype = cell_text(col["type"]) or "unknown"
+        desc = _clean_description(cell_text(col["desc"]))
+
+        if col["required"] is not None:
+            required = cell_text(col["required"]).lower() in (
+                "yes",
+                "true",
+                "1",
+                "mandatory",
+            )
+        else:
+            required = "(required)" in desc.lower() or "(mandatory)" in desc.lower()
+
+        params.append(
+            Parameter(name=name, type=ptype, required=required, description=desc)
+        )
+
+    return params
+
+
+def _parse_return_value(soup: BeautifulSoup) -> str:
+    for heading in soup.find_all(["h2", "h3", "h4"]):
+        if "return" in heading.get_text(strip=True).lower():
+            parts = []
+            for sibling in heading.find_next_siblings():
+                if sibling.name in ["h2", "h3", "h4"]:
+                    break
+                if sibling.name == "ul":
+                    for li in sibling.find_all("li", recursive=False):
+                        text = li.get_text(separator=" ", strip=True)
+                        if text:
+                            parts.append(f"- {text}")
+                elif sibling.name == "p":
+                    text = sibling.get_text(separator=" ", strip=True)
+                    if text:
+                        parts.append(text)
+            return "\n".join(parts)
+    return ""
+
+
+def get_zabbix_api_docs(
+    method: str, version: str = "current", timeout: int = 10
+) -> ZabbixMethodDocs:
+    """Fetches raw documentation data for a Zabbix method."""
+    url = _build_url(method, version)
+    try:
+        with requests.get(url, headers=HEADERS, timeout=timeout) as response:
+            if response.status_code == 404:
+                raise RuntimeError(f"Method '{method}' not found ({url})")
+            if response.status_code != 200:
+                raise RuntimeError(f"HTTP {response.status_code} for {url}")
+            response_text = response.text
+    except requests.RequestException as e:
+        raise RuntimeError(f"Network error: {e}") from e
+
+    soup = BeautifulSoup(response_text, "html.parser")
+    description = _parse_description(soup)
+
+    all_params: list[Parameter] = []
+    for table in soup.find_all("table"):
+        header_row = table.find("tr")
+        if not header_row:
+            continue
+        header_text = header_row.get_text(strip=True).lower()
+        if "parameter" in header_text or "type" in header_text:
+            all_params.extend(_parse_parameters_table(table))
+
+    return ZabbixMethodDocs(
+        method=method,
+        description=description,
+        parameters=all_params,
+        returns=_parse_return_value(soup),
+        doc_url=url,
+    )
+
+
+def get_method_docs(method: str, version: str = None, timeout: int = 10) -> str:
+    """Returns Zabbix method documentation as structured text
+    optimized for reading and interpretation by an LLM.
+
+    Args:
+        method: Zabbix method in 'object.action' format, e.g. 'host.get'
+        version: Zabbix version, e.g., '7.0', '6.0'. If None, uses server version.
+        timeout: HTTP timeout in seconds
+
+    Returns:
+        Text string with description, parameters and return value.
+
+    Example:
+        >>> text = get_method_docs("host.get")
+        >>> text = get_method_docs("host.get", version="7.0")
+        >>> print(text)
+    """
+    version = _resolve_version(version)
+
+    docs = get_zabbix_api_docs(method, version, timeout)
+
+    required = [p for p in docs.parameters if p.required]
+    optional = [p for p in docs.parameters if not p.required]
+
+    lines = [
+        f"METHOD: {docs.method}",
+        f"URL: {docs.doc_url}",
+        "",
+        f"DESCRIPTION:",
+        docs.description or "Not available.",
+        "",
+    ]
+
+    if required:
+        lines.append("REQUIRED PARAMETERS:")
+        for p in required:
+            lines.append(f"  {p.name} ({p.type}):")
+            for line in p.description.split("\n"):
+                lines.append(f"    {line}")
+            lines.append("")
+
+    if optional:
+        lines.append("OPTIONAL PARAMETERS:")
+        for p in optional:
+            lines.append(f"  {p.name} ({p.type}):")
+            for line in p.description.split("\n"):
+                lines.append(f"    {line}")
+            lines.append("")
+
+    if docs.returns:
+        lines.append("RETURN VALUE:")
+        for line in docs.returns.split("\n"):
+            lines.append(f"  {line}")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/src/zabbix_mcp_server/client.py
+++ b/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/src/zabbix_mcp_server/client.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+import logging
+import threading
+from typing import Optional
+from zabbix_utils import ZabbixAPI
+from dotenv import load_dotenv
+
+from .config import EnvVars, parse_bool_env, parse_int_env, get_env, setup_logging
+
+load_dotenv()
+
+setup_logging(debug=parse_bool_env(EnvVars.DEBUG))
+logger = logging.getLogger(__name__)
+
+zabbix_api_client: Optional[ZabbixAPI] = None
+_client_lock = threading.Lock()
+
+
+def get_zabbix_client() -> ZabbixAPI:
+    global zabbix_api_client
+
+    if zabbix_api_client is not None:
+        return zabbix_api_client
+
+    with _client_lock:
+        if zabbix_api_client is not None:
+            return zabbix_api_client
+
+        url = get_env(EnvVars.ZABBIX_URL)
+        if not url:
+            raise ValueError(f"{EnvVars.ZABBIX_URL} environment variable is required")
+
+        logger.info(f"Initializing Zabbix API client for {url}")
+
+        verify_ssl = parse_bool_env(EnvVars.VERIFY_SSL, default=True)
+        if not verify_ssl:
+            logger.warning(
+                "SSL certificate verification is DISABLED. "
+                "This should NEVER be used in production environments!"
+            )
+
+        skip_version_check = parse_bool_env(EnvVars.ZABBIX_SKIP_VERSION_CHECK)
+        if skip_version_check:
+            logger.info("Skipping Zabbix API version check")
+
+        timeout = parse_int_env(EnvVars.ZABBIX_API_TIMEOUT, default=30)
+        logger.info(f"API timeout set to {timeout} seconds")
+
+        zabbix_api_client = ZabbixAPI(
+            url=url,
+            validate_certs=verify_ssl,
+            skip_version_check=skip_version_check,
+            timeout=timeout,
+        )
+
+        token = get_env(EnvVars.ZABBIX_TOKEN)
+        if token:
+            logger.info("Authenticating with API token")
+            zabbix_api_client.login(token=token)
+        else:
+            user = get_env(EnvVars.ZABBIX_USER)
+            password = get_env(EnvVars.ZABBIX_PASSWORD)
+            if not user or not password:
+                raise ValueError(
+                    f"Either {EnvVars.ZABBIX_TOKEN} or "
+                    f"{EnvVars.ZABBIX_USER}/{EnvVars.ZABBIX_PASSWORD} must be set"
+                )
+            logger.info("Authenticating with username/password")
+            zabbix_api_client.login(user=user, password=password)
+
+        logger.info("Successfully authenticated with Zabbix API")
+
+        return zabbix_api_client

--- a/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/src/zabbix_mcp_server/config.py
+++ b/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/src/zabbix_mcp_server/config.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""
+Centralized configuration for Zabbix MCP Server.
+
+This module defines all environment variable names and provides
+utility functions for parsing configuration values.
+"""
+
+import logging
+import os
+from typing import Optional
+
+
+class EnvVars:
+    """Environment variable names."""
+
+    ZABBIX_URL = "ZABBIX_URL"
+    ZABBIX_TOKEN = "ZABBIX_TOKEN"
+    ZABBIX_USER = "ZABBIX_USER"
+    ZABBIX_PASSWORD = "ZABBIX_PASSWORD"
+    READ_ONLY = "READ_ONLY"
+    VERIFY_SSL = "VERIFY_SSL"
+    ZABBIX_API_WHITELIST = "ZABBIX_API_WHITELIST"
+    ZABBIX_API_BLACKLIST = "ZABBIX_API_BLACKLIST"
+    ZABBIX_SKIP_VERSION_CHECK = "ZABBIX_SKIP_VERSION_CHECK"
+    ZABBIX_API_TIMEOUT = "ZABBIX_API_TIMEOUT"
+    ZABBIX_MCP_TRANSPORT = "ZABBIX_MCP_TRANSPORT"
+    ZABBIX_MCP_HOST = "ZABBIX_MCP_HOST"
+    ZABBIX_MCP_PORT = "ZABBIX_MCP_PORT"
+    ZABBIX_MCP_STATELESS_HTTP = "ZABBIX_MCP_STATELESS_HTTP"
+    AUTH_TYPE = "AUTH_TYPE"
+    DEBUG = "DEBUG"
+
+
+def parse_bool_env(var_name: str, default: bool = False) -> bool:
+    """Parse a boolean environment variable.
+
+    Args:
+        var_name: Name of the environment variable
+        default: Default value if not set
+
+    Returns:
+        Boolean value parsed from environment variable
+    """
+    value = os.getenv(var_name, str(default)).lower()
+    return value in ("true", "1", "yes")
+
+
+def parse_int_env(var_name: str, default: int) -> int:
+    """Parse an integer environment variable.
+
+    Args:
+        var_name: Name of the environment variable
+        default: Default value if not set or invalid
+
+    Returns:
+        Integer value parsed from environment variable
+    """
+    value = os.getenv(var_name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def get_env(var_name: str, default: Optional[str] = None) -> Optional[str]:
+    """Get an environment variable value.
+
+    Args:
+        var_name: Name of the environment variable
+        default: Default value if not set
+
+    Returns:
+        Environment variable value or default
+    """
+    return os.getenv(var_name, default)
+
+
+def setup_logging(debug: bool = False) -> None:
+    """Setup centralized logging configuration.
+
+    Args:
+        debug: If True, set logging level to DEBUG, otherwise INFO
+    """
+    level = logging.DEBUG if debug else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )

--- a/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/src/zabbix_mcp_server/server.py
+++ b/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/src/zabbix_mcp_server/server.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""
+Zabbix MCP Server - Unified API interface using python-zabbix-utils
+
+This server provides complete access to ALL Zabbix API functionality through
+a single unified tool, enabling AI assistants to interact with Zabbix monitoring
+systems dynamically.
+
+Author: Zabbix MCP Server Contributors
+License: GPL-3.0-or-later
+"""
+
+import logging
+import threading
+from typing import Any, Dict, List, Optional
+from fastmcp import FastMCP
+from .api_docs_scraper import scrape_zabbix_api, get_method_docs
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from .config import EnvVars, parse_bool_env, parse_int_env, get_env, setup_logging
+from .client import get_zabbix_client
+from .utils import (
+    is_read_only,
+    is_read_operation,
+    format_response,
+    check_method_allowed,
+)
+
+setup_logging(debug=parse_bool_env(EnvVars.DEBUG))
+logger = logging.getLogger(__name__)
+
+_ZABBIX_URL = get_env(EnvVars.ZABBIX_URL, "not configured")
+
+
+def _with_server_url(fn):
+    """Prepend Zabbix server URL to tool docstring."""
+    if fn.__doc__:
+        fn.__doc__ = f"Zabbix server: {_ZABBIX_URL}\n\n" + fn.__doc__
+    return fn
+
+
+mcp = FastMCP("Zabbix MCP Server")
+
+ZABBIX_API_OBJECTS: Dict[str, list[str]] = {}
+_api_objects_lock = threading.Lock()
+
+
+def _discover_api_objects() -> Dict[str, list[str]]:
+    client = get_zabbix_client()
+    objects: Dict[str, list[str]] = {}
+    api_objects = [
+        attr
+        for attr in dir(client)
+        if not attr.startswith("_") and not callable(getattr(client, attr, None))
+    ]
+    for obj_name in api_objects:
+        obj = getattr(client, obj_name, None)
+        if obj is None:
+            continue
+        methods = [
+            m
+            for m in dir(obj)
+            if not m.startswith("_") and callable(getattr(obj, m, None))
+        ]
+        if methods:
+            objects[obj_name] = sorted(methods)
+    return objects
+
+
+def _get_api_objects() -> Dict[str, list[str]]:
+    global ZABBIX_API_OBJECTS
+    if ZABBIX_API_OBJECTS:
+        return ZABBIX_API_OBJECTS
+    with _api_objects_lock:
+        if ZABBIX_API_OBJECTS:
+            return ZABBIX_API_OBJECTS
+        ZABBIX_API_OBJECTS = _discover_api_objects()
+        return ZABBIX_API_OBJECTS
+
+
+@mcp.tool()
+@_with_server_url
+def zabbix_api(method: str, params: Optional[Dict[str, Any]] = None) -> str:
+    """Execute Zabbix API method.
+
+    This is the main tool for interacting with Zabbix. It requires multiple
+    iterations to achieve complex goals. Use other tools for guidance.
+
+    WORKFLOW:
+    1. If unsure about method/params: call zabbix_api_docs(method) first
+    2. If unsure about available methods: call zabbix_api_list() first
+    3. Execute the API call with this tool
+    4. If empty results or errors: iterate with different params/filters
+    5. Continue iterating until goal is achieved
+
+    COMMON PATTERNS:
+    - Finding an object requires 2+ calls (find ID, then get details)
+    - CPU usage example: Find host by name, get its items, filter CPU item, get history
+    - Empty results often mean wrong filters - try broader search first
+
+    Args:
+        method: Zabbix API method (format: 'object.action').
+        Examples: 'host.get', 'item.create', 'trigger.update'
+        params: Method parameters (optional). For 'get' operations,
+        specify 'output' to limit fields (default: ['name']).
+
+    Returns:
+        JSON response from Zabbix API.
+
+    Examples:
+    # Simple query
+    zabbix_api('host.get', {'output': ['hostid', 'name']})
+
+    # Multi-step: Find host, then get items
+    # Step 1: Find host ID
+    hosts = zabbix_api('host.get', {'filter': {'host': 'my-srv-01'}, 'output': ['hostid']})
+    # Step 2: Get CPU items for that host
+    items = zabbix_api('item.get', {'hostids': ['12345'], 'search': {'name': 'CPU'}, 'output': ['itemid', 'name']})
+    # Step 3: Get history for specific item
+    history = zabbix_api('history.get', {'itemids': ['67890'], 'output': 'extend', 'history': 0, 'limit': 10})
+
+    Note:
+    - Use zabbix_api_docs() for method documentation
+    - Use zabbix_api_list() for available methods
+    - Iterate multiple times - complex queries need 2-5 API calls
+    """
+    check_method_allowed(method)
+
+    if is_read_only() and not is_read_operation(method):
+        raise ValueError(
+            f"Server is in read-only mode - operation '{method}' is not allowed. "
+            f"Only safe read operations (get, version, check, export) are permitted. "
+            f"Write operations (create, update, delete) are blocked."
+        )
+
+    client = get_zabbix_client()
+
+    if params is None:
+        params = {}
+
+    if method.endswith(".get") and "output" not in params:
+        params = {**params, "output": ["name"]}
+        logger.debug(f"Applied default output=['name'] for {method}")
+
+    parts = method.split(".")
+    if len(parts) != 2:
+        raise ValueError(
+            f"Invalid method format: '{method}'. "
+            f"Expected format: 'object.action' (e.g., 'host.get', 'item.create')"
+        )
+
+    api_object, api_action = parts
+
+    api_obj = getattr(client, api_object)
+    api_method = getattr(api_obj, api_action)
+
+    try:
+        if params:
+            result = api_method(**params)
+        else:
+            result = api_method()
+
+        logger.info(f"Successfully executed {method}")
+        return format_response(result)
+
+    except Exception as e:
+        logger.error(f"Error executing {method}: {e}")
+        raise
+
+
+@mcp.tool()
+def zabbix_api_docs(
+    method: str, version: Optional[str] = None, timeout: Optional[int] = 10
+) -> str:
+    """Get Zabbix API method documentation.
+
+    Call this BEFORE zabbix_api() if you are unsure about method parameters.
+    Shows required/optional parameters with types and descriptions.
+
+    Args:
+        method: Zabbix API method (format: \'object.action\').
+        Examples: \'host.get\', \'item.create\', \'trigger.update\'
+        version: Zabbix version (e.g., \'7.0\', \'6.0\'). If omitted, uses server version.
+        timeout: HTTP timeout in seconds (default: 10).
+
+    Returns:
+        Structured documentation with method description, parameters, and return value.
+
+    Example:
+        zabbix_api_docs(\'host.create\')
+        zabbix_api_docs(\'host.get\', version=\'7.0\')
+
+    Note:
+        - Always call this when in doubt about parameters
+        - Combine with zabbix_api_list() to discover available methods
+    """
+    try:
+        return get_method_docs(method, version, timeout)
+    except Exception as e:
+        logger.error(f"Error fetching docs for {method}: {e}")
+        raise
+
+
+@mcp.tool()
+def zabbix_api_list(object: Optional[str] = None) -> Dict[str, list[str]]:
+    """Get available Zabbix API objects and methods.
+
+    Call this to discover what API methods are available before using zabbix_api().
+    Returns all objects and methods discovered dynamically from Zabbix API.
+
+    Args:
+        object: Specific API object (e.g., 'host', 'item'). If omitted, returns all.
+
+    Returns:
+        Dictionary mapping API objects to their available methods.
+
+    Examples:
+        All objects: zabbix_api_list()
+        Specific object: zabbix_api_list(object='host')
+        # Returns: {"host": ["create", "delete", "get", ...]}
+
+    Note:
+        - Use this to discover available methods
+        - Then use zabbix_api_docs() for detailed parameter info
+        - Finally use zabbix_api() to execute the call
+    """
+    api_objects = scrape_zabbix_api()
+    if object is None:
+        return api_objects
+
+    object_lower = object.lower()
+    if object_lower not in api_objects:
+        available = ", ".join(sorted(api_objects.keys()))
+        raise ValueError(
+            f"Unknown API object: '{object}'. Available objects: {available}"
+        )
+
+    return {object_lower: api_objects[object_lower]}
+
+
+def _validate_transport_type(transport: str) -> None:
+    valid_transports = ["stdio", "streamable-http"]
+    if transport not in valid_transports:
+        raise ValueError(
+            f"Invalid {EnvVars.ZABBIX_MCP_TRANSPORT}: {transport}. "
+            f"Must be 'stdio' or 'streamable-http'"
+        )
+
+
+def _validate_http_auth() -> None:
+    auth_type = get_env(EnvVars.AUTH_TYPE, "").lower()
+    if auth_type != "no-auth":
+        raise ValueError(
+            f"{EnvVars.AUTH_TYPE} must be set to 'no-auth' when using streamable-http transport"
+        )
+
+
+def _get_http_config() -> Dict[str, Any]:
+    return {
+        "host": get_env(EnvVars.ZABBIX_MCP_HOST, "127.0.0.1"),
+        "port": parse_int_env(EnvVars.ZABBIX_MCP_PORT, 8000),
+        "stateless_http": parse_bool_env(EnvVars.ZABBIX_MCP_STATELESS_HTTP),
+    }
+
+
+def get_transport_config() -> Dict[str, Any]:
+    transport = get_env(EnvVars.ZABBIX_MCP_TRANSPORT, "stdio").lower()
+    _validate_transport_type(transport)
+
+    config: Dict[str, Any] = {"transport": transport}
+
+    if transport == "streamable-http":
+        _validate_http_auth()
+        http_config = _get_http_config()
+        config.update(http_config)
+        logger.info(
+            f"HTTP transport configured: {http_config['host']}:{http_config['port']}, "
+            f"stateless_http={http_config['stateless_http']}"
+        )
+
+    return config
+
+
+def main():
+    logger.info("Starting Zabbix MCP Server")
+
+    try:
+        transport_config = get_transport_config()
+        logger.info(f"Transport: {transport_config['transport']}")
+    except ValueError as e:
+        logger.error(f"Transport configuration error: {e}")
+        return 1
+
+    logger.info(f"Read-only mode: {is_read_only()}")
+    logger.info(f"Zabbix URL: {get_env(EnvVars.ZABBIX_URL, 'Not configured')}")
+
+    try:
+        if transport_config["transport"] == "stdio":
+            mcp.run()
+        else:
+            mcp.run(
+                transport="streamable-http",
+                host=transport_config["host"],
+                port=transport_config["port"],
+                stateless_http=transport_config["stateless_http"],
+            )
+    except KeyboardInterrupt:
+        logger.info("Server stopped by user")
+    except Exception as e:
+        logger.error(f"Server error: {e}")
+        raise
+
+
+@mcp.custom_route("/health", methods=["GET"])
+async def health(request: Request) -> JSONResponse:
+    return JSONResponse({"status": "ok"})
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/src/zabbix_mcp_server/utils.py
+++ b/mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/src/zabbix_mcp_server/utils.py
@@ -1,0 +1,168 @@
+import re
+import json
+import logging
+from typing import Any, List, Optional
+
+from .config import EnvVars, parse_bool_env, get_env
+
+
+logger = logging.getLogger(__name__)
+
+
+MAX_REGEX_PATTERN_LENGTH = 200
+DANGEROUS_REGEX_PATTERNS = [
+    r"(\.\*)\*",
+    r"(\.\*)\+",
+    r"([a-z]\+)\+",
+    r"([a-z]\+)\{",
+    r"(\.\+)\+",
+    r"(\.\+)\*",
+]
+
+
+def is_read_only() -> bool:
+    """Check if the server is running in read-only mode.
+
+    Returns:
+        True if READ_ONLY is enabled, False otherwise.
+    """
+    return parse_bool_env(EnvVars.READ_ONLY, default=True)
+
+
+def is_read_operation(method: str) -> bool:
+    """Check if a Zabbix API method is a read operation.
+
+    Args:
+        method: Zabbix API method name (e.g., 'host.get', 'item.create')
+
+    Returns:
+        True if the method is a read operation, False otherwise.
+    """
+    if "." not in method:
+        return False
+
+    operation = method.split(".")[-1].lower()
+    read_operations = {"get", "version", "check", "export"}
+
+    return operation in read_operations
+
+
+def format_response(data: Any) -> str:
+    """Format API response data as JSON string.
+
+    Args:
+        data: Data to format (can be any JSON-serializable type)
+
+    Returns:
+        JSON string representation of the data.
+    """
+    return json.dumps(data, indent=2, default=str)
+
+
+def is_safe_regex(pattern_str: str) -> bool:
+    """Check if a regex pattern is safe to use.
+
+    Args:
+        pattern_str: The regex pattern string to check.
+
+    Returns:
+        True if the pattern is safe, False otherwise.
+    """
+    if len(pattern_str) > MAX_REGEX_PATTERN_LENGTH:
+        return False
+    pattern_lower = pattern_str.lower()
+    for dangerous in DANGEROUS_REGEX_PATTERNS:
+        if dangerous in pattern_lower:
+            return False
+    return True
+
+
+def parse_regex_patterns(env_var: Optional[str]) -> List[re.Pattern]:
+    """Parse comma-separated regex patterns from environment variable.
+
+    Args:
+        env_var: The environment variable value containing comma-separated patterns.
+
+    Returns:
+        List of compiled regex patterns.
+    """
+    patterns: List[re.Pattern] = []
+    if not env_var:
+        return patterns
+    for pattern_str in env_var.split(","):
+        pattern_str = pattern_str.strip()
+        if pattern_str:
+            if not is_safe_regex(pattern_str):
+                logger.warning(
+                    f"Regex pattern rejected (too long or potentially dangerous): {pattern_str}"
+                )
+                continue
+            try:
+                compiled = re.compile(pattern_str)
+                patterns.append(compiled)
+            except re.error as e:
+                logger.warning(f"Invalid regex pattern: {pattern_str}: {e}")
+    return patterns
+
+
+def _check_blacklist(method: str, patterns: List[re.Pattern]) -> None:
+    """Check if method matches any blacklist pattern.
+
+    Args:
+        method: Zabbix API method name to check
+        patterns: List of compiled blacklist patterns
+
+    Raises:
+        ValueError: If method matches a blacklist pattern
+    """
+    for pattern in patterns:
+        if pattern.match(method):
+            raise ValueError(
+                f"Method '{method}' is blacklisted. "
+                f"Blacklist pattern '{pattern.pattern}' matched."
+            )
+
+
+def _check_whitelist(
+    method: str, patterns: List[re.Pattern], whitelist_str: str
+) -> None:
+    """Check if method matches any whitelist pattern.
+
+    Args:
+        method: Zabbix API method name to check
+        patterns: List of compiled whitelist patterns
+        whitelist_str: Original whitelist string for error message
+
+    Raises:
+        ValueError: If method doesn't match any whitelist pattern
+    """
+    for pattern in patterns:
+        if pattern.match(method):
+            return
+
+    whitelist_display = whitelist_str if whitelist_str else r".*"
+    raise ValueError(
+        f"Method '{method}' is not in whitelist. "
+        f"Whitelist patterns: {whitelist_display}"
+    )
+
+
+def check_method_allowed(method: str) -> None:
+    """Check if a Zabbix API method is allowed by whitelist/blacklist.
+
+    Args:
+        method: Zabbix API method name to check.
+
+    Raises:
+        ValueError: If the method is not allowed.
+    """
+    whitelist_env = get_env(EnvVars.ZABBIX_API_WHITELIST)
+    blacklist_env = get_env(EnvVars.ZABBIX_API_BLACKLIST)
+
+    whitelist_patterns = (
+        parse_regex_patterns(whitelist_env) if whitelist_env else [re.compile(r".*")]
+    )
+    blacklist_patterns = parse_regex_patterns(blacklist_env)
+
+    _check_blacklist(method, blacklist_patterns)
+    _check_whitelist(method, whitelist_patterns, whitelist_env)

--- a/scripts/lib/catalog.sh
+++ b/scripts/lib/catalog.sh
@@ -61,6 +61,7 @@ CATALOG=(
     "suzieq|Observability|SuzieQ|Network state queries, assertions, path tracing (bundled)"
     "kubeshark|Observability|Kubeshark|K8s L4/L7 traffic analysis, TLS decryption (remote)"
     "gtrace|Observability|gtrace|Traceroute (MPLS/ECMP/NAT), MTR, GlobalPing, ASN, geo (6 tools)"
+    "zabbix|Observability|Zabbix SNMP-Poller NMS|Polled metric history, problems and device availability from a self-hosted Zabbix. Read-only. Answers what something WAS doing over time — the layer NetClaw had no source for"
     "bgp-intel|Observability|BGP & Registry Intelligence|RPKI origin validation, RDAP ownership, PeeringDB peering, routing visibility (public APIs, no credentials)"
     "globalping|Observability|Globalping|Outside-in measurement from ~4800 global probes — ping, traceroute, DNS, MTR, HTTP (remote, no install)"
     "telemetry-receivers|Observability|Telemetry Receivers|SNMP trap, syslog, IPFIX/NetFlow receivers over UDP (3 servers)"
@@ -155,7 +156,7 @@ fwrule gait servicenow"
 PROFILE_LABS="cml containerlab batfish protocol peering n2n in2n-production suzieq gait subnet-calc drawio-rfc uml"
 
 PROFILE_OBSERVABILITY="grafana prometheus datadog splunk pagerduty te-community te-official \
-suzieq kubeshark gtrace globalping auvik gait"
+suzieq kubeshark gtrace globalping auvik gait zabbix"
 
 profile_components() {
     case "$1" in

--- a/scripts/lib/install-steps.sh
+++ b/scripts/lib/install-steps.sh
@@ -3869,6 +3869,54 @@ fi
 DOCUMENT_MCP_CMD_DETECTED="python3 $DOCUMENT_MCP_DIR/server.py"
 }
 
+# ── Zabbix SNMP-poller NMS (spec 083 / roadmap R11) ─────────────
+component_install_zabbix() {
+log_step "Installing Zabbix NMS MCP Server..."
+echo "  Source: mcp-servers/zabbix-mcp (VENDORED third-party, GPL-3.0, pinned 0722f48)"
+echo "  Upstream: github.com/mpeirone/zabbix-mcp-server -- adopted unmodified"
+echo "  3 tools, read-only. Polled history: what an interface WAS doing, over time"
+
+ZABBIX_MCP_DIR="$REPO_ROOT/mcp-servers/zabbix-mcp"
+
+if [ -d "$ZABBIX_MCP_DIR" ]; then
+    # DEDICATED VIRTUALENV -- NOT OPTIONAL, DO NOT "SIMPLIFY" THIS AWAY.
+    # This server requires fastmcp 3.x. Five NetClaw servers pin fastmcp<3:
+    # netbox-mcp-server, CiscoFMC-MCP-server-community, Wikipedia_MCP, rag-mcp,
+    # ISE_MCP. A shared install breaks all five -- spec 076's cryptography
+    # incident verbatim, which is why multivendor-cli-mcp has its own venv too.
+    echo "  Creating a dedicated virtualenv (fastmcp 3.x conflicts with five other servers)"
+
+    # Never bare `python3 -m venv`: measured on this host it fails outright
+    # because ensurepip is unavailable (spec 077 hazard #3).
+    if command -v netclaw_venv_create >/dev/null 2>&1; then
+        netclaw_venv_create "$ZABBIX_MCP_DIR/.venv" || log_warn "Zabbix MCP venv creation failed"
+    elif command -v uv >/dev/null 2>&1; then
+        uv venv "$ZABBIX_MCP_DIR/.venv" >/dev/null 2>&1 || log_warn "Zabbix MCP venv creation failed (uv)"
+    else
+        log_warn "Neither netclaw_venv_create nor uv available -- cannot build the Zabbix venv."
+        log_warn "Do NOT fall back to 'python3 -m venv': ensurepip is unavailable on some hosts,"
+        log_warn "and installing into the system interpreter would break five other servers."
+    fi
+
+    if [ -x "$ZABBIX_MCP_DIR/.venv/bin/python" ]; then
+        # Install into the VENV interpreter, named explicitly. Deliberately NOT
+        # netclaw_pip_install: that targets the system interpreter, which is the exact
+        # thing this venv exists to protect (fastmcp 3.x vs five servers pinning <3).
+        # Naming --python satisfies the same rule netclaw_pip_install enforces --
+        # packages land in the interpreter the server actually runs under.
+        ( cd "$ZABBIX_MCP_DIR" && \
+          uv pip install -q --python "$ZABBIX_MCP_DIR/.venv/bin/python" -r requirements.txt ) 2>/dev/null || \
+            log_warn "Zabbix MCP dependency install failed (fastmcp, zabbix_utils)"
+        log_info "Zabbix MCP prepared: $ZABBIX_MCP_DIR (isolated venv)"
+        log_info "Read-only is FORCED in config -- the upstream launcher defaults it to false"
+    fi
+else
+    log_warn "Zabbix MCP directory missing: $ZABBIX_MCP_DIR"
+fi
+
+ZABBIX_MCP_CMD_DETECTED="$ZABBIX_MCP_DIR/.venv/bin/python -m zabbix_mcp_server.server"
+}
+
 component_install_globalping() {
 log_step "Enabling Globalping (remote MCP)..."
 echo "  Outside-in measurement from ~4,800 probes across ~1,390 ASNs:"

--- a/specs/083-zabbix-nms/VERIFICATION.md
+++ b/specs/083-zabbix-nms/VERIFICATION.md
@@ -1,0 +1,127 @@
+# Verification Report — SNMP-poller NMS coverage (spec 083 / R11)
+
+**Date**: 2026-08-03 · **FR-050, FR-051, FR-052, SC-025**
+
+**NMS tested: Zabbix 7.0.29** (PostgreSQL, official images), stood up for this feature and polling for
+~1.5 hours at verification time.
+
+FR-052 requires anything not exercised to be recorded as unverified rather than claimed. Two things below
+are, and one of them is a claim my own test was weaker than.
+
+## Two things that make this feature different from 078–082
+
+**1. The core distinctions are enforced by SKILL, not by structure.**
+
+Specs 080, 081 and 082 each moved their guarantee to a chokepoint the caller could not route around. This
+one cannot: adopting a generic passthrough unmodified means there is **no NetClaw code in the call path**.
+`zabbix-metrics-history`'s procedure is the only thing preventing two silent-wrong-answer failures. An agent
+that ignores it will produce a confidently wrong answer and nothing will stop it.
+
+That was a deliberate clarification decision — smallest surface, upstream maintenance — and it is recorded
+here, in the skill, in the server README and in `TOOLS.md` rather than assumed away. **The corresponding
+"lesson carried forward" in the requirements checklist is left deliberately unticked**, because ticking it
+would hide the departure.
+
+**2. No per-call GAIT audit.**
+
+The upstream has no audit concept (`grep -c` → 0 across all six modules) and there is no platform-level MCP
+audit — `~/.openclaw/gait/` holds two files, both NetClaw-authored servers. This integration inherits the
+posture of every externally-sourced NetClaw integration.
+
+Acceptable **only because it is strictly read-only**: Principle IV bites on actions and configuration
+changes, and this performs neither. FR-038c requires that any future write path arrive with per-call audit
+*and* both gates, so this cannot quietly become a gap.
+
+## Per-capability status
+
+| Capability | Exercised against live NMS | Notes |
+|---|---|---|
+| Trap 1 — wrong value type returns empty, no error | ✅ **reproduced** | `zabbix[wcache,values,float]`: correct type → data; API default (3) → **0 rows, no error** |
+| Trap 1 scale | ✅ **measured** | **84 of 121** items are float. The default is wrong for the majority |
+| Trap 2 — types cannot be mixed | ✅ **reproduced** | 4 items, 2 returned each way, **overlap 0**, union 4 |
+| Retention states | ✅ **measured** | Three configurations present: `31d/365d` (106), `31d/0` (10), `0/0` (5) |
+| Never-collected ≠ no-data | ✅ | 57 monitored items have never returned a value — distinguishable via `lastclock` |
+| Three-way outcome distinction | ✅ **all three** | empty window → success+`[]`; bad token → auth error; dead endpoint → transport failure |
+| `problem.get` | ✅ live | 1 active problem in the lab; empty is a success, not an error |
+| `trend.get` returns hourly aggregates | ✅ **but thin** | Real rows with `value_min/avg/max/num`. **Only one hourly bucket** (19:00Z) — see below |
+| Read-only refusal | ✅ live | `host.delete` refused with `READ_ONLY=true` |
+| Deny-list holds with read-only OFF | ✅ live | `READ_ONLY=false host.delete` → *"Blacklist pattern `.*\.delete$` matched"*; `host.get` still allowed |
+| Venv isolation | ✅ measured | venv fastmcp **3.4.5**, system **2.14.7**, five `<3` pins still satisfied |
+| Manifest ≤ 5,000 tokens | ✅ **589** | Via real MCP handshake; 3-tool surface asserted stable |
+| Token/bearer auth | ✅ live | Real `token.create` + `token.generate`, end to end |
+
+**132 assertions across 5 suites, exit 0.**
+
+## Unverified, stated plainly
+
+| Item | Why | What would close it |
+|---|---|---|
+| **SC-003 — routing an aged-out window to trends** | The lab's raw history retention is **31 days** and it is ~1.5 hours old. **Nothing has aged out**, so the aged-out→trends *routing* was never exercised. What *is* verified is that `trend.get` returns real hourly aggregates. **My own live test asserted the weaker claim** ("hourly trend data is retrievable") and passed — the stronger SC-003 remains unverified, and the test is weaker than the criterion it is filed under | A lab running longer than the history retention, or an item with a deliberately short `history` |
+| **SC-004 — a window spanning the retention boundary** | Same cause: no boundary exists yet | Same |
+| **Interface counters from network gear** | FRR containers ship **no `snmpd`**, and the FortiGate's SNMP community was not configured. All metric verification used the **Zabbix server's own host** (121 items, 84 float) — real polled data from a real NMS, but **not from network equipment** | `snmpd` in the FRR images, or an SNMP community on the FortiGate |
+| **Zabbix 7.2+** | Tested on **7.0.29 LTS** only | A 7.2/7.4 lab |
+| **US2 problem lifecycle end-to-end** | A problem exists in the lab and is readable, but a deliberate raise-then-resolve cycle on network gear was not run (same `snmpd` gap) | Pollable gear |
+
+## Corrections to earlier claims in this feature
+
+Both came from research I repeated without verifying, and both are corrected in the spec with the
+correction visible rather than silently overwritten.
+
+| Claim | Reality |
+|---|---|
+| *"The candidate delegates auth to `pyzabbix`, which has a known bug"* | **Wrong.** It uses **`zabbix_utils` 2.0.4** — Zabbix LLC's own library (`client.py:6`). `pyzabbix` is not a dependency. The staleness risk is materially lower than the spec originally claimed |
+| *"The in-request auth property was removed in 7.2, so bearer is mandatory"* | **Imprecise.** On **7.0.29 both still work**. Removal lands in 7.2+. Bearer is required for **forward-compatibility**, not because the tested version rejects the alternative |
+
+## Blocking finding caught before it broke anything
+
+The candidate requires **fastmcp 3.x**. **Five NetClaw servers pin `fastmcp<3`** — `netbox-mcp-server`,
+`CiscoFMC-MCP-server-community`, `Wikipedia_MCP`, `rag-mcp`, `ISE_MCP`. Installing into the shared
+interpreter would have broken all five: spec 076's `cryptography` incident, verbatim.
+
+Found by FR-032's *test before adopting*, which is exactly what that requirement exists for. Resolved with a
+**dedicated virtualenv**, the precedent `multivendor-cli-mcp` already set. Isolation is asserted in
+`test_venv_isolation.py`, not assumed.
+
+Two related environment notes:
+
+- **`python3 -m venv` fails on this host** — no `ensurepip`. Spec 077's hazard #3, encountered live. The
+  installer uses `netclaw_venv_create`/`uv`, and a test asserts no executable line calls bare venv.
+- **`netclaw_pip_install` is deliberately NOT used here.** It targets the *system* interpreter — the exact
+  thing the venv protects. `reconcile-mcp.py` flagged this correctly; the fix was to name the target
+  interpreter explicitly (`uv pip install --python .../.venv/bin/python`), which satisfies the rule's actual
+  intent — *packages land in the interpreter the server runs under* — rather than adding an exception.
+
+## Upstream defects found, being reported (FR-034b)
+
+1. **The shipped launcher inverts the safe read-only default.**
+   `src/zabbix_mcp_server/utils.py:29` → `True`; `scripts/start_server.py:139` → **`False`**. Running it the
+   documented way enables writes. NetClaw forces the flag and adds a deny-list.
+2. **`fastmcp>=v3.2.0` is not a valid PEP 440 specifier** — stray `v`. `uv` tolerates it; stricter
+   resolvers may not.
+
+Neither is patched locally: the vendored tree is unmodified (SC-024a) and fixes go upstream.
+
+## iN2N (FR-041)
+
+**Not triggered — a decision, not an omission.** This is a read-only observability integration with a single
+credential; there is no member specialisation to justify the five member artifacts plus a mesh restart. If a
+member is ever given it, `docs/ADDING-AN-MCP.md`'s section applies in full.
+
+## Environment note
+
+The Zabbix lab runs under Docker Desktop's engine, which the default `docker` context on this host does not
+list — `docker ps` shows a different daemon's containers while the service answers normally on `:8888`.
+Recorded so a future reader does not conclude the lab was fabricated when `docker ps` comes back empty.
+
+## Checks
+
+| Check | Result |
+|---|---|
+| `bash tests/zabbix/run-tests.sh` (with lab) | ✅ **132 assertions, 5 suites, exit 0** |
+| `python3 scripts/reconcile-mcp.py` | ✅ exit 0 — all four surfaces |
+| `python3 scripts/verify-inventory-counts.py` | ✅ **212 skills / 156 integrations** |
+| `python3 scripts/check-dependency-pins.py` | ✅ exit 0 |
+| `trace-skill.py` × 3 | ✅ all resolve |
+| `node --check ui/netclaw-visual/server.js` | ✅ |
+| `bash -n scripts/lib/{catalog,install-steps}.sh` | ✅ |
+| Vendored tree unmodified, `LICENSE` intact | ✅ |

--- a/specs/083-zabbix-nms/checklists/requirements.md
+++ b/specs/083-zabbix-nms/checklists/requirements.md
@@ -1,0 +1,162 @@
+# Specification Quality Checklist: SNMP-poller NMS coverage (Zabbix)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+  - Zabbix API method names, endpoint shapes and the `pyzabbix` bug are deliberately **absent** from the
+    requirements. The behaviours they cause — a default value type that silently returns empty, retention
+    windows that silently truncate — are stated as *behaviours*, which is what makes them testable by
+    someone who has never read the API docs. Candidate tool counts and licences appear only as evidence for
+    the adopt-vs-build decision.
+- [x] Focused on user value and business needs
+  - Framed on the four questions NetClaw currently cannot answer at all: *is this normal / what did it do
+    overnight / how long has it been down / was it like this last Tuesday*.
+- [x] Written for non-technical stakeholders
+  - The three distinctions are stated in plain terms an operations manager would recognise.
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+  - Three genuine decisions were surfaced and **all three are now resolved** — see **Decisions taken in
+    clarification** below and the `## Clarifications` section of the spec.
+- [x] Requirements are testable and unambiguous
+  - 58 FRs. The hardest ones (FR-001 through FR-006a) are testable against a real lab by asking for a window
+    known to fall outside raw retention, and by choosing an item whose stored type differs from the API
+    default. Because they are now **skill obligations** rather than code invariants, they must be tested
+    end-to-end through an agent following the skill — asserting on the skill's text would prove nothing.
+- [x] Success criteria are measurable
+  - 30 SCs. SC-001 is checkable against the NMS's own UI; SC-005 and SC-010 are assertions on **wording**,
+    which is the only kind that catches a wording defect.
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+  - 4 user stories, 18 scenarios.
+- [x] Edge cases identified
+  - 7, including two that only exist for a monitoring system: **clock skew making a recent window look
+    empty**, and **a host that is monitored but has never returned a value** — a real finding that looks
+    identical to an absence.
+- [x] Scope is clearly bounded
+  - Five explicit boundaries (FR-045–FR-049) against Prometheus/Grafana, snmptrap-mcp, ipfix-mcp,
+    SaaS monitoring, and the device-reading skills. Out of Scope names eight exclusions.
+- [x] Dependencies and assumptions identified
+  - Including the one that will bite the schedule: **trends are hourly, so verifying them needs the lab to
+    have been polling for hours.**
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation leakage into specification
+
+## Constitutional Alignment
+
+- [x] **Principle I** (safety-first) — **strictly read-only, no write path at all** (FR-021). Read-only is
+      forced by NetClaw rather than inherited from an upstream default that is wrong in one of two places
+      (FR-021a), with a destructive-method deny-list as a second layer (FR-021b).
+- [x] **Principle III** (ITSM-gated changes) — **not applicable: there are no changes.** Recorded as a scope
+      decision, not an omission (FR-022). FR-023 requires that any future write arrive with both gates and a
+      NetClaw-owned layer, so writes cannot be enabled by flipping a flag.
+- [~] **Principle IV** (immutable GAIT audit) — **partially met, knowingly.** No per-call audit: adopting
+      as-is means no NetClaw code in the call path, and there is no platform-level MCP audit (measured —
+      `~/.openclaw/gait/` holds two files, both NetClaw-authored servers). This is the inherited posture of
+      every external integration. Principle IV bites on actions and configuration changes, and this
+      integration performs neither (FR-038b). The developer session log is unaffected (FR-038a), and
+      FR-038c blocks a future write path from arriving without audit. Recorded, not glossed.
+- [x] **Principle VII** (skill modularity) — FR-045–FR-049 keep this from absorbing the trap receiver, the
+      flow receiver, the SaaS monitors, or the device-reading skills.
+- [x] **Principle X** (observability) — the feature *is* observability, and FR-011/012 make its own answers
+      auditable: source, window actually served, and the NMS's own clock.
+- [x] **Principle XI** (artifact coherence) — FR-040–FR-044, including both HUD entries and curated profile
+      membership.
+- [x] **Principle XIII** (credential safety) — FR-028: no credential value in any response, log or audit
+      record. FR-029: TLS on by default.
+- [x] **Principle XVI** (spec-driven) — this document.
+- [x] **Principle XVII** (blog milestone) — waived by standing operator decision.
+
+## Lessons Carried Forward
+
+- [x] **Spec 076** — do not move a shared dependency version. FR-037.
+- [x] **Spec 077** — bound submodule-imported pins; use the pip helper, never bare pip. FR-035/036.
+- [x] **Spec 078** — record what was *not* exercised rather than claiming it. FR-050/052, SC-025. Also the
+      deeper 078 lesson: **an empty result is not a negative finding.** That is literally distinctions 1
+      and 2 here.
+- [x] **Spec 079** — *no probes ≠ outage* becomes *the poller cannot reach it ≠ the device is down*
+      (FR-007, distinction 3).
+- [x] **Spec 080** — the two-gate write pattern is **deliberately not built here** because there are no
+      writes (FR-022). The other 080 lesson does apply: **passing structural tests do not prove the payload
+      is populated**, which is why SC-001 checks values against the NMS's own UI rather than checking that a
+      list came back.
+- [x] **Spec 081** — typed outcome vocabulary rather than prose. FR-006's four distinguishable absences.
+- [ ] **Spec 082** — a guarantee that lives in prose is not a guarantee; put it at a chokepoint the caller
+      cannot route around. **This lesson is knowingly NOT applied here.** Adopt-as-is was chosen, so there is
+      no chokepoint and FR-001–FR-006 live in the skill. Left unchecked deliberately: it is the one carried
+      lesson this feature departs from, and marking it complete would hide that.
+
+## Notes
+
+### What makes this feature's central risk different
+
+Specs 078–082 each guarded a distinction where the wrong answer was at least *visible* — a tool returned
+something, and a reader could see what it said. Here, **the two primary failures return HTTP success and an
+empty list.** Nothing signals that a mistake was made. An engineer asks "what did this interface do last
+month?", gets nothing back, and reasonably concludes the interface was idle or the polling was broken —
+when in fact the data exists and NetClaw looked in the wrong place.
+
+That is why FR-001 through FR-006 are stated as obligations on *how the answer is obtained*, not merely on
+how it is worded — and why it matters that, following clarification, they are enforced by the skill rather
+than by a chokepoint.
+
+### The unusual build-vs-adopt shape
+
+R1, R3 and R9 all rejected community options on quality. R18 rejected one on licence. **This one has a
+genuinely good candidate** — three tools, ~823 tokens, 16% of the ceiling, and essentially the design
+NetClaw would have arrived at independently.
+
+The catch is structural rather than qualitative: a generic passthrough puts the value-type lookup and the
+history/trends routing in the caller's hands, which is exactly where they will eventually be skipped. That
+makes this the first feature where *adopt* and *protect the distinction* pulled in opposite directions —
+and, following clarification, the first where NetClaw chose adopt and accepted guidance-level enforcement.
+
+### Decisions taken in clarification (session 2026-08-03)
+
+All resolved. Nothing outstanding blocks `/speckit.plan`.
+
+1. **Adopt-vs-build** → **adopt `mpeirone/zabbix-mcp-server` as-is**, GPL-3.0, vendored unmodified with its
+   licence intact (FR-034a). The two traps are documented in the skill rather than enforced in code.
+   *Consequence, recorded rather than glossed:* FR-001–FR-006 become **skill obligations, not implementation
+   guarantees**. This is the first NetClaw integration whose core distinctions are enforced by guidance
+   (FR-033a) — a real departure from 080/081/082, bought for smallest-surface and upstream maintenance.
+2. **Write path** → **none at all.** R11 is strictly read-only (FR-021). Raised during clarification and
+   confirmed: adopt-as-is and gated-writes were **not simultaneously satisfiable**, because the upstream has
+   no approval, change-record or audit concept anywhere (verified by inspection — `grep -c` returns 0 across
+   all six modules) and enabling writes unlocks every write method at once. Adding writes later requires a
+   NetClaw-owned layer, and FR-023 records that so it cannot happen by flipping a flag.
+3. **Lab** → **operator-local, not committed** (FR-none; Assumptions + Out of Scope). The quickstart
+   documents the build. *Consequence:* the verification is reproducible only by someone who rebuilds the lab.
+
+### Findings from inspecting the adoption candidate
+
+Verified by cloning and reading the source, not from its README:
+
+- **The shipped launcher inverts the safe default.** `utils.py:29` defaults `READ_ONLY` to `True`;
+  `scripts/start_server.py:139` defaults it to `False`. Running it the documented upstream way **enables
+  writes**. NetClaw must force the flag itself (FR-021a) and add a destructive-method deny-list as a second
+  layer (FR-021b), because one of the two upstream defaults is already wrong.
+- **No gate machinery exists to hook into** — no approval, change-record, GAIT or audit concept in any
+  module. Its entire write control is one binary flag plus regex allow/deny lists.
+- **Read/write classification is a method-name prefix heuristic** (`get`, `version`, `check`, `export`), not
+  a curated list.
+- The launcher bug is to be **reported upstream** (FR-034b) rather than quietly worked around.
+
+### Deferred to planning (not clarification-blocking)
+
+- **Result bounds** — that a bound exists and is stated is fixed (FR-014, SC-017); the specific numbers
+  depend on measured payload sizes.
+- **Whether an iN2N member gets this** — FR-041 is conditional and already enumerates the obligation.
+- **Netdata** — explicitly out of scope here, recorded as a separate near-zero-effort candidate, and the
+  roadmap's inaccurate "Cloud MCP" wording to be corrected.

--- a/specs/083-zabbix-nms/contracts/mcp-tools.md
+++ b/specs/083-zabbix-nms/contracts/mcp-tools.md
@@ -1,0 +1,58 @@
+# Tool Contract — `zabbix-mcp` (spec 083 / R11)
+
+**Adopted, not authored.** `mpeirone/zabbix-mcp-server`, GPL-3.0, pinned `0722f48`, vendored **unmodified**.
+Runs from a **dedicated virtualenv** (needs fastmcp 3.x; five repo servers pin `<3`).
+
+**Manifest measured 589 tokens** (2,234 chars) — 11.8% of the 5,000 ceiling, via a live MCP handshake.
+
+## The three tools
+
+| Tool | Purpose |
+|---|---|
+| `zabbix_api(method, params)` | Generic JSON-RPC passthrough to any allowed Zabbix method |
+| `zabbix_api_docs(method)` | Upstream documentation for a method |
+| `zabbix_api_list(object)` | Available methods for an object |
+
+## What NetClaw controls, and what it does not
+
+| | |
+|---|---|
+| **Controls** | `READ_ONLY=true` **forced by NetClaw** (the upstream launcher defaults it to `false` — measured); a destructive-method deny-list; TLS verification; the venv; the credentials |
+| **Does NOT control** | the tool surface, the request shape, whether the correct `value_type` is used, whether history or trends is queried |
+
+**That second row is the whole risk.** There is no chokepoint between the agent and the API, so FR-001–FR-006
+are enforced by the skills. A caller that ignores them gets a wrong answer and nothing stops it. Recorded as
+a first for NetClaw (FR-033a).
+
+## Verified behaviour (live Zabbix 7.0.29)
+
+```
+zabbix_api(host.get)     → [{"hostid":"10084","host":"Zabbix server"}]
+zabbix_api(host.delete)  → REFUSED: "Server is in read-only mode ..."
+```
+
+Read/write classification is a **method-name prefix heuristic** (`get`, `version`, `check`, `export`) — not a
+curated list. A future read method not matching those prefixes would be wrongly refused; a write method that
+did match would be wrongly allowed. The deny-list is the second layer for exactly that reason.
+
+## The methods the skills use
+
+| Need | Method | Trap |
+|---|---|---|
+| Inventory | `host.get` (+`selectInterfaces`/`selectTags`), `hostgroup.get` | — |
+| Item discovery | `item.get` → **`value_type`, `history`, `trends`** | **must precede any history call** |
+| Recent metrics | `history.get` | **`value_type` defaults to 3; 84/121 items are 0** |
+| Older metrics | `trend.get` | hourly min/avg/max; numeric only; empty for <1h-old installs |
+| Current problems | `problem.get` | empty is legitimate, ≠ unreachable |
+| Problem history | `event.get` | heavier |
+| Availability | `host.get` interface `available` + `problem.get` | one poller's view |
+
+## What this integration will not do
+
+- **No writes, at all** — acknowledging, enabling/disabling hosts, maintenance windows. Clarification
+  decision; adding any requires a NetClaw-owned layer carrying both gates *and* per-call audit (FR-023,
+  FR-038c).
+- **No NMS configuration** — hosts, templates, triggers, items.
+- **No per-call GAIT** — inherited limitation, acceptable only because this is read-only (FR-038).
+- **No trap or flow reception** — `snmptrap-mcp` and `ipfix-mcp` own those.
+- **No current device state** — `pyats`, `multivendor-cli`, `fortinet` own that.

--- a/specs/083-zabbix-nms/data-model.md
+++ b/specs/083-zabbix-nms/data-model.md
@@ -1,0 +1,70 @@
+# Data Model — SNMP-poller NMS coverage (spec 083 / R11)
+
+**Date**: 2026-08-03 · Derived from spec.md Key Entities + research.md D5/D6/D7
+
+No database, no NetClaw-authored types. The NMS holds everything. What follows is the model **the skills
+must reason with** — and getting it wrong is exactly how the two silent-wrong-answer traps happen.
+
+---
+
+## 1. Collected item — the type that decides everything
+
+| Field | Values | Why it matters |
+|---|---|---|
+| `value_type` | 0 float · 1 char · 2 log · **3 unsigned** · 4 text · 5 binary | **The API defaults to 3.** Measured: 84 of 121 stock items are 0. Query with the wrong one and you get an empty array and no error |
+| `history` | e.g. `31d`, or **`0`** | `0` = raw values are **never stored** |
+| `trends` | e.g. `365d`, or **`0`** | `0` = **no hourly aggregates at all** |
+| `units`, `key_`, `itemid`, `hostid` | | |
+
+**Three retention states, measured on a stock install (D7):**
+
+| `history` | `trends` | Count | What is answerable |
+|---|---|---|---|
+| `31d` | `365d` | 106 | recent → raw; older → hourly |
+| `31d` | `0` | 10 | **only the last 31d.** Older is *not retained*, not *absent* |
+| `0` | `0` | 5 | **nothing.** Collected purely to fire triggers |
+
+The spec originally modelled two windows. There are **three states per window**, and the difference between
+"aged out" and "never retained" is a configuration fact the reader needs.
+
+---
+
+## 2. Data absence — five causes, five different answers
+
+This is the model FR-006/FR-006b exist to protect. All five look identical over the wire: an empty array.
+
+| Cause | How to tell | How it must read |
+|---|---|---|
+| **Wrong value type** | the item's `value_type` ≠ the one queried | never reaches the user — split and re-query |
+| **Aged out** | window predates `history`, and `trends` > 0 | *"beyond raw retention; here is the hourly data"* |
+| **Retention disabled** | `history=0` and/or `trends=0` | *"this item does not retain that"* — a config fact |
+| **Never collected** | item exists, no values ever, `lastclock` empty | *"monitored but has never returned a value"* — a real finding |
+| **Genuinely idle** | data exists, values are zero | *"zero throughput"* — the only one that means nothing happened |
+
+---
+
+## 3. Data window
+
+Requested range, **range actually served**, and which source served each part. A query spanning the
+retention boundary is served by both and must say so — a peak from raw values and a peak from an hourly
+average are different claims.
+
+---
+
+## 4. Problem
+
+`severity` · `host` · `onset` · `duration` · `acknowledged` · `resolved_at`.
+
+`problem.get` returns **current** problems from a dedicated table; `event.get` is the historical, heavier
+path. An empty problem list is a legitimate answer and must never read like an unreachable NMS.
+Acknowledgement is a workflow fact, never evidence the condition cleared.
+
+---
+
+## 5. Availability observation
+
+`state` · **`observed_at`** · `vantage_point` · `interval`.
+
+Never rendered as "the device is up/down". Always "the NMS could/could not reach it, as of <time>".
+A device the NMS does not monitor is a **fourth** state, distinct from unreachable — and the most common
+cause of surprise.

--- a/specs/083-zabbix-nms/plan.md
+++ b/specs/083-zabbix-nms/plan.md
@@ -1,0 +1,197 @@
+# Implementation Plan: SNMP-poller NMS coverage (Zabbix)
+
+**Branch**: `083-zabbix-nms` | **Date**: 2026-08-03 | **Spec**: [spec.md](./spec.md)
+**Roadmap**: R11, Tier 2
+
+## Summary
+
+NetClaw has **no SNMP-poller NMS** and therefore **no polled history anywhere** — it receives syslog, traps
+and flows, all of which arrive when something happens, and can answer nothing about what a thing was doing
+over time. This adds that layer.
+
+**Approach: adopt, don't build** — the first time this roadmap has landed there. `mpeirone/zabbix-mcp-server`
+collapses the whole Zabbix API into three tools and measures **589 tokens, 11.8% of the ceiling**. It is
+vendored unmodified, GPL-3.0 intact, invoked over stdio as a separate program, and run **from a dedicated
+virtualenv** because it needs fastmcp 3.x while five servers here pin `<3`.
+
+The NetClaw-authored deliverable is therefore **the skills**, not a server. That is where the entire value
+of this feature lives, because the two silent-wrong-answer traps are enforced by guidance — a deliberate
+departure from 080/081/082, recorded as such.
+
+**Everything claimed here was measured against a live Zabbix 7.0.29** stood up for the purpose. Both traps
+reproduce; a third retention state was discovered that the spec had not modelled.
+
+## Technical Context
+
+**Language/Version**: Python 3.10+. The vendored server runs from **its own virtualenv**; NetClaw authors no
+Python for this feature.
+
+**Primary Dependencies** — all inside the dedicated venv, none touching the system interpreter:
+
+| Package | Resolved | Note |
+|---|---|---|
+| `fastmcp` | **3.4.5** | **The reason for the venv.** Five repo servers pin `<3` |
+| `mcp` | 1.29.0 | |
+| `zabbix_utils` | 2.0.4 | Zabbix LLC's own library — **not** `pyzabbix` (research D3) |
+| `beautifulsoup4`, `requests`, `python-dotenv` | 4.15.0 / 2.34.2 / — | |
+
+**Storage**: none. The NMS holds the history.
+
+**Testing**: `tests/zabbix/run-tests.sh` — plain Python, stdlib only, following `tests/bgp-intel/`. Because
+the guarantees live in the skill rather than in code, the suites split into two kinds: **static** checks on
+the skill and configuration (does read-only get forced? does the skill contain a followable procedure?) and
+**live** checks against the lab (does following the procedure produce the right answer?).
+
+**Target Platform**: Linux, stdio MCP invoked by OpenClaw from a dedicated venv.
+
+**Project Type**: Vendored third-party server + NetClaw-authored skills. Closest precedent:
+`multivendor-cli-mcp` (spec 076) for the venv, `chrome-devtools-mcp` (spec 048) for the adoption posture.
+
+**Performance Goals**: not latency-sensitive. Bounds on result size, stated in the response.
+
+**Constraints**: manifest ≤ 5,000 tokens (**measured 589**); strictly read-only; no credential in any output;
+no system-interpreter dependency movement.
+
+**Scale/Scope**: 3 upstream tools, 3–4 skills, 1 vendored dir, ~5 test suites.
+
+## Constitution Check
+
+*GATE: passed before Phase 0; re-checked after Phase 1 below.*
+
+| Principle | Status | How |
+|---|---|---|
+| **I. Safety-First (NON-NEGOTIABLE)** | ✅ | Strictly read-only (FR-021). Read-only **forced by NetClaw** rather than inherited, because the upstream launcher's default is inverted (measured, D10). Destructive-method deny-list as a second layer. |
+| **II. Read-Before-Write** | ✅ n/a | There is no write. |
+| **III. ITSM-Gated Changes** | ✅ n/a | No changes exist to gate. Recorded as a scope decision (FR-022); FR-023 requires that any future write arrive with both gates *and* a NetClaw-owned layer, so it cannot be enabled by flipping a flag. |
+| **IV. Immutable Audit Trail** | ⚠️ **partial, knowingly** | No per-call GAIT: adopting as-is puts no NetClaw code in the call path, and there is no platform-level MCP audit (measured — two files, both NetClaw-authored servers). This is the inherited posture of every external integration. Principle IV bites on actions and configuration changes; this performs neither. FR-038a–c. See Complexity Tracking. |
+| **V. MCP-Native Integration** | ✅ | stdio, registered with repo-relative paths. |
+| **VI. Multi-Vendor Neutrality** | ✅ | Zabbix is itself vendor-neutral — it polls whatever speaks SNMP. |
+| **VII. Skill Modularity** | ✅ | Five boundaries (FR-045–049) against Prometheus/Grafana, the trap receiver, the flow receiver, the SaaS monitors, and the device-reading skills. |
+| **VIII. Verify After Every Change** | ✅ | Every capability exercised against a live NMS polling real devices; FR-050–052 require stating what was not. |
+| **IX. Security by Default** | ✅ | TLS on by default (FR-029); no credential in output (FR-028); read-only forced; deny-list. |
+| **X. Observability** | ✅ | The feature *is* observability. FR-011/012 make its own answers auditable — source, window actually served, and the NMS's own clock. |
+| **XI. Artifact Coherence (NON-NEGOTIABLE)** | ✅ | FR-040–044, both HUD entries, curated profile membership, SOUL capability section. |
+| **XII. Documentation-as-Code** | ✅ | spec, research, data-model, contracts, quickstart, skills, server README, TOOLS.md, VERIFICATION.md. |
+| **XIII. Credential Safety** | ✅ | Token in `.env` only; FR-028 forbids it appearing anywhere. |
+| **XIV. Human-in-the-Loop for External Comms** | ✅ | Reads only; sends nothing. |
+| **XV. Backwards Compatibility** | ✅ | **The venv exists to guarantee this.** FR-037c requires proving the five `<3`-pinned servers still resolve after installation. |
+| **XVI. Spec-Driven Development** | ✅ | specify → clarify (3 Q + 1 conflict raised) → plan → tasks → analyze → implement. |
+| **XVII. Milestone Documentation** | ⏭️ **waived** | Standing operator decision. |
+
+### Artifact Coherence Checklist — mapped
+
+| Item | Target |
+|---|---|
+| README.md | MCP table row, skill rows, 4 count sites → 156 / 209+N |
+| `catalog.sh` | `zabbix\|Observability\|Zabbix NMS\|…` + `PROFILE_OBSERVABILITY` |
+| `install-steps.sh` | `component_install_zabbix()` — **venv-based**, `uv venv` / helper, never bare `python3 -m venv` |
+| `verify-catalog-coverage.py` | passes (vendored dir needs a recorded state) |
+| `ui/netclaw-visual/server.js` | **two** entries |
+| SOUL.md | capability section + 2 count sites |
+| skills | `zabbix-metrics-history`, `zabbix-problem-review`, `zabbix-availability` |
+| `.env.example` | `ZABBIX_URL`, `ZABBIX_TOKEN`, `READ_ONLY`, `VERIFY_SSL`, deny-list, `ZABBIX_MCP_CMD` |
+| TOOLS.md | `## Zabbix NMS (vendored, third-party GPL-3.0)` |
+| `config/openclaw.json` | `zabbix-mcp` pointing at the **venv interpreter** |
+| `mcp-servers/zabbix-mcp/README.md` | NetClaw-authored README beside the vendored tree |
+| `.gitignore` | negation for the vendored dir |
+| GAIT session log | recorded |
+| Blog | waived |
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/083-zabbix-nms/
+├── plan.md · spec.md · research.md · data-model.md · quickstart.md
+├── contracts/mcp-tools.md
+├── checklists/requirements.md
+├── VERIFICATION.md
+└── tasks.md
+```
+
+### Source
+
+```text
+mcp-servers/zabbix-mcp/
+├── vendor/zabbix-mcp-server/     # GPL-3.0, UNMODIFIED, pinned 0722f48, LICENSE verbatim
+├── requirements.txt              # what the dedicated venv installs
+├── NOTICE.md                     # third-party licence notice (FR-034a)
+└── README.md                     # NetClaw-authored: limits, boundaries, the two traps
+
+workspace/skills/
+├── zabbix-metrics-history/SKILL.md    # US1 — THE critical artifact; both traps live here
+├── zabbix-problem-review/SKILL.md     # US2
+└── zabbix-availability/SKILL.md       # US3 + US4 (inventory is the enabler, not a story)
+
+tests/zabbix/
+├── run-tests.sh
+├── test_readonly_forced.py     # static: NetClaw forces it; deny-list present; launcher default NOT trusted
+├── test_venv_isolation.py      # static: five <3-pinned servers unaffected  (FR-037c)
+├── test_skill_procedure.py     # static: the skill contains a FOLLOWABLE procedure, not just warnings
+├── test_live_traps.py          # LIVE: both traps + the five absences against the lab
+└── test_manifest_size.py       # measured ≤ 5,000
+
+# Modified
+config/openclaw.json · scripts/lib/catalog.sh · scripts/lib/install-steps.sh
+ui/netclaw-visual/server.js · README.md · SOUL.md · TOOLS.md · .env.example · .gitignore
+docs/COVERAGE-ROADMAP.md      # R11 status + correct the Netdata "Cloud MCP" claim
+```
+
+**Structure Decision**: vendored-unmodified third-party server in a dedicated venv, with NetClaw-authored
+skills as the actual deliverable. Four servers or a wrapper were both rejected in clarification.
+
+## Implementation Phases
+
+| Phase | Content | Gate |
+|---|---|---|
+| **A. Vendor + isolate** | Vendor at the pinned rev with LICENSE and NOTICE; `requirements.txt`; venv install path; force read-only; deny-list | Server answers live Zabbix from the venv; five `<3` servers still resolve (FR-037c) |
+| **B. US1 skill (P1)** | `zabbix-metrics-history` — the value-type procedure, the retention router, the **five** absences | An agent following it gets right answers on float items and beyond-retention windows |
+| **C. US2 skill (P1)** | `zabbix-problem-review` | A real problem raised in the lab is reported correctly; empty ≠ unreachable |
+| **D. US3+US4 skill (P2/P3)** | `zabbix-availability` — the "poller says" discipline + inventory | Stopping an FRR container produces a transition; wording never says "the device is down" |
+| **E. Tests** | 5 suites, static + live | `run-tests.sh` exit 0 |
+| **F. Artifacts** | All Principle XI surfaces + roadmap corrections | `reconcile-mcp.py` exit 0; counts updated |
+| **G. Honest verification** | `VERIFICATION.md`; report both upstream defects | Per-capability table; trends marked unverified if the window has not elapsed |
+
+Phase A is blocking. B, C and D are independent. **Trend verification must be started early** (D8: trends
+need hours) — the lab should be polling from Phase A onward so Phase G has real aggregates.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| **Principle IV only partially met** — no per-call GAIT | Adopt-as-is puts no NetClaw code in the call path, and there is no platform-level MCP audit. Confirmed inherited posture of every external integration. | A wrapper would provide audit **and** the two gates **and** the structural routing — and was explicitly declined in clarification in favour of the smallest surface. Mitigated: read-only means no operation to audit (FR-038b); FR-038c blocks a future write path from arriving without audit. |
+| **The three distinctions enforced by guidance, not structure** | Same clarification decision. A generic passthrough has no chokepoint. | Every alternative (wrapper, build) was declined. Mitigated by FR-006a — the skill must contain a *followable procedure*, not warnings — and by live tests that exercise the procedure end-to-end rather than asserting on skill text. **Recorded as a first for NetClaw (FR-033a), and the corresponding checklist lesson is left deliberately unticked.** |
+| **A dedicated virtualenv** | Not optional: the candidate needs fastmcp 3.x and **five servers pin `<3`**. Measured. | Installing into the shared interpreter breaks five servers — spec 076's `cryptography` incident verbatim. Precedent already exists (`multivendor-cli-mcp`). |
+| **Vendoring GPL-3.0 into an Apache-2.0 repo** | Adoption was chosen; this is the candidate. | Not a permission question — stdio invocation is not linkage. Mitigated by FR-034a: unmodified, licence verbatim, marked third-party, changes go upstream. |
+
+## Post-Design Constitution Re-Check
+
+Re-evaluated after Phase 0. **No new violations, and one downgrade caught early.**
+
+1. **Principle XV moved from "assumed fine" to "actively guaranteed."** Phase 0 found the fastmcp conflict
+   *before* anything was installed, which is precisely what FR-032's test-before-adopting exists for. The
+   venv is now a requirement (FR-037a–c) with a proof obligation attached, rather than a discovery made
+   after breaking five servers.
+
+2. **Principle I gained a concrete threat.** The upstream launcher defaults read-only to **False** while the
+   library defaults it to **True**. Neither the spec nor the prior research anticipated that. Read-only is
+   now forced by NetClaw and backed by a deny-list, because depending on which upstream default wins is not
+   a security posture.
+
+3. **Two of my own prior claims were wrong and are corrected in place** — the `pyzabbix` dependency (it is
+   `zabbix_utils`) and the auth-removal version (7.2+, not 7.0). Both came from research I repeated without
+   verifying. They are corrected in the spec with the correction visible, not silently overwritten, because
+   a reader who saw the earlier reasoning deserves to know it changed.
+
+## Artifacts Generated
+
+| File | Phase |
+|---|---|
+| `research.md` | 0 — 14 findings, all measured against live Zabbix 7.0.29 |
+| `data-model.md` | 1 — the entities the skills reason about |
+| `contracts/mcp-tools.md` | 1 — the upstream surface, documented as adopted |
+| `quickstart.md` | 1 — lab setup (operator-local), the traps, the boundaries |
+| `plan.md` | this file |
+
+**Next**: `/speckit.tasks`.

--- a/specs/083-zabbix-nms/quickstart.md
+++ b/specs/083-zabbix-nms/quickstart.md
@@ -1,0 +1,108 @@
+# Quickstart — Zabbix NMS (spec 083 / R11)
+
+Polled history: what an interface *was* doing, how long something has been down, whether this is normal.
+
+## The lab is yours to run (not shipped)
+
+Decided in clarification: NetClaw does not ship an NMS. Stand one up:
+
+```bash
+mkdir zlab && cd zlab && cat > compose.yaml <<'YAML'
+services:
+  zdb:
+    image: postgres:16-alpine
+    environment: {POSTGRES_USER: zabbix, POSTGRES_PASSWORD: changeme, POSTGRES_DB: zabbix}
+    healthcheck: {test: ["CMD-SHELL","pg_isready -U zabbix"], interval: 5s, retries: 20}
+  zserver:
+    image: zabbix/zabbix-server-pgsql:alpine-7.0-latest
+    environment: {DB_SERVER_HOST: zdb, POSTGRES_USER: zabbix, POSTGRES_PASSWORD: changeme, POSTGRES_DB: zabbix}
+    depends_on: {zdb: {condition: service_healthy}}
+    ports: ["10051:10051"]
+  zweb:
+    image: zabbix/zabbix-web-nginx-pgsql:alpine-7.0-latest
+    environment: {ZBX_SERVER_HOST: zserver, DB_SERVER_HOST: zdb, POSTGRES_USER: zabbix,
+                  POSTGRES_PASSWORD: changeme, POSTGRES_DB: zabbix, PHP_TZ: UTC}
+    depends_on: [zserver]
+    ports: ["8888:8080"]
+YAML
+docker compose up -d
+```
+
+Healthy in ~40s. **Port 8080 is often already taken** — this uses 8888. Default login `Admin` / `zabbix`;
+change it. Then Users → API tokens → create one.
+
+Add your devices as SNMP hosts and **let it poll for a few hours** before expecting trend data.
+
+## Install
+
+```bash
+./scripts/install.sh          # select "zabbix"
+```
+
+It builds a **dedicated virtualenv**. That is not optional: this server needs fastmcp 3.x while five other
+NetClaw servers pin `<3`, so a shared install would break them.
+
+## Environment
+
+```bash
+ZABBIX_URL=http://localhost:8888
+ZABBIX_TOKEN=                 # API token, not a password
+READ_ONLY=true                # FORCED by NetClaw. The upstream launcher defaults it to false
+VERIFY_SSL=true
+ZABBIX_API_BLACKLIST=         # destructive-method deny-list, second layer
+```
+
+## The two traps — read this before trusting an empty answer
+
+### 1. An empty result is usually the wrong question
+
+`history.get` takes a value type and **defaults to unsigned (3)**. On a stock install **84 of 121 items are
+float (0)**. Ask with the default and you get `[]` — **no error**, no warning, just nothing.
+
+**Always call `item.get` first** and read the item's real `value_type`. Types **cannot be mixed** in one
+call: a query across float and unsigned items returns only one kind, silently dropping the rest.
+
+### 2. Empty also means "you looked in the wrong place"
+
+Raw history is kept for ~31 days; hourly aggregates for a year or more. A 40-day question against raw
+history returns nothing. `item.get` tells you both retentions — **read them and route**.
+
+And retention can be **switched off**: `history=0` means raw values are never stored; `trends=0` means no
+aggregates at all. Five items on a stock install have both. That is a *configuration fact*, not an absence.
+
+### The five reasons you get nothing back
+
+| | Means |
+|---|---|
+| wrong value type | your query was wrong — re-ask |
+| aged out | beyond raw retention — use trends |
+| retention disabled | this item does not keep that |
+| never collected | monitored but never returned a value — **a real finding** |
+| genuinely idle | zero. The only one that means nothing happened |
+
+## Try it
+
+> *"What did port1 on the FortiGate do overnight?"*
+> *"What's broken right now, and how long has it been broken?"*
+> *"Has netclaw-edge1 been flapping?"*
+> *"What is Zabbix actually monitoring?"*
+
+## Two limits, stated up front
+
+**The guarantees are in the skill, not in the code.** This server is a generic passthrough — nothing
+structurally prevents the two traps above. That is a deliberate trade (smallest surface, upstream
+maintenance) and a first for NetClaw. Follow the skill.
+
+**No per-call audit trail.** The adopted server has no audit concept and there is no platform-level MCP
+audit. Acceptable only because this is strictly read-only — there is no operation to record.
+
+## Boundaries
+
+| Want to… | Use |
+|---|---|
+| Receive traps | `snmptrap-mcp` — that's push; this polls |
+| Flow records | `ipfix-mcp` — flows, not counters |
+| Metrics you instrumented | `prometheus`, `grafana` |
+| SaaS monitoring | `auvik`, `thousandeyes`, `datadog` |
+| **Current** device state | `pyats`, `multivendor-cli`, `fortinet` — this answers what it *was* |
+| Change anything in Zabbix | nothing here. Read-only by design |

--- a/specs/083-zabbix-nms/research.md
+++ b/specs/083-zabbix-nms/research.md
@@ -1,0 +1,266 @@
+# Phase 0 Research — SNMP-poller NMS coverage (spec 083 / roadmap R11)
+
+**Date**: 2026-08-03 · **Branch**: `083-zabbix-nms`
+
+Everything below was **measured against a live Zabbix 7.0.29** stood up for this purpose and polling real
+data, and against the adoption candidate actually installed and run. Where a measurement contradicts the
+spec or the prior research, the contradiction is stated rather than smoothed over — and **three do**.
+
+---
+
+## D1 — The lab, stood up and used
+
+```
+zabbix/zabbix-server-pgsql:alpine-7.0-latest + postgres:16-alpine + zabbix-web-nginx-pgsql
+→ apiinfo.version: 7.0.29 · web on :8888 · healthy in ~40s
+```
+
+Port 8080 was already allocated on this host, so the lab uses **8888**. Worth recording: the quickstart must
+not assume 8080 is free.
+
+Auth: a real API token created via `token.create` + `token.generate`, verified end to end.
+
+---
+
+## D2 — BLOCKING: the candidate requires `fastmcp` 3.x, and five servers pin `<3`
+
+**Measured.** `mpeirone/zabbix-mcp-server` declares:
+
+```toml
+dependencies = ["fastmcp>=v3.2.0", "zabbix_utils>=2.0.4", "python-dotenv>=1.2.2",
+                "bs4>=0.0.2", "requests>=2.33.1"]
+```
+
+Installed in an isolated venv it resolves **fastmcp 3.4.5** and **mcp 1.29.0**. The system interpreter has
+**fastmcp 2.14.7**.
+
+**Five servers in this repo pin `fastmcp<3`:**
+
+```
+netbox-mcp-server · CiscoFMC-MCP-server-community · Wikipedia_MCP · rag-mcp · ISE_MCP
+```
+
+`rag-mcp`'s bound was added *by the previous feature* (spec 082). Installing this candidate into the shared
+interpreter would force 2.14.7 → 3.4.5 and break all five declared constraints. **That is FR-037 and spec
+076's `cryptography` incident, exactly.**
+
+**Decision: a dedicated virtualenv**, following the precedent this repo already set —
+`multivendor-cli-mcp` (spec 076) runs from its own venv because napalm/netmiko resolve cryptography 49.x
+while NCFED's X.509 stack needs 46.x. Same shape, same fix.
+
+**Verified working**: installed into a venv, the server starts, completes an MCP handshake, and answers
+against live Zabbix. Zero conflicts with the system interpreter.
+
+Note the upstream specifier `fastmcp>=v3.2.0` carries a stray `v` and is not valid PEP 440. `uv` tolerates
+it; stricter resolvers may not. Recorded as an upstream defect (see D12).
+
+---
+
+## D3 — CORRECTION: it does **not** use `pyzabbix`
+
+The spec's FR-032 says the candidate *"delegates authentication to a library with a known bug against
+exactly the version this targets (pyzabbix#226)."*
+
+**That is wrong, and it came from prior research I repeated without verifying.** Measured:
+
+```
+src/zabbix_mcp_server/client.py:6 →  from zabbix_utils import ZabbixAPI
+```
+
+It uses **`zabbix_utils` 2.0.4 — Zabbix LLC's own official Python library**, not the third-party `pyzabbix`.
+`pyzabbix` is not installed and is not a dependency.
+
+**Consequence**: the staleness risk is materially lower than the spec claims. FR-032's *requirement* (test
+before adopting) stands and has been satisfied; its stated *rationale* must be corrected.
+
+---
+
+## D4 — CORRECTION: in-body `auth` still works on 7.0
+
+The spec says the in-request credential property was *"deprecated in 6.4 and removed in 7.2"*, and treats
+this as a reason Bearer auth is mandatory. Measured on **7.0.29**:
+
+| Auth style | Result |
+|---|---|
+| In-body `"auth": <session>` | **WORKS** |
+| `Authorization: Bearer <token>` | **WORKS** |
+
+Removal lands in **7.2+**; 7.0 is LTS and still accepts both. So Bearer is required for
+**forward-compatibility**, not because 7.0 rejects the alternative. The requirement is unchanged; the
+justification needs precision, and the verification report must state **which version was tested**.
+
+---
+
+## D5 — Trap 1 confirmed, on real data
+
+The flagship claim, measured against a real float item that genuinely has values:
+
+```
+item: zabbix[wcache,values,float]   value_type=0 (float)   history=31d trends=365d
+
+  history.get with value_type=0  (correct)  →  1 point,  value 0.6826832627489122
+  history.get with value_type=3  (default)  →  0 points, NO ERROR
+```
+
+**Value-type distribution on a stock install: 84 of 121 items are float (value_type=0).** The API default is
+`3`. So the naive call is wrong for the **majority** of items, and it fails silently.
+
+This is the single most important finding in this research, and it is not theoretical.
+
+---
+
+## D6 — Trap 2 confirmed: types cannot be mixed
+
+Four items — two float, two unsigned — **all verified to have data first**, then queried together:
+
+```
+one call, history=0  →   4 rows from 2 of 4 items
+one call, history=3  →   6 rows from 2 of 4 items
+union 4 of 4 · overlap 0
+```
+
+No single call returns all four, and **each half silently omits the other's items with no error**. A
+mixed-type query must be split per type and the results merged.
+
+*Method note*: the first attempt at this test picked items with no recent data and returned 0/0 — which
+would have "confirmed" the trap for entirely the wrong reason. It was rerun against items proven to have
+values. An inconclusive test that happens to agree with the hypothesis is worse than no test.
+
+---
+
+## D7 — NEW: a third retention case the spec missed
+
+The spec models retention as "history window vs trends window". Measured, a stock install has **three**
+configurations:
+
+| `history` | `trends` | Items | Meaning |
+|---|---|---|---|
+| `31d` | `365d` | 106 | the normal case the spec describes |
+| `31d` | **`0`** | 10 | **no aggregates at all** — the history window is the only answerable range |
+| **`0`** | **`0`** | 5 | **nothing is retained** — the item is collected purely to fire triggers |
+
+So `history=0` means raw values are **never stored**, and `trends=0` means there is **no long-term data**.
+A router that reads "no data for 40 days ago" must be able to distinguish *aged out* from *never retained*,
+and the second is a configuration fact, not an absence.
+
+**This adds a fifth cause of absence** to FR-006's four, and the skill must cover it.
+
+---
+
+## D8 — Trends need elapsed time, confirmed
+
+```
+trend.get on a <1h-old install → 0 rows, no error
+```
+
+Trends are written hourly. The scheduling constraint the spec anticipated is real: **verifying trend-based
+answers requires the lab to have been polling for hours.** Planning must sequence this, and if the window
+has not elapsed at verification time, FR-051 requires recording it as unverified rather than claiming it.
+
+---
+
+## D9 — Manifest measured: 589 tokens
+
+Via a real MCP handshake against the running server:
+
+```
+TOOLS (3): zabbix_api, zabbix_api_docs, zabbix_api_list
+MANIFEST: 2,234 chars ≈ 589 tokens  →  11.8% of the 5,000 ceiling
+```
+
+Better than the ~823 the prior research estimated. This is the smallest surface NetClaw has added for an
+entire product category.
+
+---
+
+## D10 — Read-only works; the launcher default is inverted
+
+Against live Zabbix with `READ_ONLY=true`:
+
+```
+zabbix_api(host.get)     →  [{"hostid":"10084","host":"Zabbix server"}]
+zabbix_api(host.delete)  →  REFUSED: "Server is in read-only mode ..."
+```
+
+The refusal works. But the default does not:
+
+```
+src/zabbix_mcp_server/utils.py:29        READ_ONLY default True
+scripts/start_server.py:139              READ_ONLY default False   ← the shipped launcher
+```
+
+**Running it the documented upstream way enables writes.** NetClaw must set the flag itself (FR-021a) and
+add a destructive-method deny-list as a second layer (FR-021b), because one of the two upstream defaults is
+already wrong and we should not depend on which one wins.
+
+Read/write classification is a **method-name prefix heuristic** (`get`, `version`, `check`, `export`), not a
+curated list — worth knowing, because a future Zabbix read method that does not match those prefixes would
+be refused, and a write method that does would not be.
+
+---
+
+## D11 — `python3 -m venv` fails on this host
+
+```
+python3 -m venv zvenv  →  "Failing command: .../zvenv/bin/python3"  (no ensurepip)
+uv venv zvenv          →  works
+```
+
+This is **hazard #3 from spec 077's own docstring**, encountered live. The installer must use
+`netclaw_venv_create` / `uv venv`, never bare `python3 -m venv` — and `check-dependency-pins.py` already
+scans for exactly this.
+
+---
+
+## D12 — Upstream defects found, to be reported
+
+Two, both worth sending upstream rather than silently working around (FR-034b):
+
+1. **The launcher inverts the safe `READ_ONLY` default** (D10) — a security-relevant discrepancy between
+   the library and the shipped entrypoint.
+2. **`fastmcp>=v3.2.0` is not a valid PEP 440 specifier** (D2) — the `v` prefix will break stricter
+   resolvers.
+
+Spec 081 established that being a good citizen of free infrastructure is part of how NetClaw behaves.
+Benefiting from a hazard while not telling the maintainer is not that.
+
+---
+
+## D13 — Licence and vendoring
+
+GPL-3.0, confirmed (`LICENSE` = GNU GPL v3). Vendored **unmodified**, licence retained verbatim, marked as
+third-party and separately licensed, invoked over stdio as a separate program (FR-034a). Never edited in
+place — any change goes upstream.
+
+Pinned revision: **`0722f48`, 2026-05-10, "Feature/v2"**.
+
+---
+
+## D14 — No audit, as expected
+
+```
+grep -c "approval|change_record|servicenow|gait|audit"  →  0  across all six modules
+~/.openclaw/gait/  →  2 files, both NetClaw-authored servers
+```
+
+No per-call GAIT, and no platform-level MCP audit to fall back on. Resolved in clarification: recorded as an
+inherited limitation (FR-038), acceptable because the integration is strictly read-only and therefore
+performs no operation to audit (FR-038b). FR-038c blocks a future write path from arriving without audit.
+
+---
+
+## Summary of measured findings that change the spec
+
+| # | Finding | Action |
+|---|---|---|
+| **D2** | Candidate needs fastmcp 3.x; **five servers pin `<3`** | **Dedicated venv**, per spec 076's precedent. Blocking otherwise |
+| **D3** | Uses `zabbix_utils` (Zabbix LLC), **not `pyzabbix`** | Correct FR-032's rationale; staleness risk is lower than stated |
+| **D4** | In-body `auth` still works on 7.0; removal is 7.2+ | Correct the justification; state the tested version |
+| **D5** | 84/121 items are float; the default returns **0 points, no error** | Confirms trap 1 with real data |
+| **D6** | Mixed types: 2-of-4 each way, overlap 0 | Confirms trap 2; splitting is mandatory |
+| **D7** | **`history=0` and `trends=0` are real configurations** | **Fifth cause of absence** — extend FR-006 and the skill |
+| **D8** | Trends empty on a fresh install | Sequence verification; record unverified if the window has not elapsed |
+| **D9** | Manifest **589 tokens** (11.8%) | Record; ceiling is comfortable |
+| **D10** | Refusal works; **launcher default inverted** | Force the flag; add a deny-list; report upstream |
+| **D11** | `python3 -m venv` fails here (no ensurepip) | Use the repo helper — spec 077 hazard #3, live |
+| **D12** | Two upstream defects | Report them (FR-034b) |

--- a/specs/083-zabbix-nms/spec.md
+++ b/specs/083-zabbix-nms/spec.md
@@ -1,0 +1,608 @@
+# Feature Specification: SNMP-poller NMS coverage (Zabbix)
+
+**Feature Branch**: `083-zabbix-nms`
+**Created**: 2026-08-03
+**Status**: Draft
+**Roadmap**: R11, Tier 2
+
+## Overview
+
+NetClaw covers Prometheus, Grafana, Datadog, Splunk, Auvik and ThousandEyes. It has **no SNMP-poller NMS at
+all** — and Zabbix and LibreNMS are what a large share of enterprises actually run.
+
+The consequence is sharper than a missing vendor. NetClaw **has no polled history anywhere.** It receives
+syslog, SNMP traps and IPFIX — all of which are things that arrive when something happens. Nothing in the
+platform answers:
+
+- *Is this normal?*
+- *What did this interface do overnight?*
+- *How long has this been down?*
+- *Was it like this last Tuesday?*
+
+`SOUL.md` already names the gap out loud, in the Globalping section: *"use ThousandEyes when a baseline or
+trend matters — Globalping holds no history."* That sentence is currently a dead end for anyone without a
+ThousandEyes licence.
+
+This feature adds the polled-history layer underneath everything else NetClaw already sees.
+
+## The distinctions this feature exists to protect
+
+Every feature since 078 has protected one distinction. This one has **three**, and the first two are
+**silent-wrong-answer** failures — the API returns an empty list and a success status, and nothing anywhere
+says a mistake was made. That is the most dangerous shape a defect can take, because the caller has no
+signal at all that the answer is wrong.
+
+### 1. An empty history result is not "nothing happened"
+
+Zabbix's history retrieval takes a **value type**, and it **defaults to "numeric unsigned."** Interface
+counters are frequently stored as float. Ask for the wrong type and Zabbix returns an **empty array, not an
+error**.
+
+So the naive implementation reports *"no data for this interface"* about a perfectly healthy, actively
+forwarding link — and reports it with total confidence. Worse, "no data" reads like a finding: an engineer
+sees it and starts investigating a polling failure that does not exist.
+
+The item's real value type must be read from the item definition **before** history is requested, and value
+types **cannot be mixed in one request**, so a query spanning items of different types must be split.
+
+### 2. History exhausted is not "no data"
+
+Zabbix keeps two things:
+
+| | Holds | Typical retention |
+|---|---|---|
+| **History** | every raw polled value | ~14 days |
+| **Trends** | hourly min / avg / max / count, numeric only | 365 days – 5 years |
+
+Housekeeping deletes history past its window. **Any question older than that window returns nothing from
+history** — and again, empty, not an error.
+
+So *"what did this interface do last month?"* silently returns nothing, and NetClaw reports an absence that
+is purely an artefact of where it looked. The retention windows are declared per item, so a correct
+implementation **reads them and routes to trends automatically**. Zabbix's own graphs do exactly this.
+
+A query spanning the boundary needs both sources, and the answer must say which parts came from raw values
+and which from hourly aggregates — because "the peak was 400 Mbps" from raw data and from an hourly average
+are different claims.
+
+### 3. "The poller says unreachable" is not "the device is down"
+
+An NMS reports what **one poller**, from **one vantage point**, at **one interval**, observed. That is
+evidence, not a verdict. A device can be unreachable from the NMS and perfectly healthy from everywhere
+else — a firewall rule, a management-VRF problem, or a dead SNMP daemon on an otherwise forwarding router.
+
+This is the same discipline spec 079 applied to Globalping (*"no probes ≠ outage"*), and it matters more
+here, because an NMS *feels* authoritative in a way a probe network does not.
+
+## The tension, and how it was resolved
+
+**Build-vs-adopt research is complete, and unusually it points at adopt** — unlike R1, R3 and R9, where
+every candidate was inadequate. But the strongest candidate is in direct tension with the three distinctions
+above, and that tension is the central decision here.
+
+### The candidate landscape (measured, not read off READMEs)
+
+| Server | Tools | Licence | Last commit | Note |
+|---|---|---|---|---|
+| `mpeirone/zabbix-mcp-server` | **3** (~823 tokens, **16% of ceiling**) | **GPL-3.0** | 2026-05-10 (~3 mo stale) | Read-only default true, plus an allow/deny gate |
+| `initMAX/zabbix-mcp-server` | **237** | AGPL-3.0 | active | Supports subsetting. **`mcpservers.org` labels this "Official" — that label is wrong**; initMAX is a Zabbix Premium Partner, not Zabbix LLC |
+| `mhajder/zabbix-mcp` | 53 | MIT | active | |
+| 2 JavaScript servers | — | one has **no licence at all** | 2025 | stale / abandoned |
+
+**There is no official Zabbix LLC MCP server.** Zabbix's own AI direction is WebMCP, a browser standard, not
+a server that can be adopted.
+
+### Why the elegant option was not an obvious yes
+
+`mpeirone` collapses the entire Zabbix API into three tools: a generic passthrough, a documentation lookup,
+and an object lister. It is a genuinely good design, it is the smallest manifest of any candidate NetClaw
+has ever evaluated, and **it is essentially the design NetClaw would arrive at independently**.
+
+But a generic passthrough means **the model composes the history request itself** — choosing the value type
+and choosing between history and trends. That is precisely where both silent-wrong-answer failures live. A
+passthrough **cannot structurally prevent them**; it can only document them and hope.
+
+Specs 080, 081 and 082 all reached the same conclusion by different routes: a guarantee that lives in prose
+is not a guarantee. Spec 082 made provenance impossible to omit by putting it at a chokepoint the caller
+cannot route around. The same logic applies here — if the value-type lookup and the history/trends routing
+are the caller's job, they will eventually be skipped, and the failure will be silent.
+
+**Resolved in clarification: adopt as-is.** The traps are documented in the skill rather than enforced in
+code, accepting that a caller who ignores the skill will get a wrong answer with nothing to stop it. What
+this buys is the smallest surface NetClaw has ever added for a whole product category, and an upstream that
+keeps maintaining it. What it costs is enforceability, and the cost is recorded rather than glossed —
+see FR-033/FR-033a and the Clarifications section.
+
+### The licence question is separate and also real
+
+`mpeirone` is GPL-3.0. NetClaw ships Apache-2.0 and its other vendored servers are MIT/Apache.
+
+This is **not** spec 082's situation. There, the upstream was "for demonstration and educational purposes
+only" and simply could not be used. GPL-3.0 *is* open source, and invoking a separate program across a
+subprocess/stdio boundary is not linkage. So the question is about **vendoring and redistribution posture**,
+not permission — and it deserved a decision on its own terms rather than being folded into the technical
+one.
+
+**Resolved: vendor it, unmodified, with its own licence intact** (FR-034a). It stays a separately-licensed
+third-party program invoked over stdio, never edited in place. Any change we need goes upstream — including
+the launcher default-inversion bug this evaluation found (FR-034b).
+
+## The infrastructure is real, and it is here today
+
+Nothing in this feature is blocked on a VM, a trial or a licence — the situation that has R4 parked.
+
+| | |
+|---|---|
+| **NMS** | Zabbix ships a first-party Docker compose (server + database + web UI), up in 1–3 minutes, ~2 GiB for a lab |
+| **Host capacity** | 23 GiB RAM available, 700 GB free, Docker running |
+| **Things to poll** | Three live FRR routers (`netclaw-core`, `netclaw-edge1`, `netclaw-edge2`) and a licensed FortiGate at 192.168.2.130 on FortiOS 7.6.7 |
+
+**Every capability this feature claims can be exercised against a real NMS polling real devices.** There is
+no reason for anything here to ship unverified — a stronger position than R3, where 12 of 21 tools still
+await appliance access.
+
+One consequence worth stating: **trend data takes real time to accumulate.** Trends are hourly, so a
+meaningful trends verification needs the lab to have been polling for hours, not minutes. That is a
+scheduling constraint on verification, not a design problem, but it must not be discovered late.
+
+## Clarifications
+
+### Session 2026-08-03
+
+- Q: Adopt the 3-tool GPL-3.0 passthrough as-is, adopt it behind a thin NetClaw layer, or build a purpose-shaped server? → A: **Adopt `mpeirone/zabbix-mcp-server` as-is.** The two traps are documented in the skill rather than enforced in code. Smallest surface, upstream keeps maintaining it, and the manifest is ~16% of the ceiling.
+- Q: Should any write path be exposed, even behind the two gates? → A: **No. R11 is strictly read-only.** Writes are deferred entirely.
+- Q: Should the Zabbix lab be committed to the repository as a reproducible fixture? → A: **No.** Operator-local, documented in the quickstart only. The repo does not ship an NMS.
+- Q: (raised during clarification) `mpeirone` has **no approval, change-record, or audit concept anywhere in its source** — verified by inspection, `grep -c` returns 0 across all six modules. Its only write control is a binary `READ_ONLY` flag plus regex allow/deny lists, and enabling writes unlocks *every* write method at once. Two gates cannot be inserted without a wrapper, which is the option that was declined. → A: **Confirmed read-only; the combination is resolved in favour of no writes.** Adopt-as-is and gated-writes were not simultaneously satisfiable.
+
+### What these decisions cost, recorded plainly
+
+**This is the first NetClaw integration where a core distinction is NOT structurally enforced.**
+
+Specs 080, 081 and 082 each concluded that a guarantee living in prose is not a guarantee, and each moved
+its guarantee to a chokepoint the caller could not route around. A generic passthrough has no such
+chokepoint: the model composes the history request itself, choosing the value type and choosing between raw
+history and hourly trends.
+
+So FR-001 through FR-006 below are stated as **skill obligations**, not implementation guarantees, and the
+feature is honest about the difference. That is a deliberate trade — bought smallest-surface and upstream
+maintenance, paid for in enforceability — and it MUST be visible in the spec, the skill, and the
+verification report rather than quietly assumed away.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — What did this interface actually do? (Priority: P1)
+
+An engineer is investigating a complaint about slowness last night. They need the utilization history for a
+specific interface over a specific window — which may be within the raw-history window, beyond it, or
+spanning the boundary.
+
+**Why this priority**: It is the flagship capability, the reason the roadmap lists R11 at all, and the place
+where **both** silent-wrong-answer failures live. Nothing else in this feature is worth shipping if this one
+lies.
+
+**Independent Test**: request utilization for a real interface on a real polled device across three windows
+— inside the history window, entirely beyond it, and spanning the boundary — and confirm each returns real
+data with its source stated.
+
+**Acceptance Scenarios**:
+
+1. **Given** an interface polled for hours, **When** utilization is requested for the last hour, **Then**
+   real values are returned with their timestamps and units.
+2. **Given** an interface whose counter is stored as a float, **When** utilization is requested, **Then**
+   real values are returned. It MUST NOT report "no data" because it guessed the wrong value type.
+3. **Given** a window older than the raw-history retention, **When** utilization is requested, **Then** the
+   answer comes from hourly aggregates and **says so**, including that min/avg/max are hourly rather than
+   instantaneous.
+4. **Given** a window spanning the retention boundary, **Then** both sources are used and the response
+   states which part came from which.
+5. **Given** an interface that genuinely has never been polled, **Then** the response says *no such data has
+   been collected* — and this is **distinguishable** from a retention or type miss.
+6. **Given** an item that is not numeric, **When** utilization is requested, **Then** the response explains
+   that aggregates do not exist for non-numeric items rather than returning empty.
+
+---
+
+### User Story 2 — What is wrong right now, and what has been wrong? (Priority: P1)
+
+An engineer wants the current problem list, with severity, duration, and whether anyone has acknowledged it.
+
+**Why this priority**: The most frequent daily use of an NMS, and independently valuable with nothing else
+built. It is also where "how long has this been going on?" — the question NetClaw currently cannot answer at
+all — gets answered.
+
+**Independent Test**: trigger a real problem in the lab (down an interface on an FRR router), confirm it
+appears with correct severity and start time, restore it, and confirm the resolution is visible.
+
+**Acceptance Scenarios**:
+
+1. **Given** active problems, **When** the problem list is requested, **Then** each carries severity, the
+   host, when it started, how long it has been active, and its acknowledgement state.
+2. **Given** no active problems, **Then** the response says *no active problems* — explicitly distinct from
+   *the NMS could not be reached*.
+3. **Given** a problem that has been resolved, **When** history is requested, **Then** both onset and
+   resolution are visible with their times.
+4. **Given** a severity filter, **Then** filtering happens before the response is returned, not by asking
+   the reader to ignore rows.
+5. **Given** an acknowledged problem, **Then** the acknowledgement is shown as a fact about the workflow —
+   never as evidence the underlying condition has cleared.
+
+---
+
+### User Story 3 — Is this device reachable, and since when? (Priority: P2)
+
+An engineer wants availability for a device or group: reachable now, and the recent pattern of transitions.
+
+**Why this priority**: Real and frequently asked, and it is where distinction 3 lives. Slightly lower than
+US1/US2 because "is it up right now" is partly answerable today by other NetClaw skills — what is missing is
+*since when*, and *how often*.
+
+**Independent Test**: stop one FRR container, confirm the transition appears with a timestamp, restart it,
+confirm recovery appears — and confirm the wording never claims more than one poller can know.
+
+**Acceptance Scenarios**:
+
+1. **Given** a polled device, **Then** availability is reported with **when that state was last observed**,
+   not as a timeless fact.
+2. **Given** a device the NMS reports unreachable, **Then** the response says the **NMS cannot reach it** and
+   names the vantage point. It MUST NOT state the device is down.
+3. **Given** a device that has flapped, **Then** the transitions are visible with times, so "it has been
+   down for 40 minutes" and "it has bounced nine times" are distinguishable.
+4. **Given** a device not monitored by the NMS at all, **Then** the response says it is **not monitored** —
+   which is not the same as unreachable, and is a much more common cause of surprise.
+
+---
+
+### User Story 4 — What does the NMS know about? (Priority: P3)
+
+An engineer wants the monitored inventory: hosts, groups, interfaces, and what is actually being collected
+for each.
+
+**Why this priority**: Genuinely useful — including for reconciling the NMS against the source of truth —
+but it is the enabling capability behind the other three rather than the reason to build them.
+
+**Independent Test**: list the monitored inventory and confirm it matches what the lab NMS is actually
+configured to poll.
+
+**Acceptance Scenarios**:
+
+1. **Given** monitored hosts, **Then** each is listed with its groups, interfaces and monitoring state.
+2. **Given** a host, **Then** the collected items are listable, with their units and retention windows — so
+   an engineer can see *before asking* how far back a question can be answered.
+3. **Given** a host that exists but is disabled, **Then** it is shown as **disabled**, not omitted. A host
+   nobody is watching is a finding, not an absence.
+
+---
+
+### Edge Cases
+
+- **The NMS is unreachable.** Reported as *the NMS is unreachable* — never as "no problems" or "no data".
+  An unreachable monitoring system is the single most misleading empty result in this feature.
+- **Credentials are missing or expired.** Reported distinctly from unreachable, and from empty.
+- **A very large result** — thousands of history points or hundreds of hosts. Bounded, with the bound stated
+  in the response, and the caller told how to narrow.
+- **A device is monitored but its items have never collected a value** (template attached, polling failing).
+  Distinct from both "no such host" and "no data in this window", and a real finding.
+- **Clock skew** between the NMS and the caller makes a "last 5 minutes" query return nothing. The response
+  must expose the NMS's own notion of time so this is diagnosable rather than baffling.
+- **A window in the future**, or reversed start/end. Refused with the reason, not silently returning empty.
+- **An item exists on multiple hosts with the same key.** The response must never merge them into one series
+  without saying so.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### The three distinctions — enforced by SKILL, not by code
+
+> **Read this before implementing.** Adoption-as-is was chosen in clarification, so there is no NetClaw
+> chokepoint between the model and the API. FR-001 through FR-006 are therefore **obligations the skill
+> places on the agent**, verified by live behaviour, not invariants the server can enforce. Unlike specs
+> 080/081/082, a caller that ignores the skill will produce a wrong answer and nothing will stop it.
+> This limitation is required to be stated in the skill and the verification report (FR-033a).
+
+- **FR-001**: The skill MUST require the item's real value type to be read from its definition **before**
+  history is requested, and MUST state that the API's default silently returns empty for a mismatched type.
+- **FR-002**: The skill MUST require a history request spanning items of differing value types to be split
+  per type, and MUST state that types cannot be mixed in one request.
+- **FR-003**: The skill MUST require per-item history and trend retention to be read, and the request routed
+  to raw history, hourly trends, or both, according to the requested window. The routing rule MUST be stated
+  concretely enough to follow without consulting vendor documentation.
+- **FR-004**: An answer drawn from hourly aggregates MUST say so, and MUST state that min/avg/max are hourly
+  rather than instantaneous. A peak from an hourly average is a different claim from a peak from raw values,
+  and the reader must be able to tell.
+- **FR-005**: An answer spanning both sources MUST state which portion came from which.
+- **FR-006**: **Never collected**, **aged out of retention**, **wrong-type miss**, **genuinely idle** and
+  **retention disabled** MUST be five outcomes the agent distinguishes and reports differently. Collapsing
+  any of them into a bare "no data" is prohibited, and the skill MUST give the agent a way to tell them
+  apart.
+- **FR-006b**: *(Added from Phase 0, D7.)* **Retention can be disabled per item**, and a stock install ships
+  items in that state: `history=0` means raw values are **never stored**; `trends=0` means there are **no
+  aggregates at all**; both zero means the item is collected only to fire triggers and nothing is kept. The
+  skill MUST require these to be read from the item definition and reported as a **configuration fact**,
+  never as an absence of data. The spec originally modelled only two retention windows; there are three
+  states per window.
+- **FR-006a**: The skill MUST be written so that following it produces the correct answer **without the
+  agent needing to already know** the two traps. Guidance that merely mentions the hazards without giving a
+  procedure is not sufficient — it is the only enforcement mechanism this feature has.
+- **FR-007**: Availability MUST be reported as **what the NMS observed, from its vantage point, at its
+  polling interval** — never as an unqualified statement that a device is up or down.
+- **FR-008**: Every availability answer MUST carry **when that state was last observed**.
+- **FR-009**: A device **not monitored** by the NMS MUST be reported as not monitored, distinct from
+  unreachable.
+- **FR-010**: An **unreachable NMS** MUST be a distinct outcome from an empty result. It MUST NOT be
+  reported as "no problems" or "no data".
+
+#### Provenance and time
+
+- **FR-011**: Every response MUST carry its source, the time window actually queried (which may differ from
+  the one requested), and whether raw or aggregated data was used.
+- **FR-012**: Every response MUST expose the NMS's own notion of current time, so clock skew is diagnosable.
+- **FR-013**: Timestamps MUST be unambiguous as to timezone.
+- **FR-014**: Where a bound was applied, the response MUST state the bound and how to narrow the query.
+
+#### Capabilities
+
+- **FR-015**: Interface utilization history over an arbitrary window MUST be retrievable.
+- **FR-016**: The current problem list MUST be retrievable with severity, host, onset, duration and
+  acknowledgement state.
+- **FR-017**: Problem history — including resolution times — MUST be retrievable.
+- **FR-018**: Device and group availability, with recent transitions, MUST be retrievable.
+- **FR-019**: Monitored inventory — hosts, groups, interfaces, collected items with units and retention —
+  MUST be retrievable.
+- **FR-020**: Severity and host/group filtering MUST happen before the response is returned.
+
+#### Read-only posture — no write path at all
+
+- **FR-021**: The integration MUST be **strictly read-only**. **No write path is exposed in this feature.**
+- **FR-021a**: Read-only mode MUST be **forced explicitly in NetClaw's own configuration and installer**,
+  never left to the upstream default. Measured 2026-08-03: the library defaults it to safe
+  (`utils.py:29` → `True`) but **the shipped launcher inverts that** (`scripts/start_server.py:139` →
+  `False`). Running it the documented upstream way enables writes.
+- **FR-021b**: A **deny-list of destructive methods** MUST additionally be configured as defence in depth,
+  so a misconfigured read-only flag is not the only thing standing between an agent and `host.delete`.
+  Belt and braces, because the upstream default is known to be wrong in one of two places.
+- **FR-022**: Because writes are absent, the two-gate machinery (approval + approved change record) is **not
+  built in this feature**. This is recorded as a scope decision, not an omission: adopting a passthrough
+  as-is leaves nowhere to insert gates, and a gate an agent can decline to invoke is not a gate.
+- **FR-023**: If a write path is ever added, it MUST arrive with both gates, which necessarily means a
+  NetClaw-owned layer between the agent and the API. That requirement MUST be recorded so a future change
+  cannot enable writes by flipping a flag.
+- **FR-024**: An attempted write MUST be refused with a message stating that this integration is read-only
+  by design and naming what would be required to change that.
+- **FR-025**: Configuration of the NMS itself — creating or modifying hosts, templates, triggers, items —
+  is **out of scope** and MUST NOT be reachable, including via the generic passthrough.
+
+#### Auth and transport
+
+- **FR-026**: Authentication MUST use the **API-token / bearer** mechanism. *(Measured on 7.0.29: the older
+  in-request credential property still works there — removal lands in 7.2+. So bearer is required for
+  **forward-compatibility**, not because the tested version rejects the alternative. The verification report
+  MUST state which version was tested.)*
+- **FR-027**: A missing, invalid or expired credential MUST be a distinct outcome from an unreachable NMS
+  and from an empty result.
+- **FR-028**: No credential value may appear in any response, log, or audit record.
+- **FR-029**: TLS verification MUST default to on, with any override explicit and documented.
+
+#### Adoption, licence, and provenance of code
+
+- **FR-030**: The build-vs-adopt decision MUST be recorded with its reasoning, including the **measured**
+  tool counts and licences of every candidate evaluated.
+- **FR-031**: The licence of any adopted code MUST be recorded explicitly, along with why it is acceptable
+  for NetClaw to ship or invoke it.
+- **FR-032**: Any adopted server MUST be **tested against a live NMS before adoption**, not after, and the
+  tested version MUST be recorded. *(Correction from Phase 0: an earlier draft justified this by claiming the
+  candidate delegates auth to `pyzabbix`, which has a known bug against this version. Measured — it uses
+  `zabbix_utils`, Zabbix LLC's own library. The requirement stands; the stated reason was wrong and has been
+  removed rather than left to mislead.)*
+- **FR-033**: The adopted component **cannot** structurally enforce FR-001 through FR-006. This MUST be
+  stated as a known limitation in the skill, the server README, `TOOLS.md` and the verification report —
+  in each case as a limitation, not as a footnote.
+- **FR-033a**: The verification report MUST state plainly that **this is the first NetClaw integration whose
+  core distinctions are enforced by guidance rather than by structure**, and why that trade was accepted.
+  A future maintainer must be able to see the decision, not infer it.
+- **FR-034**: The incorrect "Official Zabbix MCP Server" label carried by a third-party directory MUST be
+  recorded so nobody adopts on the strength of it.
+- **FR-034a**: The adopted code is **GPL-3.0** while NetClaw is Apache-2.0. The vendored copy MUST retain
+  its own `LICENSE` verbatim, MUST be clearly marked as third-party and separately licensed, and MUST NOT
+  be modified in place — a local fork would create a maintenance burden and a licence-obligation question
+  that adopting-as-is exists to avoid. If upstream must be changed, the change goes upstream.
+- **FR-034b**: The upstream launcher's inverted read-only default (FR-021a) MUST be reported upstream as a
+  bug. Recording a hazard we benefit from without telling the maintainer is not a good-citizen posture, and
+  spec 081 established that being a good citizen of free infrastructure is part of how NetClaw behaves.
+
+#### Dependencies
+
+- **FR-035**: Installation MUST use the repository's pip helper, never a bare `pip`/`pip3` (spec 077).
+- **FR-036**: Any pin on a package whose submodule is imported MUST be upper-bounded (spec 077).
+- **FR-037**: No shared dependency version may be moved for another feature's benefit (spec 076's lesson).
+- **FR-037a**: *(Added from Phase 0, D2 — blocking.)* The adopted server requires **fastmcp 3.x**, while
+  **five servers in this repository pin `fastmcp<3`** (`netbox-mcp-server`, `CiscoFMC-MCP-server-community`,
+  `Wikipedia_MCP`, `rag-mcp`, `ISE_MCP`). Installing it into the shared interpreter would break all five.
+  It MUST therefore run from a **dedicated virtualenv**, following the precedent `multivendor-cli-mcp`
+  (spec 076) set for exactly this class of conflict.
+- **FR-037b**: The virtualenv MUST be created with the repository's helper or `uv`, **never bare
+  `python3 -m venv`** — measured on this host, that fails outright because `ensurepip` is unavailable
+  (spec 077 hazard #3, encountered live).
+- **FR-037c**: The dedicated venv MUST be proven not to perturb the system interpreter: the five `<3`-pinned
+  servers MUST still resolve their own fastmcp after installation.
+
+#### Audit — inherited posture, recorded as a limitation
+
+> Measured 2026-08-03: only NetClaw-**authored** servers write GAIT, each implementing it itself
+> (`~/.openclaw/gait/` contains exactly two files). There is **no platform-level MCP call audit**. An as-is
+> adoption therefore produces no per-call audit trail, and the upstream has no audit concept to enable.
+
+- **FR-038**: Per-call GAIT records are **NOT** produced by this integration. It inherits the standard
+  posture of every externally-sourced NetClaw integration. This MUST be recorded as a known limitation in
+  the skill, the server README, `TOOLS.md` and the verification report — alongside the enforcement
+  limitation (FR-033a), not buried separately.
+- **FR-038a**: The developer session MUST be GAIT-logged as normal, per the `docs/ADDING-AN-MCP.md`
+  checklist. That obligation is unaffected.
+- **FR-038b**: The rationale MUST be recorded: Principle IV's requirement that *"no operation may execute
+  silently"* bites on actions and configuration changes, and **this integration performs neither** — it is
+  strictly read-only (FR-021). A read-only integration with no write path has no operation to audit.
+- **FR-038c**: If a write path is ever added, the NetClaw-owned layer required by FR-023 MUST carry
+  **per-call GAIT audit as well as the two gates**. Writes without audit are not acceptable at any point,
+  and recording this here is what prevents a future change from adding one without the other.
+- **FR-039**: Wherever this feature does produce records of its own — installer output, error paths, the
+  verification report — credentials MUST be redacted.
+
+#### Artifact coherence (Principle XI)
+
+- **FR-040**: All of the following MUST be updated: registration or an `EXTERNAL_INTEGRATIONS` entry with a
+  reason; `scripts/lib/catalog.sh` entry **and curated profile membership**; `scripts/lib/install-steps.sh`
+  install function; **both** HUD entries in `ui/netclaw-visual/server.js`; `README.md` and `SOUL.md`
+  including counts **and** a SOUL capability section; skill documentation; `.env.example`; `TOOLS.md`; a
+  server `README.md`.
+- **FR-041**: If an iN2N member should use it, the **five member artifacts plus a mesh restart** from
+  `docs/ADDING-AN-MCP.md` MUST be completed.
+- **FR-042**: `python3 scripts/reconcile-mcp.py` MUST exit 0 across all four surfaces.
+- **FR-043**: `python3 scripts/verify-inventory-counts.py` MUST exit 0 with updated counts.
+- **FR-044**: The tool manifest MUST measure **≤ 5,000 tokens**, with the figure recorded.
+
+#### Boundaries
+
+- **FR-045**: The boundary against `prometheus`/`grafana` MUST be stated: those are pull-based stores for
+  infrastructure you instrumented; this is the SNMP-polled NMS for network gear you did not.
+- **FR-046**: The boundary against `snmptrap-mcp` (feature 010) MUST be stated: that **receives** unsolicited
+  traps; this **polls** on an interval and keeps history. Trap versus poll.
+- **FR-047**: The boundary against `ipfix-mcp` MUST be stated: flow records, not counters.
+- **FR-048**: The boundary against `auvik`/`thousandeyes`/`datadog` MUST be stated: SaaS monitoring with
+  their own agents; this is the self-hosted NMS an enterprise already runs.
+- **FR-049**: The boundary against `pyats`/`multivendor-cli`/`fortinet` MUST be stated: those read
+  **current** state from the device itself; this answers **what it was over time**, from a poller, and can
+  answer for a device that is unreachable right now.
+
+#### Honest verification
+
+- **FR-050**: On completion, the feature MUST state per capability what was **actually exercised against the
+  live NMS polling real devices**, versus what merely ran without error.
+- **FR-051**: Trend-based answers MUST be verified against **genuinely accumulated** hourly data, not
+  synthesised. If the lab has not polled long enough at verification time, that MUST be recorded as
+  unverified rather than claimed.
+- **FR-052**: Anything not exercised MUST be marked unverified or cut.
+
+### Key Entities
+
+- **Monitored host** — a device the NMS polls, with groups, interfaces, monitoring state, and whether it has
+  ever returned data.
+- **Collected item** — one metric on one host, with its value type, units, and **its own** history and trend
+  retention windows.
+- **Data window** — a requested time range, the range actually served, and which source served each part.
+- **Data absence** — a first-class outcome with four distinguishable causes: never collected, aged out,
+  type mismatch, genuinely idle.
+- **Problem** — an active or resolved condition with severity, host, onset, duration, resolution and
+  acknowledgement state.
+- **Availability observation** — what one poller saw, from one vantage point, at one interval, at a stated
+  time.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Utilization history for a real interface on a real polled device is retrieved and the values
+  match what the NMS's own UI shows for the same window.
+- **SC-002**: An interface whose counter is stored as a float returns real data — verified against an item
+  that would return empty under the API's default type.
+- **SC-003**: A window beyond raw retention returns aggregated data and the response states that the values
+  are hourly.
+- **SC-004**: A window spanning the retention boundary returns both, and the response identifies which part
+  came from which.
+- **SC-005**: Never-collected, aged-out, type-mismatch and genuinely-idle produce four distinguishable
+  answers, verified by wording against the live NMS. Because enforcement is by guidance, this MUST be tested
+  **end to end through the agent following the skill** — asserting on the skill's text alone would prove
+  nothing about the answer a user receives.
+- **SC-006**: A real problem raised in the lab appears with correct severity and onset; after resolution,
+  both onset and resolution are retrievable.
+- **SC-007**: With no active problems, the response says so — and is textually distinct from the response
+  when the NMS is unreachable.
+- **SC-008**: An acknowledged problem is shown as acknowledged, and the wording never implies the condition
+  has cleared.
+- **SC-009**: Stopping a real device produces an availability transition with a timestamp; restarting it
+  produces a recovery.
+- **SC-010**: No availability response asserts that a device is down. Every one attributes the observation
+  to the NMS and states when it was observed.
+- **SC-011**: A device not monitored is reported as not monitored, distinct from unreachable.
+- **SC-012**: Monitored inventory matches what the lab NMS is configured to poll, including a disabled host
+  shown as disabled rather than omitted.
+- **SC-013**: Collected items are listable with units and retention, so an engineer can see how far back a
+  question can be answered before asking it.
+- **SC-014**: Every response carries its source, the window actually queried, and whether raw or aggregated
+  data was used.
+- **SC-015**: Every response exposes the NMS's own current time.
+- **SC-016**: An unreachable NMS, a missing credential and an empty result are three distinguishable
+  outcomes.
+- **SC-017**: A bounded result states its bound and how to narrow the query.
+- **SC-018**: An attempted write is refused, and the refusal states that this integration is read-only by
+  design. Verified against the live NMS with a real write method.
+- **SC-018a**: Read-only is forced in NetClaw's own configuration and installer, not inherited from the
+  upstream default — proven by showing NetClaw's setting overrides the launcher's `False`.
+- **SC-018b**: A destructive method is refused by the deny-list **even with read-only deliberately
+  disabled**, proving the second layer is real and not decorative.
+- **SC-019**: No credential value appears in any response, log or audit record.
+- **SC-020**: The absence of per-call GAIT is stated as a known limitation in all four required places, and
+  the developer session GAIT log exists. No document claims an audit trail this integration does not have.
+- **SC-021**: The manifest measures ≤ 5,000 tokens, with the figure recorded.
+- **SC-022**: `reconcile-mcp.py` exits 0 across all four surfaces; `verify-inventory-counts.py` exits 0 with
+  updated counts; `trace-skill.py` resolves for every skill added.
+- **SC-023**: `SOUL.md` gains a capability section describing the polled-history capability and the three
+  distinctions — not merely an incremented count.
+- **SC-024**: The build-vs-adopt decision, every candidate's measured tool count and licence, and the
+  incorrect "Official" label are all recorded.
+- **SC-024a**: The vendored copy retains its own GPL-3.0 `LICENSE` verbatim, is marked as third-party and
+  separately licensed, and is byte-identical to upstream at the pinned revision.
+- **SC-024b**: The skill, the server README, `TOOLS.md` and the verification report each state that the
+  three distinctions are enforced by guidance rather than structure, and that this is a first for NetClaw.
+- **SC-024c**: Both upstream defects — the inverted read-only default and the invalid `fastmcp>=v3.2.0`
+  specifier — are reported upstream, with links recorded.
+- **SC-026**: The server runs from a dedicated virtualenv, and after installation the five servers pinning
+  `fastmcp<3` still resolve their own version — proven by measurement, not assumed.
+- **SC-027**: The virtualenv is created without bare `python3 -m venv`, which fails on this host.
+- **SC-028**: A five-way absence is demonstrated: never-collected, aged-out, wrong-type, genuinely-idle and
+  **retention-disabled** each produce a different answer against the live NMS.
+- **SC-029**: The verification report states the exact NMS version tested, and notes that the in-body auth
+  property still works there while being removed in 7.2+.
+- **SC-030**: The measured manifest token count is recorded.
+- **SC-025**: A per-capability verification table exists distinguishing **exercised against the live NMS**
+  from **executed without error**, with anything uninspected marked unverified or cut.
+
+## Assumptions
+
+- **Zabbix is the only target.** LibreNMS's only MCP server exposes 111 tools and busts the manifest
+  ceiling; Observium's sole server is abandoned and bypasses the API entirely for direct database and
+  filesystem access. Both are out of scope here.
+- **Netdata is not in this category and belongs elsewhere.** It is agent/push-based, not SNMP-polling. Worth
+  recording separately: MCP is built into the **free open-source agent**, not only the paid cloud tier — the
+  roadmap's "official Cloud MCP" description is inaccurate and should be corrected. That makes Netdata a
+  near-zero-effort *separate* item, not part of this one.
+- **Current-generation Zabbix is the target.** Authentication uses API tokens; the older in-request
+  credential property has been removed, so compatibility with pre-token versions is not pursued.
+- **The lab is the verification environment**, and it polls real devices — three FRR routers and a licensed
+  FortiGate. No capability needs to ship unverified.
+- **The lab is operator-local and NOT committed.** Decided in clarification: the quickstart documents how to
+  stand it up; the repository ships no compose file and no NMS. Consequence to accept honestly — the
+  verification is reproducible only by someone who rebuilds the lab from the quickstart.
+- **Trend verification needs elapsed time.** Trends are hourly, so verifying them requires the lab to have
+  been polling for hours. This is a scheduling constraint on verification and must be planned for, not
+  discovered.
+- **No new persistent state.** The NMS holds the history; this feature stores nothing of its own.
+
+## Out of Scope
+
+- **Every write, without exception** — acknowledging problems, enabling or disabling hosts, maintenance
+  windows. Decided in clarification (FR-021/022). Adding any of them later requires a NetClaw-owned layer
+  carrying both gates, not a configuration flag.
+- **Configuring the NMS** — creating or modifying hosts, templates, triggers, items, actions or media types.
+  This reads an NMS someone else runs (FR-025).
+- **A committed lab** — no compose file, no NMS shipped in the repository (clarification Q3).
+- **LibreNMS, Observium and Netdata** — see Assumptions. Netdata is a credible separate item.
+- **Replacing `prometheus`, `grafana`, `datadog`, `auvik` or `thousandeyes`** — different data, different
+  collection model, all already covered.
+- **Receiving traps or flows** — `snmptrap-mcp` and `ipfix-mcp` own those. Trap and flow are not poll.
+- **Reading current device state** — `pyats`, `multivendor-cli` and `fortinet` own that. This answers what
+  state *was*, over time.
+- **Graph or dashboard rendering.** This returns data; the existing visualization skills render it.
+- **Alerting or notification delivery.** Reading the problem list is in scope; sending anything anywhere is
+  Principle XIV territory and belongs to the delivery skills.
+- **Capacity forecasting or anomaly detection.** Returning history is in scope; drawing conclusions from it
+  is a separate feature with its own honesty requirements.

--- a/specs/083-zabbix-nms/tasks.md
+++ b/specs/083-zabbix-nms/tasks.md
@@ -1,0 +1,236 @@
+# Tasks: SNMP-poller NMS coverage (Zabbix)
+
+**Feature**: spec 083 / roadmap R11 · **Branch**: `083-zabbix-nms` · **Date**: 2026-08-03
+**Input**: [spec.md](./spec.md) · [plan.md](./plan.md) · [research.md](./research.md) · [data-model.md](./data-model.md) · [contracts/mcp-tools.md](./contracts/mcp-tools.md)
+
+**Tests are included and are not optional.** But note what is being tested here is unusual: this feature
+adopts a third-party server unmodified, so **NetClaw authors no server code**. The guarantees live in the
+skills. Tests therefore split in two:
+
+- **Static** — does NetClaw force read-only? is the deny-list present? does the skill contain a *followable
+  procedure* rather than a warning?
+- **Live** — does an agent following that procedure get the right answer from a real NMS?
+
+Asserting on skill text alone would prove nothing about the answer a user receives. That is the whole risk
+of the adopt-as-is decision, and the test strategy has to face it.
+
+**Total: 111 tasks** (15 added by `/speckit.analyze` remediation). MVP = Phase 1 + 2 + 3 (T001–T045, US1 — the metrics history skill).
+
+---
+
+## Phase 1: Setup — vendor and isolate (BLOCKING)
+
+**Nothing else can start until the server runs from its own venv without disturbing the system interpreter.**
+
+- [X] T001 Record the current resolution of `fastmcp` on the **system** interpreter and the five servers pinning `<3` (`netbox-mcp-server`, `CiscoFMC-MCP-server-community`, `Wikipedia_MCP`, `rag-mcp`, `ISE_MCP`) — this is the "before" measurement FR-037c compares against
+- [X] T002 *(FR-030/FR-032 — adoption decision, tested before adopting in Phase 0 against live 7.0.29.)* Create `mcp-servers/zabbix-mcp/` and vendor `mpeirone/zabbix-mcp-server` at pinned revision **`0722f48`** into `mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/`, **unmodified** (FR-034a)
+- [X] T003 Confirm the vendored tree is byte-identical to upstream at that revision, and that its `LICENSE` (GNU GPL v3) is present verbatim
+- [X] T004 *(FR-031, FR-034a, SC-024a.)* Create `mcp-servers/zabbix-mcp/NOTICE.md` — third-party attribution, GPL-3.0, the pinned revision, upstream URL, and an explicit statement that **NetClaw does not modify it and any change goes upstream** (FR-034a)
+- [X] T005 Add the `.gitignore` negation for `mcp-servers/zabbix-mcp/` following the existing `!mcp-servers/<name>/` pattern — without it the whole tree is invisible to git
+- [X] T005a **Re-ignore the venv**: add `mcp-servers/zabbix-mcp/.venv/` after the negation. `.venv/` is globally ignored at line 14, but `!mcp-servers/zabbix-mcp/` re-includes *everything* beneath it — so without this line the entire virtualenv gets committed. `multivendor-cli-mcp` carries exactly this line (`.gitignore:71`) for exactly this reason
+- [X] T005b Prove it: run `git status --porcelain` after the venv exists and confirm no `.venv` path appears, and `git check-ignore -v mcp-servers/zabbix-mcp/.venv/pyvenv.cfg` reports the re-ignore rule
+- [X] T006 *(FR-035, FR-036, FR-037.)* Create `mcp-servers/zabbix-mcp/requirements.txt` describing what the dedicated venv installs, with a comment stating **why the venv exists**: fastmcp 3.x versus five servers pinning `<3` (FR-037a)
+- [X] T007 [P] Create `tests/zabbix/` and `tests/zabbix/run-tests.sh` following `tests/bgp-intel/run-tests.sh` in structure
+
+**Checkpoint**: vendored, licensed, git-visible.
+
+---
+
+## Phase 2: Foundational — the venv, read-only, and the deny-list (BLOCKING)
+
+- [X] T008 Add `component_install_zabbix()` to `scripts/lib/install-steps.sh` creating a **dedicated virtualenv** at `mcp-servers/zabbix-mcp/.venv`
+- [X] T009 In T008, create the venv with `netclaw_venv_create` or `uv venv` — **never bare `python3 -m venv`**, which fails on this host because `ensurepip` is unavailable (FR-037b; spec 077 hazard #3, hit live in Phase 0)
+- [X] T010 In T008, install the vendored package into that venv, never into the system interpreter. Export `ZABBIX_MCP_CMD_DETECTED` pointing at **the venv's interpreter**
+- [X] T011 In T008, `log_warn` on failure and print the reason the venv exists, so a future maintainer does not "simplify" it away
+- [X] T012 Register `zabbix-mcp` in `config/openclaw.json` with repo-relative paths pointing at **the venv interpreter**, `command`/`args` separate, `${VAR}` env passthrough only
+- [X] T013 In the registration, set **`READ_ONLY=true` explicitly** — never rely on the upstream default. Measured: `utils.py:29` defaults True but `scripts/start_server.py:139` defaults **False** (FR-021a)
+- [X] T014 In the registration, set a **destructive-method deny-list** via `ZABBIX_API_BLACKLIST` covering at minimum `.*\.delete`, `.*\.create`, `.*\.update`, `.*\.massdelete`, `.*\.massupdate`, `.*\.import`, `.*acknowledge` (FR-021b) — second layer, because one of the two upstream defaults is already wrong. `.*acknowledge` is already blocked by the read-only heuristic; it is listed deliberately so the deny-list stays correct if read-only is ever misconfigured
+- [X] T015 Set `VERIFY_SSL=true` in the registration (FR-029)
+- [X] T015a Configure **API-token (bearer) auth**, not username/password: `ZABBIX_TOKEN` from `.env`, never a literal. Measured on 7.0.29 the in-body property still works, but it is removed in 7.2+, so token is required for forward-compatibility (FR-026)
+- [X] T015b Confirm no credential value appears in any response, log line or artifact — grep the live run output for the token (FR-028, SC-019)
+- [X] T016 [P] Create `tests/zabbix/test_venv_isolation.py`: assert `mcp-servers/zabbix-mcp/.venv` exists and resolves fastmcp **3.x**, while the system interpreter still resolves **2.x** (FR-037c, SC-026)
+- [X] T017 In `test_venv_isolation.py`: assert each of the five `<3`-pinned servers still has its constraint satisfied by the system interpreter after installation — compare against T001's recorded baseline
+- [X] T018 In `test_venv_isolation.py`: assert the installer contains no bare `python3 -m venv` (SC-027)
+- [X] T019 [P] Create `tests/zabbix/test_readonly_forced.py`: assert NetClaw's own registration sets `READ_ONLY=true` explicitly, and that the value is not left to the upstream default (SC-018a)
+- [X] T020 In `test_readonly_forced.py`: assert the deny-list is configured and covers every destructive verb from T014 (SC-018b)
+- [X] T021 In `test_readonly_forced.py`: prove the deny-list is **non-vacuous** by checking a known-destructive method name against the configured patterns and confirming it matches
+- [X] T022 Wire T016 and T019 into `run-tests.sh`
+- [X] T023 **Start the lab polling now** and leave it running — trends are hourly and Phase 7 needs real aggregates (research D8)
+- [X] T023a **Verify what can actually be polled before relying on it.** FRR containers do not run `snmpd` by default and the FortiGate needs an SNMP community configured. Establish pollability *first*; if neither yields real interface counters, fall back to the Zabbix server's own host (which has 84 float items, confirmed in Phase 0) and **record in `VERIFICATION.md` that interface counters came from the NMS host rather than network gear**. Discovering this at verification time is how US1's live proof gets quietly downgraded
+- [X] T024 Verify the server answers live Zabbix from the venv end to end: MCP handshake, `zabbix_api(host.get)` returns real hosts, `zabbix_api(host.delete)` is **refused with a message naming read-only** (FR-021, FR-024, SC-018)
+
+**Checkpoint**: isolated, read-only, answering a real NMS. Lab accumulating history.
+
+---
+
+## Phase 3: User Story 1 — Interface metrics history (Priority: P1) 🎯 MVP
+
+**Goal**: an engineer asks what an interface did over a window, and gets a true answer whether the window is
+inside raw retention, beyond it, or spanning the boundary.
+
+**This skill is the single most important artifact in the feature.** Both silent-wrong-answer traps live
+here, and after the adopt-as-is decision it is the *only* thing standing between a user and a confidently
+wrong "no data".
+
+**Independent Test**: ask for three windows against a real polled float item and confirm each returns real
+data with its source stated.
+
+- [X] T025 [P] [US1] Create `workspace/skills/zabbix-metrics-history/SKILL.md` with frontmatter copied exactly from `workspace/skills/bgp-registry-intel/SKILL.md` (quoted single-line `description` ending in a "Use when …" clause, `version`, `license: Apache-2.0`, `tags`, `user-invocable: true`, inline-JSON `metadata.openclaw.requires`)
+- [X] T026 [US1] *(FR-015 — this is the interface-utilization capability.)* Write the **value-type procedure** as numbered, followable steps: call `item.get` first, read `value_type`, pass it explicitly to `history.get`. State the measured fact that **the API defaults to 3 while 84 of 121 stock items are 0** (FR-001, FR-006a)
+- [X] T027 [US1] Write the **type-splitting rule**: types cannot be mixed; a query across float and unsigned items must be split per type and merged. State the measured evidence — 4 items, 2 returned each way, overlap 0 (FR-002)
+- [X] T028 [US1] Write the **retention router** as a decision procedure: read `history` and `trends` from `item.get`; window inside history → raw; beyond → trends; spanning → both (FR-003)
+- [X] T029 [US1] Add the **three retention states** discovered in Phase 0: `history=0` (raw never stored), `trends=0` (no aggregates), both zero (nothing retained, trigger-only). Require these be reported as **configuration facts, not absences** (FR-006b)
+- [X] T030 [US1] Require any aggregate-derived answer to say so, and to state that min/avg/max are **hourly rather than instantaneous** — a peak from an hourly average is a different claim (FR-004)
+- [X] T031 [US1] Require a boundary-spanning answer to state which portion came from which source (FR-005)
+- [X] T032 [US1] *(SC-005.)* Write the **five absences** as a lookup table the agent can apply: wrong-type, aged-out, retention-disabled, never-collected, genuinely-idle — each with how to tell and how to word it (FR-006)
+- [X] T033 [US1] *(SC-014.)* Require every answer to carry source, the **window actually served** (which may differ from the one requested), and whether raw or aggregated (FR-011)
+- [X] T034 [US1] *(SC-015.)* Require the NMS's own current time to be surfaced, so clock skew is diagnosable rather than baffling (FR-012)
+- [X] T035 [US1] Require unambiguous timezones on all timestamps (FR-013)
+- [X] T036 [US1] Require bounded results to state the bound and how to narrow (FR-014, SC-017)
+- [X] T037 [US1] Refuse a future window or reversed start/end with the reason, rather than returning empty
+- [X] T038 [US1] State that an item existing on multiple hosts with the same key must never be silently merged into one series
+- [X] T039 [P] [US1] Create `tests/zabbix/test_skill_procedure.py`: assert the skill contains a **numbered procedure** mentioning `item.get` **before** `history.get`, not merely a warning that the trap exists (FR-006a)
+- [X] T040 [US1] In `test_skill_procedure.py`: assert all five absence causes appear with distinct guidance, and that the three retention states are covered
+- [X] T041 [P] [US1] Create `tests/zabbix/test_live_traps.py`: **against the live lab**, take a real float item with data and show the default value type returns 0 rows while the correct one returns data — the trap reproduced in NetClaw's own test suite (SC-002)
+- [X] T042 [US1] In `test_live_traps.py`: mix float and unsigned items in one call and assert neither call returns all of them, proving splitting is mandatory (FR-002)
+- [X] T043 [US1] In `test_live_traps.py`: assert an item with `history=0` or `trends=0` exists in the lab and is distinguishable from an item that simply has no data in the window (FR-006b, SC-028)
+- [X] T043a [US1] In `test_live_traps.py`: prove the **three-way outcome distinction** against the lab — (a) valid token + healthy NMS + empty window → *empty*, (b) deliberately wrong token → *credential failure*, (c) NMS stopped → *unreachable*. All three must be distinguishable, and none may read as "no data" (FR-010, FR-027, SC-016)
+- [X] T043b [US1] In `test_live_traps.py`: query a window **beyond raw retention** and assert the answer comes from hourly aggregates and says so (FR-004, SC-003). If the lab has not accumulated trends yet, **fail loudly rather than skipping silently** — a skipped test that looks green is how SC-003 slips
+- [X] T043c [US1] In `test_live_traps.py`: query a window **spanning the retention boundary** and assert both sources are used and identified (FR-005, SC-004)
+- [X] T043d [US1] In `test_live_traps.py`: assert every answer carries source, the window actually served, and the NMS's own current time (FR-011, FR-012, SC-014, SC-015); and that a bounded result states its bound (FR-014, SC-017)
+- [X] T044 [US1] Wire `test_skill_procedure.py` and `test_live_traps.py` into `run-tests.sh`
+- [X] T045 [US1] **End-to-end**: ask NetClaw for interface utilization on a real polled device across three windows and confirm the answers are correct and correctly attributed. Record for `VERIFICATION.md` (SC-001)
+
+**Checkpoint**: US1 independently deliverable and live-verified.
+
+---
+
+## Phase 4: User Story 2 — Problem review (Priority: P1)
+
+- [X] T046 [P] [US2] Create `workspace/skills/zabbix-problem-review/SKILL.md` with the standard frontmatter
+- [X] T047 [US2] Document `problem.get` for **current** problems (dedicated table) versus `event.get` for history, and when each is right (FR-016, FR-017)
+- [X] T048 [US2] Require severity, host, onset, duration and acknowledgement state on every problem (FR-016)
+- [X] T049 [US2] Require **"no active problems"** to read as an explicit finding, textually distinct from "the NMS could not be reached" (FR-010, SC-007) — an unreachable monitoring system is the most misleading empty result in this feature
+- [X] T050 [US2] Require acknowledgement to be reported as a **workflow fact**, never as evidence the condition cleared (FR-016, SC-008)
+- [X] T051 [US2] Require severity and host/group filtering to happen before the answer, not by asking the reader to ignore rows (FR-020)
+- [X] T052 [US2] Require resolved problems to carry both onset and resolution times (FR-017)
+- [X] T053 [P] [US2] In `test_live_traps.py`: assert `problem.get` against the healthy lab returns an empty list **without error**, and that this is the "no problems" case not the "unreachable" case
+- [X] T054 [US2] **Live**: raise a real problem in the lab (down an interface on an FRR router), confirm severity and onset, restore it, confirm resolution is retrievable. Record for `VERIFICATION.md` (SC-006)
+
+---
+
+## Phase 5: User Story 3 + 4 — Availability and inventory (Priority: P2 / P3)
+
+- [X] T055 [P] [US3] Create `workspace/skills/zabbix-availability/SKILL.md` with the standard frontmatter
+- [X] T056 [US3] Write **the wording rule** as the skill's headline: report *"the NMS could not reach it, as of <time>"* — **never** "the device is down". One poller, one vantage point, one interval (FR-007, SC-010)
+- [X] T057 [US3] Require every availability answer to carry **when that state was last observed** (FR-008)
+- [X] T058 [US3] Require transitions with times, so "down for 40 minutes" and "bounced nine times" are distinguishable (FR-018)
+- [X] T059 [US3] Require **not monitored** to be a distinct answer from unreachable — the most common cause of surprise (FR-009, SC-011)
+- [X] T060 [US4] In the same skill, cover inventory: hosts with groups, interfaces and monitoring state (FR-019)
+- [X] T061 [US4] Require collected items to be listable **with units and retention**, so an engineer can see how far back a question can be answered *before* asking it (FR-019, SC-013)
+- [X] T062 [US4] Require a **disabled** host to be shown as disabled, not omitted — a host nobody is watching is a finding, not an absence (SC-012)
+- [X] T062a **All five boundaries in every skill** (FR-045, FR-046, FR-047, FR-048, FR-049): `prometheus`/`grafana` are pull-based stores for infrastructure you instrumented; `snmptrap-mcp` **receives** traps while this **polls**; `ipfix-mcp` is flows not counters; `auvik`/`thousandeyes`/`datadog` are SaaS with their own agents; `pyats`/`multivendor-cli`/`fortinet` read **current** state while this answers **what it was over time**
+- [X] T062b In `test_skill_procedure.py`: assert all three skills name all five boundaries — Principle VII rests on these and nothing else checks them
+- [X] T063 [US3] In `test_skill_procedure.py`: assert the availability skill never contains an unqualified "the device is down" phrasing and always attributes to the NMS
+- [X] T064 [US3] **Live**: stop an FRR container, confirm a transition with a timestamp; restart it, confirm recovery. Record for `VERIFICATION.md` (SC-009)
+- [X] T065 [US4] **Live**: list inventory and confirm it matches what the lab is configured to poll, including a deliberately disabled host shown as disabled (SC-012)
+
+---
+
+## Phase 6: Artifact coherence (Principle XI)
+
+- [X] T066 *(FR-040.)* Add the `zabbix` entry to `scripts/lib/catalog.sh` under `Observability`, **and add it to `PROFILE_OBSERVABILITY`** — profile membership is the easy-to-miss artifact `docs/ADDING-AN-MCP.md` calls out
+- [X] T067 Add **both** HUD entries to `ui/netclaw-visual/server.js`: the `INTEGRATION_CATALOG` node (id `zabbix`, category `Observability`, prefixes `['zabbix_']`, transport `stdio`, toolEstimate 3) **and** the `ENV_MAP` annotation with a `notes` string covering read-only, the venv, and the two traps. One entry is not enough
+- [X] T068 Update `.env.example` with the box-header block: `ZABBIX_MCP_CMD`, `ZABBIX_URL`, `ZABBIX_TOKEN`, `READ_ONLY`, `VERIFY_SSL`, `ZABBIX_API_BLACKLIST` — names and defaults only, plus a comment that read-only is forced because the upstream launcher default is inverted
+- [X] T069 Update `TOOLS.md` with `## Zabbix NMS (\`zabbix-mcp\`, vendored third-party, GPL-3.0)` following the bgp-intel block's shape, including the measured **589-token** manifest, the venv rationale, the two traps, the three retention states, and the five boundaries
+- [X] T070 Create `mcp-servers/zabbix-mcp/README.md` — NetClaw-authored, beside the vendored tree: what is adopted, the pinned revision, the licence, why the venv exists, the two limitations (**guidance-not-structure, FR-033**; no per-call audit), the fact that **no write path exists and NMS configuration is unreachable** (FR-022, FR-025), and all five boundaries (FR-046, FR-047, FR-048)
+- [X] T071 Update `SOUL.md`: add a `### SNMP-Poller NMS (3)` capability section describing the polled-history capability, the three distinctions, and — plainly — that the guarantees are guidance-level here (FR-033a, SC-023)
+- [X] T072 In `SOUL.md`, fix the Globalping line that currently says *"use ThousandEyes when a baseline or trend matters"* — Zabbix is now a credential-free self-hosted answer to that, and leaving the old sentence sends readers to a licence they may not have
+- [X] T073 Update both `SOUL.md` count sites and all four `README.md` count sites to **156 MCP integrations / 212 skills** (155+1, 209+3) — confirm against `verify-inventory-counts.py`'s computed truth rather than arithmetic
+- [X] T074 Add the `README.md` MCP table row and the skill rows for the three new skills
+- [X] T075 Update `docs/COVERAGE-ROADMAP.md`: mark R11 with its spec link and status, and **correct the Netdata claim** — MCP is built into the **free open-source agent** (v2.6.0+, `:19999/mcp`), not only the paid Cloud tier, which makes Netdata a separate near-zero-effort item rather than part of R11
+- [X] T076 In `docs/COVERAGE-ROADMAP.md`, record that **LibreNMS's only MCP server is 111 tools** and **Observium's is abandoned and bypasses the API for direct DB + RRD access** — so the next reader does not re-research them
+- [X] T077 Verify the vendored directory has a recorded state for `verify-catalog-coverage.py`
+
+---
+
+## Phase 7: Honest verification
+
+- [X] T078 [P] *(FR-044.)* Create `tests/zabbix/test_manifest_size.py`: measure the manifest via a real MCP handshake and assert **≤ 5,000 tokens**; record the figure (SC-021, SC-030)
+- [X] T079 In `test_manifest_size.py`: assert exactly **3** tools are exposed, so an upstream bump that explodes the surface is caught
+- [X] T080 Wire `test_manifest_size.py` into `run-tests.sh`
+- [X] T081 Run `bash tests/zabbix/run-tests.sh` and confirm all suites pass
+- [X] T082 Run `python3 scripts/reconcile-mcp.py; echo $?` and confirm **exit 0** across all four surfaces — read the exit code directly, never through a pipe (FR-042)
+- [X] T083 Run `python3 scripts/verify-inventory-counts.py; echo $?` and confirm exit 0 with updated counts (FR-043, SC-022)
+- [X] T084 Run `python3 scripts/trace-skill.py` for each of the three new skills and confirm all resolve
+- [X] T085 *(FR-035, FR-036, FR-039.)* Run `python3 scripts/check-dependency-pins.py; echo $?` and confirm exit 0 — the venv must not introduce a new unbounded submodule-imported pin into the scanned surface
+- [X] T086 **Re-verify the five `<3`-pinned servers still work** after installation, not just that their pins are unchanged — import-level check (FR-037c)
+- [X] T087 Create `specs/083-zabbix-nms/VERIFICATION.md` with a per-capability table distinguishing **exercised against the live NMS** from **executed without error** (FR-050, SC-025)
+- [X] T088 In `VERIFICATION.md`, state the **exact NMS version tested** (7.0.29) and note that the in-body auth property still works there while being removed in 7.2+ (SC-029)
+- [X] T089 In `VERIFICATION.md`, record the **trend verification honestly**: if the lab has not accumulated hourly aggregates by verification time, mark trend-based answers **unverified** rather than claiming them (FR-051)
+- [X] T090 In `VERIFICATION.md`, record the two **corrections to earlier claims** — the candidate uses `zabbix_utils` not `pyzabbix`, and in-body auth survives on 7.0 — with the note that both came from research repeated without verification
+- [X] T091 In `VERIFICATION.md`, state prominently that **this is the first NetClaw integration whose core distinctions are enforced by guidance rather than structure**, and why that trade was accepted (FR-033, FR-033a, SC-024b). Also record that the two-gate machinery is deliberately **not built** because there are no writes, and that any future write requires a NetClaw-owned layer (FR-022, FR-023)
+- [X] T092 In `VERIFICATION.md`, state the **no-per-call-GAIT** limitation and its rationale (FR-038, FR-038b, FR-038c, SC-020)
+- [X] T092a In `VERIFICATION.md`, record the **iN2N decision** (FR-041) explicitly — whether a member gets this and why. A conditional requirement resolved silently reads as an omitted one
+- [X] T092b In `mcp-servers/zabbix-mcp/README.md`, record the **build-vs-adopt decision with the measured candidate table** — 3 / 53 / 111 / 237 tools, their licences, and that `mcpservers.org` labels initMAX "Official" when it is not (FR-030, FR-031, FR-034, SC-024). It belongs in a shipped artifact, not only in `specs/`
+- [X] T092c In `VERIFICATION.md`, state anything not exercised as **unverified or cut** (FR-052)
+- [X] T093 Report the two upstream defects: the **inverted `READ_ONLY` launcher default** and the invalid **`fastmcp>=v3.2.0`** specifier. Record the issue links (FR-034b, SC-024c)
+- [X] T094 Confirm the vendored tree is unmodified and its `LICENSE` intact at commit time (SC-024a)
+- [X] T095 Secret-scan the diff; confirm no token, password or host leaked into any artifact (FR-028, SC-019)
+- [X] T096 Record the GAIT session log for this feature (FR-038a)
+
+---
+
+## Dependencies
+
+```
+Phase 1 (vendor + isolate)
+   └─▶ Phase 2 (venv, read-only, deny-list)  ── BLOCKING ──┐
+                                                           ├─▶ Phase 3 (US1 metrics, P1) 🎯 MVP
+                                                           ├─▶ Phase 4 (US2 problems, P1)
+                                                           └─▶ Phase 5 (US3+US4, P2/P3)
+                                                                        │
+                                                             Phase 6 (artifacts)
+                                                                        │
+                                                             Phase 7 (verification)
+```
+
+**T023 (start the lab polling) must happen in Phase 2**, not Phase 7. Trends are hourly; if the lab starts
+accumulating only at verification time, trend-based answers cannot be verified and FR-051 forces marking
+them unverified. This is the one scheduling constraint that cannot be fixed late.
+
+**Story independence**: US1, US2 and US3/US4 each depend only on Phase 2.
+
+## Parallel execution
+
+**Phase 2** — T016 and T019 are different new test files, both `[P]`. T008–T015 all edit installer or config
+and must serialise.
+
+**Across stories** — the three skills are three separate files:
+```
+T025 zabbix-metrics-history   (US1) ┐
+T046 zabbix-problem-review    (US2) ├── all [P]
+T055 zabbix-availability      (US3) ┘
+```
+Their live-test additions share `test_live_traps.py` and must serialise.
+
+## Independent test criteria
+
+| Story | Independently testable by |
+|---|---|
+| **US1** (P1) | Three windows against a real polled float item — inside retention, beyond it, spanning. Correct data, source stated, no false "no data" |
+| **US2** (P1) | Raise a real problem in the lab; correct severity and onset; resolution retrievable; empty ≠ unreachable |
+| **US3** (P2) | Stop an FRR container; transition with timestamp; wording never says "the device is down" |
+| **US4** (P3) | Inventory matches what the lab polls, disabled host shown as disabled |
+
+## Implementation strategy
+
+**MVP** = Phases 1–3 (T001–T045). That is the polled-history capability with both traps addressed, which is
+the reason R11 exists.
+
+**Then** Phase 4 (the most frequent daily use), Phase 5, then 6 and 7.
+
+**The rule that governs Phase 7**: because the guarantees are guidance-level, a passing static test proves
+only that the skill *says* the right thing. Every claim in `VERIFICATION.md` must say whether it was
+**exercised against the live NMS** or merely **executed without error** — and the trend row must say
+*unverified* if the hours have not elapsed.

--- a/tests/zabbix/_harness.py
+++ b/tests/zabbix/_harness.py
@@ -1,0 +1,59 @@
+"""Shared harness for the zabbix-mcp suites. Spec 083.
+
+Plain Python, stdlib only, following tests/bgp-intel/.
+
+NOTE ON WHAT THESE TESTS CAN AND CANNOT PROVE. This feature adopts a third-party server
+unmodified, so NetClaw authors no server code and there is no chokepoint to test. The
+guarantees live in the skills. So the suites split:
+
+  STATIC  — does NetClaw force read-only? is the deny-list real? does the skill contain a
+            FOLLOWABLE PROCEDURE rather than a warning?
+  LIVE    — does following that procedure produce the right answer from a real NMS?
+
+Asserting on skill text alone would prove nothing about the answer a user receives. That
+is the cost of the adopt-as-is decision, and the test strategy has to face it rather than
+generate green ticks around it.
+"""
+from __future__ import annotations
+import os, sys
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+FAILURES: list[str] = []
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  PASS  {name}")
+    else:
+        FAILURES.append(f"{name}: {detail}")
+        print(f"  FAIL  {name} — {detail}")
+
+def skip(name: str, why: str) -> None:
+    print(f"  SKIP  {name} — {why}")
+
+def run(tests, title: str) -> int:
+    for fn in tests:
+        print(f"\n{fn.__name__}")
+        fn()
+    print()
+    if FAILURES:
+        print(f"{len(FAILURES)} FAILED")
+        for f in FAILURES:
+            print(f"  - {f}")
+        return 1
+    print(f"all {title} tests passed")
+    return 0
+
+def repo(*parts) -> str:
+    return os.path.join(REPO, *parts)
+
+def read(*parts) -> str:
+    with open(repo(*parts), encoding="utf-8") as fh:
+        return fh.read()
+
+def zabbix_env() -> dict | None:
+    """Live-test config, or None if no lab is configured."""
+    url = os.environ.get("ZABBIX_URL")
+    token = os.environ.get("ZABBIX_TOKEN")
+    if not url or not token:
+        return None
+    return {"url": url, "token": token}

--- a/tests/zabbix/run-tests.sh
+++ b/tests/zabbix/run-tests.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Contract tests for zabbix-mcp — spec 083 (roadmap R11).
+#
+# Bash + stdlib only, following tests/bgp-intel/run-tests.sh (spec 075 lineage).
+#
+# TWO KINDS OF TEST, and the split matters. This feature ADOPTS a third-party server
+# unmodified, so NetClaw authors no server code and there is no chokepoint to test:
+#
+#   STATIC  — runs anywhere. Does NetClaw force read-only? Is the deny-list real and
+#             non-vacuous? Does the venv isolate? Does the skill contain a FOLLOWABLE
+#             PROCEDURE rather than a warning?
+#   LIVE    — needs ZABBIX_URL + ZABBIX_TOKEN. Does following that procedure produce the
+#             right answer from a real NMS? Skipped without a lab.
+#
+# Asserting on skill text alone would prove nothing about the answer a user receives.
+# That is the cost of adopt-as-is, and this suite is built to face it rather than
+# generate green ticks around it.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+export PYTHONPATH="$REPO_ROOT/tests/zabbix:${PYTHONPATH:-}"
+
+FAILED=0
+run() {
+    local name="$1" path="$2"
+    echo
+    echo "=============================================================="
+    echo "  $name"
+    echo "=============================================================="
+    python3 "$path" || { FAILED=$((FAILED + 1)); return 1; }
+}
+
+run "read-only  — forced by NetClaw, deny-list non-vacuous (FR-021a/b, SC-018a/b)" tests/zabbix/test_readonly_forced.py
+run "venv       — fastmcp 3.x isolated from five <3 pins (FR-037a/b/c, SC-026/027)"  tests/zabbix/test_venv_isolation.py
+run "skills     — a followable PROCEDURE, not a warning (FR-006a, FR-045..049)"      tests/zabbix/test_skill_procedure.py
+run "manifest   — <= 5,000 tokens, 3-tool surface stable (FR-044, SC-021/030)"       tests/zabbix/test_manifest_size.py
+
+if [ -n "${ZABBIX_URL:-}" ] && [ -n "${ZABBIX_TOKEN:-}" ]; then
+    run "LIVE traps — both reproduce against a real NMS (FR-001..006b, SC-002..005/016)" tests/zabbix/test_live_traps.py
+else
+    echo
+    echo "=============================================================="
+    echo "  LIVE traps — SKIPPED (set ZABBIX_URL and ZABBIX_TOKEN)"
+    echo "  Static tests prove the skill SAYS the right thing."
+    echo "  Only the live suite proves following it gives the right ANSWER."
+    echo "=============================================================="
+fi
+
+echo
+echo "=============================================================="
+if [ "$FAILED" -eq 0 ]; then
+    echo "  ALL SUITES PASSED"
+    exit 0
+fi
+echo "  $FAILED SUITE(S) FAILED"
+exit 1

--- a/tests/zabbix/test_live_traps.py
+++ b/tests/zabbix/test_live_traps.py
@@ -1,0 +1,178 @@
+"""The traps, reproduced against a LIVE NMS. Spec 083, FR-001..006b, SC-002/003/004/005/016.
+
+Static tests prove the skill SAYS the right thing. These prove that following it produces
+the right ANSWER — which is the only claim that matters after the adopt-as-is decision.
+
+Requires ZABBIX_URL and ZABBIX_TOKEN. Skips loudly without them, EXCEPT where a skip would
+hide a requirement (SC-003 trends) — there it fails, because a green skip is how an
+unverified claim ships.
+"""
+from __future__ import annotations
+import json, time, urllib.error, urllib.request
+from _harness import FAILURES, check, run, skip, zabbix_env  # noqa: F401
+
+ENV = zabbix_env()
+
+def api(method, params=None, token=None, url=None, timeout=20):
+    url = url or ENV["url"]
+    body = {"jsonrpc": "2.0", "method": method, "params": params or {}, "id": 1}
+    req = urllib.request.Request(url.rstrip("/") + "/api_jsonrpc.php",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json-rpc",
+                 "Authorization": f"Bearer {token or ENV['token']}"})
+    return json.loads(urllib.request.urlopen(req, timeout=timeout).read())
+
+def _monitored_hostids():
+    """Only hosts the NMS actually polls. Template items are not attached to a host and
+    have no history — including them makes every data search fail for the wrong reason."""
+    return [h["hostid"] for h in api("host.get", {"output": ["hostid"], "monitored_hosts": True})["result"]]
+
+def _items(hostid=None):
+    p = {"output": ["itemid", "key_", "value_type", "history", "trends", "lastclock"], "limit": 500}
+    p["hostids"] = hostid or _monitored_hostids()
+    return api("item.get", p)["result"]
+
+def _with_data(items, vt, since):
+    out = []
+    # Prefer items that already report a recent lastclock — avoids 500 pointless calls.
+    cands = [i for i in items if i["value_type"] == str(vt) and i.get("lastclock") not in (None, "", "0")]
+    for it in (cands or [i for i in items if i["value_type"] == str(vt)])[:60]:
+        r = api("history.get", {"itemids": [it["itemid"]], "history": vt,
+                                "output": "extend", "limit": 1, "time_from": since})["result"]
+        if r: out.append(it)
+        if len(out) >= 2: break
+    return out
+
+def test_trap1_wrong_value_type_returns_empty_with_no_error():
+    """SC-002. The flagship claim, reproduced in NetClaw's own suite."""
+    if not ENV: skip("trap 1", "no ZABBIX_URL/ZABBIX_TOKEN"); return
+    since = int(time.time()) - 7200
+    floats = _with_data(_items(), 0, since)
+    if not floats:
+        check("a float item with data exists in the lab", False,
+              "cannot exercise trap 1 — the lab has no float item with recent values")
+        return
+    it = floats[0]
+    correct = api("history.get", {"itemids": [it["itemid"]], "history": 0,
+                                  "output": "extend", "limit": 5, "time_from": since})
+    default = api("history.get", {"itemids": [it["itemid"]], "history": 3,
+                                  "output": "extend", "limit": 5, "time_from": since})
+    check(f"correct value_type returns data for {it['key_'][:34]}",
+          len(correct["result"]) > 0, "the item has no data — test is inconclusive")
+    check("the API DEFAULT (3) returns ZERO rows for a float item",
+          len(default["result"]) == 0,
+          "the trap did not reproduce — re-check the value_type of the chosen item")
+    check("and it returns NO ERROR — a silent wrong answer",
+          "error" not in default,
+          "it errored, which would at least be visible")
+
+def test_trap1_scale_most_items_are_float():
+    if not ENV: skip("value_type distribution", "no lab"); return
+    items = _items()
+    floats = sum(1 for i in items if i["value_type"] == "0")
+    check(f"most items are float ({floats}/{len(items)}), so the default is wrong for the majority",
+          floats > len(items) / 2,
+          "distribution differs from the measured baseline — re-check the skill's '84 of 121' claim")
+
+def test_trap2_types_cannot_be_mixed():
+    """FR-002. Both halves must have data or the test is meaningless."""
+    if not ENV: skip("trap 2", "no lab"); return
+    since = int(time.time()) - 7200
+    items = _items()
+    f_ok, u_ok = _with_data(items, 0, since), _with_data(items, 3, since)
+    if not (f_ok and u_ok):
+        check("both a float and an unsigned item have data", False,
+              "cannot exercise trap 2 — an inconclusive test that agrees with the "
+              "hypothesis is worse than no test")
+        return
+    mixed = [i["itemid"] for i in f_ok + u_ok]
+    h0 = {r["itemid"] for r in api("history.get", {"itemids": mixed, "history": 0,
+          "output": "extend", "limit": 200, "time_from": since})["result"]}
+    h3 = {r["itemid"] for r in api("history.get", {"itemids": mixed, "history": 3,
+          "output": "extend", "limit": 200, "time_from": since})["result"]}
+    check("no single call returns every item", len(h0) < len(mixed) and len(h3) < len(mixed),
+          "one call returned everything — the trap did not reproduce")
+    check("the two calls do not overlap", not (h0 & h3), "unexpected overlap")
+    check("together they cover all the items", len(h0 | h3) == len(mixed),
+          "splitting by type does not recover everything")
+
+def test_retention_disabled_is_a_real_configuration():
+    """FR-006b / SC-028 — the third retention state, found in Phase 0."""
+    if not ENV: skip("retention states", "no lab"); return
+    items = _items()
+    no_hist = [i for i in items if i["history"] == "0"]
+    no_trend = [i for i in items if i["trends"] == "0"]
+    check("items with history=0 exist (raw never stored)", bool(no_hist),
+          "the skill documents a state this lab cannot demonstrate — note it in VERIFICATION.md")
+    check("items with trends=0 exist (no aggregates)", bool(no_trend), "same")
+    check("retention is per item, not global",
+          len({(i["history"], i["trends"]) for i in items}) > 1,
+          "a single global retention would make the router unnecessary")
+
+def test_never_collected_is_distinguishable_from_no_data():
+    if not ENV: skip("never-collected", "no lab"); return
+    items = _items()
+    never = [i for i in items if not i.get("lastclock") or i.get("lastclock") == "0"]
+    check("lastclock distinguishes never-collected items", True,
+          "")  # informational
+    print(f"        (lab has {len(never)} item(s) that have never returned a value)")
+
+def test_three_way_outcome_distinction():
+    """SC-016 / FR-010 / FR-027 — empty, bad credential, unreachable must differ."""
+    if not ENV: skip("three-way distinction", "no lab"); return
+    # (a) healthy + genuinely empty window
+    far_past = int(time.time()) - 86400 * 3650
+    r = api("history.get", {"itemids": ["1"], "history": 0, "output": "extend",
+                            "limit": 1, "time_from": far_past, "time_till": far_past + 60})
+    check("(a) healthy NMS + empty window → a successful empty result",
+          "result" in r and r["result"] == [], f"got {str(r)[:80]}")
+    # (b) bad credential
+    try:
+        bad = api("host.get", {"limit": 1}, token="deadbeef" * 8)
+        check("(b) a bad token → an API error, not an empty result",
+              "error" in bad, f"got {str(bad)[:80]}")
+        check("    and the error is about authorisation, distinguishable from 'no data'",
+              "error" in bad and any(w in json.dumps(bad["error"]).lower()
+                                     for w in ("auth", "permission", "logged", "token")),
+              f"unclear error: {str(bad.get('error'))[:90]}")
+    except urllib.error.HTTPError as e:
+        check("(b) a bad token → an HTTP error, not an empty result", True, str(e))
+    # (c) unreachable
+    unreachable = False
+    try:
+        api("host.get", {"limit": 1}, url="http://127.0.0.1:59999", timeout=4)
+    except Exception:
+        unreachable = True
+    check("(c) an unreachable NMS → a transport failure, not an empty result", unreachable,
+          "an unreachable NMS must never look like 'no problems'")
+
+def test_problem_get_empty_is_a_positive_finding():
+    if not ENV: skip("problem.get", "no lab"); return
+    r = api("problem.get", {"output": "extend"})
+    check("problem.get succeeds", "result" in r, str(r)[:100])
+    print(f"        (lab has {len(r.get('result', []))} active problem(s))")
+
+def test_trends_beyond_retention():
+    """SC-003. Fails rather than skips if trends have not accumulated — a green skip is
+    exactly how an unverified claim ships."""
+    if not ENV: skip("trends", "no lab"); return
+    items = [i for i in _items() if i["trends"] not in ("0", "")]
+    got = []
+    for it in items[:40]:
+        r = api("trend.get", {"itemids": [it["itemid"]], "output": "extend", "limit": 2})["result"]
+        if r: got.append(it); break
+    if got:
+        check("hourly trend data is retrievable", True, "")
+    else:
+        check("hourly trend data exists in the lab", False,
+              "NO TRENDS YET — trends are written hourly and this lab has not run long "
+              "enough. SC-003/SC-004 are UNVERIFIED and must be recorded as such in "
+              "VERIFICATION.md (FR-051). This failure is deliberate: skipping would look green.")
+
+TESTS = [test_trap1_wrong_value_type_returns_empty_with_no_error, test_trap1_scale_most_items_are_float,
+         test_trap2_types_cannot_be_mixed, test_retention_disabled_is_a_real_configuration,
+         test_never_collected_is_distinguishable_from_no_data, test_three_way_outcome_distinction,
+         test_problem_get_empty_is_a_positive_finding, test_trends_beyond_retention]
+
+if __name__ == "__main__":
+    raise SystemExit(run(TESTS, "live trap"))

--- a/tests/zabbix/test_manifest_size.py
+++ b/tests/zabbix/test_manifest_size.py
@@ -1,0 +1,89 @@
+"""Manifest ceiling and surface stability. Spec 083, FR-044, SC-021/SC-030.
+
+Measured via a real MCP handshake against the vendored server in its venv — not estimated
+from source, because the manifest is what the model actually receives.
+
+The tool-count assertion exists because we adopted upstream: a future bump that explodes
+3 tools into 237 (as one rejected candidate already does) must fail loudly here rather
+than quietly consuming the context budget.
+"""
+from __future__ import annotations
+import asyncio, os, subprocess, sys
+from _harness import FAILURES, check, repo, run, skip  # noqa: F401
+
+CEILING = 5000
+EXPECTED_TOOLS = {"zabbix_api", "zabbix_api_docs", "zabbix_api_list"}
+VENV_PY = repo("mcp-servers", "zabbix-mcp", ".venv", "bin", "python")
+
+PROBE = r'''
+import asyncio, json, os, sys
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+async def main():
+    env = dict(os.environ)
+    env.setdefault("ZABBIX_URL", "http://127.0.0.1:1")
+    env.setdefault("ZABBIX_TOKEN", "placeholder")
+    env["READ_ONLY"] = "true"
+    p = StdioServerParameters(command=sys.executable,
+                              args=["-m", "zabbix_mcp_server.server"], env=env)
+    async with stdio_client(p) as (r, w):
+        async with ClientSession(r, w) as s:
+            await s.initialize()
+            tools = (await s.list_tools()).tools
+            m = "\n".join(f"{t.name}\n{t.description or ''}\n{t.inputSchema}" for t in tools)
+            print(json.dumps({"names": [t.name for t in tools],
+                              "chars": len(m), "lines": m.count("\n")}))
+asyncio.run(main())
+'''
+
+def _probe():
+    if not os.path.exists(VENV_PY):
+        return None
+    out = subprocess.run([VENV_PY, "-c", PROBE], capture_output=True, text=True, timeout=120)
+    if out.returncode != 0:
+        return None
+    import json
+    for line in reversed(out.stdout.strip().splitlines()):
+        if line.startswith("{"):
+            return json.loads(line)
+    return None
+
+_CACHE = {}
+
+def _data():
+    if "d" not in _CACHE:
+        _CACHE["d"] = _probe()
+    return _CACHE["d"]
+
+def test_manifest_under_ceiling():
+    d = _data()
+    if not d:
+        skip("manifest measurement", "venv not built or handshake failed")
+        return
+    tokens = d["chars"] // 4 + d["lines"]
+    print(f"        measured manifest: {tokens} / {CEILING} tokens ({d['chars']} chars)")
+    check(f"manifest is <= {CEILING} tokens", tokens <= CEILING, f"measured {tokens}")
+
+def test_tool_surface_is_stable():
+    d = _data()
+    if not d:
+        skip("tool surface", "venv not built")
+        return
+    names = set(d["names"])
+    check("exactly three tools are exposed", len(names) == 3, f"got {len(names)}: {sorted(names)}")
+    check("the tool names are the expected ones", names == EXPECTED_TOOLS,
+          f"surface changed: {sorted(names)} — an upstream bump altered the contract")
+
+def test_no_write_shaped_tool_appeared():
+    d = _data()
+    if not d:
+        skip("write-shape guard", "venv not built")
+        return
+    bad = [n for n in d["names"]
+           if any(v in n.lower() for v in ("create", "update", "delete", "ack", "set", "write"))]
+    check("no tool name implies a write", not bad, f"write-shaped tools appeared: {bad}")
+
+TESTS = [test_manifest_under_ceiling, test_tool_surface_is_stable, test_no_write_shaped_tool_appeared]
+
+if __name__ == "__main__":
+    raise SystemExit(run(TESTS, "manifest and surface"))

--- a/tests/zabbix/test_readonly_forced.py
+++ b/tests/zabbix/test_readonly_forced.py
@@ -1,0 +1,77 @@
+"""Read-only is forced by NetClaw, not inherited. Spec 083, FR-021/021a/021b, SC-018a/018b.
+
+The upstream library defaults READ_ONLY to True (utils.py:29) but its shipped launcher
+defaults it to False (scripts/start_server.py:139). Running it the documented upstream
+way ENABLES WRITES. So NetClaw must set the flag itself, and must not depend on which
+upstream default wins.
+"""
+from __future__ import annotations
+import json, re
+from _harness import FAILURES, check, read, repo, run  # noqa: F401
+
+def _cfg():
+    return json.loads(read("config", "openclaw.json"))["mcpServers"]["zabbix-mcp"]
+
+def test_read_only_is_set_explicitly():
+    env = _cfg().get("env", {})
+    check("READ_ONLY is present in NetClaw's own registration", "READ_ONLY" in env,
+          "absent — the integration would inherit the upstream launcher's default of false")
+    check("READ_ONLY is literally 'true', not a passthrough variable",
+          env.get("READ_ONLY") == "true",
+          f"got {env.get('READ_ONLY')!r} — a ${{VAR}} passthrough could be unset at runtime")
+
+def test_upstream_default_is_still_inverted():
+    """If upstream ever fixes this, we want to notice — but we still force the flag."""
+    launcher = read("mcp-servers", "zabbix-mcp", "vendor", "zabbix-mcp-server",
+                    "scripts", "start_server.py")
+    lib = read("mcp-servers", "zabbix-mcp", "vendor", "zabbix-mcp-server",
+               "src", "zabbix_mcp_server", "utils.py")
+    inverted = 'parse_bool_env("READ_ONLY", default=False)' in launcher
+    safe_lib = "default=True" in lib
+    check("upstream library still defaults read-only to True", safe_lib,
+          "upstream changed — re-check the NOTICE")
+    check("upstream launcher still defaults read-only to False (the reason we force it)",
+          inverted,
+          "upstream may have fixed this; the forced flag stays regardless, but update NOTICE.md")
+
+def test_denylist_present_and_covers_every_destructive_verb():
+    deny = _cfg().get("env", {}).get("ZABBIX_API_BLACKLIST", "")
+    check("a deny-list is configured", bool(deny.strip()),
+          "no second layer — read-only would be the only thing standing between an agent and host.delete")
+    for verb in ("delete", "create", "update", "massdelete", "massupdate", "import", "acknowledge"):
+        check(f"deny-list covers '{verb}'", verb in deny, f"missing from {deny!r}")
+
+def test_denylist_is_not_vacuous():
+    """A pattern list that matches nothing is decoration."""
+    deny = _cfg().get("env", {}).get("ZABBIX_API_BLACKLIST", "")
+    pats = [re.compile(p.strip()) for p in deny.split(",") if p.strip()]
+    for method in ("host.delete", "template.delete", "action.update", "event.acknowledge"):
+        check(f"{method} matches at least one deny pattern",
+              any(p.match(method) for p in pats),
+              "the deny-list would not stop this")
+    for method in ("host.get", "item.get", "history.get", "trend.get", "problem.get"):
+        check(f"{method} is NOT denied (deny-list is not over-broad)",
+              not any(p.match(method) for p in pats),
+              "a read method is blocked — the integration would be useless")
+
+def test_tls_and_no_literal_credentials():
+    env = _cfg().get("env", {})
+    check("VERIFY_SSL is configured", "VERIFY_SSL" in env)
+    for k, v in env.items():
+        if k in ("ZABBIX_TOKEN", "ZABBIX_URL"):
+            check(f"{k} is a ${{VAR}} passthrough, not a literal",
+                  isinstance(v, str) and v.startswith("${"),
+                  f"literal value in config: {v[:20]!r}")
+
+def test_no_write_path_is_advertised():
+    for skill in ("zabbix-metrics-history", "zabbix-problem-review", "zabbix-availability"):
+        text = read("workspace", "skills", skill, "SKILL.md").lower()
+        check(f"{skill} states it is read-only", "read-only" in text,
+              "a reader could assume writes are available")
+
+TESTS = [test_read_only_is_set_explicitly, test_upstream_default_is_still_inverted,
+         test_denylist_present_and_covers_every_destructive_verb, test_denylist_is_not_vacuous,
+         test_tls_and_no_literal_credentials, test_no_write_path_is_advertised]
+
+if __name__ == "__main__":
+    raise SystemExit(run(TESTS, "read-only enforcement"))

--- a/tests/zabbix/test_skill_procedure.py
+++ b/tests/zabbix/test_skill_procedure.py
@@ -1,0 +1,128 @@
+"""The skills must contain a FOLLOWABLE PROCEDURE, not a warning. Spec 083, FR-006a.
+
+This is the most important static suite in the feature, and the reason is uncomfortable:
+after the adopt-as-is decision the skills are the ONLY thing preventing two silent
+wrong-answer failures. There is no chokepoint. A skill that merely says "beware of value
+types" is not enforcement — it is a note the agent may or may not act on.
+
+So these tests check for the ORDER and the MECHANICS of a procedure, not for the presence
+of scary words.
+"""
+from __future__ import annotations
+from _harness import FAILURES, check, read, run  # noqa: F401
+
+METRICS = "zabbix-metrics-history"
+SKILLS = [METRICS, "zabbix-problem-review", "zabbix-availability"]
+
+def _s(name): return read("workspace", "skills", name, "SKILL.md")
+
+def test_frontmatter_matches_the_schema():
+    for name in SKILLS:
+        t = _s(name)
+        check(f"{name} has frontmatter", t.startswith("---\n"), "missing")
+        head = t.split("---")[1]
+        for field in ("name:", "description:", "version:", "license:", "tags:", "user-invocable:"):
+            check(f"{name} declares {field}", field in head, "absent")
+        check(f"{name}'s description ends with a 'Use when' clause",
+              "Use when" in head, "the router cannot tell when to reach for it")
+
+def test_the_value_type_procedure_is_ordered_and_concrete():
+    t = _s(METRICS)
+    i_item, i_hist = t.find("item.get"), t.find("history.get")
+    check("item.get is mentioned before history.get", 0 <= i_item < i_hist,
+          "the order IS the procedure — reversing it is the bug")
+    check("the procedure is numbered, not prose",
+          "Step 1" in t and "Step 2" in t and "Step 3" in t and "Step 4" in t,
+          "an unnumbered caution is not a procedure")
+    check("it names the actual default the API uses",
+          "defaults" in t and "3" in t, "the trap is unstated")
+    check("it gives the value_type table so the agent can look the value up",
+          "float" in t and "unsigned" in t, "the agent cannot act without the mapping")
+    check("it quantifies how common the trap is",
+          "84" in t, "without the measurement this reads as a theoretical caveat")
+
+def test_type_splitting_is_required():
+    t = _s(METRICS)
+    check("mixing value types is explicitly prohibited",
+          "mix" in t.lower() and "one call" in t.lower(), "unstated")
+    check("the remedy is given, not just the hazard",
+          "group" in t.lower() and "merge" in t.lower(),
+          "telling an agent something is wrong without telling it what to do instead is not guidance")
+
+def test_the_retention_router_is_a_decision_table():
+    t = _s(METRICS)
+    check("trend.get is covered", "trend.get" in t, "half the retention story is missing")
+    check("routing is presented as a decision table", "Requested window" in t or "| Use |" in t,
+          "prose routing will not be followed reliably")
+    check("aggregates must be declared as hourly",
+          "hourly" in t and ("not instantaneous" in t or "instantaneous" in t),
+          "a peak from an hourly average is a different claim and must be labelled")
+    check("boundary-spanning is covered", "spans the boundary" in t or "both" in t.lower())
+
+def test_all_five_absences_are_distinguished():
+    t = _s(METRICS)
+    for cause in ("Wrong value type", "Aged out", "Retention disabled",
+                  "Never collected", "Genuinely idle"):
+        check(f"absence cause '{cause}' is named", cause in t, "collapsed into a generic 'no data'")
+    check("retention-disabled is called a configuration fact",
+          "configuration fact" in t, "it would read as an absence of data")
+    check("never-collected is called a finding",
+          "real finding" in t, "a broken poll must not read as 'nothing happened'")
+    check("history=0 and trends=0 are both covered",
+          "history=0" in t and "trends=0" in t, "the third retention state is missing")
+
+def test_availability_never_asserts_a_device_is_down():
+    t = _s("zabbix-availability")
+    lowered = t.lower()
+    check("the wording rule is the headline", "not" in lowered and "the device is down" in lowered,
+          "the central discipline of this skill is missing")
+    check("it requires attributing to the NMS", "vantage point" in lowered,
+          "one poller's view must be framed as such")
+    check("it requires a timestamp on every observation",
+          "last observed" in lowered or "when that state was last observed" in lowered
+          or "timestamp the observation" in lowered)
+    check("not-monitored is distinguished from unreachable",
+          "not monitored" in lowered, "the most common cause of surprise is unhandled")
+    check("flapping is distinguished from sustained down",
+          "flap" in lowered or "transitions" in lowered)
+
+def test_problem_review_separates_empty_from_unreachable():
+    t = _s("zabbix-problem-review")
+    check("empty vs unreachable is called out",
+          "no active problems" in t.lower() and "unreachable" in t.lower(),
+          "reporting an unreachable NMS as 'no problems' is the worst failure in this skill")
+    check("acknowledgement is not resolution",
+          "acknowledged" in t.lower() and ("never" in t.lower() or "still happening" in t.lower()))
+    check("duration is required, not just onset", "duration" in t.lower() or "how long" in t.lower())
+
+def test_every_skill_states_all_five_boundaries():
+    """FR-045..FR-049. Principle VII rests on these and nothing else checks them."""
+    needles = {
+        "prometheus/grafana": ("prometheus", "grafana"),
+        "snmptrap (push vs poll)": ("snmptrap-mcp",),
+        "ipfix (flows vs counters)": ("ipfix-mcp",),
+        "SaaS monitoring": ("auvik", "thousandeyes", "datadog"),
+        "device-reading skills": ("pyats", "multivendor-cli"),
+    }
+    for name in SKILLS:
+        t = _s(name).lower()
+        for label, words in needles.items():
+            check(f"{name} names the {label} boundary",
+                  all(w in t for w in words), f"missing one of {words}")
+
+def test_the_enforcement_limitation_is_stated():
+    t = _s(METRICS)
+    check("the metrics skill warns that nothing structurally prevents the traps",
+          "passthrough" in t.lower() and "will not stop you" in t.lower(),
+          "an agent must know the guardrail is guidance, not code")
+    check("the absence of a per-call audit trail is stated",
+          "audit" in t.lower(), "a user needing an auditable record must be told there is none")
+
+TESTS = [test_frontmatter_matches_the_schema, test_the_value_type_procedure_is_ordered_and_concrete,
+         test_type_splitting_is_required, test_the_retention_router_is_a_decision_table,
+         test_all_five_absences_are_distinguished, test_availability_never_asserts_a_device_is_down,
+         test_problem_review_separates_empty_from_unreachable,
+         test_every_skill_states_all_five_boundaries, test_the_enforcement_limitation_is_stated]
+
+if __name__ == "__main__":
+    raise SystemExit(run(TESTS, "skill procedure"))

--- a/tests/zabbix/test_venv_isolation.py
+++ b/tests/zabbix/test_venv_isolation.py
@@ -1,0 +1,110 @@
+"""The dedicated venv, and proof it does not disturb the system interpreter.
+Spec 083, FR-037a/b/c, SC-026/027.
+
+This is not hygiene. The vendored server requires fastmcp 3.x; FIVE NetClaw servers pin
+fastmcp<3. A shared install breaks all five — spec 076's cryptography incident verbatim.
+"""
+from __future__ import annotations
+import json, os, re, subprocess
+from _harness import FAILURES, check, read, repo, run, skip  # noqa: F401
+
+PINNED_BELOW_3 = ["netbox-mcp-server", "CiscoFMC-MCP-server-community",
+                  "Wikipedia_MCP", "rag-mcp", "ISE_MCP"]
+VENV_PY = repo("mcp-servers", "zabbix-mcp", ".venv", "bin", "python")
+
+def _version(python_exe: str, dist: str) -> str | None:
+    out = subprocess.run([python_exe, "-c",
+        f"import importlib.metadata as m;print(m.version({dist!r}))"],
+        capture_output=True, text=True)
+    return out.stdout.strip() if out.returncode == 0 else None
+
+def test_venv_exists_and_holds_fastmcp_3():
+    if not os.path.exists(VENV_PY):
+        skip("venv checks", "venv not built — run the installer")
+        return
+    v = _version(VENV_PY, "fastmcp")
+    check("the venv resolves fastmcp 3.x", bool(v) and v.startswith("3."), f"got {v}")
+    check("the venv has the vendored package installed",
+          _version(VENV_PY, "zabbix-mcp-server") is not None, "not installed")
+
+def test_system_interpreter_is_untouched():
+    import importlib.metadata as md
+    try:
+        sysv = md.version("fastmcp")
+    except Exception:
+        skip("system fastmcp check", "fastmcp not installed system-wide")
+        return
+    check("the SYSTEM interpreter still resolves fastmcp 2.x", sysv.startswith("2."),
+          f"got {sysv} — installing the Zabbix server leaked into the shared interpreter, "
+          f"which breaks {', '.join(PINNED_BELOW_3)}")
+
+def test_the_five_pinned_servers_are_still_satisfied():
+    import importlib.metadata as md
+    try:
+        sysv = md.version("fastmcp")
+    except Exception:
+        skip("pinned-server check", "fastmcp not installed system-wide")
+        return
+    major = int(sysv.split(".")[0])
+    for server in PINNED_BELOW_3:
+        found = False
+        for fn in ("pyproject.toml", "requirements.txt"):
+            p = repo("mcp-servers", server, fn)
+            if os.path.exists(p):
+                if re.search(r"fastmcp[^\n]*<\s*3", open(p, encoding="utf-8").read()):
+                    found = True
+        check(f"{server} still declares fastmcp<3", found,
+              "its pin vanished — either it was relaxed, or this list is stale")
+    check(f"the installed system fastmcp ({sysv}) satisfies <3", major < 3,
+          "all five pinned servers are now unsatisfiable")
+
+def test_installer_never_uses_bare_venv():
+    steps = read("scripts", "lib", "install-steps.sh")
+    fn = steps[steps.index("component_install_zabbix()"):]
+    fn = fn[:fn.index("\n}\n")]
+    # Line-aware, not string-aware: this function deliberately MENTIONS bare venv in a
+    # comment and in a log_warn that tells the operator not to use it. Matching the raw
+    # string would flag the warning as the offence it warns about.
+    offenders = []
+    for line in fn.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#") or stripped.startswith("log_warn") or stripped.startswith("echo"):
+            continue
+        if "python3 -m venv" in stripped:
+            offenders.append(stripped)
+    check("no executable line calls bare `python3 -m venv`", not offenders,
+          f"bare venv fails on hosts without ensurepip (spec 077 hazard #3, hit live in "
+          f"Phase 0). Offending line(s): {offenders}")
+    check("the installer uses netclaw_venv_create or uv",
+          "netclaw_venv_create" in fn or "uv venv" in fn, "no supported venv creation path")
+    check("the installer explains why the venv exists",
+          "fastmcp" in fn and ("<3" in fn or "3.x" in fn),
+          "without the rationale a maintainer will 'simplify' it away")
+
+def test_registration_points_at_the_venv():
+    cfg = json.loads(read("config", "openclaw.json"))["mcpServers"]["zabbix-mcp"]
+    check("the registered command is the venv interpreter",
+          ".venv/bin/python" in cfg["command"],
+          f"got {cfg['command']!r} — a system python would resolve the wrong fastmcp")
+    check("the command path is repo-relative", not cfg["command"].startswith("/"),
+          "an absolute path breaks on every other machine")
+
+def test_venv_is_gitignored():
+    out = subprocess.run(["git", "check-ignore", "-v",
+                          "mcp-servers/zabbix-mcp/.venv/pyvenv.cfg"],
+                         capture_output=True, text=True, cwd=repo())
+    check("the venv is git-ignored", out.returncode == 0,
+          "the negation !mcp-servers/zabbix-mcp/ re-includes everything beneath it — "
+          "without an explicit re-ignore the whole virtualenv gets committed")
+    check("the vendored source is NOT ignored",
+          subprocess.run(["git", "check-ignore",
+                          "mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/pyproject.toml"],
+                         capture_output=True, cwd=repo()).returncode != 0,
+          "the vendored tree is invisible to git")
+
+TESTS = [test_venv_exists_and_holds_fastmcp_3, test_system_interpreter_is_untouched,
+         test_the_five_pinned_servers_are_still_satisfied, test_installer_never_uses_bare_venv,
+         test_registration_points_at_the_venv, test_venv_is_gitignored]
+
+if __name__ == "__main__":
+    raise SystemExit(run(TESTS, "venv isolation"))

--- a/ui/netclaw-visual/server.js
+++ b/ui/netclaw-visual/server.js
@@ -67,6 +67,7 @@ const INTEGRATION_CATALOG = [
   { id: 'kubeshark', name: 'Kubeshark', category: 'Observability', prefixes: ['kubeshark-'], color: '#ffcb77', transport: 'http', toolEstimate: 6, description: 'Kubernetes packet and flow visibility.' },
   { id: 'gtrace', name: 'gtrace', category: 'Observability', prefixes: ['gtrace-'], color: '#bde0fe', transport: 'stdio', toolEstimate: 6, description: 'Path tracing and IP enrichment.' },
   { id: 'bgp-intel', name: 'BGP & Registry Intel', category: 'Observability', prefixes: ['rpki_', 'registry_', 'routing_', 'peering_', 'atlas_', 'resource_'], color: '#8ac926', transport: 'stdio', toolEstimate: 10, description: 'RPKI origin validation, RDAP ownership, PeeringDB peering, routing visibility. Public APIs, no credentials. not-found is NOT invalid.' },
+  { id: 'zabbix', name: 'Zabbix NMS', category: 'Observability', prefixes: ['zabbix_'], color: '#d40000', transport: 'stdio', toolEstimate: 3, description: 'Self-hosted SNMP-poller NMS — polled metric history, problems, device availability. Read-only, vendored third-party (GPL-3.0) in its own venv. The only source of POLLED HISTORY: what something was doing over time. An empty history result is usually the wrong value_type, not an absence.' },
   { id: 'document', name: 'Document Generation', category: 'Platform Services', prefixes: ['docx_', 'xlsx_', 'pptx_', 'pdf_', 'list_documents'], color: '#4c956c', transport: 'stdio', toolEstimate: 6, description: 'Change-record .docx, audit .xlsx, exec .pptx and PDF form filling from real NetClaw data. No credentials, writes files only. Per-element provenance at a chokepoint — a missing value renders as NOT AVAILABLE, never as a blank.' },
   { id: 'globalping', name: 'Globalping', category: 'Observability', prefixes: ['globalping-'], color: '#00b4d8', transport: 'http', toolEstimate: 12, description: 'Outside-in measurement from ~4,800 probes across ~1,390 ASNs — ping, traceroute, DNS, MTR and HTTP toward a public target. The only vantage point NetClaw has outside its own administrative domain. Public endpoints only; "no probes matched" is not "the service is down".' },
   { id: 'suzieq', name: 'SuzieQ', category: 'Observability', prefixes: ['suzieq-'], color: '#a8dadc', transport: 'stdio', toolEstimate: 5, description: 'Network state queries, assertions, summaries, and path tracing.' },
@@ -247,6 +248,11 @@ const ENV_MAP = {
     env: ['BGP_INTEL_MCP_CMD', 'BGP_INTEL_USER_AGENT', 'BGP_INTEL_MAX_RPS', 'BGP_INTEL_AUDIT_LOG'],
     files: ['mcp-servers/bgp-intel-mcp/server.py'],
     notes: 'No credentials required — all five sources are public unauthenticated APIs. Read-only. Self-imposed 4 req/s serial ceiling against volunteer-funded infrastructure (RIPE NCC, PeeringDB). Every response carries its source and is GAIT-audited. RPKI not-found means no ROA exists and is NOT a finding.',
+  },
+  zabbix: {
+    env: ['ZABBIX_MCP_CMD', 'ZABBIX_URL', 'ZABBIX_TOKEN', 'READ_ONLY', 'VERIFY_SSL', 'ZABBIX_API_BLACKLIST'],
+    files: ['mcp-servers/zabbix-mcp/vendor/zabbix-mcp-server/src/zabbix_mcp_server/server.py'],
+    notes: 'Vendored third-party (mpeirone/zabbix-mcp-server, GPL-3.0, pinned 0722f48), adopted UNMODIFIED and run from a dedicated virtualenv because it needs fastmcp 3.x while five NetClaw servers pin <3. Strictly read-only: NetClaw FORCES READ_ONLY=true because the upstream launcher inverts that default, plus a destructive-method deny-list as a second layer. Three tools, 589-token manifest. NOTE: this is a generic passthrough, so the two silent-wrong-answer traps (history.get defaults to the wrong value_type; raw history ages out into hourly trends) are enforced by the SKILLS, not by code — the first NetClaw integration where that is true. No per-call GAIT audit.',
   },
   document: {
     env: ['DOCUMENT_MCP_CMD', 'DOCUMENT_OUTPUT_DIR', 'DOCUMENT_MAX_ROWS', 'DOCUMENT_MAX_BLOCKS', 'DOCUMENT_MAX_SLIDES', 'DOCUMENT_AUDIT_LOG'],

--- a/workspace/skills/zabbix-availability/SKILL.md
+++ b/workspace/skills/zabbix-availability/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: zabbix-availability
+description: "Device availability and monitored inventory from Zabbix — is a device reachable, since when, how often has it flapped, and what is the NMS actually watching. Use when someone asks how long a device has been down, whether it is flapping, or what is and is not being monitored."
+version: 1.0.0
+license: Apache-2.0
+tags: [zabbix, nms, snmp, monitoring, availability, uptime, inventory, observability]
+user-invocable: true
+metadata:
+  { "openclaw": { "requires": { "bins": ["python3"], "env": ["ZABBIX_URL", "ZABBIX_TOKEN"] } } }
+---
+
+# Zabbix Availability & Inventory
+
+## Server
+
+`zabbix-mcp` — vendored third-party, read-only, three tools. See
+[zabbix-metrics-history](../zabbix-metrics-history/SKILL.md) for the shared cautions.
+
+## ⚠ The wording rule — this is the whole skill
+
+> ### "Zabbix cannot reach it" is **not** "the device is down."
+
+An NMS reports what **one poller** saw, from **one vantage point**, at **one polling interval**. That is
+evidence, not a verdict.
+
+A device can be unreachable from Zabbix and completely healthy: a firewall rule, a management-VRF problem,
+a dead SNMP daemon on an otherwise forwarding router, or a poller that has simply not tried recently.
+
+**Never write "the device is down."** Write:
+
+> *"Zabbix has been unable to reach rtr-01 since 14:02 UTC. That is the monitoring system's view from its
+> own vantage point — it is not confirmation the device is down. `pyats` or `multivendor-cli` can check the
+> device directly."*
+
+This is the same discipline `globalping-external-checks` applies to probes, and it matters **more** here,
+because an NMS *feels* authoritative in a way a probe network does not.
+
+## Four states, not two
+
+| State | `available` | Say |
+|---|---|---|
+| Reachable | `1` | *"Zabbix reached it at \<time>"* |
+| Unreachable | `2` | *"Zabbix cannot reach it as of \<time>"* — never "it is down" |
+| Unknown | `0` | *"Zabbix has not yet established reachability"* — not the same as unreachable |
+| **Not monitored** | host absent | *"this device is not monitored by Zabbix"* — **not the same as unreachable**, and by far the most common cause of surprise |
+
+```jsonc
+zabbix_api("host.get", {
+  "output": ["hostid","host","name","status"],
+  "selectInterfaces": ["interfaceid","ip","dns","port","available","error","errors_from"],
+  "selectTags": "extend"
+})
+```
+
+## Always carry the time
+
+Availability without a timestamp is a claim about the present that may be minutes or hours stale. **Every
+answer states when that state was last observed.** `errors_from` gives you when the failure began.
+
+## Down vs flapping — different problems
+
+*"It has been down for 40 minutes"* and *"it has bounced nine times in 40 minutes"* lead to completely
+different investigations. Get the transitions, not just the current state — `event.get` against the
+unreachability trigger gives you the history.
+
+Report the **count of transitions** as well as the current state whenever the window contains more than one.
+
+## Inventory — what is the NMS actually watching?
+
+```jsonc
+zabbix_api("host.get",      {"output":["hostid","host","status"], "selectInterfaces":"extend",
+                             "selectParentTemplates":["name"], "selectHostGroups":["name"]})
+zabbix_api("hostgroup.get", {"output":"extend"})
+zabbix_api("item.get",      {"hostids":["<id>"],
+                             "output":["itemid","name","key_","value_type","units","history","trends","lastclock"]})
+```
+
+Two rules:
+
+- **A disabled host (`status: 1`) is shown as disabled, never omitted.** A device nobody is watching is a
+  **finding**, not an absence — it is usually how a gap in monitoring is discovered.
+- **List items with their units and retention** (`history`, `trends`). This lets an engineer see *how far
+  back a question can be answered* before they ask it, which is far better than asking and getting nothing.
+
+An item whose `lastclock` is empty is **monitored but has never returned a value** — a broken poll, and a
+real finding. Do not report it as "no data".
+
+## Boundaries
+
+| Want to… | Use |
+|---|---|
+| Metric values over time | `zabbix-metrics-history` |
+| Problems and alerts | `zabbix-problem-review` |
+| Unsolicited traps | `snmptrap-mcp` — push, not poll |
+| Flows | `ipfix-mcp` |
+| Instrumented metrics | `prometheus`, `grafana` |
+| SaaS monitoring | `auvik`, `thousandeyes`, `datadog` |
+| **Confirm** whether a device is actually down | `pyats`, `multivendor-cli`, `fortinet` — go ask the device. This skill only reports what the poller saw |
+| Add, enable or disable a host | **nothing here.** Read-only; NMS configuration is out of scope entirely |
+
+## Rules
+
+1. **Never say "the device is down."** Say what Zabbix observed, and when.
+2. **Always timestamp the observation.**
+3. **Not monitored ≠ unreachable.** Check before you conclude.
+4. **Report flap counts, not just current state.**
+5. **Show disabled hosts.** Omitting them hides the gap.
+6. **Read-only.**

--- a/workspace/skills/zabbix-metrics-history/SKILL.md
+++ b/workspace/skills/zabbix-metrics-history/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: zabbix-metrics-history
+description: "Retrieve polled metric history from Zabbix — interface utilization, counters and any collected item — over any time window, correctly routed between raw history and hourly trends. Use when someone asks what something WAS doing over time: is this normal, what did this interface do overnight, was it like this last Tuesday. This is the only NetClaw skill that can answer a question about the past from a poller."
+version: 1.0.0
+license: Apache-2.0
+tags: [zabbix, nms, snmp, monitoring, history, trends, utilization, baseline, observability]
+user-invocable: true
+metadata:
+  { "openclaw": { "requires": { "bins": ["python3"], "env": ["ZABBIX_URL", "ZABBIX_TOKEN"] } } }
+---
+
+# Zabbix Metrics History
+
+## Server
+
+`zabbix-mcp` — **vendored third-party** (`mpeirone/zabbix-mcp-server`, GPL-3.0, pinned `0722f48`), running
+from its own virtualenv. Three tools: `zabbix_api(method, params)`, `zabbix_api_docs(method)`,
+`zabbix_api_list(object)`. **Read-only, enforced two ways** (forced flag + destructive-method deny-list).
+
+## ⚠ Read this before you report "no data"
+
+**This server is a generic passthrough. It will not stop you getting a wrong answer.**
+
+Unlike most NetClaw integrations, there is no code between you and the API enforcing correctness. Zabbix has
+two traps that return **an empty array and a success status** — no error, no warning. If you skip the
+procedure below you will confidently tell an engineer an interface was idle when it was carrying traffic.
+
+Follow the procedure. It is the only safeguard that exists.
+
+---
+
+## The procedure — always, in this order
+
+### Step 1 — `item.get` FIRST. Never call `history.get` without it.
+
+```jsonc
+zabbix_api("item.get", {
+  "hostids": ["<hostid>"],
+  "search": {"key_": "net.if.in"},          // or whatever you're after
+  "output": ["itemid","name","key_","value_type","units","history","trends"]
+})
+```
+
+You need four fields off every item:
+
+| Field | Why |
+|---|---|
+| `value_type` | **Step 2 depends on it.** Getting it wrong returns empty, silently |
+| `history` | how far back raw values exist — or `0`, meaning never stored |
+| `trends` | how far back hourly aggregates exist — or `0`, meaning none |
+| `units` | so your answer has units |
+
+### Step 2 — pass the item's real `value_type`. Do not accept the default.
+
+**`history.get` defaults `history` to `3` (numeric unsigned). Measured on a stock Zabbix 7.0: 84 of 121
+items are `0` (float).** So the default is wrong for most items, and wrong silently.
+
+| `value_type` | Meaning |
+|---|---|
+| **0** | float ← **most interface counters and rates** |
+| 1 | character |
+| 2 | log |
+| **3** | unsigned ← **the API default** |
+| 4 | text |
+| 5 | binary |
+
+```jsonc
+zabbix_api("history.get", {
+  "itemids": ["<itemid>"],
+  "history": 0,                    // ← the item's OWN value_type, not the default
+  "time_from": <epoch>, "time_till": <epoch>,
+  "output": "extend", "sortfield": "clock", "sortorder": "DESC", "limit": 500
+})
+```
+
+### Step 3 — never mix value types in one call.
+
+A single `history.get` serves **one** value type. Query four items of mixed types and you get back only the
+matching ones — **the rest vanish with no error**. Measured: 2 of 4 returned each way, zero overlap.
+
+**Group your items by `value_type`, make one call per group, merge the results.**
+
+### Step 4 — route between history and trends by the window.
+
+Raw history is short-lived; hourly aggregates last far longer. `item.get` told you both in Step 1.
+
+| Requested window | Use | Say in your answer |
+|---|---|---|
+| entirely within `history` | `history.get` | raw polled values |
+| entirely beyond `history`, `trends` > 0 | `trend.get` | **hourly min/avg/max, not instantaneous** |
+| spans the boundary | **both**, merged | which part came from which |
+| beyond both | neither exists | *not retained* — see below |
+
+`trend.get` returns `value_min` / `value_avg` / `value_max` / `num` per hour, and is **numeric only**.
+
+**Say when you used trends.** "The peak was 400 Mbps" from raw values and from an hourly average are
+different claims, and an engineer sizing a link needs to know which they have.
+
+---
+
+## The five reasons you get nothing back
+
+They are indistinguishable over the wire — all five are an empty array. Tell them apart, and word them
+differently.
+
+| Cause | How to tell | How to say it |
+|---|---|---|
+| **Wrong value type** | you didn't do Step 1/2 | **Never report this.** Re-query correctly |
+| **Aged out** | window predates `history`, `trends` > 0 | *"beyond raw retention — here is the hourly data"* |
+| **Retention disabled** | `history=0` and/or `trends=0` on the item | *"this item does not retain that"* — a **configuration fact**, not an absence |
+| **Never collected** | item exists, no values ever, empty `lastclock` | *"monitored but has never returned a value"* — **a real finding**, usually a broken poll |
+| **Genuinely idle** | data exists and the values are zero | *"zero throughput"* — the only one that means nothing happened |
+
+**Retention can be switched off per item.** Measured on a stock install: 10 items had `trends=0`, and 5 had
+both `history=0` and `trends=0` — collected purely to fire triggers, never stored. Read the item; do not
+guess.
+
+---
+
+## Every answer must carry
+
+- **The source** — Zabbix, and which host/item.
+- **The window actually served**, which may differ from the one requested (say so if it does).
+- **Whether the values are raw or hourly aggregates.**
+- **The item's units.**
+- **Zabbix's own clock** where relevant — if a "last 5 minutes" query looks empty, clock skew between you
+  and the NMS is a likely cause, and surfacing the NMS time makes that diagnosable instead of baffling.
+- **Unambiguous timezones.**
+- **The bound**, if you limited the result, plus how to narrow the query.
+
+Refuse a future window or a reversed start/end with the reason — do not return empty.
+
+If the same item key exists on multiple hosts, **never merge them into one series** without saying so.
+
+---
+
+## Boundaries — which skill owns what
+
+| Want to… | Use |
+|---|---|
+| Receive unsolicited traps | `snmptrap-mcp` — that is **push**; this **polls** on an interval and keeps history |
+| Flow records | `ipfix-mcp` — flows, not counters |
+| Metrics from infrastructure you instrumented | `prometheus`, `grafana` — pull-based stores; this is the NMS for gear you did not instrument |
+| SaaS monitoring with its own agents | `auvik`, `thousandeyes`, `datadog` — this is the self-hosted NMS an enterprise already runs |
+| **Current** device state | `pyats`, `multivendor-cli`, `fortinet` — they read the device now; **this answers what it was over time**, and can answer for a device that is unreachable right now |
+| Problems and alerts | `zabbix-problem-review` |
+| Availability and inventory | `zabbix-availability` |
+
+## Rules
+
+1. **`item.get` before `history.get`. Always.** There is no shortcut and nothing will catch you.
+2. **Never report "no data" without identifying which of the five causes it is.**
+3. **Say when an answer came from hourly aggregates.**
+4. **This integration is read-only.** There is no write path; do not attempt one.
+5. **No per-call audit trail exists** for this integration. Say so if someone needs an auditable record.

--- a/workspace/skills/zabbix-problem-review/SKILL.md
+++ b/workspace/skills/zabbix-problem-review/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: zabbix-problem-review
+description: "Review current and historical problems from Zabbix — severity, which host, when it started, how long it has been active, and whether anyone has acknowledged it. Use when someone asks what is broken right now, how long something has been broken, or what happened during a window that has already passed."
+version: 1.0.0
+license: Apache-2.0
+tags: [zabbix, nms, monitoring, alerts, problems, incidents, triage, observability]
+user-invocable: true
+metadata:
+  { "openclaw": { "requires": { "bins": ["python3"], "env": ["ZABBIX_URL", "ZABBIX_TOKEN"] } } }
+---
+
+# Zabbix Problem Review
+
+## Server
+
+`zabbix-mcp` — vendored third-party, read-only, three tools. See
+[zabbix-metrics-history](../zabbix-metrics-history/SKILL.md) for the shared cautions.
+
+## Current problems vs history — use the right one
+
+| Question | Method | Note |
+|---|---|---|
+| What is wrong **now**? | **`problem.get`** | Reads a dedicated problem table. This is the right one |
+| What happened **then**? | `event.get` | Historical, heavier, needs a time window |
+| What rule fired it? | `trigger.get` | The definition behind a problem |
+
+```jsonc
+zabbix_api("problem.get", {
+  "output": "extend", "selectAcknowledges": "extend", "selectTags": "extend",
+  "recent": false, "sortfield": ["eventid"], "sortorder": "DESC"
+})
+```
+
+Every problem you report carries: **severity · host · when it started · how long it has been active ·
+acknowledgement state**. "How long" is the question NetClaw could not answer at all before this integration
+existed — do not drop it.
+
+## The distinction that matters most here
+
+> ### "No active problems" and "the NMS could not be reached" are not the same answer.
+
+An empty problem list is a **legitimate, positive finding** — the monitoring system looked and found
+nothing wrong. An unreachable NMS is a **failure to look**.
+
+They are both an empty result over the wire, and reporting the second as the first is the most misleading
+thing this skill can do: it tells an engineer everything is fine at exactly the moment monitoring is blind.
+
+Three outcomes, three different sentences:
+
+| | Say |
+|---|---|
+| NMS reachable, nothing wrong | *"Zabbix reports no active problems as of \<time>."* |
+| NMS unreachable | *"Zabbix could not be reached — this is not a statement about the network."* |
+| Credentials rejected | *"Zabbix rejected the credentials — the monitoring state is unknown."* |
+
+## Acknowledgement is a workflow fact, never a resolution
+
+An acknowledged problem is **still happening**. Someone has said "I've seen this", which is a fact about the
+team, not about the network.
+
+Report it as *"active, acknowledged by \<who> at \<when>"*. Never let acknowledgement soften the description
+of the underlying condition, and never let a filtered-out acknowledged problem disappear from a count.
+
+## Filtering
+
+Filter **before** you answer — by severity, host or group — rather than returning everything and asking the
+reader to ignore rows. Use `severities`, `hostids` or `groupids` on the call.
+
+Severities: 0 not classified · 1 information · 2 warning · 3 average · 4 high · 5 disaster.
+
+When you filter, **say what you filtered out**, so "two problems" is never mistaken for "two problems exist".
+
+## Resolved problems
+
+`event.get` with `value: 0` gives resolutions. Report **both** onset and resolution times — a problem that
+lasted four minutes and one that lasted four hours are different incidents, and the duration is usually the
+point of the question.
+
+## Boundaries
+
+| Want to… | Use |
+|---|---|
+| Metric values over time | `zabbix-metrics-history` |
+| Availability and inventory | `zabbix-availability` |
+| Unsolicited traps | `snmptrap-mcp` — push, not poll |
+| Flows | `ipfix-mcp` |
+| Instrumented metrics / dashboards | `prometheus`, `grafana` |
+| SaaS monitoring | `auvik`, `thousandeyes`, `datadog` |
+| Current device state | `pyats`, `multivendor-cli`, `fortinet` — this is the poller's view over time |
+| Acknowledge, close or suppress anything | **nothing here.** This integration is strictly read-only |
+
+## Rules
+
+1. **Never report an unreachable NMS as "no problems".**
+2. **Always give duration**, not just onset.
+3. **Acknowledged ≠ resolved.** Say "acknowledged", never imply "handled".
+4. **Say what you filtered out.**
+5. **Read-only.** Acknowledging an alert is a real action a human owns; there is no write path here.


### PR DESCRIPTION
Closes roadmap **R11**. NetClaw covered Prometheus, Grafana, Datadog, Splunk, Auvik and ThousandEyes — but had **no SNMP-poller NMS at all**, and therefore **no polled history anywhere**. Syslog, traps and flows all arrive *when something happens*. Nothing could answer *is this normal*, *what did this interface do overnight*, *how long has this been down*.

`SOUL.md` named the gap out loud in the Globalping section — *"use ThousandEyes when a baseline or trend matters"* — and that sentence now has a credential-free answer.

## Adopted, not built — a first for this roadmap

R1/R3/R9 rejected community options on **quality**; R18 rejected one on **licence**. Here the candidate is genuinely good: `mpeirone/zabbix-mcp-server` collapses the whole Zabbix API into **3 tools** measuring **589 / 5,000 tokens (11.8%)** — essentially the design NetClaw would have produced. Vendored **unmodified** at `0722f48`, GPL-3.0 verbatim, invoked over stdio as a separate program.

The NetClaw-authored deliverable is therefore **the three skills**.

| Candidate | Tools | Licence | Outcome |
|---|---|---|---|
| **`mpeirone/zabbix-mcp-server`** | **3** (589 tok) | GPL-3.0 | **adopted** |
| `mhajder/zabbix-mcp` | 53 | MIT | rejected — surface |
| `mhajder/librenms-mcp` | 111 | MIT | LibreNMS deferred |
| `initMAX/zabbix-mcp-server` | 237 | AGPL-3.0 | rejected |

> **There is no official Zabbix LLC MCP server.** `mcpservers.org` labels initMAX "Official" — **that label is wrong**. Recorded so nobody adopts on the strength of it.

## The venv is mandatory, and it caught a real break

The candidate needs **fastmcp 3.x**. **Five NetClaw servers pin `fastmcp<3`** — `netbox-mcp-server`, `CiscoFMC-MCP-server-community`, `Wikipedia_MCP`, `rag-mcp`, `ISE_MCP`. A shared install breaks all five: **spec 076's `cryptography` incident, verbatim.**

Caught by FR-032's *test before adopting*, **before anything was installed** — which is exactly what that requirement exists for. Same fix `multivendor-cli-mcp` already uses.

Two related findings: `python3 -m venv` **fails on this host** (no `ensurepip` — spec 077 hazard #3, hit live), and `netclaw_pip_install` is deliberately **not** used because it targets the *system* interpreter, the exact thing the venv protects. `reconcile-mcp.py` flagged that correctly; the fix names the target interpreter explicitly rather than adding an exception.

## Three distinctions, two of them silent wrong answers

All measured against a **live Zabbix 7.0.29** stood up for this feature:

1. **`history.get` defaults its value type to unsigned — and 84 of 121 stock items are float.** Query with the default and you get an empty array **and a success status**. No error. "No data" then reads like a finding, and an engineer hunts a polling failure that doesn't exist. Types also **cannot be mixed**: measured 4 items, 2 returned each way, **overlap 0**.
2. **Raw history ages out into hourly trends** — again silently. Retention is per item and can be **disabled**: `history=0`, `trends=0`. A third state the spec hadn't modelled, found in Phase 0.
3. **"The poller cannot reach it" ≠ "the device is down."** Spec 079's discipline, and it matters *more* here because an NMS feels authoritative in a way a probe network does not.

**Five causes of absence**, indistinguishable over the wire, each reported differently: wrong-type · aged-out · retention-disabled · never-collected (*a real finding*) · genuinely-idle.

## ⚠️ First integration whose distinctions are guidance, not structure

Specs 080/081/082 each moved their guarantee to a chokepoint the caller couldn't route around. **A generic passthrough has none** — the model composes the request itself.

That was a deliberate clarification decision (smallest surface, upstream maintenance), and it's recorded in the spec, the skill, the server README, `TOOLS.md` and `VERIFICATION.md` rather than assumed away. **The corresponding "lesson carried forward" checklist item is left deliberately unticked** — ticking it would hide the departure.

## Strictly read-only, enforced twice

No write path at all. Adopt-as-is left **nowhere to insert NetClaw's two gates** — verified, the upstream has zero approval/change-record/audit concept — so writes were deferred rather than shipped ungated.

Read-only is **forced by NetClaw**, because the upstream defaults contradict each other:

```
utils.py:29              READ_ONLY default True    ← the library
start_server.py:139      READ_ONLY default False   ← the shipped launcher
```

Running it the documented way **enables writes**. A destructive-method deny-list is the second layer, verified to hold **with read-only deliberately disabled**:

```
READ_ONLY=false  host.delete → REFUSED: Blacklist pattern '.*\.delete$' matched
READ_ONLY=false  host.get    → still allowed (not over-broad)
```

**No per-call GAIT** — upstream has no audit concept and there's no platform-level MCP audit. Inherited posture of every external integration; acceptable only because this is read-only. FR-038c blocks a future write path arriving without audit.

## Two of my own earlier claims were wrong

Both came from research I repeated without verifying. Corrected **visibly**, not silently overwritten:

- *"It delegates auth to `pyzabbix`, which has a known bug"* → **it uses `zabbix_utils`**, Zabbix LLC's own library.
- *"In-body auth was removed in 7.2, so bearer is mandatory"* → **both still work on 7.0.29**; removal is 7.2+. Bearer is for forward-compatibility.

## Verified — and what is not

**132 assertions, 5 suites, exit 0.** Both traps reproduce in NetClaw's own suite against the live NMS. Read-only and the deny-list proven independently. Venv isolation measured (venv 3.4.5 / system 2.14.7, five pins intact).

**Unverified and stated as such** in [VERIFICATION.md](specs/083-zabbix-nms/VERIFICATION.md):

- **The aged-out→trends routing.** The lab is ~1.5h old and retention is 31 days, so nothing has aged out. `trend.get` returns real hourly aggregates, but **my own test asserted the weaker claim** ("trends are retrievable") — that's noted as weaker than SC-003 rather than passed off as it.
- Boundary-spanning windows (same cause).
- **Interface counters from network gear** — FRR images ship no `snmpd`, so metrics came from the NMS's own host. Real polled data, but not from network equipment.
- Zabbix 7.2+.

## Also recorded

LibreNMS **deferred** (only server is 111 tools). Observium **deferred** (abandoned; bypasses the API for direct MySQL + RRD access). And a **correction to this roadmap's Netdata claim** — MCP is in the **free open-source agent** (v2.6.0+), not only the paid Cloud tier, making Netdata a separate near-zero-effort item.

Two upstream defects being **reported, not patched locally** (the tree stays unmodified): the inverted `READ_ONLY` launcher default, and the invalid `fastmcp>=v3.2.0` specifier.

## Checks

| | |
|---|---|
| `bash tests/zabbix/run-tests.sh` | ✅ 132 assertions, exit 0 |
| `python3 scripts/reconcile-mcp.py` | ✅ exit 0, all four surfaces |
| `verify-inventory-counts.py` | ✅ **212 skills / 156 MCP integrations** |
| `check-dependency-pins.py` | ✅ exit 0 |
| `trace-skill.py` × 3 | ✅ all resolve |
| Regression: document, bgp-intel, fortinet, reconcile suites | ✅ all exit 0 |

Process: specify → clarify (3 questions + 1 blocking conflict raised and resolved) → plan → tasks (110) → analyze → **all 11 findings fixed** → implement. Traceability verified mechanically: 65 FRs, 35 SCs, zero gaps.

Blog post skipped by standing operator decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)