### PR TITLE
docs(095): SDD artifacts for Juniper Mist — plan, research, tasks

### DIFF
--- a/specs/095-juniper-mist/plan.md
+++ b/specs/095-juniper-mist/plan.md
@@ -1,0 +1,84 @@
+# Implementation Plan: Juniper Mist (R5) — measure, reject adoption, specify the build
+
+**Branch**: `095-juniper-mist` | **Date**: 2026-08-05 | **Spec**: [spec.md](spec.md)
+**Measurements**: [VERIFICATION.md](VERIFICATION.md)
+
+> **Note on sequence.** This plan was written **after** `spec.md`, in the same session and before the
+> feature merged — not a post-merge reconstruction like 087–094. The gap it closes is that 095
+> originally shipped `spec.md` + `VERIFICATION.md` alone, which breached Principle XVI's
+> specify → plan → task → implement requirement.
+>
+> Nothing was implemented before this plan existed, because **the feature's outcome is a decision,
+> not code.**
+
+## Summary
+
+R5 set out to **adopt** Juniper's official remote Mist MCP on the 089 model — remote endpoint, zero
+code. That is not available: **7 tools, 11,783 tokens, 2.36× the ceiling**, with no tool-filtering
+mechanism in NetClaw's config to load a subset.
+
+Separately, the org available for verification has **1 site and 0 devices**, so the assurance
+capabilities R5 exists to deliver cannot be exercised.
+
+This spec therefore delivers a **measurement, a rejection with the number that justifies it, a build
+specification, and a gate on that build** — rather than an integration.
+
+## Technical Context
+
+**Language/Version**: None authored. The deliverable is documentation plus one stdlib Python probe
+script
+**Primary Dependencies**: None. `scripts/probe-mist-mcp.py` is Python stdlib only (`urllib`, `json`);
+`--count` mode calls the Anthropic `count_tokens` endpoint
+**Storage**: None
+**Testing**: Live measurement against `https://mcp.ai.juniper.net/mcp/mist` with the operator's own
+`ac5` credential; re-runnable via the committed probe
+**Target Platform**: Any — the endpoint is remote
+**Project Type**: Roadmap measurement + deferred build specification
+**Constraints**: Manifest ceiling 5,000 tokens; **no credential may enter the repository**
+**Scale/Scope**: 7 upstream tools measured; 0 registered
+
+## Constitution Check
+
+| Principle | Gate | Status |
+|---|---|---|
+| **V. MCP-Native Integration** | Capability should arrive as an MCP server | **DEFERRED** — the available server cannot be loaded within the ceiling |
+| **IX. Security by Default** | Least privilege | **FINDING** — the operator's token carries `role: admin`; an Observer-role token is made a requirement on the build path |
+| **XI. Full-Stack Artifact Coherence** | All touchpoints updated | **N/A by scope** — nothing is registered, so no catalog entry, install step or `EXTERNAL_INTEGRATIONS` record is due. `reconcile-mcp.py` exits 0 |
+| **XIII. Credential Safety** | No secrets in the repo | **PASS** — verified by direct unpiped grep; `.env.example` carries names only |
+| **XVI. Spec-Driven Development** | specify → plan → task → implement | **VIOLATED then remedied in-flight** — see Complexity Tracking |
+
+## Project Structure
+
+```text
+specs/095-juniper-mist/
+├── spec.md            # decision, build design, exit conditions
+├── VERIFICATION.md    # every measurement, reproducible
+├── plan.md            # this file
+├── research.md
+└── tasks.md
+
+scripts/probe-mist-mcp.py   # re-runs the ceiling check; flags drift >500 tokens from 11,783
+.env.example                # MIST_API_HOST, MIST_ORG_ID, MIST_API_TOKEN — names only
+docs/COVERAGE-ROADMAP.md    # R5 -> BLOCKED — measured
+```
+
+**Structure Decision**: No `mcp-servers/` directory and no registration. Committing a probe script
+rather than only prose means the rejection is **re-checkable by anyone** — if Juniper shrinks the
+manifest, the script says so instead of the decision silently going stale.
+
+## The build, when unblocked
+
+A NetClaw-authored read-only Mist client following 094 (GET-only transport) and 087 (dispatcher
+shape): 4 tools, ≤1,500-token manifest counted not estimated, Observer-role credential, and an
+explicit *no telemetry* versus *no problems* distinction in every assurance response.
+
+**Gated** on a populated org, because that distinction is the feature's central failure mode and
+cannot be exercised against an empty one.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| **Principle XVI breached** — `spec.md` and `VERIFICATION.md` shipped without plan/research/tasks | Nothing justified it; part of the 087–096 drift, caused by sampling recent specs and mistaking the drift for the convention | Remedied here **before merge**, plus a gate so the gap cannot recur undetected |
+| **Specifying a build that is not built** | The measurement is only actionable if the alternative is written down; otherwise the next person re-runs the same probe to reach the same conclusion | Deferring silently (leaving R5 `NOT STARTED`) was the status quo that wasted the investigation. Building unverifiable assurance skills was rejected — see the gate below |
+| **Gating the build on an external dependency** | The verification org has 0 devices; `sites_sle` there returns `count: 1` with no metrics, so *no telemetry* and *no problems* are the same shape | Shipping three skills whose central failure mode cannot be tested would repeat R3's unverified manager/analyzer planes **by default rather than by decision** |

