### PR TITLE
docs(085): IETF MCP landscape survey → NCFED -01 input — R23

### DIFF
--- a/docs/COVERAGE-ROADMAP.md
+++ b/docs/COVERAGE-ROADMAP.md
@@ -142,7 +142,7 @@ and the IETF datatracker.
 
 | ID | Title | Spec # | Status |
 |----|-------|--------|--------|
-| **R23** | IETF MCP-for-network-management landscape → NCFED `-01` input | — | `NOT STARTED` |
+| **R23** | IETF MCP-for-network-management landscape → NCFED `-01` input | [survey](ietf/IETF-MCP-LANDSCAPE-2026-08.md) | `DONE` — surveyed 2026-08-04. **One of the four named drafts is EXPIRED**; the count went *down* to 13; and the roadmap missed the `agentproto` **WG-forming BOF** (154–51 for a WG, scope rejected 38–124). 8 recommendations seeded into the `-01` backlog |
 
 ### Open territory (build candidates — assess before scheduling)
 
@@ -798,33 +798,55 @@ Both appear on Itential's list. NetClaw has drawio as a *skill* only.
 
 # R23 — IETF MCP-for-network-management landscape
 
-**Status:** `NOT STARTED` · **Strategic, not tooling**
+**Status:** `DONE` — surveyed 2026-08-04 · **Strategic, not tooling**
 
-MCP has arrived at the IETF: 15+ active Internet-Drafts as of April 2026, from Cisco, Google,
-Huawei, Deutsche Telekom, Orange, Telefónica, and independents. No working group has adopted
-any of them and no MCP WG exists yet.
+Full survey: **[`docs/ietf/IETF-MCP-LANDSCAPE-2026-08.md`](ietf/IETF-MCP-LANDSCAPE-2026-08.md)**.
+Recommendations seeded into `docs/ietf/NCFED-HARDENING-BACKLOG.md`; `AGENTPROTO-POSITIONING.md` corrected.
 
-Directly in NetClaw's lane:
-
-| Draft | Relevance |
-|---|---|
-| `draft-zw-opsawg-mcp-network-mgmt` | "MCP Extensions for Network Equipment Management" |
-| `draft-yang-nmrg-mcp-nm` | "Applicability of MCP to Network Management" |
-| `draft-serra-mcp-discovery-uri` | `mcp` URI scheme + `/.well-known/mcp-server` discovery |
-| `draft-morrison-mcp-dns-discovery` | MCP server discovery via DNS TXT records |
-
-`draft-capobianco-ncfed-00` is already in flight. The discovery drafts in particular overlap the
-federation/enrollment problem NCFED solved differently — worth reconciling before `-01`.
+> **⚠️ This section's original April-2026 draft list was stale. Corrected below.**
 
 **Checklist**
-- [ ] Read all four drafts in full
-- [ ] Write a positioning note: where NCFED agrees with, diverges from, or could cite each
-- [ ] Decide whether NCFED `-01` should reference the discovery drafts, and whether NetClaw's
-      TOFU-pinned enrollment is worth contributing back as an alternative
-- [ ] Check opsawg / nmrg mailing list activity for adoption signals
-- [ ] Feed conclusions into the existing NCFED `-01` backlog
+- [x] Read all four drafts — and found **`draft-zw-opsawg-mcp-network-mgmt` is EXPIRED**, one terminal of a
+      four-name rename chain in which *every* link is now expired or replaced. There is no active revision of
+      that work anywhere. **Do not cite it.**
+- [x] Positioning note written — the discovery drafts answer *"where is this domain's endpoint?"*, never
+      *"how do two agents come to trust each other?"*. Serra defines **no key pinning** and defers auth to
+      OAuth; Morrison pins keys in DNS but **admits it has no revocation**
+- [x] Decided on `-01` references — 8 recommendations, in priority order, in the backlog
+- [x] Checked opsawg / nmrg — **opsawg has no live MCP work** (all expired; migrated to NMRG and NMOP).
+      `draft-yang-nmrg-mcp-nm` reached **`-03`** with six authors across five carriers/vendors, but no
+      adoption call was found
+- [x] Fed into the `-01` backlog
 
