### PR TITLE
feat(088): startup check as 5th reconcile surface — 7 registered servers cannot start

### DIFF
--- a/docs/ADDING-AN-MCP.md
+++ b/docs/ADDING-AN-MCP.md
@@ -99,7 +99,21 @@ To check one surface while iterating:
 ```bash
 scripts/reconcile-mcp.py --surface catalog
 scripts/reconcile-mcp.py --surface portability
+scripts/reconcile-mcp.py --surface startup      # actually launches your server
 ```
+
+The `startup` surface (spec 088) launches every registered stdio server and reports the ones that
+cannot start. Use it on your own server before pushing:
+
+```bash
+scripts/check-server-startup.py --only <your-server-key>
+```
+
+A **timeout is success** — a server that imports cleanly and then blocks reading stdio is behaving
+correctly. Only a fatal startup error (missing module, absent entry point, syntax error) is a
+finding. This surface currently reports as `WARN` rather than failing the build, because seven
+pre-existing servers cannot start and two of them need an SDK that is not publicly distributable;
+see `specs/088-server-startup-check/spec.md` for the exit condition.
 
 To confirm a skill's chain resolves:
 
@@ -109,9 +123,16 @@ scripts/trace-skill.py <skill-name>
 
 ### 7. Confirm installability
 
-The property that actually matters is that a *fresh user* can obtain this. `reconcile-mcp.py`
-verifies it statically: installer coverage exists and no path is machine-specific. No running agent
-is needed, and your own live gateway's contents are irrelevant.
+The property that actually matters is that a *fresh user* can obtain this — and that what they
+obtain can actually run. `reconcile-mcp.py` checks both:
+
+- **Statically** (`catalog`, `docs`, `portability`, `dependencies`): installer coverage exists, no
+  path is machine-specific, counts agree, pins are bounded.
+- **Dynamically** (`startup`, spec 088): your server is launched and must not die on import.
+
+No running agent is needed, and your own live gateway's contents are irrelevant. The static surfaces
+alone were not enough: they compare declarations against each other, so for four specs' worth of
+history they all passed while seven registered servers could not start.
 
 ---
 
@@ -128,6 +149,7 @@ is needed, and your own live gateway's contents are irrelevant.
 [ ] README.md updated INCLUDING counts
 [ ] SOUL.md updated INCLUDING counts
 [ ] SKILL.md created (if adding a skill)
+[ ] check-server-startup.py --only <key> reports no finding (timeout is success)
 [ ] .env.example updated (names only)
 [ ] TOOLS.md updated
 [ ] mcp-servers/<name>/README.md created