--- a/specs/095-juniper-mist/research.md
+++ b/specs/095-juniper-mist/research.md
@@ -1,0 +1,151 @@
+# Phase 0 Research — Juniper Mist (R5)
+
+**Date**: 2026-08-05 | **Plan**: [plan.md](plan.md) | **Measurements**: [VERIFICATION.md](VERIFICATION.md)
+
+> Written after `spec.md` in the same session, before merge. Every finding below was measured live
+> against Juniper's endpoint with the operator's own credential — nothing is quoted from
+> documentation except two header names, which measurement then confirmed.
+
+---
+
+## R1 — Which server, and is adoption the shape?
+
+**Decision**: Juniper's official remote MCP was the only serious candidate. **Adoption is not
+available.**
+
+`https://mcp.ai.juniper.net/mcp/mist` — first-party, remote, no install. The 089 (Meraki) precedent
+suggested this would be the cleanest possible integration.
+
+It measures **7 tools / 11,783 tokens — 2.36× the 5,000 ceiling.**
+
+**Alternatives considered**: `junos-mcp-server` (already present; covers *devices*, not Mist
+assurance — a different question); community Mist servers (not evaluated, since the first-party
+option exists and the blocker is manifest size, which a community wrapper would not improve).
+
+---
+
+## R2 — Reaching the server at all: two undocumented-by-default requirements
+
+| Attempt | Result |
+|---|---|
+| `Authorization: Token <t>` | `no supported Authorization scheme found in request` |
+| `Authorization: Bearer <t>`, no region header | `authentication failed: Mist API rejected credentials (HTTP 401)` |
+| `Bearer` + `X-Mist-Base-URL: https://api.ac5.mist.com` | **success** |
+
+Two failures that look identical from the client and are not:
+
+- The Mist **REST API** accepts `Authorization: Token`. The **MCP server accepts only `Bearer`.**
+- Without `X-Mist-Base-URL` the server defaults to `api.mist.com`, where a valid `ac5` token is
+  rejected with a **401 that reads as a bad credential, not a wrong region**.
+
+**Both clouds 401 identically to an unauthenticated request**, so a 401 alone cannot distinguish a
+bad token from a wrong region. The region must come from the operator's `manage.<region>.mist.com`
+URL, never inferred from a failure.
+
+`X-Mist-Org-ID` is accepted but does **not** populate the per-call `org_id` argument.
+
+---
+
+## R3 — Manifest cost (the gate)
+
+**Decision**: Fails, decisively.
+
+| Tool | Tokens |
+|---|---|
+| `search_mist_data` | 4,229 |
+| `get_mist_insights` | 2,815 |
+| `get_mist_stats` | 2,542 |
+| `get_mist_config` | 1,879 |
+| `find_mist_entity` | 1,776 |
+| `get_mist_constants` | 812 |
+| `get_mist_self` | 669 |
+| **Manifest** | **11,746** |
+| `instructions` | 37 |
+| **Total** | **11,783 — 2.36×** |
+
+**~1,678 tokens per tool** — the opposite failure mode from every prior rejection. Catalyst Center
+(087) failed at 515 tools averaging ~283 each; this fails at *seven*.
+
+---
+
+## R4 — Can a subset be loaded?
+
+**Decision**: **No.** `config/openclaw.json` entries use only `command`, `args`, `env`, `headers`,
+`url` across all 101 registered servers. There is no tool-filtering key.
+
+The three cheapest tools would fit (3,257 tokens) but exclude every assurance capability R5 exists
+to obtain.
+
+---
+
+## R5 — A methodological finding: chars/4 under-reports
+
+**Decision**: Estimation is unsafe near the ceiling.
+
+The roadmap has estimated manifests at chars÷4 throughout (089's 818 chars → ~204 tokens is exactly
+that). Applied here it gives **10,052** against a measured **11,783** — a **17% under-report**.
+
+Dense JSON schemas tokenize worse than prose. Safe for the low-cost adoptions it has been used on;
+**any measurement within ~20% of 5,000 must be counted, not estimated.**
+
+---
+
+## R6 — Two defects in the shipped schemas
+
+**6.1 `get_mist_insights` requires a parameter its schema never declares.** The schema lists
+`duration, end_time, insight_type, limit, next_cursor, org_id, page, params, site_id, start_time` —
+no `query_type`. Yet supplying `query_type` at the top level gets it **silently dropped** and then
+reported missing. The working form nests it inside the undeclared generic `params` object.
+
+**A model working from the schema alone cannot construct a valid SLE call** — and SLE is the single
+most valuable capability for R5's purpose.
+
+**6.2 `X-Mist-Org-ID` does not populate `org_id`.** Every org-scoped call must repeat it explicitly.
+
+Not all errors are this soft: `stats_type` and `search_type` are strict enums that reject invalid
+values loudly, naming the full valid set. **The inconsistency is the hazard.**
+
+---
+
+## R7 — Read-only posture, and a credential finding
+
+All seven tools are read-shaped; the manifest contains no create/update/delete/reboot verb, so no
+mutating operation is reachable **through this server** regardless of credential.
+
+But `GET /api/v1/self` returns `role: admin` for the operator's token — full write reach over the
+org **through the REST API**. Nothing in the design uses it; an **Observer-role org token** is made
+a requirement on the build path, not a preference.
+
+---
+
+## R8 — What the empty org can and cannot establish
+
+Org `NetClaw`: **1 site, 0 devices, 0 inventory, 0 alarms, 0 licences** (`trial_enabled: true`).
+
+Proven: identity, org resolution, constants (**284 device models** — a real, non-trivial payload),
+and that every org-scoped query returns a well-formed zero.
+
+**Not proven**: that any assurance payload parses correctly. The one tool exercised against real
+data is `get_mist_constants`, a **static catalogue** that touches no org state.
+
+### The trap, stated precisely
+
+`sites_sle` returns **`count: 1`** — a non-zero count, a real site ID, and **no SLE metrics**. Asked
+"how is wireless health at this site?", a model receiving that can report the site as healthy.
+
+It is not healthy. It has no APs, no clients, no telemetry. **A site with no data and a site with no
+problems are the same shape in this response.**
+
+Same class as R15's box-vs-network distinction and R13's zero-signature Suricata: an absence
+rendered as a negative finding. NetClaw's discipline is to reproduce such traps and block them
+structurally — which requires an org where the difference is observable.
+
+---
+
+## R9 — Adopt, build, or defer?
+
+**Decision**: Reject adoption (R3/R4); specify the build; **gate it** (R8).
+
+Contrast with 096 (Elastic), decided the same day: there the manifest measured 1,094 tokens and the
+one defect had a verified mitigation, so adoption proceeded despite a deprecated upstream. **The
+manifest cost is what separates the two outcomes**, not a preference for adopting or building.