----
+**Corrected landscape (verified 2026-08-04)**
+
+| Draft | Rev | State |
+|---|---|---|
+| `draft-zw-opsawg-mcp-network-mgmt` | 00 | **EXPIRED — do not cite** |
+| `draft-yang-nmrg-mcp-nm` | **03** | Active to 2027-01-07. The healthy one; cite this |
+| `draft-serra-mcp-discovery-uri` | 04 | Active but **expires 2026-09-25** |
+| `draft-morrison-mcp-dns-discovery` | **05** | Active. `-05` is a **retraction revision** |
+
+**Active MCP drafts: 13, not "15+".** The count went *down* — the Huawei cluster expired faster than new
+drafts arrived. Searching "agent" instead returns **199** active drafts: MCP is a small corner of a much
+larger space, and NCFED sits in the larger one.
+
+**What the original entry missed entirely**
+
+- **`agentproto` WG-forming BOF, IETF 126 Vienna, 2026-07-23.** Form a WG: **154–51 yes**. Proposed scope:
+  **38–124 — rejected.** The room wants a WG and refused the charter it was handed; the refocus toward
+  *context propagation across trust boundaries* is **closer to NCFED's contribution** than the original
+  session-layer framing. **Not chartered yet.**
+- **`dawn` BOF** ("Discovery of Agents, Workloads, Named Entities"). Its problem statement explicitly
+  assumes trust is already established and proposes **no trust model** — precisely NCFED's slot, and a
+  better citation target than either MCP discovery draft.
+- **`draft-bu-agentproto-security-principal-binding-04`** (2026-08-02) supplies a reusable claims matrix
+  authors are meant to fill in. **The cheapest high-credibility `-01` addition available.**
+- **The pushback to pre-empt is revocation** — the IETF direction is WIMSE/SPIFFE short-lived credentials
+  (`draft-klrc-aiagent-auth-03`), and NCFED's long-lived pinned keys will draw exactly that question.
+
+**Follow-on:** none as tooling. This item is complete as strategy; the work it generated lives in the NCFED
+`-01` backlog.
 
 # R24 — Open-territory triage
 

--- a/docs/ietf/AGENTPROTO-POSITIONING.md
+++ b/docs/ietf/AGENTPROTO-POSITIONING.md
@@ -5,13 +5,36 @@ adoption (spec US4 / FR-021).
 
 ## Venue
 
-- **Primary: the IETF `agentproto` effort.** A Birds-of-a-Feather (`agentproto`, at
-  IETF 126) is building on an IETF 124 side meeting and framework/use-case work
-  (Rosenberg, Jennings), aiming to charter a Working Group for agent-to-agent and
-  agent-to-tool communication (MCP, A2A, ACP, ANP, and related I-Ds are in scope).
-  This is the correct home for NCFED. Submit the `-00` (submissiontype `IETF`,
-  individual), then post to the `agentproto` list and request a slot at a
-  side meeting / the BoF.
+- **Primary: the IETF `agentproto` effort.** ART area, chairs **Leslie Daigle** and
+  **Orie Steele**, responsible AD Charles Eckel. Still the correct home for NCFED.
+  Post to `agentproto@ietf.org` and request a slot.
+
+  **UPDATED 2026-08-04 — the BOF has happened, and the outcome matters.** The
+  WG-forming BOF met at **IETF 126 Vienna on 2026-07-23**. Sense of the room:
+
+  | Question | Yes | No |
+  |---|---|---|
+  | Problem space is real | 124 | 72 |
+  | Interoperability needed | 155 | 30 |
+  | IETF is the right venue | 158 | 30 |
+  | **Proposed scope acceptable** | **38** | **124** ← rejected |
+  | **Form a WG** | **154** | **51** ← clear support |
+
+  **The room wants a WG and rejected the charter it was handed.** The recommended
+  refocus — away from a "session layer", toward **context propagation signalling
+  across trust boundaries and multiple parties** — is *closer* to NCFED's actual
+  contribution than the original framing was, so NCFED's fit improves if the revised
+  charter lands there.
+
+  `charter-ietf-agentproto` 404s and the group page still reads *"Not chartered
+  yet"*; BOF minutes remain *"DRAFT for chair review"*. **Treat as not chartered.**
+  Watch for the narrowed charter and the time-boxed call for contributions.
+
+  A second BOF is also relevant: **`dawn`** ("Discovery of Agents, Workloads, Named
+  Entities", Internet area, chairs Adrian Farrel and Wes Hardaker, also not
+  chartered). Its problem statement explicitly assumes trust is already established
+  and proposes no trust model — which is precisely the slot NCFED fills. See
+  `IETF-MCP-LANDSCAPE-2026-08.md`.
 - **Fallback: Independent Submission (ISE), Experimental.** If the WG does not take
   it up, the ISE can publish it as an Experimental RFC for citability. Note that
   under RFC 5742 the IESG conflict-review would likely defer to a forming WG, so the