--- a/scripts/check-server-startup.py
+++ b/scripts/check-server-startup.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Catch registered MCP servers that cannot start.
+
+Spec 088. The gap this closes, in one sentence: **reconcile validated that servers were
+declared consistently, never that they worked.**
+
+Found 2026-08-04 while checking one thing about Meraki. Six of 98 registered servers could
+not start — one of them (`aruba-cx-mcp`) had no server file at all — while
+`reconcile-mcp.py` exited 0 and reported everything healthy. Twenty skills pointed at
+dead servers.
+
+That is the same shape as the two gaps before it:
+
+  * `check-dependency-pins.py` read only `requirements.txt`, so a server declaring deps in
+    `pyproject.toml` was never scanned at all (fixed by spec 082).
+  * `verify-inventory-counts.py` checks headline arithmetic, not table membership, so the
+    README sat two specs behind while every count passed (found by spec 082).
+
+Each time, the check validated a *declaration* rather than a *fact*. This one runs the
+thing.
+
+TECHNIQUE, AND ITS LIMIT. Static import analysis was tried first and produced 11 findings,
+5 of them false: several servers import a shared module resolved at runtime via sys.path,
+which a static scan cannot see. Only *launching* the process gave the truth. So this
+launches each server with a short timeout and reads what it says on the way down. That is
+slower and it is the only thing that works.
+
+We deliberately do NOT assert a successful MCP handshake — many servers legitimately exit
+or block without credentials. The signal is narrower and reliable: a missing module, a
+missing entry point, or a syntax error. Those are never correct.
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CONFIG = os.path.join(REPO_ROOT, "config", "openclaw.json")
+# A server that is going to fail on import dies in well under a second; one that is
+# healthy blocks on stdio forever. So the timeout only needs to be long enough to
+# distinguish those, and it is the dominant cost of this check — at 25s across ~35
+# servers it took over ten minutes, which is too slow to sit in CI.
+TIMEOUT = 6
+WORKERS = 8
+
+# Recorded exceptions, each with a reason (the discipline spec 077 established).
+# A server here is KNOWN not to start and that is accepted for a stated reason.
+STARTUP_EXCEPTIONS: dict[str, str] = {}
+
+# ── The seven found on 2026-08-04, and why each needs a DIFFERENT fix ──────────
+#
+# Deliberately NOT added to STARTUP_EXCEPTIONS: they are real breakage, and silencing
+# them would defeat the check on the day it was written. They are recorded here, and this
+# check runs in --warn-only mode from reconcile until they are resolved (spec 088).
+#
+# 1. GATED SDK — not publicly distributable, so no install can fix it:
+#      prisma-sdwan-mcp   missing prisma_sase   (no matching distribution on PyPI)
+#      radkit-mcp         missing radkit_client (Cisco RADKit, licensed)
+#    These should carry an EXTERNAL_INTEGRATIONS entry or be unregistered. A registered
+#    server nobody can install is advertising a capability NetClaw does not have.
+#
+# 2. NO ENTRY POINT AT ALL:
+#      aruba-cx-mcp       mcp-servers/aruba-cx-mcp/aruba_cx_mcp_server.py does not exist
+#    4 skills route to it. Either vendor the server or unregister it.
+#
+# 3. WRONG ENVIRONMENT, not a missing package:
+#      arista-cvp-mcp     missing urllib3
+#    It launches via `uv run --directory ... --with fastmcp`, i.e. an ephemeral uv
+#    environment. urllib3 IS installed system-wide (2.6.3) — it is absent from THAT env.
+#    The fix is that server's `--with` list, not a system install. Recorded because the
+#    naive reading ("install urllib3") is wrong and would waste someone's afternoon.
+#
+# 4. INSTALLABLE, BLOCKED BY THE HOST:
+#      meraki-magic-mcp   missing meraki      (PyPI: 4.3.1)
+#      gnmi-mcp           missing pygnmi      (PyPI: 0.8.15)
+#      junos-mcp          missing jnpr        (PyPI: junos-eznc 2.8.2)
+#    All three are publicly available and pull NO shared pin (verified by dry-run: none
+#    touches fastmcp/mcp/httpx/cryptography/pydantic). But this host's system interpreter
+#    is PEP 668 externally-managed, and `netclaw_pip_install` is a bare
+#    `"$py" -m pip install "$@"` with no PEP 668 handling — so it cannot install them
+#    either. That is a gap in the helper, not in these servers.
+
+# Patterns that mean "this can never work", as opposed to "this needs configuration".
+FATAL = [
+    (re.compile(r"ModuleNotFoundError: No module named '([^']+)'"),
+     "missing Python module {0}"),
+    (re.compile(r"can't open file '([^']+)': \[Errno 2\] No such file or directory"),
+     "entry point does not exist: {0}"),
+    (re.compile(r"No such file or directory"), "entry point or interpreter not found"),
+    (re.compile(r"SyntaxError: (.+)"), "syntax error: {0}"),
+    (re.compile(r"ImportError: (.+)"), "import error: {0}"),
+]
+
+
+def registered(config: str = CONFIG) -> dict:
+    with open(config, encoding="utf-8") as fh:
+        return json.load(fh).get("mcpServers", {})
+
+
+def launchable(name: str, spec: dict) -> tuple[list[str], str] | None:
+    """The argv to try, or None with a reason to skip.
+
+    Skips remote/HTTP servers and anything whose interpreter is absent from this host —
+    a missing `node` is an install gap, not a broken registration, and conflating them
+    would make this check noisy enough to ignore.
+    """
+    cmd = spec.get("command")
+    if not cmd:
+        return None
+    if cmd in ("npx", "uvx", "docker", "node", "npm") and not shutil.which(cmd):
+        return None
+    if cmd not in ("npx", "uvx", "docker", "node", "npm") and not (
+        shutil.which(cmd) or os.path.exists(os.path.join(REPO_ROOT, cmd))
+    ):
+        return None
+    argv = [cmd] + list(spec.get("args", []))
+    return argv, ""
+
+
+def probe(name: str, argv: list[str]) -> str | None:
+    """Launch it. Return a failure description, or None if it is not provably broken."""
+    env = dict(os.environ)
+    env.setdefault("PYTHONUNBUFFERED", "1")
+    try:
+        p = subprocess.run(argv, cwd=REPO_ROOT, env=env, stdin=subprocess.DEVNULL,
+                           capture_output=True, text=True, timeout=TIMEOUT)
+    except subprocess.TimeoutExpired:
+        # Blocking on stdio is the CORRECT behaviour for an MCP server. Not a failure.
+        return None
+    except (OSError, ValueError) as exc:
+        return f"could not launch: {exc}"
+    blob = (p.stderr or "") + (p.stdout or "")
+    for pat, tmpl in FATAL:
+        m = pat.search(blob)
+        if m:
+            return tmpl.format(*m.groups()) if m.groups() else tmpl
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--warn-only", action="store_true",
+                    help="report findings but exit 0")
+    ap.add_argument("--only", help="check a single server by name")
+    # Overridable so this check is testable against fixture servers with known startup
+    # behaviour, rather than only against the live repository config.
+    ap.add_argument("--config", default=CONFIG,
+                    help=f"registration file to read (default: {CONFIG})")
+    args = ap.parse_args()
+
+    servers = registered(args.config)
+    checked, skipped, failures = 0, [], []
+
+    todo = []
+    for name in sorted(servers):
+        if args.only and name != args.only:
+            continue
+        if name in STARTUP_EXCEPTIONS:
+            continue
+        got = launchable(name, servers[name])
+        if got is None:
+            skipped.append(name)
+            continue
+        todo.append((name, got[0]))
+
+    checked = len(todo)
+    # Launched in parallel: each probe is dominated by waiting out TIMEOUT, so serial
+    # execution made this check unusable in CI.
+    with ThreadPoolExecutor(max_workers=WORKERS) as pool:
+        for (name, _), why in zip(todo, pool.map(lambda t: probe(*t), todo)):
+            if why:
+                failures.append((name, why))
+
+    print(f"Servers registered: {len(servers)}")
+    print(f"  launched and checked: {checked}")
+    print(f"  skipped (remote, or interpreter absent): {len(skipped)}")
+    if STARTUP_EXCEPTIONS:
+        print(f"  recorded exceptions: {len(STARTUP_EXCEPTIONS)}")
+
+    if not failures:
+        print("\nServer startup check: PASS")
+        return 0
+
+    print(f"\nServer startup check: FAIL ({len(failures)})")
+    for name, why in failures:
+        print(f"  startup: {name}: {why}")
+    print("\nA registered server that cannot start is worse than an absent one: it is "
+          "advertised in the catalog, counted in the docs, and skills route to it. Either "
+          "fix it, unregister it, or record it in STARTUP_EXCEPTIONS with a reason.")
+    return 0 if args.warn_only else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reconcile-mcp.py
+++ b/scripts/reconcile-mcp.py
@@ -44,6 +44,17 @@ SURFACES = {
     "catalog": ("verify-catalog-coverage.py", "installer coverage and vendored state"),
     "docs": ("verify-inventory-counts.py", "documented counts"),
     "portability": ("check-mcp-portability.py", "registration portability"),
+    # Added by spec 088: a registered server that cannot START. Every other surface here
+    # validates that things are DECLARED consistently; none of them ran anything. Found
+    # by launching all 98 registered servers: seven could not start, one had no server
+    # file at all, and 22 skills routed to them — while this script exited 0.
+    #
+    # Runs --warn-only until the seven are resolved, because they need four different
+    # fixes (two SDKs are not publicly distributable, one server has no entry point, one
+    # is a uv-env issue, three are blocked by PEP 668 on this host). Flipping it to
+    # hard-fail is the follow-up, and the reason it is not hard-fail today is written
+    # down rather than left as a mystery.
+    "startup": ("check-server-startup.py", "registered servers can actually start"),
     # Added by spec 077 (R0a): dependency breakage that only affects FRESH
     # installs — unbounded pins on packages whose submodules are imported, bare
     # pip invocations, and ensurepip-dependent venv creation.
@@ -51,6 +62,20 @@ SURFACES = {
 }
 
 EXIT_OK = 0
+# Surfaces that report findings but never fail the build, regardless of --warn-only.
+# A surface belongs here only with a written reason and an exit condition -- otherwise it
+# becomes a permanent way to ignore real breakage, which is the failure mode spec 088 was
+# written to fix in the first place.
+ALWAYS_WARN = {
+    # spec 088: the seven servers this found are genuinely broken, and two of them need an
+    # SDK that is not publicly distributable -- so nobody can make this green today. Hard-
+    # failing would mean either reverting the check or papering the seven into
+    # STARTUP_EXCEPTIONS. Warn-only keeps them visible on every run instead.
+    # EXIT CONDITION: remove this entry once the seven in check-server-startup.py are
+    # resolved. After that, a server that cannot start should break the build.
+    "startup",
+}
+
 EXIT_FAIL = 1
 EXIT_CANNOT_RUN = 2
 
@@ -90,7 +115,8 @@ def extract_findings(output):
         if stripped.startswith("- ") or stripped.startswith("* "):
             findings.append(stripped[2:])
         elif stripped.startswith(("portability:", "unlocatable:", "flagged:", "note:",
-                                  "ERROR:", "pins:", "bare-pip:", "venv:")):
+                                  "ERROR:", "pins:", "bare-pip:", "venv:",
+                                  "startup:")):
             findings.append(stripped)
         elif line.startswith("  ") and (
             "claims" in stripped or "no matching" in stripped or "no recorded state" in stripped
@@ -120,27 +146,39 @@ def main():
     any_failed = False
 
     for name in selected:
-        code, output = run_surface(name, args.warn_only)
+        always_warn = name in ALWAYS_WARN
+        # Deliberately NOT passing warn_only for an ALWAYS_WARN surface: the check should
+        # still report its true exit code, and this wrapper downgrades it below. Silencing
+        # it at the source would make the finding invisible here too.
+        code, output = run_surface(name, args.warn_only and not always_warn)
         findings = extract_findings(output)
         if code == EXIT_CANNOT_RUN:
             status = "cannot_run"
             cannot_run = True
         elif code != EXIT_OK:
-            status = "fail"
-            any_failed = True
+            # An ALWAYS_WARN surface reports but does not fail the build. It is still
+            # rendered distinctly ("warn"), so a reader can never mistake it for a pass.
+            status = "warn" if always_warn else "fail"
+            any_failed = any_failed or not always_warn
         else:
             status = "flagged" if any(f.startswith("flagged:") for f in findings) else "pass"
         results[name] = {"status": status, "exit_code": code, "findings": findings}
 
     if args.as_json:
-        overall = "cannot_run" if cannot_run else ("fail" if any_failed else "pass")
+        any_warn = any(r["status"] == "warn" for r in results.values())
+        overall = ("cannot_run" if cannot_run else "fail" if any_failed
+                   else "pass_with_warnings" if any_warn else "pass")
         print(json.dumps({"overall": overall, "surfaces": results}, indent=2))
     else:
-        overall = "CANNOT RUN" if cannot_run else ("FAIL" if any_failed else "PASS")
+        # A WARN surface must not render as a bare PASS. The whole point of spec 088 is
+        # that a green summary concealed seven dead servers.
+        any_warn = any(r["status"] == "warn" for r in results.values())
+        overall = ("CANNOT RUN" if cannot_run else "FAIL" if any_failed
+                   else "PASS (with warnings)" if any_warn else "PASS")
         print(f"Reconciliation: {overall}")
         for name in selected:
             r = results[name]
-            label = {"pass": "pass", "fail": "FAIL",
+            label = {"pass": "pass", "fail": "FAIL", "warn": "WARN",
                      "flagged": "pass*", "cannot_run": "ERROR"}[r["status"]]
             _, noun = SURFACES[name]
             if args.quiet and r["status"] in ("pass", "flagged"):

--- a/specs/088-server-startup-check/spec.md
+++ b/specs/088-server-startup-check/spec.md
@@ -1,0 +1,131 @@
+# Spec 088 — Server Startup Check (fifth reconcile surface)
+
+**Status**: implemented
+**Branch**: `088-server-startup-check`
+**Date**: 2026-08-04
+
+## Problem
+
+NetClaw's reconciliation gate (`scripts/reconcile-mcp.py`, spec 075, extended by 077)
+had four surfaces. All four validate that things are **declared** consistently:
+
+| Surface | What it compares |
+|---|---|
+| `catalog` | installer coverage vs. vendored state |
+| `docs` | documented capability counts vs. registrations |
+| `portability` | registration paths vs. portability rules |
+| `dependencies` | pin bounds and install paths in `requirements.txt` / install steps |
+
+**None of them ran anything.** Nothing in the repository ever checked whether a
+registered MCP server could start. So `reconcile-mcp.py` exited 0 — and CI passed —
+while **seven of the 98 registered servers could not start at all**, with **22 skills**
+routing to them.
+
+This is the third instance of the same meta-pattern in this repo, and the reason this
+spec generalises rather than just fixing the seven:
+
+1. `check-dependency-pins.py` read only `requirements.txt`, never an installed version.
+2. `verify-inventory-counts.py` checks headline arithmetic, never table membership.
+3. Nothing checked whether a registered server can start.
+
+A check that validates declarations cannot detect a declaration that is uniformly,
+consistently wrong.
+
+### How the seven were found — and why static analysis was not enough
+
+A first pass by static import analysis reported 11 findings, **5 of them false**:
+`netclaw_tokens` resolves at runtime via `sys.path`, so reading source cannot tell
+whether an import will succeed. Only launching the process gave the truth. That result
+is recorded in the script's own docstring so nobody repeats the shortcut.
+
+## Requirements
+
+- **FR-001** Launch every registered stdio server and detect fatal startup failure.
+- **FR-002** A server that imports cleanly and then blocks reading stdio is **correct
+  MCP behaviour**. A timeout MUST NOT be reported as a failure. (Getting this backwards
+  flags all 75 working servers.)
+- **FR-003** Distinguish *missing Python module* from *entry point does not exist* — they
+  need different fixes, and installing packages would never have fixed `aruba-cx-mcp`.
+- **FR-004** Skip remote/HTTP servers and servers whose interpreter is absent from the
+  host: a missing `node` is an install gap, not a broken registration, and conflating
+  them makes the check noisy enough to ignore.
+- **FR-005** Name both the server and the specific cause in every finding.
+- **FR-006** Support `--warn-only` (exit 0 with findings), matching every other surface.
+- **FR-007** Support `--config` so the check is testable against fixtures with known
+  startup behaviour, not only the live repository config.
+- **FR-008** Run fast enough for CI. (First working version took **>10 minutes**;
+  `TIMEOUT` 25→6 plus `ThreadPoolExecutor(8)` brought it to **14 s**.)
+- **FR-009** Register as a fifth reconcile surface.
+- **FR-010** A `WARN` surface MUST NOT render as a bare `PASS`. The summary line reads
+  `PASS (with warnings)`.
+
+## The seven findings, and why each needs a different fix
+
+Deliberately **not** silenced into `STARTUP_EXCEPTIONS` — that would defeat the check on
+the day it was written. Recorded in the script, and visible on every run.
+
+**1. Gated SDK — no install can fix it**
+- `prisma-sdwan-mcp` → `prisma_sase` (no matching distribution on PyPI)
+- `radkit-mcp` → `radkit_client` (Cisco RADKit, licensed)
+
+Needs an `EXTERNAL_INTEGRATIONS` entry or unregistration. A registered server nobody can
+install advertises a capability NetClaw does not have.
+
+**2. No entry point at all**
+- `aruba-cx-mcp` → `mcp-servers/aruba-cx-mcp/aruba_cx_mcp_server.py` does not exist
+
+5 skills route to it. Either vendor the server or unregister it.
+
+**3. Wrong environment, not a missing package**
+- `arista-cvp-mcp` → `urllib3`
+
+It launches via `uv run --directory ... --with fastmcp`, an ephemeral uv environment.
+`urllib3` **is** installed system-wide (2.6.3) — it is absent from *that* env. The fix is
+that server's `--with` list. Recorded because the naive reading ("install urllib3") is
+wrong and would waste someone's afternoon. This server has 0 skills routing to it.
+
+**4. Installable, blocked by the host**
+- `meraki-magic-mcp` → `meraki` (PyPI 4.3.1)
+- `gnmi-mcp` → `pygnmi` (PyPI 0.8.15)
+- `junos-mcp` → `jnpr` (PyPI junos-eznc 2.8.2)
+
+All three are public and a dry-run confirmed **none pulls a shared pin**
+(fastmcp/mcp/httpx/cryptography/pydantic all unmoved). But this host's system
+interpreter is **PEP 668 externally-managed**, and `netclaw_pip_install`
+(`scripts/lib/pip-helper.sh`) is a bare `"$py" -m pip install "$@"` with **no PEP 668
+handling** — so it cannot install them either.
+
+> **This is a gap in the helper, not in these servers.** Spec 077 mandates
+> `netclaw_pip_install` as the only sanctioned install path, and on this host that path
+> does not work for new packages. Filed as follow-up; not fixed here, because changing the
+> repo's single install helper is its own change with its own blast radius.
+
+## Why warn-only, and when it stops
+
+`startup` is in `ALWAYS_WARN` in `reconcile-mcp.py`: it reports but never fails the
+build, regardless of `--warn-only`. Two of the seven need an SDK that is not publicly
+distributable, so **nobody can make this surface green today**. Hard-failing would force
+either reverting the check or papering the seven into `STARTUP_EXCEPTIONS` — both worse
+than a loud warning.
+
+**Exit condition, written into the code:** remove `"startup"` from `ALWAYS_WARN` once the
+seven are resolved. After that, a server that cannot start breaks the build.
+
+## Verification
+
+`tests/reconcile/run-tests.sh` — 32 assertions total (23 pre-existing, 9 new), bash +
+Python stdlib only, fixtures in a temp dir, repository never modified. New assertions
+cover: stdio-blocking is not a failure, missing module fails and is named, absent entry
+point is distinguished, `--warn-only` exits 0, remote servers are skipped, and
+`STARTUP_EXCEPTIONS` actually suppresses (an untested suppression list is how a check
+quietly stops checking).
+
+Every assertion captures the exit code **directly** — never through a pipe. That mistake
+misdiagnosed spec 075's central premise.
+
+## Out of scope
+
+- Fixing the seven (four different fixes, two impossible without vendor access).
+- Adding PEP 668 handling to `netclaw_pip_install` (follow-up).
+- Checking that a server that starts also serves a valid tool manifest — a deeper probe
+  requiring an MCP handshake, not just a launch.

--- a/tests/reconcile/run-tests.sh
+++ b/tests/reconcile/run-tests.sh
@@ -166,6 +166,97 @@ printf 'pip3 install something\n' >"$TMP/depsrv/scripts/lib/install-steps.sh"
 assert_exit 0 "--warn-only exits 0 despite findings" \
     python3 "$TMP/depsrv/scripts/check-dependency-pins.py" --warn-only
 
+# ── Startup surface (spec 088) ────────────────────────────────────────────────
+# This surface exists because the four checks above validate DECLARATIONS and none
+# of them ran anything: seven registered servers could not start while
+# reconcile-mcp.py exited 0. These tests build fixture servers whose startup
+# behaviour is known, since the real failure was found only by launching.
+echo
+echo "--- startup surface ---"
+SUP="$TMP/startup"
+mkdir -p "$SUP/scripts" "$SUP/mcp-servers/good-mcp" "$SUP/mcp-servers/broken-mcp"
+cp "$REPO_ROOT/scripts/check-server-startup.py" "$SUP/scripts/"
+
+# A server that imports cleanly and then blocks reading stdio is CORRECT MCP
+# behaviour -- a timeout must never be reported as a failure. Getting this
+# backwards would flag all 75 working servers.
+cat >"$SUP/mcp-servers/good-mcp/server.py" <<'EOF'
+import sys, json
+sys.stdin.read()
+EOF
+cat >"$SUP/mcp-servers/broken-mcp/server.py" <<'EOF'
+import nonexistent_module_xyz
+EOF
+write_cfg() { printf '%s
+' "$1" >"$SUP/config.json"; }
+mkdir -p "$SUP/config"
+run_startup() { python3 "$SUP/scripts/check-server-startup.py" --config "$SUP/config/openclaw.json" "$@"; }
+
+python3 - "$SUP" <<'EOF'
+import json, sys, os
+root = sys.argv[1]
+cfg = {"mcpServers": {"good-mcp": {"command": "python3",
+        "args": [os.path.join(root, "mcp-servers/good-mcp/server.py")]}}}
+os.makedirs(os.path.join(root, "config"), exist_ok=True)
+json.dump(cfg, open(os.path.join(root, "config/openclaw.json"), "w"))
+EOF
+assert_exit 0 "a server that blocks on stdio is not a failure (timeout != broken)" \
+    run_startup
+
+# Missing module must fail, and must name both the server and the module -- a
+# finding that says only "failed" sends the reader back to the shell.
+python3 - "$SUP" <<'EOF'
+import json, sys, os
+root = sys.argv[1]
+cfg = {"mcpServers": {"broken-mcp": {"command": "python3",
+        "args": [os.path.join(root, "mcp-servers/broken-mcp/server.py")]}}}
+json.dump(cfg, open(os.path.join(root, "config/openclaw.json"), "w"))
+EOF
+assert_exit 1 "a server with a missing module fails" run_startup
+assert_mentions "broken-mcp" "the finding names the server" run_startup
+assert_mentions "nonexistent_module_xyz" "the finding names the missing module" run_startup
+
+# A registered server whose file is absent -- the aruba-cx-mcp case, which no
+# amount of installing packages would have fixed.
+python3 - "$SUP" <<'EOF'
+import json, sys, os
+root = sys.argv[1]
+cfg = {"mcpServers": {"absent-mcp": {"command": "python3",
+        "args": [os.path.join(root, "mcp-servers/absent-mcp/server.py")]}}}
+json.dump(cfg, open(os.path.join(root, "config/openclaw.json"), "w"))
+EOF
+assert_exit 1 "a registered server with no entry point fails" run_startup
+assert_mentions "does not exist" "the finding distinguishes absent file from missing module" \
+    run_startup
+
+# --warn-only reports without failing, matching every other surface.
+python3 - "$SUP" <<'EOF'
+import json, sys, os
+root = sys.argv[1]
+cfg = {"mcpServers": {"broken-mcp": {"command": "python3",
+        "args": [os.path.join(root, "mcp-servers/broken-mcp/server.py")]}}}
+json.dump(cfg, open(os.path.join(root, "config/openclaw.json"), "w"))
+EOF
+assert_exit 0 "--warn-only exits 0 despite startup findings" run_startup --warn-only
+
+# STARTUP_EXCEPTIONS is the documented escape hatch, so it must actually work --
+# an untested suppression list is how a check quietly stops checking.
+sed 's/^STARTUP_EXCEPTIONS: dict\[str, str\] = {}/STARTUP_EXCEPTIONS = {"broken-mcp": "known"}/' \
+    "$REPO_ROOT/scripts/check-server-startup.py" >"$SUP/scripts/excepted.py"
+assert_exit 0 "a server in STARTUP_EXCEPTIONS is suppressed" \
+    python3 "$SUP/scripts/excepted.py" --config "$SUP/config/openclaw.json"
+
+# A remote/HTTP server has no local process to launch and must be skipped, not
+# reported as broken.
+python3 - "$SUP" <<'EOF'
+import json, sys, os
+root = sys.argv[1]
+cfg = {"mcpServers": {"remote-mcp": {"type": "http",
+        "url": "https://example.invalid/mcp"}}}
+json.dump(cfg, open(os.path.join(root, "config/openclaw.json"), "w"))
+EOF
+assert_exit 0 "a remote server is skipped, not failed" run_startup
+
 echo
 echo "=== Summary ==="
 printf '  passed: %d\n  failed: %d\n' "$PASS" "$FAIL"


### PR DESCRIPTION
## The gap

`reconcile-mcp.py` had four surfaces. All four compare **declarations** against each other — installer coverage vs. vendored state, documented counts vs. registrations, paths vs. portability rules, pins vs. bounds. **None of them ran anything.**

So it exited 0, and CI passed, while **7 of the 98 registered MCP servers could not start at all** and **22 skills** routed to them.

This is the third instance of one meta-pattern:

1. `check-dependency-pins.py` read only `requirements.txt`, never an installed version
2. `verify-inventory-counts.py` checks headline arithmetic, never table membership
3. nothing checked whether a registered server can start

A check that validates declarations cannot detect a declaration that is uniformly, consistently wrong.

## Why launching, not static analysis

Static import analysis was tried first: **11 findings, 5 of them false.** `netclaw_tokens` resolves at runtime via `sys.path`, so reading source cannot predict whether an import succeeds. Only launching the process gave truth. Recorded in the script's docstring so nobody repeats the shortcut.

## The seven — four different fixes, which is why this PR fixes none of them

| Cause | Servers | Fix |
|---|---|---|
| Gated SDK, not publicly distributable | `prisma-sdwan-mcp` (`prisma_sase`), `radkit-mcp` (`radkit_client`) | `EXTERNAL_INTEGRATIONS` entry or unregister |
| **No entry point at all** | `aruba-cx-mcp` — server file absent (5 skills) | vendor it or unregister |
| **Wrong environment, not a missing package** | `arista-cvp-mcp` — `urllib3` | fix its `uv run --with` list |
| Installable, host blocks it | `meraki-magic-mcp`, `gnmi-mcp`, `junos-mcp` | see below |

`arista-cvp-mcp` is worth calling out: `urllib3` **is** installed system-wide (2.6.3). That server launches via `uv run --directory ... --with fastmcp`, an ephemeral env where it is absent. The naive reading — "install urllib3" — is wrong and would waste an afternoon.

The last three are public and a dry-run confirmed **none pulls a shared pin** (fastmcp/mcp/httpx/cryptography/pydantic all unmoved). But this host's interpreter is **PEP 668 externally-managed**, and `netclaw_pip_install` is a bare `"$py" -m pip install "$@"` with no PEP 668 handling — so the one install path spec 077 mandates cannot install them. **Gap in the helper, not in these servers.** Filed as follow-up; not fixed here, because changing the repo's single install helper carries its own blast radius.

## Warn-only, with a written exit condition

`startup` is in `ALWAYS_WARN`: it reports on every run but never fails the build. Two of the seven need a non-distributable SDK, so nobody can make this green today, and the alternatives were reverting the check or papering the seven into `STARTUP_EXCEPTIONS` — both worse than a loud warning.

The exit condition is in the code: drop `"startup"` from `ALWAYS_WARN` once the seven are resolved, after which a server that cannot start breaks the build.

The summary line now reads `PASS (with warnings)`. A `WARN` surface must never render as a bare `PASS` — that misreading is the entire reason this feature exists.

```
Reconciliation: PASS (with warnings)
  startup      WARN   registered servers can actually start
      startup: arista-cvp-mcp: missing Python module urllib3
      startup: aruba-cx-mcp: entry point does not exist: .../aruba_cx_mcp_server.py
      ... 5 more
```

## Two behaviours that had to be right

- **A timeout is success.** A server that imports cleanly then blocks reading stdio is correct MCP behaviour. Inverting this flags all 75 working servers. Asserted directly.
- **Fast enough for CI.** First working version took **>10 minutes**; `TIMEOUT` 25→6 plus `ThreadPoolExecutor(8)` brought it to **14 s**.

## Verification

`tests/reconcile/run-tests.sh` — **32 assertions, 0 failures** (23 pre-existing, 9 new). Bash + Python stdlib only, fixtures in a temp dir, repository never modified.

New assertions: stdio-blocking is not a failure; missing module fails and both server and module are named; absent entry point is distinguished from missing module; `--warn-only` exits 0; remote servers are skipped; and `STARTUP_EXCEPTIONS` actually suppresses — an untested suppression list is how a check quietly stops checking.

Every assertion captures the exit code **directly, never through a pipe**. That mistake misdiagnosed spec 075's central premise.

## Also

`docs/ADDING-AN-MCP.md` step 7 claimed reconciliation "verifies it statically" — no longer true. Now documents both the static and dynamic surfaces, adds `check-server-startup.py --only <key>` to the workflow with the timeout-is-success caveat, and adds a checklist line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)