--- a/specs/095-juniper-mist/tasks.md
+++ b/specs/095-juniper-mist/tasks.md
@@ -1,0 +1,96 @@
+# Tasks — Juniper Mist (R5)
+
+**Branch**: `095-juniper-mist` | **Spec**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md)
+
+> Written after `spec.md` in the same session, before merge — closing the Principle XVI gap that
+> 087–096 all shared. T001–T017 are complete; T018 onward are the **gated build**, deliberately not
+> started.
+
+---
+
+## Phase 0 — Access (BLOCKING)
+
+- [X] **T001** Operator creates a Mist org and an API token; region identified as `ac5` from the
+      `manage.ac5.mist.com` URL
+- [X] **T002** Store `MIST_API_HOST`, `MIST_ORG_ID`, `MIST_API_TOKEN` in `~/.openclaw/.env`; confirm
+      the token value reaches no repository file
+
+## Phase 1 — Establish the connection contract
+
+- [X] **T003** `GET /api/v1/self` on `api.ac5.mist.com` → 200, org `NetClaw`, **`role: admin`**
+- [X] **T004** Find the auth scheme: **`Bearer` only** — the REST API's `Token` scheme is refused
+- [X] **T005** Find the region mechanism: `X-Mist-Base-URL`; without it a valid `ac5` token 401s
+      against the default `api.mist.com`
+- [X] **T006** Record that a wrong region and a bad token are **indistinguishable** — both 401
+
+## Phase 2 — The ceiling gate (decides the feature)
+
+- [X] **T007** `initialize` + `tools/list` → 7 tools, `instructions` 170 chars
+- [X] **T008** Estimate by chars/4: ~10,052
+- [X] **T009** **Count exactly** via `count_tokens`: **11,783 — 2.36× over**
+- [X] **T010** Record that chars/4 **under-reported by 17%** — estimation is unsafe near the ceiling
+- [X] **T011** Check for a tool-filtering mechanism across all 101 registered servers — **none
+      exists**; a subset cannot be loaded
+- [X] **T012** **Decision: reject adoption**
+
+## Phase 3 — Characterise what the org can and cannot prove
+
+- [X] **T013** Inventory the org: 1 site, 0 devices, 0 inventory, 0 alarms, 0 licences
+- [X] **T014** Exercise every reachable tool; only `get_mist_constants` (284 device models) returns
+      real data, and it is a static catalogue
+- [X] **T015** Reproduce the trap: `sites_sle` returns `count: 1` with **no metrics** — *no
+      telemetry* and *no problems* share a shape
+- [X] **T016** Find and reproduce two schema defects: `get_mist_insights` requires an undeclared
+      `query_type` (silently dropped at top level, must nest in `params`); `X-Mist-Org-ID` does not
+      populate `org_id`
+
+## Phase 4 — Make the decision durable
+
+- [X] **T017** Commit `scripts/probe-mist-mcp.py` so the rejection is **re-checkable**, flagging any
+      drift >500 tokens from 11,783
+- [X] **T018** `.env.example` — three variable names, with the region and Observer-role warnings
+- [X] **T019** `docs/COVERAGE-ROADMAP.md` — R5 → `BLOCKED — measured`, with the number
+- [X] **T020** `reconcile-mcp.py` exits 0 (nothing registered, so no catalog/install/external entry
+      is due)
+- [X] **T021** Verify no credential in the repository (direct unpiped grep)
+
+---
+
+## Phase 5 — The gated build (NOT STARTED — blocked on external access)
+
+> **Gate**: proceed only when a Mist org with at least one live AP or switch is reachable, **or**
+> the operator accepts on the record that assurance tools ship unverified, as R3's manager and
+> analyzer planes did.
+
+- [ ] **T022** Obtain a populated org — Juniper SE demo org, or hardware (`trial_enabled: true`)
+- [ ] **T023** Create an **Observer-role** org token and replace the admin token
+- [ ] **T024** Build the GET-only client — no HTTP verb but `GET`, following 094's transport
+      discipline
+- [ ] **T025** Four dispatchers: `mist_inventory`, `mist_stats`, `mist_assurance`, `mist_search`
+- [ ] **T026** Manifest ≤ 1,500 tokens, **counted** with `count_tokens`, never estimated
+- [ ] **T027** Structural emptiness distinction: zero devices in scope ⇒ assurance answers report
+      "no telemetry — cannot characterise health", never a health verdict. Enforced at a chokepoint
+      that raises, following 091/094
+- [ ] **T028** Exercise the trap against real telemetry — a healthy site and an empty site must
+      produce different answers
+- [ ] **T029** Skills: wireless assurance, client troubleshooting, Marvis query, SLE review
+- [ ] **T030** Full `docs/ADDING-AN-MCP.md` pass: registration, catalog, install step, profile,
+      docs, counts, HUD's two entries
+
+---
+
+## Dependencies
+
+```
+T003 → T004 → T005      (each connection failure had to be resolved to reach the next)
+T007 → T009 → T012      (the count, not the estimate, is what rejects adoption)
+T011 → T012             (a filterable manifest would have changed the decision)
+T013 → T015             (the trap is only visible in an empty org — the one thing it IS good for)
+T022 gates T024–T029    (the central failure mode cannot be tested without telemetry)
+T023 gates T024         (build against least privilege, not admin)
+```
+
+## Out of scope
+
+Apstra (stays with R6, paired per the roadmap); any write path; and adopting the remote server at a
+later date **unless** `probe-mist-mcp.py` shows Juniper has materially shrunk the manifest.