@@ -51,3 +74,21 @@ adoption (spec US4 / FR-021).
 - **Loop/prompt-injection safety?** Default-deny per-peer authorization, Border audit,
   production-mode guardrails, cross-boundary content treated as untrusted, and a
   SHOULD-level delegation-depth bound.
+
+---
+
+## Landscape survey
+
+A full survey of the MCP / agent-protocol draft landscape, with verified revisions and
+expiries, is in **[`IETF-MCP-LANDSCAPE-2026-08.md`](./IETF-MCP-LANDSCAPE-2026-08.md)**
+(roadmap R23, surveyed 2026-08-04).
+
+Three headlines from it that change this note:
+
+1. **`draft-zw-opsawg-mcp-network-mgmt` is EXPIRED** — one terminal of a four-name
+   rename chain in which every link is now expired or replaced. Do not cite it.
+2. **The MCP draft count went down**, not up: 13 active, against the "15+" of April
+   2026. MCP is a small corner of a 199-draft agent-protocol space.
+3. **`draft-bu-agentproto-security-principal-binding-04`** (revised 2026-08-02)
+   supplies a reusable claims matrix protocol authors are meant to fill in. Filling it
+   for NCFED is the cheapest high-credibility `-01` addition available.

--- a/docs/ietf/IETF-MCP-LANDSCAPE-2026-08.md
+++ b/docs/ietf/IETF-MCP-LANDSCAPE-2026-08.md
@@ -1,0 +1,259 @@
+# IETF MCP / agent-protocol landscape → NCFED `-01` input
+
+**Surveyed 2026-08-04** · roadmap **R23** · feeds `NCFED-HARDENING-BACKLOG.md` and
+`AGENTPROTO-POSITIONING.md`
+
+All draft states verified against `datatracker.ietf.org` on the survey date. Internet-Drafts expire
+six months after revision, so **every citation below carries its revision and expiry** — a `-01` that cites
+a lapsed draft is worse than one that cites nothing.
+
+---
+
+## Three things the roadmap got wrong
+
+The roadmap's R23 entry was written from an April 2026 snapshot. Correcting it is the first deliverable.
+
+### 1. One of the four named drafts is dead
+
+**`draft-zw-opsawg-mcp-network-mgmt` is EXPIRED. Do not cite it.**
+
+It is `-00`, last revised 2025-11-02, and datatracker banners it *"no longer active"*. Worse, it is one
+terminal of a four-name venue-shopping chain in which **every link is now expired or replaced**:
+
+| Name | Rev | Date | State |
+|---|---|---|---|
+| `draft-zeng-mcp-network-mgmt` | 01 | 2025-10-16 | Replaced |
+| `draft-zw-rtgwg-mcp-network-mgmt` | 00 | 2025-10-20 | Replaced |
+| `draft-zw-nmrg-mcp-network-mgmt` | 00 | 2025-10-20 | **Expired**, no successor recorded |
+| `draft-zw-opsawg-mcp-network-mgmt` | 00 | 2025-11-02 | **Expired** |
+
+There is **no active revision** of the MCP-extensions-for-network-equipment work anywhere. Four sibling
+Huawei drafts from the same cluster also expired on 2025-11-02.
+
+The live successor to that line is **`draft-zeng-nmrg-mcp-usecases-requirements-00`** (2026-02-14) — but
+it **expires 2026-08-18, two weeks after this survey**. Cite it only if `-01` is submitted before then, or
+expect it to lapse.
+
+### 2. The draft count went *down*, not up
+
+The roadmap says "15+ active as of April 2026". Measured: **13 active**. The Huawei cluster expired faster
+than new drafts arrived. "MCP at the IETF is growing" is not currently true — *agent protocols* at the IETF
+are growing (199 active drafts match "agent"), and MCP is a small corner of that.
+
+### 3. The roadmap misses the single biggest development
+
+**A WG-forming BOF happened.** `agentproto` — "Agent Communication Protocols", ART area, chairs **Leslie
+Daigle** and **Orie Steele**, AD Charles Eckel — met at **IETF 126 Vienna on 2026-07-23**.
+
+The sense-of-the-room results are the load-bearing detail:
+
+| Question | Yes | No |
+|---|---|---|
+| Problem space is real | 124 | 72 |
+| Interoperability needed | 155 | 30 |
+| IETF is the right venue | 158 | 30 |
+| **Proposed scope acceptable** | **38** | **124** ← rejected |
+| **Form a WG** | **154** | **51** ← clear support |
+
+**The room wants a WG and rejected the charter it was handed.** Recommended refocus: away from a "session
+layer", toward **context propagation signalling across trust boundaries and multiple parties**. Next steps
+were a new list, a narrowed charter, and a time-boxed call for contributions.
+
+`charter-ietf-agentproto` returns 404 and the group page still reads *"Not chartered yet"* — **treat as not
+chartered** as of 2026-08-04. BOF minutes remain *"DRAFT for chair review"*.
+
+`AGENTPROTO-POSITIONING.md` still describes this BOF in the future tense and has been updated accordingly.
+
+---
+
+## Current state of the four named drafts
+
+| Draft | Rev | Revised | Expires | State |
+|---|---|---|---|---|
+| `draft-zw-opsawg-mcp-network-mgmt` | 00 | 2025-11-02 | — | **EXPIRED — do not cite** |
+| `draft-yang-nmrg-mcp-nm` | **03** | 2026-07-06 | 2027-01-07 | Active, not adopted. **The healthy one** |
+| `draft-serra-mcp-discovery-uri` | 04 | 2026-03-25 | **2026-09-25** | Active, single author, lapses soon |
+| `draft-morrison-mcp-dns-discovery` | **05** | 2026-07-22 | 2027-01-23 | Active, single author, 66pp |
+
+**`draft-yang-nmrg-mcp-nm-03`** is the one to cite for *"MCP is being discussed for network management at
+the IETF"*: six authors across Huawei, Telefónica, Deutsche Telekom, Orange and Nokia, four revisions,
+presented at NMRG. It is an individual submission — an adopted RG document would be `draft-irtf-nmrg-*`.
+No adoption call was found.
+
+**opsawg has no live MCP work.** All opsawg-named MCP drafts expired; the work migrated to **NMRG** and
+**NMOP**. The roadmap's "check opsawg / nmrg activity" item resolves to: opsawg dead, NMRG alive but no
+adoption call.
+
+---
+
+## The discovery drafts: they do not solve NCFED's problem
+
+Both answer *"given a domain name I already trust, where is its MCP endpoint and what does it speak?"*
+**Neither answers "how do two agents come to trust each other in the first place?"** — which is the entire
+substance of NCFED's enrollment.
+
+### Serra — `mcp://` URI + `/.well-known/mcp-server`
+
+Three-step cascade: an optional `_mcp.{host}` TXT hint, then a **required** `GET
+https://{host}/.well-known/mcp-server` returning a JSON manifest (`mcp_version`, `name`, `endpoint`,
+`transport`), then a last-resort `https://{host}/mcp`.
+
+Trust is **WebPKI plus same-origin**: authenticity comes from the HTTPS certificate, and the manifest's
+`endpoint` host must match or be a subdomain of the manifest's own host. DNSSEC is SHOULD only.
+
+**Key pinning is explicitly absent** — the draft states *"No key pinning"*. Authentication is only
+*declared*, never performed: the `auth` object advertises `none`/`bearer`/`mtls`/`apikey`/`oauth2`, and the
+draft says outright that authentication *"is covered by … OAuth 2.1 respectively"*.
+
+### Morrison — DNS TXT records at underscore labels
+
+`_mcp.<domain>` for service discovery, `_org-alter.` and `_alter.` for identity. Records carry
+`pk=ed25519:<base64url>` and an `epoch=` rotation counter, with detached Ed25519 signatures over
+RFC 8785-canonicalised JSON.
+
+Trust is **DNSSEC + DANE + in-DNS key pinning**. DNSSEC is REQUIRED for `_alter` envelopes; where an
+envelope and a session are one transaction a **DANE TLSA record is mandatory** and clients *"MUST NOT fall
+back to PKIX-only validation"*.
+
+Two things to know before citing it:
+
+- **`-05` is a retraction revision.** It *withdraws* `-04`'s requirement to cross-reference an IdentityLog
+  root against four named witness surfaces — *"That requirement is WITHDRAWN. It named surfaces that do not
+  exist"* — and marks per-individual DNS envelope publication NOT RECOMMENDED. The author has publicly
+  walked back his own trust machinery.
+- **It admits it has no revocation.** *"Revocation status cannot presently be established from DNS alone.
+  This is a gap in the mechanism."*
+
+### The argument this gives NCFED
+
+A clean Related-Work position, citing both as **contrast, not dependency**:
+
+- **vs Serra** — WebPKI + name binding, **zero key pinning**, authentication deferred to OAuth. NCFED's
+  enrollment-token + pinned-key model is *strictly stronger on peer authentication* and **does not require
+  the peer to operate a public HTTPS origin at all**.
+- **vs Morrison** — genuine key pinning, and the only real overlap with NCFED's TOFU model. But it pins
+  keys *in the DNS zone*, relocating trust to the zone operator plus DNSSEC plus DANE, and then concedes it
+  cannot do revocation. NCFED pins out-of-band via single-use enrollment tokens, so it needs neither a
+  signed zone nor DANE, and severing is a local database operation.
+- **vs both** — they assume a **public, name-addressable server**. NCFED peers are explicitly configured,
+  may be NAT'd or private, and are *peers* rather than servers. The discovery problem genuinely does not
+  arise.
+
+---
+
+## The better citation target the roadmap missed: DAWN
+
+**`draft-akhavain-moussa-dawn-problem-statement-05`** (2026-07-19, expires 2027-01-20, Active) — plus a
+second BOF, **`dawn`** ("Discovery of Agents, Workloads, Named Entities", Internet area, chairs Adrian
+Farrel and Wes Hardaker, also **not chartered yet**).
+
+DAWN frames the general cross-organisational agent discovery problem — and **explicitly assumes trust is
+already solved**:
+
+> *"Assuming that trust has already been established between entities… the discovering entity must learn
+> what the remote entity does."*
+
+It names the two trust questions — whether the discovery source is authoritative, and whether the
+registered entity is what it claims — and **proposes no trust model, identity binding, or key
+distribution**. It also declines to endorse DNS or well-known-URI discovery, listing DNS-SD/SSDP/WebFinger
+as prior art *"needing careful analysis to identify key gaps"*.
+
+**This is the strongest citation available to NCFED.** NCFED's explicit-configuration-plus-TOFU model is a
+legitimate answer to DAWN's unfilled trust-establishment slot, and DAWN's own framing licenses manual
+configuration as a current approach rather than dismissing it. It is a better fit than either MCP discovery
+draft, because it is a *problem statement in the area NCFED occupies* rather than a competing mechanism.
+
+---
+
+## The most actionable item: fill in the security-principal-binding matrix
+
+**`draft-bu-agentproto-security-principal-binding-04`**, revised **2026-08-02** — two days before this
+survey — and it sits in the `agentproto` document set.
+
+It defines a verifier-facing model separating claims about user authority, agent instance identity, tool
+identity, delegation state, session continuity and action evidence — and provides a **reusable matrix that
+protocol authors are meant to fill in**, stating for each claim which field carries it, who verifies it,
+what binding and freshness rules apply, and the required failure behaviour.
+
+**Filling that matrix in for NCFED is the single highest-value, lowest-cost `-01` addition identified by
+this survey.** It is cheap (NCFED already has the mechanisms; this is a tabulation), it is high-credibility
+(it demonstrates engagement with agentproto rather than the MCP corner), and it aligns NCFED with a
+document that is *current within the forming WG* rather than with drafts that are expiring.
+
+---
+
+## The pushback to pre-empt in `-01`: revocation
+
+The IETF consensus direction for agent identity is **WIMSE/SPIFFE identifiers with short-lived
+credentials and OAuth-based delegation**. The heavyweight is **`draft-klrc-aiagent-auth-03`** (2026-07-06,
+expires 2027-01-07) — Kasselman (Defakto), Lombardo (AWS), Rosomakho (Zscaler), Campbell (Ping), Steele
+(OpenAI), Parecki (Okta) — which mandates *"exactly one WIMSE identifier, which MAY be a SPIFFE ID"* with
+short-lived X.509-SVID / JWT-SVID credentials **rather than static keys**, and does cover agent-to-agent via
+transaction tokens and OAuth token exchange.
+
+**NCFED's TOFU-pinned long-lived keys are orthogonal to that**, and reviewers from this crowd will push on
+exactly one thing: **revocation**. The agentproto BOF minutes explicitly flag *"continued discussion on
+trust boundaries, revocation, and authorization frameworks"*, and it is the same gap Morrison admits to.
+
+NCFED does have an answer — severing revokes the local grant, and it is a local database operation rather
+than a log pre-image reveal — but `-00` treats severing as an operator lifecycle action rather than framing
+it as *the* revocation story. **`-01` should make the revocation argument explicitly and up front**, because
+it is the first question this audience will ask.
+
+Adjacent drafts worth a sentence each if space allows: `draft-okutomi-session-bound-agent-identity-06`
+(channel binding — conceptually close to NCFED's long-lived pinned session),
+`draft-singla-agent-identity-protocol-03` (DIDs + capability delegation),
+`draft-niyikiza-oauth-attenuating-agent-tokens-01` (attenuating tokens — relevant if NCFED ever narrows a
+delegated task's authority).
+
+MCP-specific security work exists but is thin: `draft-mohiuddin-mcp-security-considerations-00`
+(2026-06-01) and `draft-sharif-mcps-secure-mcp-00` (2026-03-14, 43pp).
+
+---
+
+## Also new since April 2026, relevant to NCFED
+
+| Draft | Why it matters |
+|---|---|
+| **`draft-abbott-mcp-ax-00`** (2026-05-04) | Hierarchical tool-namespace delegation across MCP servers — the closest thing to a federation/aggregation story in MCP-land. Worth comparing against NCFED's iN2N hub-and-spoke |
+| `draft-feng-nmop-naim-mcp-00` (2026-07-18) | NAIM framework over MCP, in NMOP |
+| `draft-morrison-mcp-tool-surface-names-registry-00` | IANA registry for tool names |
+| `draft-jennings-agentproto-mcp-over-moqt-00` | MCP over MoQ; note it is now `agentproto`-named |
+
+---
+
+## Recommendations for `-01`
+
+In priority order, each traceable to a finding above:
+
+1. **Fill in the `draft-bu-agentproto-security-principal-binding` matrix.** Cheapest high-credibility win.
+2. **Make revocation an explicit, prominent argument**, not a lifecycle footnote. It is the first question
+   this audience asks, and NCFED's answer is genuinely better than the DNS-based alternatives'.
+3. **Cite DAWN's problem statement** as the framing NCFED answers — a stronger position than citing either
+   MCP discovery draft.
+4. **Cite Serra `-04` and Morrison `-05` as contrast**, with revisions stated, noting that Serra defines no
+   key pinning and Morrison admits no revocation. **Note Serra may lapse 2026-09-25.**
+5. **Cite `draft-yang-nmrg-mcp-nm-03`** for MCP-in-network-management. **Do not cite
+   `draft-zw-opsawg-mcp-network-mgmt` — it is dead.**
+6. **Compare against `draft-abbott-mcp-ax`** on hierarchical delegation, since iN2N solves an adjacent
+   problem.
+7. **Reconcile with the WIMSE/SPIFFE direction** — a paragraph acknowledging short-lived credentials as the
+   consensus direction and explaining why a pinned long-lived key is appropriate for a BGP-adjacent peering
+   session that must survive control-plane restarts.
+8. **Watch the `agentproto` charter.** The scope was rejected 38–124 and is being rewritten toward *context
+   propagation across trust boundaries* — which is closer to NCFED's actual contribution than the original
+   session-layer framing was. If the revised charter lands there, NCFED's fit improves.
+
+## What this survey did not verify
+
+Stated so nothing here is mistaken for settled:
+
+- Whether the `agentproto` charter has been approved since the BOF. Group page still reads "Not chartered
+  yet"; minutes are still draft.
+- Whether any NMRG/NMOP **adoption call** exists for `draft-yang-nmrg-mcp-nm` — session presence and
+  "related work" status were found, an adoption call was not.
+- Which expired terminal name Huawei treats as canonical for the network-equipment-extensions work.
+- Serra `-04`'s exact revision date — datatracker's document page says 2026-03-25, its search index says
+  2026-03-26.
+- The full 199-draft "agent" set was not enumerated; datatracker paginates at ~10 rows across 83 pages. The
+  `agentproto` and `dawn` document sets were captured in full.

--- a/docs/ietf/NCFED-HARDENING-BACKLOG.md
+++ b/docs/ietf/NCFED-HARDENING-BACKLOG.md
@@ -283,3 +283,46 @@ in the draft (FR-010):
 - Selection (which peer collection answers) is deterministic embedding-cosine over the
   advertised descriptions with a configurable threshold — an implementation/agent
   concern, not a wire element, so it need not appear in the draft beyond a sentence.
+
+## `-01` seed — IETF landscape reconciliation (roadmap R23, 2026-08-04)
+
+From the survey in [`IETF-MCP-LANDSCAPE-2026-08.md`](./IETF-MCP-LANDSCAPE-2026-08.md). Ordered by
+value-per-effort; every item traces to a verified draft state.
+
+### Tier 1 — cheap, high-credibility
+
+- **Fill in the `draft-bu-agentproto-security-principal-binding-04` claims matrix** for NCFED (user
+  authority · agent instance identity · tool identity · delegation state · session continuity · action
+  evidence; for each: carrying field, verifier, binding/freshness rule, failure behaviour). NCFED already has
+  the mechanisms — this is tabulation, and it demonstrates engagement with `agentproto` rather than the
+  expiring MCP corner. **Highest value per unit of effort identified by the survey.**
+- **Promote revocation from lifecycle footnote to explicit argument.** `-00` treats severing as an operator
+  action ({{prior-art}} / §"Lifecycle"). The agentproto BOF minutes flag *"continued discussion on trust
+  boundaries, revocation, and authorization frameworks"*, and it is the **first question** this audience
+  asks. NCFED's answer is genuinely stronger than the DNS-based alternatives' — Morrison
+  `-05` concedes *"Revocation status cannot presently be established from DNS alone"* — so this is a win
+  currently being left on the table.
+- **Fix the Related Work citations.** Add `draft-akhavain-moussa-dawn-problem-statement-05` as the framing
+  NCFED answers; cite `draft-serra-mcp-discovery-uri-04` (no key pinning, auth deferred to OAuth) and
+  `draft-morrison-mcp-dns-discovery-05` (DNS-rooted pinning, admits no revocation) as **contrast**; cite
+  `draft-yang-nmrg-mcp-nm-03` for MCP-in-network-management. **Do NOT cite
+  `draft-zw-opsawg-mcp-network-mgmt` — it is expired.**
+
+### Tier 2 — real writing
+
+- **Reconcile with WIMSE/SPIFFE.** `draft-klrc-aiagent-auth-03` (Kasselman, Lombardo, Rosomakho, Campbell,
+  Steele, Parecki) mandates one WIMSE identifier with **short-lived** SVID credentials rather than static
+  keys. Add a paragraph explaining why a pinned long-lived key suits a BGP-adjacent peering session that must
+  survive control-plane restarts. Expect to be asked; better to answer first.
+- **Compare against `draft-abbott-mcp-ax-00`** (hierarchical tool-namespace delegation across MCP servers) —
+  the closest thing to a federation story in MCP-land, and adjacent to iN2N's hub-and-spoke.
+
+### Timing constraints
+
+- **`draft-serra-mcp-discovery-uri-04` expires 2026-09-25.** If `-01` cites it, either submit before then or
+  note the revision explicitly.
+- **`draft-zeng-nmrg-mcp-usecases-requirements-00` expires 2026-08-18** — two weeks after the survey. Likely
+  to lapse before `-01`.
+- **Watch the `agentproto` charter.** Scope was rejected 38–124 and is being rewritten toward *context
+  propagation across trust boundaries*, which is **closer to NCFED's contribution** than the original
+  session-layer framing. NCFED's fit improves if it lands there.


### PR DESCRIPTION
Closes roadmap **R23**. Explicitly *"strategic, not tooling"* — no server, no skill, no counts — so the full spec-kit pipeline was **deliberately not applied**. Running 50 tasks over a read-and-write job would be ceremony over substance. The deliverable is the survey and the `-01` recommendations it generated.

## Three things the roadmap got wrong

All verified against `datatracker.ietf.org` on 2026-08-04.

**1. One of the four named drafts is dead.** `draft-zw-opsawg-mcp-network-mgmt` is **EXPIRED** — and it's one terminal of a four-name venue-shopping chain in which *every* link is now expired or replaced:

| Name | State |
|---|---|
| `draft-zeng-mcp-network-mgmt-01` | Replaced |
| `draft-zw-rtgwg-mcp-network-mgmt-00` | Replaced |
| `draft-zw-nmrg-mcp-network-mgmt-00` | **Expired**, no successor |
| `draft-zw-opsawg-mcp-network-mgmt-00` | **Expired** |

There is no active revision of that work anywhere. Citing it in `-01` would have cited a dead draft.

**2. The count went *down*.** 13 active MCP drafts, against the roadmap's "15+ as of April 2026" — the Huawei cluster expired faster than new ones arrived. Searching "agent" instead returns **199** active drafts. MCP is a small corner of a much larger space, and NCFED sits in the larger one.

**3. The roadmap missed the biggest development entirely** — the `agentproto` **WG-forming BOF**, IETF 126 Vienna, 2026-07-23:

| Question | Yes | No |
|---|---|---|
| IETF is the right venue | 158 | 30 |
| **Proposed scope acceptable** | **38** | **124** ← rejected |
| **Form a WG** | **154** | **51** ← clear support |

**The room wants a WG and refused the charter it was handed.** The recommended refocus — *context propagation across trust boundaries* — is **closer to NCFED's contribution** than the original session-layer framing. Not chartered yet; minutes still draft.

`AGENTPROTO-POSITIONING.md` described that BOF in the future tense. Corrected.

## The discovery drafts don't solve NCFED's problem

Both answer *"given a domain I already trust, where is its endpoint?"* — **neither answers "how do two agents come to trust each other?"**, which is the entire substance of NCFED's enrollment.

- **Serra `-04`** states outright **"No key pinning"** and defers authentication to OAuth 2.1. NCFED's enrollment-token + pinned-key model is strictly stronger on peer authentication and needs no public HTTPS origin.
- **Morrison `-05`** *does* pin keys — but in the DNS zone (DNSSEC + DANE), and concedes *"Revocation status cannot presently be established from DNS alone. This is a gap."* Its `-05` is also a **retraction revision**, withdrawing `-04`'s own trust machinery as naming *"surfaces that do not exist"*.

Cite both as **contrast, not dependency**.

## The better citation target the roadmap missed: DAWN

`draft-akhavain-moussa-dawn-problem-statement-05`, plus a second BOF. It frames cross-organisational agent discovery and **explicitly assumes trust is already established**, proposing no trust model:

> *"Assuming that trust has already been established between entities…"*

That is precisely the slot NCFED fills — and DAWN's framing *licenses* manual configuration rather than dismissing it. A stronger position than citing either MCP discovery draft.

## The most actionable finding

`draft-bu-agentproto-security-principal-binding-04`, revised **two days before the survey**, supplies a **reusable claims matrix protocol authors are meant to fill in**. Filling it for NCFED is tabulation of mechanisms NCFED already has, and it demonstrates engagement with `agentproto` rather than the expiring MCP corner. **Cheapest high-credibility `-01` addition available.**

## The pushback to pre-empt: revocation

The IETF direction is **WIMSE/SPIFFE short-lived credentials** — `draft-klrc-aiagent-auth-03` (Kasselman, Lombardo, Rosomakho, Campbell, Steele, Parecki) mandates one WIMSE identifier with SVID credentials *rather than static keys*. NCFED's long-lived pinned keys will draw exactly that question, and the BOF minutes flag *"continued discussion on trust boundaries, revocation, and authorization frameworks"*.

NCFED's answer is **better** than the DNS alternatives' — but `-00` buries severing as a lifecycle footnote. A win currently left on the table.

## Deliverables

- **`docs/ietf/IETF-MCP-LANDSCAPE-2026-08.md`** — the survey, with every citation carrying its revision and expiry
- **`docs/ietf/NCFED-HARDENING-BACKLOG.md`** — 8 recommendations in priority order, plus two timing constraints (Serra expires 2026-09-25; the nmrg use-cases draft expires 2026-08-18)
- **`docs/ietf/AGENTPROTO-POSITIONING.md`** — corrected for the BOF outcome
- **`docs/COVERAGE-ROADMAP.md`** — R23 marked done, stale draft list replaced

Everything I could not confirm is listed as unverified: the charter's post-BOF status, whether any NMRG adoption call exists, and which expired terminal Huawei treats as canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)