### PR TITLE
spec(095): Juniper Mist measured — adoption rejected on the ceiling (R5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,13 @@ NETCLAW_ENABLE_PASSWORD=changeme
 # JUNOS_DEVICES_FILE=devices.json       # Path to device inventory JSON
 # JUNOS_TIMEOUT=360                     # Default command timeout in seconds
 
+# Juniper Mist (spec 095 / R5 — measured, NOT yet registered; see specs/095-juniper-mist/)
+# MIST_API_HOST=api.mist.com            # Regional cloud: api.eu / api.gc1 / api.ac5 ... — a wrong
+#                                       # region 401s identically to a bad token. Take it from the
+#                                       # manage.<region>.mist.com URL you log in to.
+# MIST_ORG_ID=00000000-0000-0000-0000-000000000000   # Org UUID (the org NAME is not usable by the API)
+# MIST_API_TOKEN=your_observer_role_org_token        # Observer role — an admin token holds write reach
+
 # Arista CloudVision Portal (CVP) — inventory, events, connectivity, tags (4 tools)
 # CVP=www.arista.io                     # CloudVision hostname (no https://)
 # CVPTOKEN=your_service_account_token   # Service account token from CVP Settings

--- a/docs/COVERAGE-ROADMAP.md
+++ b/docs/COVERAGE-ROADMAP.md
@@ -100,7 +100,7 @@ and the IETF datatracker.
 | **R2** | Cisco PSIRT vulnerability intelligence | [078](../specs/078-cisco-psirt-vulnerability/spec.md) | `DONE` — 52/52. **Rescoped from four API families to one**: Bug/EoX/Case/Serial all return 403 under the API Console grant, CX Cloud 504. All 7 PSIRT OSTypes live-verified; `iosxr` is not an OSType (404). Full chain proven on live CML: pyATS read 17.16.1a → 26 advisories, 1 Critical |
 | **R3** | Fortinet (FortiOS / FortiManager / FortiAnalyzer) | [080](../specs/080-fortinet-coverage/spec.md) | `DONE` — 21 tools, 3 planes, 2,486/5,000 token manifest. Device plane live-verified from Slack on FortiOS 7.6.7; manager/analyzer implemented, unverified. **Built, not adopted** — no candidate emits a plane field, and their manifests are 69–204 tools each |
 | **R4** | Palo Alto PAN-OS / Panorama NGFW | — | `NOT STARTED` |
-| **R5** | Juniper Mist (official) + Apstra | — | `NOT STARTED` |
+| **R5** | Juniper Mist (official) + Apstra | [095](../specs/095-juniper-mist/spec.md) | **`BLOCKED — measured`** — measured 2026-08-05 against the live endpoint with the operator's own org. **Adoption rejected on the ceiling: 7 tools, 11,783 tokens, 2.36× over**, and `config/openclaw.json` has no tool-filtering key across 101 servers, so a subset cannot be loaded. The opposite failure mode from every prior rejection — not too many tools, but **~1,678 tokens per tool**. Build path specified (GET-only client, ≤1,500-token target, 087 shape) and **gated on a populated org**: the verification org has 1 site and 0 devices, so no assurance path can be exercised. Three durable findings: the **chars/4 convention under-reports by 17%** near the ceiling; `get_mist_insights` requires a `query_type` its schema never declares (silently dropped, then reported missing); and `sites_sle` on an empty org returns `count: 1` with no metrics — **no telemetry and no problems are the same shape** |
 | **R6** | HPE Aruba Central / ClearPass / EdgeConnect / GreenLake | — | `NOT STARTED` |
 | **R7** | Cisco Nexus Dashboard / Intersight / UCS | — | `NOT STARTED` |
 | — | Cisco Catalyst Center (official) — operator request, not an R item | [087](../specs/087-catalyst-center-official/spec.md) | `DONE` — 514 read ops via 8 dispatchers + find/describe, 1,821/5,000 tokens. Built a client over Cisco's catalogue because the official server's 515 tools bust the ceiling |
@@ -367,15 +367,30 @@ FortiAnalyzer-VM (separate 15-day trials) to verify 12 of the 21 tools; a Servic
 
 ## R5 — Juniper Mist (official) + Apstra
 
-**Status:** `NOT STARTED`
+**Status:** `BLOCKED — measured` · [spec 095](../specs/095-juniper-mist/spec.md) ·
+[measurements](../specs/095-juniper-mist/VERIFICATION.md)
 
 `junos-mcp-server` covers devices. Nothing covers Mist wired/wireless assurance or Marvis.
-Juniper ships an **official** Mist MCP server (Claude Desktop beta).
+Juniper ships an **official** Mist MCP server (Claude Desktop beta) — **measured and rejected**.
+
+> **Adoption is not available.** `https://mcp.ai.juniper.net/mcp/mist` exposes 7 tools costing
+> **11,783 tokens against the 5,000 ceiling (2.36×)**, counted with `count_tokens`, not estimated.
+> No tool-filtering key exists in `config/openclaw.json` across 101 registered servers, so a
+> cheaper subset cannot be loaded. Re-check with `python3 scripts/probe-mist-mcp.py --count`.
+
+> **The build is gated, not merely unstarted.** The verification org has **1 site, 0 devices**.
+> `sites_sle` there returns `count: 1` with no metrics — a site with no telemetry and a site with
+> no problems are indistinguishable in the response. Assurance skills whose central failure mode
+> cannot be exercised are not built; see spec 095's exit conditions.
 
 **Checklist**
-- [ ] Adopt the official Juniper Mist MCP server; note its beta status and org scoping
-- [ ] Mist API token + org ID handling
-- [ ] Skills: wireless assurance, client troubleshooting, Marvis query, SLE review
+- [x] Measure the official server against the ceiling — **11,783, rejected**
+- [x] Mist API token + org ID handling — `Bearer` only, `X-Mist-Base-URL` mandatory for regional
+      clouds, per-call `org_id` required (the `X-Mist-Org-ID` header does not supply it)
+- [ ] Obtain a populated org (Juniper SE demo org, or hardware — `trial_enabled: true` already)
+- [ ] Build the GET-only client (≤1,500-token manifest, 4 dispatchers, 087 shape)
+- [ ] Skills: wireless assurance, client troubleshooting, Marvis query, SLE review — **after** the
+      above, so the empty-vs-healthy trap can be reproduced and blocked
 - [ ] Assess Apstra separately (community only) — DC fabric intent; may fold into R6 if the
       unified HPE server covers it adequately
 

--- a/scripts/probe-mist-mcp.py
+++ b/scripts/probe-mist-mcp.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Re-run spec 095's ceiling check against Juniper's remote Mist MCP server.
+
+Reads MIST_API_TOKEN, MIST_API_HOST and MIST_ORG_ID from the environment
+(`set -a; source ~/.openclaw/.env; set +a`).
+
+    python3 scripts/probe-mist-mcp.py            # initialize + tools/list, chars/4 sizing
+    python3 scripts/probe-mist-mcp.py --count    # exact token count (needs ANTHROPIC_API_KEY)
+
+Spec 095 measured 11,783 tokens against a 5,000 ceiling. A materially different
+number means Juniper changed the manifest and the adoption decision is stale.
+"""
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+ENDPOINT = os.environ.get("MIST_MCP_URL", "https://mcp.ai.juniper.net/mcp/mist")
+CEILING = 5000
+SPEC_095_TOTAL = 11783
+COUNT_MODEL = "claude-opus-4-5-20251101"
+
+_session_id = None
+
+
+def rpc(method, params=None, notify=False):
+    """One JSON-RPC call over MCP streamable HTTP. Returns the decoded message."""
+    global _session_id
+    body = {"jsonrpc": "2.0", "method": method}
+    if not notify:
+        body["id"] = 1
+    if params is not None:
+        body["params"] = params
+
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        # The MCP server accepts Bearer only — the REST API's `Token` scheme is refused.
+        "Authorization": f"Bearer {os.environ['MIST_API_TOKEN']}",
+        # Without this the server defaults to api.mist.com and a regional token 401s.
+        "X-Mist-Base-URL": f"https://{os.environ.get('MIST_API_HOST', 'api.mist.com')}",
+    }
+    if os.environ.get("MIST_ORG_ID"):
+        headers["X-Mist-Org-ID"] = os.environ["MIST_ORG_ID"]
+    if _session_id:
+        headers["Mcp-Session-Id"] = _session_id
+
+    req = urllib.request.Request(
+        ENDPOINT, data=json.dumps(body).encode(), headers=headers, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as r:
+            sid = r.headers.get("Mcp-Session-Id")
+            if sid:
+                _session_id = sid
+            raw = r.read().decode("utf-8", "replace")
+            ctype = r.headers.get("Content-Type", "")
+    except urllib.error.HTTPError as e:
+        raw, ctype = e.read().decode("utf-8", "replace"), ""
+
+    if "event-stream" in ctype:
+        for line in raw.splitlines():
+            if line.startswith("data:"):
+                try:
+                    return json.loads(line[5:].strip())
+                except json.JSONDecodeError:
+                    continue
+        return {"raw": raw[:400]}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {"raw": raw[:400]}
+
+
+def count_tokens(tools, instructions):
+    """Exact count via the Anthropic count_tokens endpoint, as a delta over baseline."""
+    key = os.environ.get("ANTHROPIC_API_KEY")
+    if not key:
+        print("ANTHROPIC_API_KEY not set — cannot count exactly", file=sys.stderr)
+        return None
+
+    def _count(payload):
+        req = urllib.request.Request(
+            "https://api.anthropic.com/v1/messages/count_tokens",
+            data=json.dumps(payload).encode(),
+            headers={
+                "content-type": "application/json",
+                "x-api-key": key,
+                "anthropic-version": "2023-06-01",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=60) as r:
+            return json.load(r)["input_tokens"]
+
+    msg = [{"role": "user", "content": "hi"}]
+    baseline = _count({"model": COUNT_MODEL, "messages": msg})
+    as_tools = [
+        {
+            "name": t["name"],
+            "description": t.get("description", ""),
+            "input_schema": t.get("inputSchema", {"type": "object"}),
+        }
+        for t in tools
+    ]
+
+    print("\nper-tool cost:")
+    for t in as_tools:
+        c = _count({"model": COUNT_MODEL, "messages": msg, "tools": [t]}) - baseline
+        print(f"  {t['name']:<22} {c:>6}")
+
+    manifest = _count({"model": COUNT_MODEL, "messages": msg, "tools": as_tools}) - baseline
+    instr = 0
+    if instructions:
+        instr = _count({"model": COUNT_MODEL, "messages": [{"role": "user", "content": instructions}]}) - baseline
+    return manifest, instr
+
+
+def main():
+    if not os.environ.get("MIST_API_TOKEN"):
+        print("MIST_API_TOKEN not set. source ~/.openclaw/.env first.", file=sys.stderr)
+        return 2
+
+    init = rpc(
+        "initialize",
+        {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "netclaw-probe", "version": "0.1"},
+        },
+    )
+    if "result" not in init:
+        print("initialize failed:", json.dumps(init)[:400], file=sys.stderr)
+        return 1
+
+    res = init["result"]
+    instructions = res.get("instructions") or ""
+    print(f"server      : {json.dumps(res.get('serverInfo', {}))}")
+    print(f"protocol    : {res.get('protocolVersion')}")
+    print(f"instructions: {len(instructions)} chars")
+
+    rpc("notifications/initialized", notify=True)
+
+    listed = rpc("tools/list")
+    if "result" not in listed:
+        print("tools/list failed:", json.dumps(listed)[:400], file=sys.stderr)
+        return 1
+    tools = listed["result"].get("tools", [])
+    print(f"tools       : {len(tools)}")
+
+    chars = len(json.dumps(tools)) + len(instructions)
+    print(f"\nchars/4 estimate : ~{chars // 4} tokens")
+    print("  (spec 095: this convention under-reported by 17% here — estimate only)")
+
+    total = None
+    if "--count" in sys.argv:
+        counted = count_tokens(tools, instructions)
+        if counted:
+            manifest, instr = counted
+            total = manifest + instr
+            print(f"\nmanifest     : {manifest}")
+            print(f"instructions : {instr}")
+            print(f"TOTAL        : {total}  (ceiling {CEILING})")
+
+    verdict = total if total is not None else chars // 4
+    print(f"\nvs ceiling   : {verdict / CEILING:.2f}x")
+    if total is not None and abs(total - SPEC_095_TOTAL) > 500:
+        print(
+            f"CHANGED: spec 095 measured {SPEC_095_TOTAL}; now {total}. "
+            "Re-check the adoption decision."
+        )
+    return 0 if verdict <= CEILING else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/specs/095-juniper-mist/VERIFICATION.md
+++ b/specs/095-juniper-mist/VERIFICATION.md
@@ -1,0 +1,197 @@
+# Spec 095 — Verification
+
+**Date**: 2026-08-05
+**Endpoint**: `https://mcp.ai.juniper.net/mcp/mist` — `initialize` reports `mistapi`, version empty string
+**Protocol**: MCP `2025-06-18`, streamable HTTP, SSE responses
+**Credential**: operator's own Mist token, org **NetClaw** `867ed0fe-…dd4ea`, `ac5` regional cloud.
+Stored only in `~/.openclaw/.env` — **the token appears in no file in this repository**, verified with a
+direct (unpiped) grep across the tree.
+
+Everything below was measured live against Juniper's endpoint. Nothing is quoted from documentation
+except the two header names, which documentation supplied and measurement then confirmed.
+
+---
+
+## 1. Reaching the server at all — two undocumented-by-default requirements
+
+| Attempt | Result |
+|---|---|
+| `Authorization: Token <t>` | `no supported Authorization scheme found in request` |
+| `Authorization: Bearer <t>`, no region header | `authentication failed: Mist API rejected credentials (HTTP 401)` |
+| `Authorization: Bearer <t>` + `X-Mist-Base-URL: https://api.ac5.mist.com` | **success** |
+
+Two failures that look identical from the client and are not:
+
+- The Mist REST API accepts `Authorization: Token`. **The MCP server accepts only `Bearer`.** A
+  credential that works against the REST API fails at the MCP with a scheme error.
+- Without `X-Mist-Base-URL` the server defaults to `api.mist.com`. A valid `ac5` token is rejected
+  there with a **401 that reads as a bad credential, not as a wrong region**.
+
+Both `api.mist.com` and `api.ac5.mist.com` return `401` to an unauthenticated `GET /api/v1/self`, so
+**a 401 alone cannot distinguish a bad token from a wrong region.** The regional cloud must be
+established from the operator's `manage.<region>.mist.com` URL, not inferred from a failure.
+
+`X-Mist-Org-ID` is accepted but is **not** a substitute for the per-call `org_id` argument — see §4.
+
+---
+
+## 2. Manifest cost — the ceiling check, and the finding that decides this spec
+
+Measured with the Anthropic `count_tokens` endpoint against `claude-opus-4-5`, taking the delta
+between an 8-token baseline request and the same request carrying the tool definitions.
+
+| Tool | Tokens |
+|---|---|
+| `search_mist_data` | 4,229 |
+| `get_mist_insights` | 2,815 |
+| `get_mist_stats` | 2,542 |
+| `get_mist_config` | 1,879 |
+| `find_mist_entity` | 1,776 |
+| `get_mist_constants` | 812 |
+| `get_mist_self` | 669 |
+| **Tool manifest total** | **11,746** |
+| `instructions` (170 chars) | 37 |
+| **Total against the 5,000 ceiling** | **11,783 — 2.36× over** |
+
+`instructions` is counted deliberately, per the R10 precedent where a 5,338-token `instructions`
+payload blew the ceiling once counted. Here it is negligible; **the schemas are the cost.**
+
+Seven tools costing 11,746 tokens is **~1,678 tokens per tool** — versus ~283/tool for Catalyst
+Center's 515-tool catalogue (087). This is the opposite failure mode from every prior rejection:
+not too many tools, but seven dispatchers with very large descriptions and schemas.
+
+### The chars/4 convention under-reports — by 17% here
+
+The roadmap has estimated manifests at chars÷4 throughout (089's 818 chars → ~204 tokens is exactly
+that). Applied here it gives **10,052** against a measured **11,783**.
+
+Dense JSON schemas tokenize worse than prose. The convention is safe for the low-cost adoptions it
+has been used on, but **any future measurement landing near the ceiling must be counted, not
+estimated** — at this error rate an estimate of 4,300 could be a real 5,000.
+
+---
+
+## 3. Why a curated subset is not available
+
+`config/openclaw.json` server entries use only `command`, `args`, `env`, `headers`, `url` across all
+101 registered servers. There is **no tool-filtering key** — no allowlist, no exclude list. Registering
+this server costs its whole manifest.
+
+The three cheapest tools (`get_mist_self` + `get_mist_constants` + `find_mist_entity` = 3,257) would
+fit the ceiling, but there is no supported way to load only those, and that subset excludes every
+assurance capability R5 exists to obtain.
+
+---
+
+## 4. Two defects in the shipped schemas
+
+**4.1 `get_mist_insights` requires a parameter its schema does not declare.**
+
+The tool's `inputSchema` declares `required: ["insight_type"]` and these properties:
+`duration, end_time, insight_type, limit, next_cursor, org_id, page, params, site_id, start_time`.
+
+There is **no `query_type` property**. Yet:
+
+```
+get_mist_insights({"insight_type":"sle","query_type":"sites_sle","scope":"org","org_id":"<org>"})
+  → Tool error: param "query_type" is required for insight_type "sle"
+```
+
+The argument was supplied at the top level, **silently dropped** (not rejected as unknown), and then
+reported missing. The working form has to be inferred — it belongs inside the undocumented generic
+`params` object:
+
+```
+get_mist_insights({"insight_type":"sle","org_id":"<org>","params":{"query_type":"sites_sle"}})
+  → {"count":1,"data":[{"site_id":"3eb28ffc-…"}],"insight_type":"sle","total":1}
+```
+
+A model constructing a call from the schema alone cannot reach the working form. It must read the
+prose in the error message and guess the nesting. This affects the single most valuable tool for R5's
+stated purpose — SLE and Marvis.
+
+**4.2 `X-Mist-Org-ID` does not populate the per-call `org_id`.**
+
+With the header set, `search_mist_data({"search_type":"wireless_clients","scope":"org"})` fails with
+`required: missing properties: ["org_id"]`. The header scopes the server; it does not fill arguments.
+Every org-scoped call must repeat `org_id` explicitly.
+
+Not every parameter error is this soft: `stats_type` and `search_type` are strict enums and reject
+invalid values loudly, naming the full valid set. The inconsistency is the hazard — some wrong
+arguments fail loudly, one important one fails misleadingly.
+
+---
+
+## 5. Read-only posture
+
+All seven tools are read-shaped (`get_*`, `find_*`, `search_*`). The manifest contains no create,
+update, delete, reboot, or claim verb, so **no mutating operation is reachable through this server**
+regardless of credential.
+
+That is a property of the tool surface, not of the credential — and it matters here, because:
+
+**The operator's token carries `role: admin`.** `GET /api/v1/self` returns:
+
+```json
+{"privileges":[{"scope":"org","role":"admin","org_id":"867ed0fe-…","name":"NetClaw"}],
+ "tags":["mist-customer"]}
+```
+
+An admin token has full write reach over the org through the REST API. Nothing in this spec's design
+uses that reach, but the credential holds it. **An Observer-role org token is the correct credential**
+and is a requirement on the build path (§7), not a preference.
+
+---
+
+## 6. What the empty org can and cannot establish
+
+Org NetClaw contains: **1 site** (`Primary Site`, `America/Los_Angeles`), **0 devices**, **0 inventory**,
+**0 alarms**, **0 licences** (`trial_enabled: true`).
+
+Verified end to end:
+
+| Call | Result |
+|---|---|
+| `get_mist_self` | full identity, privileges, org name — matches the REST API exactly |
+| `get_mist_constants{device_models}` | **284 device models** — a populated, non-trivial payload |
+| `get_mist_stats{org_devices}` | `{"count":0,"data":[]}` |
+| `search_mist_data{wireless_clients\|alarms\|devices}` | `{"count":0,"results":[]}` |
+| `get_mist_insights{marvis_actions}` | `{"count":0,"data":[]}` |
+| `get_mist_insights{sle, params.query_type=sites_sle}` | `{"count":1,"data":[{"site_id":"3eb28ffc-…"}]}` |
+
+**Not established**: whether any assurance payload parses correctly. Every count above is zero because
+the org is empty, not because a code path was exercised. `get_mist_constants` is the one tool proven
+against real data, and it is a static catalogue — it touches no org state.
+
+### The empty-org trap, stated precisely
+
+The last row is the one to be careful with. `sites_sle` returns **`count: 1`** — a non-zero count, a
+real site ID, and **no SLE metrics whatsoever**. Asked "how is wireless health at this site?", a model
+receiving `count: 1` with no failing metrics can report the site as healthy.
+
+The site is not healthy. It has no APs, no clients, and no telemetry. **A site with no data and a site
+with no problems are the same shape in this response**, and nothing in the payload distinguishes them.
+
+This is the same class as R15's box-vs-network distinction and R13's zero-signature Suricata: an
+absence being reported as a negative finding. Any skill built on this tool must establish that
+telemetry exists before characterising health — which, in an org with zero devices, it cannot.
+
+---
+
+## 7. Conclusion
+
+Adoption is **rejected on the ceiling**: 11,783 tokens, 2.36× over, no filtering mechanism available.
+
+Verification of the assurance data paths is **not possible in this org**: the one capability that
+returned real data is a static device-model catalogue.
+
+The build path and its exit conditions are specified in `spec.md`. Both blockers are external —
+neither is resolved by more implementation work here.
+
+## Reproducing
+
+```bash
+set -a; source ~/.openclaw/.env; set +a
+python3 scripts/probe-mist-mcp.py            # initialize + tools/list + manifest sizing
+python3 scripts/probe-mist-mcp.py --count    # exact token count (needs ANTHROPIC_API_KEY)
+```

--- a/specs/095-juniper-mist/spec.md
+++ b/specs/095-juniper-mist/spec.md
@@ -1,0 +1,145 @@
+# Spec 095 — Juniper Mist (R5): measure, reject adoption, specify the build
+
+**Status**: measured — adoption rejected, build specified and **gated**
+**Branch**: `095-juniper-mist`
+**Date**: 2026-08-05
+**Roadmap**: [R5](../../docs/COVERAGE-ROADMAP.md) — Juniper Mist (official) + Apstra
+**Measurements**: [VERIFICATION.md](VERIFICATION.md) — all live, operator's own org
+
+## Summary
+
+R5 set out to **adopt** Juniper's official remote Mist MCP server, on the 089 model: zero code, zero
+install, an endpoint and a token. That is not available.
+
+Measured live against `https://mcp.ai.juniper.net/mcp/mist` with the operator's `ac5` credential:
+**7 tools, 11,783 tokens, 2.36× the 5,000-token manifest ceiling**, with no tool-filtering mechanism
+in NetClaw's config to load a subset.
+
+Separately, the org available for verification (`NetClaw`, created 2026-08-05) contains **one site and
+zero devices**. The assurance capabilities R5 exists to deliver — SLE, Marvis, client troubleshooting —
+have no data to return and therefore cannot be verified.
+
+This spec records the measurement, rejects adoption with the number that justifies it, specifies the
+build that replaces it, and **gates that build on a populated org** rather than shipping unverifiable
+skills.
+
+## Decision
+
+| | |
+|---|---|
+| **Adopt the remote server** | **Rejected** — 11,783 tokens vs a 5,000 ceiling; no subset mechanism |
+| **Build a compact read-only client** | **Specified below; blocked on a populated org** |
+| **Apstra** | Deferred to R6, unchanged — the unified HPE candidate covers it and R5/R6 stay paired |
+| **R5 roadmap status** | `BLOCKED — measured` (was `NOT STARTED`) |
+
+Precedent: this is the 087 outcome, not the 089 one. Catalyst Center's official server was rejected at
+515 tools / 64,420 tokens and replaced with a curated client over the same API. The cause differs —
+**Mist fails at seven tools, ~1,678 tokens each** — but the remedy is the same.
+
+## What was measured
+
+| Measurement | Value |
+|---|---|
+| Server | `mistapi`, version reported as empty string |
+| Protocol | MCP `2025-06-18`, streamable HTTP + SSE |
+| Tools | 7 — `find_mist_entity`, `get_mist_config`, `get_mist_constants`, `get_mist_insights`, `get_mist_self`, `get_mist_stats`, `search_mist_data` |
+| Tool manifest | **11,746 tokens** |
+| `instructions` | 37 tokens (170 chars) |
+| **Total vs ceiling** | **11,783 — 2.36× over** |
+| Mutating operations reachable | **0** — no write verb exists in the manifest |
+| Auth | `Authorization: Bearer` **only**; REST-style `Token` is refused |
+| Region | `X-Mist-Base-URL` header; absent ⇒ defaults to `api.mist.com` ⇒ 401 for a regional token |
+
+Three findings that outlast this spec:
+
+1. **The chars/4 estimating convention under-reports by 17% here** (10,052 estimated vs 11,783
+   measured). Safe for the low-cost adoptions it has been used on; **not safe near the ceiling.**
+   Future manifest checks within ~20% of 5,000 must be counted, not estimated.
+2. **`get_mist_insights` requires `query_type`, which its schema never declares.** Supplied at the top
+   level it is silently dropped, then reported missing; it must be nested inside an undeclared generic
+   `params` object. A model working from the schema alone cannot construct a valid SLE call.
+3. **A wrong region and a bad token are indistinguishable** — both clouds 401 identically. The region
+   must come from the operator's `manage.<region>.mist.com` URL.
+
+## The empty-org problem — why the build is gated
+
+`sites_sle` against an org with zero devices returns `count: 1` and a site ID, with no metrics. **A
+site with no telemetry and a site with no problems are the same shape.** Asked about wireless health, a
+model receiving that response can report the site as healthy. It is not healthy; it is empty.
+
+This is the R15 box-vs-network distinction and the R13 zero-signature Suricata failure in a new
+costume: an absence rendered as a negative finding. NetClaw's discipline is that such traps are
+*reproduced and structurally blocked*, not documented and hoped away — and reproducing them requires an
+org where the difference is observable.
+
+Building `wireless-assurance`, `client-troubleshooting`, and `marvis-query` skills now would ship three
+skills whose central failure mode cannot be tested. R3's FortiManager and FortiAnalyzer planes are
+already in that state deliberately; adding three more by default is drift, not a decision.
+
+## The build, when unblocked
+
+A NetClaw-authored read-only Mist client, following 094 (Redfish) for the GET-only posture and 087 for
+the dispatcher shape.
+
+- **Transport**: direct to `https://$MIST_API_HOST/api/v1/…`. The remote MCP is not an intermediary;
+  its ceiling breach is the reason this exists.
+- **Verb discipline**: the client issues **no HTTP verb but `GET`**, as 094's Redfish client does. Write
+  reach is absent by construction, not by prompt instruction and not by credential scope.
+- **Manifest target**: **≤ 1,500 tokens**, counted with `count_tokens`, never estimated.
+- **Tools** (4, org- and site-scoped, each taking an explicit `org_id`):
+
+  | Tool | Purpose |
+  |---|---|
+  | `mist_inventory` | sites, devices, inventory — what exists |
+  | `mist_stats` | device/client/port state — what it is doing now |
+  | `mist_assurance` | SLE metrics and Marvis actions — what is wrong |
+  | `mist_search` | events, alarms, client sessions — what happened |
+
+- **Emptiness is explicit.** Every response distinguishes *no telemetry* from *no problems*. A zero
+  device count in scope makes an assurance answer report "no telemetry — cannot characterise health",
+  never a health verdict. This is the trap in §"The empty-org problem" and the client's first assertion.
+- **Credential**: an **Observer-role org token**. The operator's current token is `role: admin` and
+  carries full write reach over the org — unused by this design, but held. Least privilege is a
+  requirement, not a preference.
+
+### Exit conditions
+
+The build proceeds when **either**:
+
+- a Mist org with at least one live AP or switch is reachable (a Juniper SE demo org, or hardware in
+  the operator's own org — the org already has `trial_enabled: true`), **or**
+- the operator accepts, explicitly and on the record, that the assurance tools ship unverified against
+  real telemetry, as R3's manager and analyzer planes did.
+
+The first is preferred. Neither is resolved by more implementation work in this repository.
+
+## Scope
+
+**In scope**: the measurement above; the adoption decision; the client design; the roadmap status
+change; a committed probe script so both blockers are re-checkable by anyone.
+
+**Out of scope**: the client implementation (gated); skills (gated on the client); Apstra (R6);
+`config/openclaw.json` registration — **nothing is registered by this spec**, so no catalog entry,
+install step, or `EXTERNAL_INTEGRATIONS` record is due. `docs/ADDING-AN-MCP.md` applies in full to the
+build, not to this measurement.
+
+## Artifacts
+
+| Path | What |
+|---|---|
+| `specs/095-juniper-mist/spec.md` | this document |
+| `specs/095-juniper-mist/VERIFICATION.md` | every measurement, reproducible |
+| `scripts/probe-mist-mcp.py` | re-runs the manifest and ceiling check |
+| `.env.example` | `MIST_API_HOST`, `MIST_ORG_ID`, `MIST_API_TOKEN` — names only |
+| `docs/COVERAGE-ROADMAP.md` | R5 → `BLOCKED — measured`, with the number |
+
+## Success criteria
+
+- **SC-001** — The ceiling breach is a counted number from the live endpoint, not an estimate. ✅ 11,783
+- **SC-002** — The rejection names a mechanism (no tool filtering across 101 servers), not a preference. ✅
+- **SC-003** — The empty-org trap is stated as an observed response shape, not a hypothetical. ✅
+- **SC-004** — Both schema defects are reproduced with the exact arguments that trigger them. ✅
+- **SC-005** — The credential's `admin` role is recorded, with least privilege required on the build path. ✅
+- **SC-006** — No capability is claimed that was not exercised. The only tool proven against real data is
+  `get_mist_constants` (284 device models), a static catalogue. ✅
+- **SC-007** — Assurance skills are not built against an org that cannot exercise them. ✅ (gated)


### PR DESCRIPTION
## Summary

R5 set out to **adopt** Juniper's official remote Mist MCP server on the 089 model — remote endpoint, zero code, zero install. That is not available, and this PR records why with numbers rather than leaving R5 as `NOT STARTED` for the next person to re-investigate.

Measured live against `https://mcp.ai.juniper.net/mcp/mist` with the operator's own `ac5` org:

| | |
|---|---|
| Tools | 7 |
| Tool manifest | **11,746 tokens** |
| `instructions` | 37 tokens |
| **Total vs 5,000 ceiling** | **11,783 — 2.36× over** |

Counted with `count_tokens`, not estimated. `config/openclaw.json` has **no tool-filtering key** across 101 registered servers, so a cheaper subset cannot be loaded — adoption means paying the whole manifest.

This is the opposite failure mode from every prior rejection: not too many tools, but **seven dispatchers at ~1,678 tokens each** (vs ~283/tool for Catalyst Center's 515).

## Three findings that outlast the decision

1. **The chars/4 estimating convention under-reports by 17% here** — 10,052 estimated vs 11,783 measured. Safe for the low-cost adoptions it has been used on; **not safe near the ceiling**. Any future manifest within ~20% of 5,000 must be counted.
2. **`get_mist_insights` requires a `query_type` its schema never declares.** Supplied at the top level it is *silently dropped*, then reported missing; it must be nested inside an undeclared generic `params` object. A model working from the schema alone cannot construct a valid SLE call — and this is the tool R5 exists for.
3. **A wrong region and a bad token are indistinguishable** — both clouds return 401 identically. Region must come from the operator's `manage.<region>.mist.com` URL. Documented in `.env.example`.

## Why the build is gated, not merely unstarted

The verification org has **1 site and 0 devices**. `sites_sle` there returns `count: 1` with a site ID and **no metrics** — meaning *a site with no telemetry* and *a site with no problems* are the same response shape. Asked about wireless health, a model can read that as healthy.

That is the R15 box-vs-network trap and the R13 zero-signature Suricata failure in a new costume. NetClaw's discipline is to reproduce such traps and block them structurally, which requires an org where the difference is observable. Shipping `wireless-assurance`, `client-troubleshooting` and `marvis-query` against an org that cannot exercise them would add three untestable skills by default — drift, not a decision.

The build path is specified (GET-only client, ≤1,500-token manifest, 087 dispatcher shape, Observer-role credential) with explicit exit conditions.

## Scope

**Nothing is registered.** No `config/openclaw.json` entry, so no catalog entry, install step, or `EXTERNAL_INTEGRATIONS` record is due. `docs/ADDING-AN-MCP.md` applies to the build, not to this measurement.

- `specs/095-juniper-mist/spec.md` — decision, build design, exit conditions
- `specs/095-juniper-mist/VERIFICATION.md` — every measurement, reproducible
- `scripts/probe-mist-mcp.py` — re-runs the ceiling check; flags a drift >500 tokens from 11,783
- `docs/COVERAGE-ROADMAP.md` — R5 → `BLOCKED — measured`
- `.env.example` — names only

## Verification

- `scripts/reconcile-mcp.py` → **exit 0**, all 7 surfaces pass
- `scripts/probe-mist-mcp.py --count` reproduces 11,783 exactly
- The operator's token appears in **no file in this repository** (direct unpiped grep)
- Credential note: the operator's token carries `role: admin`; an **Observer-role org token** is a requirement on the build path

🤖 Generated with [Claude Code](https://claude.com/claude-code)