### PR DESCRIPTION
Follow-up to #224, which merged before these artifacts were written.

## Why

Spec 095 shipped `spec.md` + `VERIFICATION.md` alone. Constitution **Principle XVI** requires
`specify → plan → task → implement` and states that *"ad-hoc or undocumented feature additions
('cowboy coding') are not permitted."* 095 was one of ten consecutive specs (087–096) that skipped
the plan and task artifacts.

An audit of all 86 specs found **72 carry the full artifact set, 13 do not** — and ten of those are
the contiguous run 087–096. The drift went undetected because nothing checks for it.

## What this adds

| File | Content |
|---|---|
| `plan.md` | Technical context, Constitution Check, structure decision, Complexity Tracking |
| `research.md` | The nine research decisions behind the rejection, each with the measurement |
| `tasks.md` | T001–T021 complete; **T022–T030 the gated build, deliberately not started** |

## What they record that the spec did not

- **Why the outcome is a decision rather than code**, and why the build is *gated* rather than
  merely unstarted: the verification org has 0 devices, so the *no telemetry* vs *no problems*
  distinction — the feature's central failure mode — cannot be exercised.
- **The contrast that explains two opposite decisions made the same day**: Mist rejected at 11,783
  tokens, Elastic (096) adopted at 1,094. The manifest cost separates them, not a preference for
  adopting or building.
- **The gate conditions in task form**, so resuming the build is a checklist rather than a
  re-investigation.

No functional change. Nothing is registered; `reconcile-mcp.py` still exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)