### PR TITLE
feat(101): HUD three.js 0.170→0.185.1, peer inspector fix, liveness/selection legibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # netclaw Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-08-06
+Auto-generated from all feature plans. Last updated: 2026-08-07
 
 ## Active Technologies
 - N/A (stateless server; subscription state held in-memory during runtime) (003-gnmi-mcp-server)
@@ -116,6 +116,8 @@ Auto-generated from all feature plans. Last updated: 2026-08-06
 - none. The NMS holds the history. (083-zabbix-nms)
 - Dart 3.x / Flutter (SDK constraint `^3.12.2`, matching `mobile/netclaw-mobile/pubspec.yaml`); Swift 5.0 (existing `ios/Runner/*.swift`, `ios/WatchApp Watch App/*.swift`); Bash (CI workflow is declarative YAML, no new scripting language) + No new Dart packages — reuses `flutter_local_notifications`, `firebase_messaging`, `firebase_core`, `local_auth`, `app_links`, `web_socket_channel`, `flutter_secure_storage` already in `pubspec.yaml`. New native-only surface: Apple's **ActivityKit** (Live Activity, Story 7) and **WidgetKit** (watchOS complication, Story 8) — both system frameworks, zero new third-party dependencies, consistent with every prior mobile spec (066-073) adding no new packages beyond what a given story strictly needs. (099-mobile-prerelease-sweep)
 - N/A — reuses existing on-device stores (`MessageFeedStore`, `ConversationStore`, `ApprovalClient` in-memory state, `flutter_secure_storage` for enrollment) for Dashboard data; no new persistence introduced. (099-mobile-prerelease-sweep)
+- JavaScript ES2022 (ESM), Node 22+ for tooling. No TypeScript in this package. + `three` 0.170.0 → **0.185.1** (the only dependency change); existing `gsap`, `lil-gui`, `vite` 5.4 unchanged. Addons consumed as-is: `OrbitControls`, `CSS2DRenderer`, `EffectComposer` + `RenderPass`/`UnrealBloomPass`/`ShaderPass`/`OutputPass`/`SMAAPass`/`AfterimagePass`/`FilmPass`/`GlitchPass`, `VignetteShader`, `RGBShiftShader`. **No new package.** (101-hud-threejs-modernization)
+- N/A — stateless client. All state from `GET /api/n2n` and `GET /api/graph`; nothing persisted. (101-hud-threejs-modernization)
 
 - Python 3.10+ + FastMCP (MCP framework), grpcio + grpcio-tools (gRPC transport), pygnmi (gNMI client library), protobuf, cryptography (TLS handling) (003-gnmi-mcp-server)
 
@@ -135,9 +137,9 @@ cd src [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLO
 Python 3.10+: Follow standard conventions
 
 ## Recent Changes
+- 101-hud-threejs-modernization: Added JavaScript ES2022 (ESM), Node 22+ for tooling. No TypeScript in this package. + `three` 0.170.0 → **0.185.1** (the only dependency change); existing `gsap`, `lil-gui`, `vite` 5.4 unchanged. Addons consumed as-is: `OrbitControls`, `CSS2DRenderer`, `EffectComposer` + `RenderPass`/`UnrealBloomPass`/`ShaderPass`/`OutputPass`/`SMAAPass`/`AfterimagePass`/`FilmPass`/`GlitchPass`, `VignetteShader`, `RGBShiftShader`. **No new package.**
 - 099-mobile-prerelease-sweep: Added Dart 3.x / Flutter (SDK constraint `^3.12.2`, matching `mobile/netclaw-mobile/pubspec.yaml`); Swift 5.0 (existing `ios/Runner/*.swift`, `ios/WatchApp Watch App/*.swift`); Bash (CI workflow is declarative YAML, no new scripting language) + No new Dart packages — reuses `flutter_local_notifications`, `firebase_messaging`, `firebase_core`, `local_auth`, `app_links`, `web_socket_channel`, `flutter_secure_storage` already in `pubspec.yaml`. New native-only surface: Apple's **ActivityKit** (Live Activity, Story 7) and **WidgetKit** (watchOS complication, Story 8) — both system frameworks, zero new third-party dependencies, consistent with every prior mobile spec (066-073) adding no new packages beyond what a given story strictly needs.
 - 083-zabbix-nms: Added Python 3.10+. The vendored server runs from **its own virtualenv**; NetClaw authors no
-- 082-document-generation: Added Python 3.10+, system interpreter. No dedicated venv — the four libraries are already
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/101-hud-threejs-modernization/baseline.md
+++ b/specs/101-hud-threejs-modernization/baseline.md
@@ -1,0 +1,95 @@
+# Performance Baselines & Runtime Evidence (FR-044, FR-047)
+
+**Feature**: 101-hud-threejs-modernization
+**Captured**: 2026-08-07, host `DESKTOP` (WSL2), via headless Chrome over CDP
+
+## How this was captured, and one process failure worth recording
+
+Spec 101 assumed `chrome-devtools-mcp` (feature 048) was installed and usable. **It was
+not** — 048 merged as an installable component (PR #97) but had never been enabled: no npm
+package, no profile directory, not registered in either config, and no Chrome binary on the
+host. `scripts/chrome-devtools-enable.sh` was run to provision it (Chrome
+**151.0.7922.77** at `~/.cache/chrome-devtools-mcp/browsers/`, both MCP variants registered
+with OpenClaw).
+
+The registered MCP serves the *live OpenClaw agent*, not this implementation session, so
+measurements were taken by driving the same Chrome binary directly over CDP
+(`hud-probe.mjs`): console/exception capture, median frame time over a sustained window with
+the camera idle, scene composition, and a full-page screenshot.
+
+**Process failure**: T001 required the pre-bump baseline *before* the bump, and the bump was
+landed first. The baseline was recovered by temporarily reinstalling `three@0.170.0`,
+restarting the HUD, measuring, then restoring `0.185.1` — same machine, browser, scene and
+quality mode, so the comparison holds. It should not have needed recovering, and the task
+ordering existed precisely to prevent this.
+
+## Environment (identical across all runs)
+
+| | |
+|---|---|
+Host | WSL2, no discrete GPU |
+Browser | Chrome 151.0.7922.77, `--headless=new`, 1920×1080 |
+WebGL | WebGL 2 via **ANGLE / SwiftShader** (software rasterization) |
+Scene | 42 CSS2D labels rendered; `/api/n2n`, `/api/graph`, `/api/bgp` all 200 |
+Post-processing | all seven passes active |
+Settle | 15 s before sampling; 400 frames sampled, first 60 discarded |
+
+## Measurements
+
+| Run | three.js | Median frame | p95 |
+|---|---|---|---|
+Pre-bump | `0.170.0` | **700.0 ms** | 883.3 ms |
+Post-bump run 1 | `0.185.1` | **766.7 ms** | 900.0 ms |
+Post-bump run 2 | `0.185.1` | **750.0 ms** | — |
+
+Post-bump mean ≈ **758 ms**. Delta vs pre-bump: **+8.3%** (run 1 alone: +9.5%).
+
+### FR-047 verdict: PASS, but marginal and not representative
+
+Within the 10% budget, and the delta (+8.3%) exceeds the observed run-to-run spread
+(766.7 → 750.0, ≈2.2%), so it is probably a real cost rather than noise. Two caveats stated
+plainly rather than buried:
+
+1. **Only one pre-bump sample.** The budget is nearly consumed and a second sample could move
+   the verdict either way.
+2. **A 700 ms median is ~1.4 fps — software rasterization, not a real operator machine.**
+   Frame time here is dominated by SwiftShader, so a 10% budget on 700 ms is a different
+   proposition from 10% on 16 ms, and nothing about *perceived* performance transfers. The
+   numbers that decide FR-021/FR-047 in practice are the ones from the operator's real GPU.
+
+This is exactly why SC-005 requires the numbers be recorded rather than a verdict asserted.
+
+## Console errors (FR-024, SC-004)
+
+One error, at **both** versions:
+
+```
+Failed to load resource: the server responded with a status of 404 (Not Found)
+```
+
+Traced to **`/favicon.ico`** (`/logos/netclawvisualhud.png` and all three API routes return
+200). It is cosmetic, pre-existing, and unrelated to three.js — but it does mean **FR-024's
+"zero console errors" is not currently met**, for a reason this feature did not introduce.
+Recorded rather than waved away; fixing it is a one-line addition and a judgement call about
+whether it belongs in this feature's scope.
+
+Zero uncaught exceptions at either version, which is the substantive half of SC-004.
+
+## Screenshots
+
+`/tmp/.../scratchpad/hud-evidence/hud-{pre-bump-0.170.0,post-bump-0.185.1*}.png`
+
+These are the artifacts for the **human** half of verification. SC-002 (selection legible) and
+SC-003 (six peer states mutually distinct) are deliberately not self-graded — the declared
+channels in `contracts/visual-contract.md` §3 are what a reviewer checks the screenshot
+against.
+
+## Status against the acceptance criteria
+
+| Criterion | State |
+|---|---|
+SC-004 (runs on 0.185.1, no visual regression) | **Partial** — renders, 42 labels, zero exceptions; the pre-existing favicon 404 blocks the "zero console errors" clause |
+SC-005 / FR-047 (frame time ≤110%) | **PASS, marginal** — +8.3%, software-rendering regime |
+SC-007 (bundle ≤10%) | **PASS** — 753.22 → 798.80 kB, +6.05% |
+SC-001 (7/7 peers inspectable) | **Not yet verified** — needs a click-through per peer |
+SC-002, SC-003, SC-010 | **Not yet evidenced** — US2/US3 not implemented |

--- a/specs/101-hud-threejs-modernization/contracts/visual-contract.md
+++ b/specs/101-hud-threejs-modernization/contracts/visual-contract.md
@@ -1,0 +1,170 @@
+# Phase 1 Contract: Declared Visual Channels & Panel Shape
+
+**Feature**: 101-hud-threejs-modernization
+**Date**: 2026-08-06
+**Input**: [spec.md](../spec.md) FR-046 · [data-model.md](../data-model.md)
+
+This is the artifact FR-046 requires: a declaration of **which visual channel carries which
+state**, so SC-002 and SC-003 become checkable against a screenshot instead of self-graded.
+
+It is a *contract*, not a design mock — it fixes the channels and the separability rules that
+must hold, and leaves exact constants to implementation, where `treatments.test.js`-style tests
+enforce the rules on every run.
+
+---
+
+## 1. Channel inventory
+
+Five orthogonal channels. Channels 1–4 carry **entity state**; channel 5 carries **selection**
+and must never modify 1–4.
+
+| # | Channel | Carries | Survives greyscale? | Survives reduced-motion? |
+|---|---|---|---|---|
+1 | **Form** (silhouette/geometry) | state | ✅ | ✅ |
+2 | **Colour + luminance** | state | ✅ (luminance) | ✅ |
+3 | **Motion** (pulse) | state, **redundantly** | ✅ (n/a) | ❌ — suppressed |
+4 | **Label affix** (text) | state | ✅ | ✅ |
+5 | **Outline** | selection only | ✅ | ✅ |
+
+**Motion is deliberately redundant**, carrying no information that form + colour do not already
+carry. This is feature 072's established rule (`nodes.js` header, R8) and it is why suppressing
+motion for `prefers-reduced-motion` cannot collapse the encoding.
+
+---
+
+## 2. Selection is a separate channel (FR-007/009, plan.md primary risk)
+
+**Rule**: selection MUST be expressed via channel 5 only. It MUST NOT be expressed by raising
+`emissiveIntensity`, changing colour, changing form, or changing scale.
+
+Today's treatment is `emissiveIntensity = 1.8` plus a scale bump — i.e. it *reuses state
+channels*. That is the defect behind FR-007 and it has a concrete failure mode: selecting a
+`COLD`/`STALE` node brightens it toward the healthy treatment, so the operator cannot tell
+whether they selected a dim node or a live one.
+
+**Required properties**:
+
+- Legible against all six peer states and all four member treatments.
+- Legible with seven post-processing passes active, bloom included.
+- Legible at both extremes of the camera's configured zoom range (FR-011).
+- Fully removed on deselect, leaving no residue (FR-008).
+- Static, not animated, under `prefers-reduced-motion` (FR-010).
+- At most one node selected at a time (FR-009).
+
+An outline (or equivalently a rim treatment applied outside the silhouette) satisfies these
+because it occupies space the state channels do not use. Bloom is a real hazard here — an
+additive glow can wash out an outline — so implementation MUST verify against the *bloom-enabled*
+scene, not a bare one.
+
+---
+
+## 3. Peer state → channels (US3, the defect fix)
+
+Six states from [data-model.md](../data-model.md) §2. Today all six collapse to three colours
+and one form, with five of seven live peers rendering identically to a healthy one.
+
+| State | Form (ch 1) | Luminance band (ch 2) | Motion (ch 3) | Label affix (ch 4) |
+|---|---|---|---|---|
+`LIVE` | solid peer silhouette | brightest | gentle pulse | — |
+`IDLE` | solid peer silhouette | bright, below LIVE | still | — |
+`STALE` | peer silhouette, degraded edge | mid | still | `· stale 12d` |
+`UNKNOWN` | peer silhouette, hollow/open | mid-low, cool | still | `· never seen` |
+`UNREACHABLE` | broken outline | low-mid, warm | urgent pulse | `· unreachable` |
+`SEVERED` | severed silhouette | lowest | still | `· severed` |
+
+### Binding rules
+
+- **R1 — Pairwise luminance ≥ 18.** Every pair of the six states MUST differ by ≥18 ITU-R BT.709
+  relative luminance. Reuses the exact metric and threshold already enforced by
+  `treatments.test.js`, which caught a real collision in feature 072 (COLD landed within 10
+  luminance of FAULT). Six states need a wider spread than four; if the range cannot hold six
+  at ≥18, **form and label affix must carry the difference** and the test asserts that instead
+  of loosening the threshold.
+- **R2 — `LIVE` and `IDLE` must not be confusable with `STALE`.** These are the pairs an
+  operator acts on. They are checked explicitly, not just as part of the pairwise sweep.
+- **R3 — `UNKNOWN` is not a failure state** (FR-016/017). It must not share the warm/alarm hue
+  family used by `UNREACHABLE` and `SEVERED`, or "we have never heard from AB" reads as "AB is
+  broken."
+- **R4 — Peers stay recognisable as peers.** Feature 072 gives peers a distinct octahedron so
+  band membership reads at a glance. State variation MUST modulate that silhouette, not replace
+  it with a member shape.
+- **R5 — Label affixes are additive.** They extend the existing label produced by
+  `resolveLabel`/`disambiguateLabels`; they never replace it, and never make it blank.
+
+---
+
+## 4. Member state → channels (unchanged)
+
+`HOT` / `WARM` / `COLD` / `FAULT` per `nodes.js` `TREATMENTS`. **This feature changes nothing
+here** (FR-013, data-model §4). Listed so the selection channel can be verified against all ten
+combined states, and so a reviewer can confirm the member path was deliberately left alone.
+
+---
+
+## 5. Link flow → channels (US4)
+
+| Link condition | Flow |
+|---|---|
+Peer state `LIVE` | directional flow, Border-ward |
+`IDLE` | none |
+`STALE`, `UNKNOWN`, `UNREACHABLE`, `SEVERED` | none |
+
+- **Direction MUST correspond to something real or be non-directional** (FR-019). Absent a real
+  per-link direction signal in `/api/n2n`, flow is rendered toward the Border to represent
+  *inbound capability availability*, and this choice is recorded rather than left implicit.
+- Flow respects `prefers-reduced-motion` (FR-020): conveyed by a static treatment when
+  suppressed, so the live/not-live distinction survives.
+- Flow is **redundant** with §3's state channels. A viewer who cannot see motion loses nothing.
+
+---
+
+## 6. Peer detail panel contract (US1)
+
+Rendered by the new `federation-peer` branch in `setDetail`, from
+`src/orgchart/peer-detail.js`'s view-model. Reuses existing `detail-grid` / `detail-row` markup —
+no new panel framework.
+
+| Row | Source | Notes |
+|---|---|---|
+Heading | `label` | From feature 072's disambiguation. |
+Identity | `identity` | **Required.** Two peers legitimately share "Hermes"; label alone is ambiguous. |
+State | `state` | The six-state value, not the raw API string. |
+Channel | `channel_state` | Raw, for operator cross-reference against `n2n_health`. |
+Inventory | `freshness.ageText` + `judgement` | FR-004: never a bare timestamp. |
+Chat | `chat_enabled` | |
+In-flight tasks | `in_flight_tasks[]` | Empty renders as an explicit "none", not a blank. |
+Not-in-feed banner | `presentInFeed === false` | FR-045. Only when the peer has vanished. |
+
+### Binding rules
+
+- **P1 — No fallthrough** (FR-006). An unrecognised `setDetail` kind MUST NOT reach the default
+  overview branch. It MUST be loud in development. The silent fallthrough *is* the reported bug:
+  the panel repaints with a *different subject's* content, which is why it read as "not
+  clickable" while the mesh was pickable and hover-scaling correctly.
+- **P2 — Never render `undefined`.** Every row either shows a value or an explicit placeholder.
+  This is why the panel is driven by the `/api/n2n` shape and not routed through `peer-core`,
+  whose BGP payload (`peer.as`, `peer.routerId`, `peer.peerIp`, `peer.routesReceived`,
+  `peer.adjRibIn`) is absent here and would render a panel of blanks (FR-002).
+- **P3 — Both activation paths** (FR-005): pointer (`main.js:2180`) and keyboard/a11y
+  (`main.js:2765`) must reach the same renderer.
+- **P4 — No secrets.** Peer identities and states only; no key material, no tokens.
+
+---
+
+## 7. Verification mapping
+
+| Criterion | Checked by |
+|---|---|
+SC-002 | Screenshot: selected node shows channel 5, distinct from unselected same-type node |
+SC-003 | Screenshot with LIVE + STALE + SEVERED peers: three distinct channel combinations |
+R1/R2/R3 | Unit test on the declared constants — a permanent check, not a one-off screenshot, following `treatments.test.js`'s precedent |
+FR-010/020 | Reduced-motion screenshot: encoding intact with channel 3 suppressed |
+FR-014 | Greyscale luminance test (R1) |
+SC-001 | Click each of 7 peers, panel shows that peer's identity |
+FR-045 | Remove a selected peer from the feed; panel persists with banner, scene treatment drops |
+SC-010 | Stop `netclaw-mesh.service`; no peer changes to a failure appearance, scene flags stale + age |
+
+**The greyscale and reduced-motion rules are asserted as tests, not screenshots.** They are
+properties of design constants, so they hold on every run rather than for one build on one
+machine — the reasoning feature 072 recorded in `treatments.test.js` and the reason it caught a
+real collision.

--- a/specs/101-hud-threejs-modernization/data-model.md
+++ b/specs/101-hud-threejs-modernization/data-model.md
@@ -1,0 +1,206 @@
+# Phase 1 Data Model: HUD three.js Modernization
+
+**Feature**: 101-hud-threejs-modernization
+**Date**: 2026-08-06
+**Input**: [spec.md](./spec.md) · [research.md](./research.md) · [plan.md](./plan.md)
+
+**No persistence, no schema, no API change.** Every entity here is derived client-side from a
+`GET /api/n2n` response and lives for one poll interval. FR-039 forbids touching `server.js` or
+the endpoint contract.
+
+---
+
+## 1. The measured defect this model exists to fix
+
+`nodes.js` treats peers as **structural**, so they skip the four-state health treatment
+entirely and get their colour from `colorForStructural()`:
+
+```js
+if (node.kind === 'border') return 0xffd97a;
+if (node.severed)            return 0xa85c5c;   // luminance 108
+if (node.channelState === 'unreachable' || node.channelState === 'reconnecting')
+                             return 0x86a9cc;   // luminance 164
+return 0x8ad6ff;                                // luminance 201  ← the catch-all
+```
+
+Three colours, one fixed octahedron, no motion. **`stale` is never read, and
+`channel_state: "unknown"` falls through to the healthy default.** Against the live feed:
+
+| Peer | `state` | `channel_state` | `stale` | Renders as |
+|---|---|---|---|---|
+Nate | federated | `up` | false | `0x8ad6ff` healthy |
+**Byrn** | federated | `unknown` | **true** | **`0x8ad6ff` — identical to Nate** |
+**Nicholas** | federated | `unknown` | **true** | **`0x8ad6ff` — identical to Nate** |
+**Hermes** (`as65008`) | federated | `unknown` | **true** | **`0x8ad6ff` — identical to Nate** |
+**AB** | federated | `unknown` | null | **`0x8ad6ff` — identical to Nate** |
+**Carapace** | federated | `unknown` | null | **`0x8ad6ff` — identical to Nate** |
+Hermes (`as65007`) | severed | `unknown` | null | `0xa85c5c` severed |
+
+**Five of seven peers are visually indistinguishable from the one healthy peer.** That is US3's
+whole justification, and it is a data-mapping defect rather than a rendering one — which is why
+the fix belongs in pure `src/orgchart/`, not in the render layer.
+
+---
+
+## 2. `PeerViewState` — derived, pure
+
+Computed by `src/orgchart/liveness.js` from one `/api/n2n` peer row. Six states, ordered
+most-known-good to least. Precedence is top-down: the **first** matching rule wins, so a severed
+peer is never reported as live regardless of other fields.
+
+| State | Rule | Meaning to an operator |
+|---|---|---|
+`SEVERED` | `state === 'severed'` | Deliberately cut. Terminal until re-enrolled. |
+`UNREACHABLE` | `channel_state ∈ {unreachable, reconnecting}` | Was reachable, is not now. Actionable. |
+`STALE` | `stale === true`, or inventory older than the staleness horizon | Federated, but what we know is old. |
+`UNKNOWN` | `inventory_received_at == null` | Never told us anything. **Not** a failure (FR-016/017). |
+`IDLE` | federated, no live channel, inventory fresh | Normal steady state. Nothing wrong. |
+`LIVE` | `channel_state === 'up'` | Channel up right now. |
+
+`LIVE` is last in the table but checked **first** in precedence — an `up` channel overrides
+everything below it.
+
+### Why `UNKNOWN` is its own state and not folded into `STALE`
+
+FR-016 requires `unknown` be distinct from both healthy and dead, and FR-017 forbids
+overstating confidence. AB and Carapace have never sent an inventory. Rendering them as `STALE`
+would assert their data went bad; rendering them as healthy is today's bug. "We have never
+heard from this peer" is a third thing and the only honest one.
+
+### Fields
+
+| Field | Type | Purpose |
+|---|---|---|
+`identity` | string | The stable key. Shown in the panel because two peers legitimately share a `display_name` (both Hermes rows). |
+`label` | string | From feature 072's `resolveLabel`/`disambiguateLabels` — never blank, never ambiguous. |
+`state` | one of the six above | Drives the declared channels (see visual-contract.md). |
+`freshness` | `FreshnessView` (§3) | Operator-readable inventory age. |
+`chatEnabled` | boolean | Straight through. |
+`inFlightTasks` | array | Straight through, for the panel. |
+`presentInFeed` | boolean | **False** once the peer vanishes from the feed while selected (FR-045). |
+
+`presentInFeed` is the only field not derivable from a single row — it needs the previous poll
+for comparison, which is why §5 exists.
+
+---
+
+## 3. `FreshnessView` — operator terms, not timestamps
+
+`src/orgchart/freshness.js`. FR-004 forbids showing a bare timestamp: an operator should not
+have to do date arithmetic to learn a peer went quiet twelve days ago.
+
+| Field | Type | Notes |
+|---|---|---|
+`receivedAt` | ISO string \| null | Raw value, retained for the tooltip. |
+`ageSeconds` | number \| null | `null` when never received — distinct from `0`. |
+`ageText` | string | `"just now"`, `"14m ago"`, `"12d ago"`, `"never"`. |
+`judgement` | `fresh` \| `aging` \| `stale` \| `never` | The explicit call FR-004 requires. |
+
+`judgement` is **not** a restatement of the API's `stale` flag. It is derived from age so the
+HUD can say "aging" before the daemon flips `stale`, and the API flag forces `stale` when set.
+Both inputs, one output — with the pessimistic reading winning, matching the precedence
+principle feature 072's `normalize.js` already uses for peer state.
+
+---
+
+## 4. `MemberViewState` — extend, never replace
+
+FR-013 requires consistency with feature 072's existing visual-weight rules rather than a
+competing scheme. Members already resolve to `HOT` / `WARM` / `COLD` / `FAULT` via
+`orgchart/health.js`, with `TREATMENTS` in `nodes.js` and a permanent greyscale-separability
+test in `treatments.test.js`.
+
+**This feature does not touch that.** Members are already correctly differentiated by `live`
+state. The member-side work is limited to confirming no regression. All new state modelling is
+peer-side, because that is where the defect is.
+
+---
+
+## 5. `FeedState` — freeze and flag
+
+`src/orgchart/feed-state.js`. Implements FR-041/042/043 from the Q1 clarification. In-memory,
+one instance for the page's lifetime.
+
+| Field | Type | Purpose |
+|---|---|---|
+`lastGood` | payload \| null | The last successfully parsed `/api/n2n` response. |
+`lastGoodAt` | epoch ms \| null | Drives the age reported by FR-042. |
+`consecutiveFailures` | number | For the scene-level indicator. |
+`degraded` | boolean | True while the most recent poll failed. |
+
+### Rules
+
+- A poll that throws, returns non-2xx, or fails to parse is a **failure**: `lastGood` is
+  retained untouched and **no** per-entity liveness is recomputed (FR-041). The scene keeps
+  rendering `lastGood`.
+- While `degraded`, the HUD shows a scene-level stale-data indicator carrying the age of
+  `lastGoodAt` (FR-042).
+- A successful poll clears `degraded` and resets `consecutiveFailures` on the next tick, with no
+  reload and no acknowledgement (FR-043).
+- **A successful poll containing zero peers is not a failure.** It is a real, renderable state
+  (fresh install) and must reach the empty-state path feature 072 already defines — conflating
+  "the daemon says nothing is federated" with "I could not reach the daemon" would be the same
+  class of error in the opposite direction.
+
+**Why this is pure and tested**: the decision "is this a failure, and what do we show" is the
+part most likely to be wrong and most dangerous when wrong — a bug here fabricates an outage.
+Putting it in `src/orgchart/` means it is unit-tested, whereas the render layer has no coverage
+at all (plan.md, recorded weakness).
+
+---
+
+## 6. `SelectionState` — orthogonal by construction
+
+Extends what `main.js` already holds in `state.selected`.
+
+| Field | Type | Purpose |
+|---|---|---|
+`kind` | `local-core` \| `member-core` \| `federation-peer` \| … | Now includes the previously-missing `federation-peer` (FR-001/002). |
+`nodeId` | string \| null | Which mesh carries the treatment. |
+`stillPresent` | boolean | Mirrors `presentInFeed`; false drops the scene treatment while the panel persists (FR-045). |
+
+**Invariant (FR-009)**: at most one node reads as selected. Selection is a **separate visual
+channel** from state (visual-contract.md §2), never a modification of the state channels —
+otherwise selecting a stale peer would make it look healthy, which is the collision plan.md
+names as the primary risk.
+
+---
+
+## 7. State transitions
+
+```
+        ┌──────────────── poll succeeds ────────────────┐
+        ▼                                              │
+   ┌─────────┐   poll fails    ┌────────────────────┐   │
+   │ current ├────────────────►│ degraded           │───┘   FR-043: recovery needs
+   │ (live)  │                 │ (frozen @ lastGood)│       no reload, no ack
+   └────┬────┘                 └────────────────────┘
+        │                        · per-entity liveness NOT recomputed  (FR-041)
+        │                        · scene flags stale + age of lastGood (FR-042)
+        │
+        │ peer row disappears while selected
+        ▼
+   ┌───────────────────────────────────────────────┐
+   │ panel: last known detail, marked "not in feed"│  FR-045
+   │ scene: selected treatment dropped             │
+   └───────────────────────────────────────────────┘
+```
+
+Peer state transitions (`LIVE → STALE → UNREACHABLE → SEVERED` and back) carry no special
+handling: each poll recomputes `PeerViewState` from scratch, so a transition is simply a
+different derivation. That is deliberate — there is no state machine to desynchronise, and
+`FeedState` is the only thing holding memory between polls.
+
+---
+
+## 8. Validation rules
+
+| Rule | Source |
+|---|---|
+Six peer states MUST be pairwise distinguishable in greyscale, ≥18 luminance delta | FR-014; reuses `treatments.test.js`'s existing metric and threshold |
+No state may be carried by colour alone | FR-014 |
+Precedence is top-down; a severed peer is never reported live | FR-017; mirrors `normalize.js` |
+`ageSeconds === null` (never) MUST NOT render as `0` (just now) | FR-004 |
+A failed poll MUST NOT mutate any entity's liveness | FR-041 |
+Zero peers on a **successful** poll is an empty state, not a failure | §5, feature 072 first-run |
+`identity` MUST appear in the panel, not only `label` | spec Edge Cases — two peers share "Hermes" |

--- a/specs/101-hud-threejs-modernization/evidence/hud-after-spacing-fix.json
+++ b/specs/101-hud-threejs-modernization/evidence/hud-after-spacing-fix.json
@@ -1,0 +1,21 @@
+{
+  "label": "after-spacing-fix",
+  "url": "http://localhost:3000/",
+  "settleMs": 15000,
+  "frame": {
+    "median": 749.9000000000233,
+    "p95": 1366.5999999999767,
+    "n": 340
+  },
+  "scene": {
+    "canvases": 1,
+    "labels": 42,
+    "webgl2": true,
+    "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero) (0x0000C0DE)), SwiftShader driver)",
+    "title": "NetClaw Visual"
+  },
+  "consoleErrors": [
+    "Failed to load resource: the server responded with a status of 404 (Not Found)"
+  ],
+  "pageErrors": []
+}

--- a/specs/101-hud-threejs-modernization/evidence/hud-post-bump-0.185.1-run2.json
+++ b/specs/101-hud-threejs-modernization/evidence/hud-post-bump-0.185.1-run2.json
@@ -1,0 +1,21 @@
+{
+  "label": "post-bump-0.185.1-run2",
+  "url": "http://localhost:3000/",
+  "settleMs": 15000,
+  "frame": {
+    "median": 750,
+    "p95": 1450,
+    "n": 340
+  },
+  "scene": {
+    "canvases": 1,
+    "labels": 42,
+    "webgl2": true,
+    "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero) (0x0000C0DE)), SwiftShader driver)",
+    "title": "NetClaw Visual"
+  },
+  "consoleErrors": [
+    "Failed to load resource: the server responded with a status of 404 (Not Found)"
+  ],
+  "pageErrors": []
+}

--- a/specs/101-hud-threejs-modernization/evidence/hud-post-bump-0.185.1.json
+++ b/specs/101-hud-threejs-modernization/evidence/hud-post-bump-0.185.1.json
@@ -1,0 +1,21 @@
+{
+  "label": "post-bump-0.185.1",
+  "url": "http://localhost:3000/",
+  "settleMs": 15000,
+  "frame": {
+    "median": 766.6999999999825,
+    "p95": 900,
+    "n": 340
+  },
+  "scene": {
+    "canvases": 1,
+    "labels": 42,
+    "webgl2": true,
+    "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero) (0x0000C0DE)), SwiftShader driver)",
+    "title": "NetClaw Visual"
+  },
+  "consoleErrors": [
+    "Failed to load resource: the server responded with a status of 404 (Not Found)"
+  ],
+  "pageErrors": []
+}

--- a/specs/101-hud-threejs-modernization/evidence/hud-pre-bump-0.170.0.json
+++ b/specs/101-hud-threejs-modernization/evidence/hud-pre-bump-0.170.0.json
@@ -1,0 +1,21 @@
+{
+  "label": "pre-bump-0.170.0",
+  "url": "http://localhost:3000/",
+  "settleMs": 15000,
+  "frame": {
+    "median": 699.9999999999927,
+    "p95": 883.2999999999884,
+    "n": 340
+  },
+  "scene": {
+    "canvases": 1,
+    "labels": 42,
+    "webgl2": true,
+    "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero) (0x0000C0DE)), SwiftShader driver)",
+    "title": "NetClaw Visual"
+  },
+  "consoleErrors": [
+    "Failed to load resource: the server responded with a status of 404 (Not Found)"
+  ],
+  "pageErrors": []
+}

--- a/specs/101-hud-threejs-modernization/evidence/hud-probe.mjs
+++ b/specs/101-hud-threejs-modernization/evidence/hud-probe.mjs
@@ -1,0 +1,140 @@
+/**
+ * Objective HUD measurements over CDP: console errors + median frame time + screenshot.
+ *
+ * Deliberately measures only what does not need human judgement. The subjective
+ * half (is the selection legible? are the six states distinguishable?) is a
+ * screenshot for a person to read, per spec 101 SC-002/SC-003.
+ */
+import { spawn } from 'node:child_process';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import WebSocket from '/home/johncapobianco/netclaw/ui/netclaw-visual/node_modules/ws/index.js';
+
+const CHROME = process.env.CHROME_BIN;
+const URL_ = process.env.HUD_URL || 'http://localhost:3000/';
+const LABEL = process.env.LABEL || 'run';
+const OUT = process.env.OUT_DIR || '.';
+const SETTLE_MS = Number(process.env.SETTLE_MS || 12000);
+const SAMPLE_FRAMES = Number(process.env.SAMPLE_FRAMES || 600);
+
+mkdirSync(OUT, { recursive: true });
+const PORT = 9333 + Math.floor(Math.random() * 300);
+
+const chrome = spawn(CHROME, [
+  '--headless=new', '--no-sandbox', '--disable-dev-shm-usage', `--remote-debugging-port=${PORT}`,
+  '--user-data-dir=/tmp/hud-probe-profile-' + PORT,
+  '--window-size=1920,1080', '--hide-scrollbars',
+  '--no-first-run', '--no-default-browser-check',
+  // Software GL: this host has no real GPU. Frame times are therefore
+  // comparable BETWEEN runs on this host, not to a GPU machine — which is all
+  // FR-047's relative budget needs.
+  '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader',
+  'about:blank',
+], { stdio: ['ignore', 'ignore', 'pipe'] });
+let chromeErr = '';
+chrome.stderr.on('data', (d) => { chromeErr += d.toString(); });
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function targets() {
+  for (let i = 0; i < 60; i += 1) {
+    try {
+      const r = await fetch(`http://127.0.0.1:${PORT}/json/version`);
+      if (r.ok) return (await r.json()).webSocketDebuggerUrl;
+    } catch { /* not up yet */ }
+    await sleep(500);
+  }
+  throw new Error('Chrome never opened a debugging port.\n' + chromeErr.slice(-800));
+}
+
+const wsUrl = await targets();
+const ws = new WebSocket(wsUrl, { maxPayload: 256 * 1024 * 1024 });
+await new Promise((res, rej) => { ws.once('open', res); ws.once('error', rej); });
+
+let id = 0;
+const pending = new Map();
+const consoleErrors = [];
+const pageErrors = [];
+
+ws.on('message', (raw) => {
+  const msg = JSON.parse(raw.toString());
+  if (msg.id && pending.has(msg.id)) {
+    const { res, rej } = pending.get(msg.id); pending.delete(msg.id);
+    msg.error ? rej(new Error(JSON.stringify(msg.error))) : res(msg.result);
+    return;
+  }
+  if (msg.method === 'Runtime.consoleAPICalled' && msg.params.type === 'error') {
+    consoleErrors.push((msg.params.args || []).map((a) => a.value ?? a.description ?? a.type).join(' '));
+  }
+  if (msg.method === 'Runtime.exceptionThrown') {
+    pageErrors.push(msg.params.exceptionDetails?.exception?.description
+      || msg.params.exceptionDetails?.text || 'exception');
+  }
+  if (msg.method === 'Log.entryAdded' && msg.params.entry.level === 'error') {
+    consoleErrors.push(msg.params.entry.text);
+  }
+});
+
+const send = (method, params = {}, sessionId) => new Promise((res, rej) => {
+  const mid = ++id;
+  pending.set(mid, { res, rej });
+  ws.send(JSON.stringify({ id: mid, method, params, ...(sessionId ? { sessionId } : {}) }));
+});
+
+// Attach to a fresh page target
+const { targetId } = await send('Target.createTarget', { url: 'about:blank' });
+const { sessionId } = await send('Target.attachToTarget', { targetId, flatten: true });
+const S = (m, p) => send(m, p, sessionId);
+
+await S('Runtime.enable');
+await S('Log.enable');
+await S('Page.enable');
+await S('Emulation.setDeviceMetricsOverride',
+  { width: 1920, height: 1080, deviceScaleFactor: 1, mobile: false });
+
+await S('Page.navigate', { url: URL_ });
+await sleep(SETTLE_MS);
+
+// Median frame time over a sustained window, camera idle.
+const frameJs = `new Promise((resolve) => {
+  const t = []; let p = performance.now();
+  const f = (n) => { t.push(n - p); p = n;
+    if (t.length < ${SAMPLE_FRAMES}) requestAnimationFrame(f);
+    else { const s = t.slice(60).sort((a,b)=>a-b);
+      resolve(JSON.stringify({ median: s[s.length>>1], p95: s[Math.floor(s.length*0.95)],
+                               n: s.length })); } };
+  requestAnimationFrame(f);
+})`;
+let frame = { error: 'not collected' };
+try {
+  const r = await S('Runtime.evaluate', { expression: frameJs, awaitPromise: true, returnByValue: true });
+  frame = JSON.parse(r.result.value);
+} catch (e) { frame = { error: String(e).slice(0, 200) }; }
+
+// Scene composition actually rendered, so "same scene" is checkable not assumed.
+let scene = {};
+try {
+  const r = await S('Runtime.evaluate', {
+    expression: `JSON.stringify({
+      canvases: document.querySelectorAll('canvas').length,
+      labels: document.querySelectorAll('.label').length,
+      webgl2: (()=>{try{return !!document.createElement('canvas').getContext('webgl2')}catch(e){return false}})(),
+      renderer: (()=>{try{const c=document.createElement('canvas').getContext('webgl2');
+        const d=c.getExtension('WEBGL_debug_renderer_info');
+        return d ? c.getParameter(d.UNMASKED_RENDERER_WEBGL) : 'unknown'}catch(e){return 'err'}})(),
+      title: document.title })`,
+    returnByValue: true });
+  scene = JSON.parse(r.result.value);
+} catch (e) { scene = { error: String(e).slice(0, 120) }; }
+
+const shot = await S('Page.captureScreenshot', { format: 'png' });
+writeFileSync(`${OUT}/hud-${LABEL}.png`, Buffer.from(shot.data, 'base64'));
+
+const report = { label: LABEL, url: URL_, settleMs: SETTLE_MS, frame, scene,
+                 consoleErrors, pageErrors };
+writeFileSync(`${OUT}/hud-${LABEL}.json`, JSON.stringify(report, null, 2));
+
+console.log(JSON.stringify(report, null, 2));
+
+ws.close();
+chrome.kill('SIGKILL');
+process.exit(0);

--- a/specs/101-hud-threejs-modernization/plan.md
+++ b/specs/101-hud-threejs-modernization/plan.md
@@ -31,7 +31,7 @@ would make any regression unattributable.
 **Constraints**: `server.js` and the `/api/n2n` contract MUST NOT change (FR-039). Chat interface and right-hand info bar untouched (FR-037). Feature 072's layout stability holds — no sibling moves on select/expand (FR-038). No state may be carried by color alone (FR-014). Bundle growth ≤10% of 753 kB (SC-007).
 **Scale/Scope**: ~40 nodes (7 peers + 30 members + Border + 2 edge nodes). ~6 files touched, 2–3 new pure modules.
 
-### Resolved during clarification (no NEEDS CLARIFICATION remain)
+### Resolved during clarification (no open questions remain)
 
 All five ambiguities were closed by `/speckit.clarify` and are recorded in spec.md
 Clarifications: poll-failure behavior, the performance metric, selected-peer disappearance,
@@ -54,8 +54,8 @@ initialisation anyway.
 |---|---|---|
 | **VIII. Verify After Every Change** | **PASS** | FR-044 mandates two captured baselines; FR-034/035 mandate screenshot + zero-console-error verification per story. This feature's verification is stronger than its predecessor's precisely because research R2 showed the existing test suite cannot see rendering. |
 | **X. Observability First-Class** | **PASS** | This *is* HUD work, and the clause "the Three.js HUD MUST be updated to reflect new integrations and their operational status" is the feature's whole point — US3 surfaces operational status the HUD currently fetches and discards. |
-| **XI. Full-Stack Artifact Coherence** | **PASS (subset — no new capability)** | Adds **no** MCP server, skill, integration, or installable component, so the catalog/install-steps/SOUL/SKILL/`config/openclaw.json` clauses do not apply. Applicable subset: `ui/netclaw-visual/` (the feature itself), `ui/netclaw-visual/README.md` + `THIRD_PARTY_NOTICES.md` (three.js version, FR-026), and `scripts/reconcile-mcp.py` must exit 0 (FR-027). No tool counts change. |
-| **XII. Documentation-as-Code** | **PASS** | Version references updated in the same PR (FR-026). No SKILL.md — no skill added. |
+| **XI. Full-Stack Artifact Coherence** | **PASS (subset — no new capability)** | Adds **no** MCP server, skill, integration, or installable component, so the catalog/install-steps/SOUL/SKILL/`config/openclaw.json` clauses do not apply. Applicable subset: `ui/netclaw-visual/` (the feature itself), `ui/netclaw-visual/README.md` (record the renderer stack version, FR-026 — analysis found neither README nor THIRD_PARTY_NOTICES currently cites one, so this is an addition), and `scripts/reconcile-mcp.py` must exit 0 (FR-027). No tool counts change. |
+| **XII. Documentation-as-Code** | **PASS** | Renderer stack version recorded in the same PR (FR-026). No SKILL.md — no skill added. |
 | **XIII. Credential Safety** | **PASS** | No credentials, no new environment variable. |
 | **XIV. Human-in-the-Loop (External)** | **PASS** | No external communication. Principle XVII post drafted and offered, never published unprompted. |
 | **XV. Backwards Compatibility** | **PASS** | `/api/n2n` consumed unchanged (FR-039); no API, schema or tool contract altered. The three.js bump is internal to the package. |
@@ -99,8 +99,7 @@ specs/101-hud-threejs-modernization/
 ```text
 ui/netclaw-visual/
 ├── package.json                    # US5: three 0.170.0 -> 0.185.1 (the only dep change)
-├── README.md                       # FR-026: three.js version reference
-├── THIRD_PARTY_NOTICES.md          # FR-026: three.js version reference
+├── README.md                       # FR-026: record renderer stack version (currently absent)
 └── src/
     ├── main.js                     # US1: new 'federation-peer' setDetail branch + FR-006
     │                               #      guard; US2: wire selection treatment; freeze-and-flag

--- a/specs/101-hud-threejs-modernization/plan.md
+++ b/specs/101-hud-threejs-modernization/plan.md
@@ -1,0 +1,160 @@
+# Implementation Plan: HUD three.js Modernization
+
+**Branch**: `101-hud-threejs-modernization` | **Date**: 2026-08-06 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/101-hud-threejs-modernization/spec.md`
+
+## Summary
+
+Fix the eN2N peer inspector (a `setDetail` kind with no branch, silently repainting another
+subject's content), make selection and liveness legible from the scene, animate flow on live
+federation links, and move the HUD from `three@0.170.0` to `0.185.1`.
+
+**Approach**: everything lands client-side in `ui/netclaw-visual/`, on `WebGLRenderer`. The
+renderer migration and the capabilities that need it were split to spec 102 during
+clarification. Four of the five stories are pure client work against data `/api/n2n` already
+returns; the fifth is a dependency bump verified free at build level (research R2).
+
+**Sequencing is not the same as priority.** US5 (the bump) is P2 by operator value but must land
+**first and alone**, because FR-047 gates the upgrade's own frame-time delta between two
+baselines and US2/US3/US4 are then measured against the post-bump one. Landing them together
+would make any regression unattributable.
+
+## Technical Context
+
+**Language/Version**: JavaScript ES2022 (ESM), Node 22+ for tooling. No TypeScript in this package.
+**Primary Dependencies**: `three` 0.170.0 → **0.185.1** (the only dependency change); existing `gsap`, `lil-gui`, `vite` 5.4 unchanged. Addons consumed as-is: `OrbitControls`, `CSS2DRenderer`, `EffectComposer` + `RenderPass`/`UnrealBloomPass`/`ShaderPass`/`OutputPass`/`SMAAPass`/`AfterimagePass`/`FilmPass`/`GlitchPass`, `VignetteShader`, `RGBShiftShader`. **No new package.**
+**Storage**: N/A — stateless client. All state from `GET /api/n2n` and `GET /api/graph`; nothing persisted.
+**Testing**: `node --test 'src/**/*.test.js'` (built-in runner, no framework — feature 072's choice) for pure logic under `src/orgchart/`. Runtime/visual verification via `chrome-devtools-mcp` (feature 048). **New pure modules are testable; render modules remain untested by design** — see the Testing Strategy gap below.
+**Target Platform**: Desktop Chrome/Chromium with WebGL 2, served by `netclaw-hud.service` (Express :3001 + Vite :3000).
+**Project Type**: Single frontend package inside an existing monorepo — `ui/netclaw-visual/`.
+**Performance Goals**: Median frame time within **110%** of baseline (FR-021, FR-047, SC-005). Two baselines required: at 0.170.0 and post-bump at 0.185.1 (FR-044).
+**Constraints**: `server.js` and the `/api/n2n` contract MUST NOT change (FR-039). Chat interface and right-hand info bar untouched (FR-037). Feature 072's layout stability holds — no sibling moves on select/expand (FR-038). No state may be carried by color alone (FR-014). Bundle growth ≤10% of 753 kB (SC-007).
+**Scale/Scope**: ~40 nodes (7 peers + 30 members + Border + 2 edge nodes). ~6 files touched, 2–3 new pure modules.
+
+### Resolved during clarification (no NEEDS CLARIFICATION remain)
+
+All five ambiguities were closed by `/speckit.clarify` and are recorded in spec.md
+Clarifications: poll-failure behavior, the performance metric, selected-peer disappearance,
+how SC-002/003 are validated, and which version the baseline is taken against.
+
+One item was **deferred** at quota and is resolved here rather than left open:
+
+**Browser floor** — the spec's Edge Cases ask what happens without adequate WebGL 2.
+**Decision: out of scope as a behavior change; document only.** The HUD already fails the same
+way today, this feature does not alter renderer initialisation, and inventing a fallback UI
+would be new scope justified by no observed incident. Recorded so it is a decision rather than
+an oversight. If it ever matters, it belongs with spec 102's renderer work, which touches
+initialisation anyway.
+
+## Constitution Check
+
+*GATE: evaluated before Phase 0, re-evaluated after Phase 1 design.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| **VIII. Verify After Every Change** | **PASS** | FR-044 mandates two captured baselines; FR-034/035 mandate screenshot + zero-console-error verification per story. This feature's verification is stronger than its predecessor's precisely because research R2 showed the existing test suite cannot see rendering. |
+| **X. Observability First-Class** | **PASS** | This *is* HUD work, and the clause "the Three.js HUD MUST be updated to reflect new integrations and their operational status" is the feature's whole point — US3 surfaces operational status the HUD currently fetches and discards. |
+| **XI. Full-Stack Artifact Coherence** | **PASS (subset — no new capability)** | Adds **no** MCP server, skill, integration, or installable component, so the catalog/install-steps/SOUL/SKILL/`config/openclaw.json` clauses do not apply. Applicable subset: `ui/netclaw-visual/` (the feature itself), `ui/netclaw-visual/README.md` + `THIRD_PARTY_NOTICES.md` (three.js version, FR-026), and `scripts/reconcile-mcp.py` must exit 0 (FR-027). No tool counts change. |
+| **XII. Documentation-as-Code** | **PASS** | Version references updated in the same PR (FR-026). No SKILL.md — no skill added. |
+| **XIII. Credential Safety** | **PASS** | No credentials, no new environment variable. |
+| **XIV. Human-in-the-Loop (External)** | **PASS** | No external communication. Principle XVII post drafted and offered, never published unprompted. |
+| **XV. Backwards Compatibility** | **PASS** | `/api/n2n` consumed unchanged (FR-039); no API, schema or tool contract altered. The three.js bump is internal to the package. |
+| **XVI. Spec-Driven Development** | **PASS** | specify → clarify → plan → tasks → analyze → implement. |
+| **XVII. Milestone Documentation** | **DEFERRED to completion** | Offered after implementation; publication needs approval (XIV). |
+
+**Principles I, II, III, IV, V, VI, VII, IX**: not applicable — no device interaction, no
+configuration written to network devices, no ITSM-gated change, no audit-bearing operation, no
+new MCP server, no vendor-specific logic, no new skill, no authentication surface. This is a
+read-only visualization of data another component already audits.
+
+**Gate result: PASS.** No violations, nothing to justify in Complexity Tracking.
+
+### One honest weakness, recorded not hidden
+
+Principle VIII is satisfied *procedurally* (baselines, screenshots) but the seven modules that
+import three.js have **zero automated coverage**, and this feature adds render code to them.
+Feature 072's pure/render split is what makes that tolerable — logic goes in `src/orgchart/`
+where it *is* tested — and this plan deliberately maximises what lands on the pure side
+(state→channel mapping, staleness formatting, freeze-and-flag decisions) so the untestable
+surface stays as thin as possible. That is a mitigation, not a fix.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/101-hud-threejs-modernization/
+├── spec.md              # Feature specification (5 clarifications integrated)
+├── plan.md              # This file
+├── research.md          # Phase 0 — R1..R8, empirically verified
+├── data-model.md        # Phase 1 — client-side view state, no persistence
+├── quickstart.md        # Phase 1 — how to capture baselines and verify each story
+├── contracts/
+│   └── visual-contract.md   # Phase 1 — the FR-046 declared-channel table + panel contract
+└── tasks.md             # Phase 2 (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+ui/netclaw-visual/
+├── package.json                    # US5: three 0.170.0 -> 0.185.1 (the only dep change)
+├── README.md                       # FR-026: three.js version reference
+├── THIRD_PARTY_NOTICES.md          # FR-026: three.js version reference
+└── src/
+    ├── main.js                     # US1: new 'federation-peer' setDetail branch + FR-006
+    │                               #      guard; US2: wire selection treatment; freeze-and-flag
+    │                               #      on poll failure (FR-041..043)
+    ├── orgchart/                    # PURE — never imports three.js (feature 072 rule)
+    │   ├── peer-detail.js          # NEW  US1: /api/n2n peer -> panel view-model
+    │   ├── peer-detail.test.js     # NEW
+    │   ├── liveness.js             # NEW  US3: state -> declared visual channels (FR-046)
+    │   ├── liveness.test.js        # NEW
+    │   ├── freshness.js            # NEW  US1/US3: relative-age + stale judgement (FR-004)
+    │   ├── freshness.test.js       # NEW
+    │   ├── feed-state.js           # NEW  US3: poll outcome -> freeze/flag decision (FR-041..043)
+    │   └── feed-state.test.js      # NEW
+    └── orgchart-render/            # three.js — no automated coverage (see weakness above)
+        ├── nodes.js                # US2 selection treatment, US3 liveness channels
+        ├── links.js                # US4 flow animation
+        └── index.js                # US1 activateNode -> correct detail kind
+```
+
+**Structure Decision**: no new package and no new directory. Everything extends
+`ui/netclaw-visual/`, respecting feature 072's hard split — `src/orgchart/` is pure and tested
+and must never import three.js; `src/orgchart-render/` owns all three.js contact. Four new pure
+modules exist specifically to move decision logic (what state means, how stale is stale, whether
+to freeze) out of the untested render layer and into the tested one.
+
+## Phase Sequencing and Risk
+
+Ordered by **measurement dependency**, not by story priority:
+
+1. **Baseline capture at 0.170.0** (FR-044) — blocks everything. SC-005 and FR-047 are
+   unverifiable without it, and it cannot be recreated once the bump lands.
+2. **US5 — the bump, alone** (FR-022..028, FR-047). Re-baseline at 0.185.1. Ships nothing
+   visible; exists so later measurements are attributable.
+3. **US1 — peer inspector** (P1). The reported defect. Independent of everything else.
+4. **US3 — liveness encoding** (P1) then **US2 — selection** (P1). US3 first: it establishes the
+   per-state channel declaration (FR-046) that selection must remain distinguishable *against*.
+   Doing selection first risks choosing a treatment that collides with a state channel.
+5. **US4 — link flow** (P2). Last, because it is the only story with a real perf risk and it
+   should be measured against a scene that already carries US2 and US3's additions.
+
+**Primary risk**: US2 vs US3 channel collision. Both add visual channels to the same nodes, and
+the scene already runs seven post-processing passes including bloom. A selection treatment that
+reads clearly on a healthy node may vanish on a dimmed stale one. FR-046's declared-channel
+table exists to force that conflict to be resolved on paper first — hence US3 before US2, and
+hence the contract being a Phase 1 artifact rather than an implementation detail.
+
+**Secondary risk**: the live `netclaw-hud.service` runs Vite from the working tree, so a
+dependency change is immediately visible to anyone watching the HUD. FR-028 requires the bump be
+verifiable without disturbing it, or the disruption be explicit. Research R2's isolated-probe
+technique is the pattern to reuse.
+
+**Non-risk, verified**: the bump itself. Zero deprecated APIs in use, clean build at 0.185.1,
++45.73 kB (research R2/R3). This is why it is sequenced early rather than feared.
+
+## Complexity Tracking
+
+> No Constitution Check violations. Nothing to justify.

--- a/specs/101-hud-threejs-modernization/quickstart.md
+++ b/specs/101-hud-threejs-modernization/quickstart.md
@@ -1,0 +1,200 @@
+# Phase 1 Quickstart: Verifying HUD three.js Modernization
+
+**Feature**: 101-hud-threejs-modernization
+**Date**: 2026-08-06
+**Input**: [spec.md](./spec.md) Success Criteria · [contracts/visual-contract.md](./contracts/visual-contract.md)
+
+Follows Constitution VIII — **observe → baseline → apply → verify**. The unusual thing about this
+feature is that its unit tests **cannot see rendering**: the 7 modules importing three.js have
+zero coverage, and every existing test lives on feature 072's pure side (research R2). So visual
+verification is not a nicety here, it is the only evidence for half the requirements.
+
+> **Do not read an exit code through a pipe.** `cmd | tail` reports `tail`'s status. Use
+> `cmd >/dev/null 2>&1; echo $?` (CLAUDE.md — this mistake misdiagnosed spec 075).
+
+---
+
+## 0. The two performance baselines (FR-044) — do this first, it cannot be recreated
+
+FR-047 gates the upgrade's own frame-time delta, and SC-005 measures US2/US3/US4 against the
+**post-bump** baseline. Capture the pre-bump one before touching anything.
+
+```bash
+cd ui/netclaw-visual
+node -e "console.log(JSON.parse(require('fs').readFileSync('node_modules/three/package.json')).version)"
+# expect 0.170.0
+```
+
+Record for each baseline: **machine, browser + version, scene composition (node counts by band),
+quality mode, and median frame time over a sustained window** — not an instantaneous reading.
+
+Capture frame time in the browser with the HUD open and idle (no camera movement):
+
+```js
+// paste in DevTools console; reports median frame time over ~10s
+(() => { const t=[]; let p=performance.now();
+  const f=n=>{t.push(n-p);p=n;if(t.length<600)requestAnimationFrame(f);
+    else{const s=t.slice(60).sort((a,b)=>a-b);
+      console.log('median frame ms:', s[s.length>>1].toFixed(2), 'n=', s.length);}};
+  requestAnimationFrame(f); })()
+```
+
+Also record the current scene composition, so "same scene" is checkable rather than assumed:
+
+```bash
+curl -s localhost:3001/api/n2n | python3 -c "
+import json,sys; d=json.load(sys.stdin)
+print('peers:', len(d.get('peers',[])), '| members:', len(d.get('members',[])),
+      '| live members:', sum(1 for m in d.get('members',[]) if m.get('live')),
+      '| edge nodes:', len(d.get('edgeNodes',[])))"
+```
+
+**Put all of it in the PR.** An unreproducible baseline makes FR-021, FR-047 and SC-005
+unverifiable, and SC-005 says a run that cannot produce the numbers *fails* rather than passing
+by default.
+
+---
+
+## 1. Sequencing — why the bump goes first
+
+`netclaw-hud.service` runs Vite from the working tree, so a dependency change is immediately
+visible to anyone watching the HUD (FR-028). Two options:
+
+- **Isolated probe** (research R2's technique) — copy `src/`, `index.html`, `canvas.html`,
+  `vite.config.js` to a scratch dir with its own `node_modules`. Proves the build; does not
+  disturb the running service. Note the test fixtures resolve at `<project>/../../specs/...`, so
+  that path must be mirrored or symlinked.
+- **In place**, then `systemctl --user restart netclaw-hud.service` — an explicit, confirmed step.
+
+Land US5 **alone** and re-baseline before starting US1–US4. Priority orders value; this orders
+measurement (plan.md).
+
+---
+
+## 2. US5 — the upgrade (SC-004, SC-007, FR-047)
+
+```bash
+cd ui/netclaw-visual
+npm install three@0.185.1
+npm run build >/dev/null 2>&1; echo "build exit=$?"     # expect 0
+npm test    >/dev/null 2>&1; echo "test exit=$?"        # expect 0
+```
+
+- [ ] Build exits 0 with **no source change** (already verified in an isolated probe — research R2).
+- [ ] `npm test` exits 0. **Remember this proves nothing about rendering** — no test imports three.js.
+- [ ] Bundle within ~10% of 753 kB (SC-007). Expected ~799 kB, +6.1%.
+- [ ] Post-bump baseline captured (§0) and the delta from pre-bump is **≤10%** (FR-047).
+- [ ] `ui/netclaw-visual/README.md` and `THIRD_PARTY_NOTICES.md` version references updated (FR-026).
+- [ ] `python3 scripts/reconcile-mcp.py >/dev/null 2>&1; echo $?` → `0` (FR-027).
+
+Then the visual check that the unit tests cannot do (FR-034/035), via `chrome-devtools-mcp`:
+
+- [ ] HUD loads at `localhost:3000` with **zero console errors** and no three.js deprecation warnings.
+- [ ] Screenshot: org-chart bands, labels, links, camera framing and all seven post-processing
+      passes visually intact (FR-025).
+
+---
+
+## 3. US1 — peer inspector (SC-001, FR-001..006, FR-045)
+
+Click each of the 7 peers and confirm the panel shows **that** peer:
+
+- [ ] Nate → Nate's identity, state, channel state, inventory freshness. Not the generic overview.
+- [ ] Byrn → its own detail, with staleness stated in operator terms, not a bare timestamp (FR-004).
+- [ ] Both Hermes rows (`as65007` severed, `as65008` federated) → **distinguishable**, because
+      `identity` is shown and not only the shared label.
+- [ ] AB and Carapace (`inventory_received_at: null`) → "never seen", not "0s ago" (FR-004).
+- [ ] The severed Hermes is not presented as reachable.
+- [ ] Keyboard-activate a peer → same panel (FR-005). Both paths were broken.
+- [ ] A peer with in-flight tasks lists them; a peer without shows an explicit "none", not a blank.
+- [ ] **No row renders `undefined`** (P2). This is what routing peers through `peer-core` would have caused.
+
+FR-006, the guard:
+
+- [ ] Call `setDetail` with an unknown kind in dev → fails loudly. It MUST NOT reach the default
+      overview branch. That silent fallthrough is the original bug.
+
+FR-045, selected peer vanishes:
+
+```bash
+# with a peer selected in the HUD, retire its endpoint so it changes underneath you
+#   (spec 100's tool — reversible, and the peer stays federated)
+curl -s -X POST localhost:8179/n2n/peers/forget-endpoint \
+  -H 'Content-Type: application/json' -d '{"peer":"<identity>","actor":"spec101-verify"}'
+```
+
+- [ ] Panel retains last known detail **with a not-in-feed banner**; scene drops the selected treatment.
+- [ ] Panel is neither blanked nor left reading as current.
+
+---
+
+## 4. US3 — liveness encoding (SC-003, FR-012..017)
+
+The defect being fixed: five of seven peers currently render identically to healthy Nate, because
+`colorForStructural` never reads `stale` and `channel_state: "unknown"` hits the healthy default
+(data-model §1).
+
+- [ ] Screenshot containing a LIVE, a STALE and a SEVERED peer → **three mutually distinct**
+      channel combinations per visual-contract §3 (SC-003).
+- [ ] Byrn and Nicholas (`unknown` + `stale`) no longer look like Nate.
+- [ ] AB/Carapace read as **never seen**, and are **not** in the alarm hue family (R3, FR-016/017).
+- [ ] Greyscale screenshot → all six peer states still separable (FR-014).
+- [ ] `prefers-reduced-motion` → encoding intact with motion suppressed (channel 3 is redundant).
+- [ ] Members unchanged: `HOT`/`WARM`/`COLD`/`FAULT` exactly as before (FR-013).
+- [ ] `npm test` covers the pairwise ≥18 luminance rule as a permanent test, not a screenshot.
+
+Empty and failure states:
+
+- [ ] A **successful** poll with zero peers → feature 072's empty state, not a failure indicator.
+
+---
+
+## 5. US2 — selection (SC-002, FR-007..011)
+
+- [ ] Screenshot with the panel hidden → the selected node carries every declared channel-5
+      treatment and is distinct from an unselected node of the same type (SC-002).
+- [ ] Select a **STALE** peer and a **COLD** member → selection legible on dim nodes, and the node
+      does **not** brighten toward the healthy treatment (the FR-007 defect).
+- [ ] Legible with bloom at configured strength.
+- [ ] Legible at both extremes of the camera's zoom range (FR-011).
+- [ ] Deselect → prior appearance fully restored, no residue (FR-008).
+- [ ] Exactly one node reads as selected (FR-009).
+- [ ] `prefers-reduced-motion` → static treatment (FR-010).
+
+---
+
+## 6. US4 — link flow (FR-018..021)
+
+- [ ] Nate's link (LIVE) shows directional flow.
+- [ ] Byrn's link (STALE) shows none. Severed shows none.
+- [ ] `prefers-reduced-motion` → live/not-live still distinguishable without continuous animation.
+- [ ] Median frame time within **110%** of the post-bump baseline (FR-021, SC-005), measured with
+      §0's snippet on the same machine, browser, scene and quality mode.
+
+---
+
+## 7. Preservation (FR-037..040)
+
+- [ ] Chat interface untouched.
+- [ ] Right-hand information bar untouched.
+- [ ] No sibling node moves on select or expand (FR-038, feature 072 layout stability).
+- [ ] `git diff --stat` shows **no change** to `server.js` (FR-039).
+- [ ] Keyboard navigation and the a11y tree still work; `aria-expanded` stays in step with the
+      pointer path.
+
+---
+
+## 8. Final gates
+
+```bash
+cd ui/netclaw-visual && npm test >/dev/null 2>&1; echo "hud tests exit=$?"
+cd /home/johncapobianco/netclaw
+python3 scripts/reconcile-mcp.py >/dev/null 2>&1; echo "reconcile exit=$?"
+/usr/bin/python3 -m pytest tests/n2n/ -q 2>&1 | tail -2      # must stay green — untouched
+git diff --stat -- ui/netclaw-visual/server.js               # must be empty
+```
+
+- [ ] All exit 0; `tests/n2n/` unaffected.
+- [ ] Every "verified" claim backed by a build result, screenshot, or test — never inspection alone (SC-009).
+- [ ] Branch is still `101-hud-threejs-modernization` before committing — other agents switch
+      branches in this shared checkout.

--- a/specs/101-hud-threejs-modernization/research.md
+++ b/specs/101-hud-threejs-modernization/research.md
@@ -1,0 +1,238 @@
+# Phase 0 Research: HUD three.js Modernization (0.170 → 0.185.1)
+
+**Feature**: 101-hud-threejs-modernization
+**Date**: 2026-08-06
+
+Every finding below was verified against the migration guide, the official docs, or an
+**isolated empirical build** — not inferred. Where a claim rests only on the build and
+not on runtime behavior, that limit is stated explicitly.
+
+---
+
+## R1 — Version delta: 0.170.0 → 0.185.1, fifteen releases
+
+**Ground truth from the npm registry** (`registry.npmjs.org/three`, `dist-tags.latest`),
+not from secondary articles — three of which gave three different "current" versions
+(r182, r184, r185):
+
+| | |
+|---|---|
+Installed (`ui/netclaw-visual/package.json`) | `three@^0.170.0`, resolved `0.170.0` |
+Latest | **`0.185.1`**, published **2026-07-01** |
+Releases in between | 15 (`0.171` … `0.185.1`) |
+
+Recent publish cadence: `0.183.0` 2026-02-18, `0.184.0` 2026-04-16, `0.185.0` 2026-06-25,
+`0.185.1` 2026-07-01. Roughly one minor every 6–8 weeks, so a 15-release gap is ~18 months
+of drift.
+
+---
+
+## R2 — The upgrade is empirically free for THIS codebase (build-level)
+
+**Decision**: bump the dependency with **zero code changes**.
+
+**Method** — an isolated probe, because `netclaw-hud.service` is running a live Vite dev
+server out of `ui/netclaw-visual/` and swapping `node_modules` under it would break the
+running HUD:
+
+1. Copied `src/`, `index.html`, `canvas.html`, `vite.config.js` to a scratch dir.
+2. Minimal `package.json` with the real dependency set (`three`, `gsap`, `react`,
+   `react-dom`, `vite`, `@vitejs/plugin-react`), pinned `three@0.170.0`.
+3. `npm run build` + `npm test` → baseline.
+4. `npm install three@0.185.1`, re-ran both.
+
+**Result**:
+
+| | build | tests | bundle (`hud-*.js`) |
+|---|---|---|---|
+`0.170.0` | exit **0** | exit **0** | 753.22 kB |
+`0.185.1` | exit **0** | exit 0, **85 pass / 0 fail** | 798.95 kB |
+
+**No source change was required.** Bundle grows **+45.73 kB (+6.1%)**.
+
+### ⚠️ What this does NOT prove
+
+**The 85 tests do not import three.js at all.** Feature 072 deliberately split
+`src/orgchart/` (pure logic, forbidden from importing three) from `src/orgchart-render/`
+(three.js). Every test file lives on the pure side, so a green suite says nothing about
+rendering. Verified: `grep -rl "from 'three" src/**/*.test.js` → no matches.
+
+The seven modules that *do* import three — `main.js`, `orgchart-render/{bands,camera,
+expansion,index,links,nodes}.js` — have **no test coverage at all**.
+
+So the real evidence is narrower and worth stating precisely: **module resolution and
+bundling of all 10 addon import paths succeed at 0.185.1**. That rules out the most
+likely upgrade failure (a moved or deleted addon). It does not rule out a runtime or
+visual regression, which needs browser verification (R6).
+
+---
+
+## R3 — Not one breaking change in r171–r185 touches this HUD
+
+**Decision**: no remediation work is needed for the bump.
+
+Cross-referenced the official migration guide for r171→r185 against every API the HUD
+actually uses. The HUD's complete three.js surface is 10 addon imports plus core:
+
+```
+three                                    (×7 modules)
+three/addons/controls/OrbitControls.js   (×2)
+three/addons/renderers/CSS2DRenderer.js
+three/addons/postprocessing/{EffectComposer,RenderPass,UnrealBloomPass,ShaderPass,
+                             OutputPass,SMAAPass,AfterimagePass,FilmPass,GlitchPass}.js
+three/addons/shaders/{VignetteShader,RGBShiftShader}.js
+```
+
+Grepped for every API deprecated or removed in that window — `Matrix3.translate/scale/
+rotate`, `TiledLighting`, `LWOLoader`, `SVGLoader.createShapes`, `toTrianglesDrawMode`,
+`SimplifyModifier`, `copyTextureToTexture`, `DRACOLoader.setDecoderConfig`, `FontLoader`,
+`TextGeometry`, `useLegacyLights`, `outputEncoding`, `Texture.encoding`, `updateRange`,
+`LightProbeGrid`, `BatchedMesh`, `AnamorphicNode`, `GTAO*`, `positionLocal`,
+`directionToColor`, `inverseTransformDirection`, `PCFSoftShadowMap`+WebGPU:
+
+**Zero hits.**
+
+**Why the delta is so quiet for us**: the overwhelming majority of r171–r185 breaking
+changes are in **TSL and the WebGPU node system** — `TextureNode.uv()`→`sample()`,
+`varying()`→`toVarying()`, `blendBurn()` renames, `storageObject()` deprecation,
+`PostProcessingUtils`→`RendererUtils`, `SSRNode`/`SSGINode`/`GTAONode` changes. The HUD
+uses none of it. The genuinely cross-cutting breakages (WebGL 1 removal r163, color
+management r152, `uv2`→`uv1` r152) all predate 0.170 and were already absorbed.
+
+This **corrects an earlier assessment made in conversation** that "r185's deprecation
+purge is a real breaking surface" for this HUD and should be treated as a deliberate
+sweep rather than a bump. The evidence says the opposite: for this dependency surface it
+is a bump. The one caveat is r186 (unreleased): `Object3D.dispose()` becomes a method
+custom subclasses must chain via `super.dispose()`.
+
+---
+
+## R4 — WebGPURenderer is an either/or, not an upgrade — and this is the spec's central decision
+
+**Decision**: treat the renderer choice as an explicit, staged fork. Do **not** couple it
+to the version bump.
+
+From the official WebGPURenderer manual, three constraints decide everything:
+
+| Capability | Under `WebGPURenderer` |
+|---|---|
+Automatic WebGL 2 fallback | **Yes** — also forceable with `{ forceWebGL: true }` |
+`ShaderMaterial` / `RawShaderMaterial` with raw GLSL | **NOT SUPPORTED** — must be ported to node materials + TSL |
+`onBeforeCompile()` modifications | **NOT SUPPORTED** |
+`EffectComposer` + its passes | **NOT SUPPORTED** — replaced by a node-based post-processing stack |
+
+Direct quotes: *"Custom materials based on `ShaderMaterial`, `RawShaderMaterial` and
+modifications of built-in materials via `onBeforeCompile()` are not supported in
+`WebGPURenderer`."* and *"`EffectComposer` with its effect passes are not supported
+because `WebGPURenderer` comes with a new, more modern post-processing stack."*
+
+### The measured migration cost is small but non-zero
+
+| Surface | Count | Migration |
+|---|---|---|
+`new THREE.ShaderMaterial` | **4** | port each to `NodeMaterial` + TSL |
+`vertexShader:` / `fragmentShader:` blocks | 4 / 4 | same 4 materials |
+`onBeforeCompile` hooks | **0** | nothing to port — a real saving |
+`EffectComposer` passes in the chain | **7** (`RenderPass`, `UnrealBloomPass`, `ShaderPass`×2, `SMAAPass`, `AfterimagePass`, `FilmPass`, `GlitchPass`, `OutputPass`) | rebuild on the node stack |
+
+Four shaders and one post-processing chain. Bounded, and the common effects (bloom
+especially) are already ported to node classes upstream, so this is re-wiring rather than
+re-inventing. `onBeforeCompile` being zero is the single biggest piece of luck here — that
+is usually the worst part of a WebGPU migration.
+
+**The fallback trap, stated plainly**: `forceWebGL: true` and the automatic fallback keep
+the *scene* rendering, but they do not resurrect WebGPU-only capabilities. A viewer on a
+WebGL-only browser gets no compute particles and no clustered lighting. Anything built on
+those is therefore a **progressive enhancement**, never a baseline feature, and the HUD
+must still look correct without them.
+
+---
+
+## R5 — Which "showboat" capabilities are genuinely new, and what each costs
+
+Sorted by honest value **for a ~40-node operations HUD**, not by demo impressiveness.
+
+| Capability | New since 0.170? | Needs WebGPU? | Verdict at this scale |
+|---|---|---|---|
+**Node-based post-processing** (`RenderPipeline`, r183) | Yes | **Yes** | Genuine win — replaces the 7-pass chain with a cleaner graph and makes *selective* per-object bloom straightforward, which the current `UnrealBloomPass` makes awkward |
+**ClusteredLighting** (Forward+, r185, `three/addons/lighting/ClusteredLighting.js`) | **Yes — r185** | **Yes** (overrides the WebGPU lighting system) | Real and showy: a light per live claw. At r170 dozens of dynamic lights blew the budget; clustered shading partitions the frustum so only lights reaching a fragment are evaluated |
+**Compute-shader particles** (>1M units vs ~50k WebGL ceiling) | Yes | **Yes** | **Overkill.** The headline number solves a problem 40 nodes do not have. Worth it *only* as packet-flow along links, where it is informative rather than decorative |
+**TSL** (write once → WGSL + GLSL) | Yes | Authoring layer for WebGPU | A maintenance bet, not a feature. Upstream moved shader authoring here, so the 4 GLSL shaders are now the non-idiomatic path |
+**WebXR + WebGPU** (r185) | **Yes — r185** | Yes | Deferred. A VR walkthrough of the mesh is a distinct feature, not part of this work |
+**Selection outline / selective bloom** | No — possible at 0.170 | **No** | **Highest payoff per unit effort.** The HUD has *no* `OutlinePass`; selection is `emissiveIntensity = 1.8` + a scale bump, easy to miss against a bloom-heavy scene |
+**Animated link flow** | No — possible at 0.170 | **No** | Where the "incredible" factor lives *and* it is informative: a live peer's link pulses, a 12-day-stale one goes static |
+**Liveness/staleness encoding** | No | **No** | Biggest legibility win overall. `/api/n2n` already carries `channel_state`, `stale`, `inventory_received_at`; the render ignores them |
+
+**Conclusion**: the two best improvements need no upgrade at all, and the two most
+impressive need a renderer migration. That asymmetry is why the spec stages them.
+
+---
+
+## R6 — Runtime verification must be visual, and the tooling already exists
+
+**Decision**: verify with the already-integrated `chrome-devtools-mcp` (feature 048), not
+by adding a headless-GL test rig.
+
+R2 established that the build proves module resolution only, and that the 7 three-importing
+modules have zero test coverage. A rendering regression here is *visual* — a black canvas, a
+missing bloom, mis-scaled labels — and no unit test in this repo's style would catch it.
+
+Feature 048 already vendored `chrome-devtools-mcp` with a persistent profile, giving
+navigation, console-error capture, and screenshots against `localhost:3000`. That is
+exactly the missing verification layer, it needs no new dependency, and it makes
+"the HUD still renders" a checkable claim instead of an assertion.
+
+Minimum gate: load the HUD, assert zero console errors, screenshot, and confirm the
+org-chart bands, labels, links and post-processing are visibly intact.
+
+---
+
+## R7 — The peer-detail defect is a genuine bug, already root-caused
+
+Not a three.js issue at all, but in scope because it is the concrete complaint that
+started this work: eN2N peers (e.g. "Nate") cannot be inspected in the HUD.
+
+**Root cause** (verified in source): `setDetail()` in `main.js:1172` branches on exactly
+six kinds — `local-core`, `member-core`, `integration`, `device`, `skill`, `peer-core`.
+The org-chart click path passes a **seventh name that does not exist**:
+
+```js
+// main.js:2180 (mouse) and main.js:2765 (keyboard/a11y)
+} else if (node.kind === 'peer') {
+  setDetail('federation-peer', node.payload);   // ← no such branch
+```
+
+It falls through all six into the `// Default: overview` block at `main.js:1312` and
+renders the generic "This NetClaw" + BGP summary. So the click *registers* and the panel
+*repaints* — with the wrong content, which reads as "not clickable." Peer meshes are in
+`pickableObjects()` and hover-scale correctly, which is what makes the dead click
+confusing. `border`→`local-core` and `member`→`member-core` both hit real branches, so
+members work and only peers break.
+
+**Not fixable by renaming to `peer-core`.** That branch expects a BGP-session payload
+(`peer.as`, `peer.routerId`, `peer.peerIp`, `peer.routesReceived`, `peer.adjRibIn`) from
+`/api/graph`, but `layout.js:90` sets `payload: entity` — the raw `/api/n2n` peer object
+(`identity`, `channel_state`, `inventory_version`, `stale`, `inventory`,
+`in_flight_tasks`). Pointing it at `peer-core` would render a panel of `undefined`s. It
+needs a renderer written against the federation shape — which is the *richer* one, and
+carries exactly the fields R5 identifies as the biggest legibility win.
+
+Both entry points are affected: pointer and keyboard.
+
+---
+
+## R8 — Constitution applicability
+
+| Artifact | Applies? | Why |
+|---|---|---|
+`ui/netclaw-visual/package.json` | **Yes** | The dependency bump itself |
+Principle X (HUD first-class) | **Yes** | This *is* HUD work |
+Principle XI (full-stack coherence) | **Partial** | No new MCP server, no new skill, no installable component. No new capability counts to reconcile |
+`scripts/reconcile-mcp.py` | **Yes — must run** | CLAUDE.md mandates it before push; CI fails on non-zero. Expected to be unaffected, but "expected" is not "verified" |
+Principle XII (docs-as-code) | **Yes** | `ui/netclaw-visual/README.md` documents the renderer/post-processing stack |
+`THIRD_PARTY_NOTICES.md` | **Check** | Already exists in `ui/netclaw-visual/`; a three.js version reference may need updating |
+Principle XVII (milestone post) | Deferred | Drafted at completion, **offered never published** (Principle XIV) |
+`.env.example` | No | No new environment variable |
+
+**Not applicable**: no device interaction, no vendor logic, no new MCP server, no credential
+surface.

--- a/specs/101-hud-threejs-modernization/spec.md
+++ b/specs/101-hud-threejs-modernization/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `101-hud-threejs-modernization`
 **Created**: 2026-08-06
-**Status**: Draft — awaiting clarification on the renderer decision (see Clarifications)
+**Status**: Draft — renderer decision resolved 2026-08-06 (stay on WebGLRenderer; WebGPU deferred to spec 102). Ready for `/speckit.plan`.
 **Input**: Operator request, 2026-08-06 — "I can't click on Nate / eN2N netclaws in the HUD for details, they are not clickable"; then "anything else you think the HUD needs work on especially using three.js latest and greatest stuff"; then "proceed with fix, and 2-5; and bring in some really showboat three.js stuff we couldn't do in .170 with .185.1".
 
 ## Problem Statement
@@ -43,20 +43,23 @@ Scene size | ~40 nodes (7 peers + 30 members + Border + edges) |
 
 ## Clarifications
 
-### Needed before Phase 1 — the renderer decision
+### Session 2026-08-06
 
-- **Q: Migrate to `WebGPURenderer`, or stay on `WebGLRenderer`?** → **[NEEDS CLARIFICATION]**
+- **Q: Migrate to `WebGPURenderer`, or stay on `WebGLRenderer`?** → **A: Staged. This feature
+  stays on `WebGLRenderer`.** The WebGPU migration and the capabilities that depend on it
+  become a **follow-on spec (102)** with its own risk budget.
 
-  This is the only genuinely open question and it gates User Stories 6–7 entirely.
-  `WebGPURenderer` does **not** support `ShaderMaterial` with raw GLSL, and does **not**
-  support `EffectComposer` — both must be ported (4 shaders, one 7-pass chain). In exchange it
-  is the *only* way to get compute-shader particles, `ClusteredLighting`, and node-based
-  post-processing. It falls back to WebGL 2 automatically, but the fallback does **not**
-  restore the WebGPU-only capabilities, so anything built on them is a progressive
-  enhancement that the HUD must look correct without.
+  Rationale, recorded because it is the load-bearing decision of this feature: adopting
+  `WebGPURenderer` requires porting 4 `ShaderMaterial`s to TSL *and* rebuilding a 7-pass
+  `EffectComposer` chain, because it supports neither raw GLSL shaders nor `EffectComposer`
+  (research R4). Bundling that with the peer-detail bug fix and the 0.185.1 bump — both
+  proven-safe — would make a zero-risk change hostage to a large one. Staging also means the
+  two highest-payoff improvements (selection legibility, liveness encoding) ship without
+  waiting on a renderer rewrite that, per research R5, does not itself improve them.
 
-  The spec is written so US1–US5 are renderer-agnostic and shippable either way, and US6–US7
-  are explicitly gated on this answer.
+  **Consequence for this spec**: US6 and US7 are removed and moved to Out of Scope; FR-029
+  through FR-033 and SC-008 go with them. US1–US5 are unchanged and were written to be
+  renderer-agnostic, so nothing else shifts.
 
 ### Decisions taken without asking (reasonable defaults, recorded)
 
@@ -200,53 +203,6 @@ unchanged scene.
 
 ---
 
-### User Story 6 — Node-based post-processing on WebGPU (Priority: P3) 🔒
-
-The post-processing chain runs on the modern node stack, enabling per-object selective bloom.
-
-**Why this priority**: P3 and **gated on the renderer clarification**. It requires porting 4
-`ShaderMaterial`s to TSL and rebuilding a 7-pass chain — bounded but real. Its main payoff is
-making US2's selection treatment cleaner, which US2 already achieves acceptably without it.
-
-**Independent Test**: the HUD renders identically on the node stack, and selective bloom
-applies to one object without affecting its neighbours.
-
-**Acceptance Scenarios**:
-
-1. **Given** `WebGPURenderer`, **Then** the four custom materials render as they do today.
-2. **Given** the node post-processing stack, **Then** bloom, SMAA, vignette, RGB-shift,
-   afterimage, film and glitch equivalents are all present or a deliberate, recorded omission.
-3. **Given** a WebGL-only browser, **Then** the HUD still renders correctly via fallback.
-4. **Given** selective bloom, **Then** the selected node can bloom without its neighbours doing so.
-
----
-
-### User Story 7 — Capabilities impossible at 0.170 (Priority: P3) 🔒
-
-The HUD uses genuinely new r185 capabilities: `ClusteredLighting` for per-claw lighting, and
-compute-shader particles for link flow.
-
-**Why this priority**: P3, **gated on the renderer clarification**, and explicitly a
-progressive enhancement — the WebGL fallback cannot provide these, so the HUD must be correct
-without them. This is the most visually impressive story and the least operationally necessary,
-and the priority reflects that honestly rather than rewarding novelty.
-
-**Independent Test**: on a WebGPU browser, per-claw lights and particle flow are present; on a
-WebGL-only browser, the HUD still reads correctly.
-
-**Acceptance Scenarios**:
-
-1. **Given** `ClusteredLighting` and one light per live claw, **Then** dozens of dynamic lights
-   render without the frame-rate collapse this would cause at 0.170.
-2. **Given** compute-shader particle flow on federation links, **Then** live links carry
-   visible packet flow and dead links do not.
-3. **Given** a WebGL-only browser, **Then** these degrade to US3/US4's non-WebGPU treatments
-   with no broken or empty visuals.
-4. **Given** either capability, **Then** it conveys real state — never decoration that could
-   mislead an operator about liveness.
-
----
-
 ### Edge Cases
 
 - What happens when `/api/n2n` returns zero peers (fresh install)? US3's encoding must have an
@@ -323,18 +279,6 @@ WebGL-only browser, the HUD still reads correctly.
 - **FR-028**: The upgrade MUST be verifiable without disturbing the running
   `netclaw-hud.service`, or the disruption MUST be an explicit confirmed step.
 
-### Renderer migration (US6/US7) — gated
-
-- **FR-029**: If `WebGPURenderer` is adopted, all four `ShaderMaterial`s MUST be ported to node
-  materials/TSL with no visual regression.
-- **FR-030**: If adopted, the 7-pass `EffectComposer` chain MUST be rebuilt on the node stack,
-  and any effect deliberately dropped MUST be recorded as a decision rather than silently lost.
-- **FR-031**: If adopted, the HUD MUST render correctly on a WebGL-only browser via fallback.
-- **FR-032**: WebGPU-only capabilities MUST be progressive enhancements. The HUD MUST NOT
-  depend on them for conveying any operational state.
-- **FR-033**: Any new visual channel MUST encode real state, never decoration that could be
-  misread as liveness.
-
 ### Verification
 
 - **FR-034**: Runtime verification MUST be visual, using the existing `chrome-devtools-mcp`
@@ -367,7 +311,6 @@ WebGL-only browser, the HUD still reads correctly.
 - **SC-006**: No `setDetail` call can silently render the wrong subject — an unhandled kind is
   detectable rather than plausible.
 - **SC-007**: Bundle growth from the upgrade stays within ~10% of today's 753 kB.
-- **SC-008**: If WebGPU is adopted, the HUD renders correctly on a WebGL-only browser, with
   the WebGPU-only capabilities absent rather than broken.
 - **SC-009**: Every claim of "verified" in this feature is backed by a build result, a
   screenshot, or a test — not by inspection alone.
@@ -388,6 +331,21 @@ WebGL-only browser, the HUD still reads correctly.
 
 ## Out of Scope
 
+- **The `WebGPURenderer` migration and everything gated on it — deferred to spec 102.**
+  Resolved in Clarifications, not dropped. Specifically deferred: porting the 4
+  `ShaderMaterial`s to node materials/TSL, rebuilding the 7-pass `EffectComposer` chain on the
+  node post-processing stack, `ClusteredLighting` (new in r185 — a light per live claw),
+  compute-shader particle flow, and per-object selective bloom.
+
+  Spec 102 inherits three constraints already established here, so it need not re-derive them:
+  the migration cost is **4 shaders and 0 `onBeforeCompile` hooks** (research R4); the WebGL
+  fallback keeps the scene rendering but does **not** restore WebGPU-only capabilities, making
+  every such capability a progressive enhancement the HUD must be correct without; and
+  `ClusteredLighting` overrides the WebGPU lighting system rather than layering on it.
+
+  It should be sequenced **after** 101 lands, because 101 establishes the visual baseline
+  (selection treatment, liveness encoding) that 102's post-processing rewrite must preserve —
+  attempting them together would leave no known-good reference to regress against.
 - **WebXR / VR walkthrough of the mesh.** Newly possible with WebGPU in r185 and genuinely
   interesting, but a distinct feature with its own interaction design.
 - **Rendering thousands of nodes.** Compute particles and instancing headlines target a scale

--- a/specs/101-hud-threejs-modernization/spec.md
+++ b/specs/101-hud-threejs-modernization/spec.md
@@ -61,6 +61,53 @@ Scene size | ~40 nodes (7 peers + 30 members + Border + edges) |
   through FR-033 and SC-008 go with them. US1–US5 are unchanged and were written to be
   renderer-agnostic, so nothing else shifts.
 
+- Q: What should the liveness encoding do when the `/api/n2n` poll itself fails (network
+  error, daemon down, malformed response)? → A: **Freeze and flag.** Retain the last known
+  good state, mark the whole scene as stale-data with the age of the last successful poll, and
+  never mutate per-peer liveness on a failed fetch. A failed poll is not evidence about peers;
+  conflating "I cannot see" with "they are down" would fabricate a total outage and send an
+  operator chasing it.
+
+- Q: How should the performance target be quantified, given FR-021's unfalsifiable
+  "measurably"? → A: **Relative budget — frame time may not increase more than 10% versus a
+  captured pre-change baseline on the same machine and the same scene.**
+
+  Because a relative budget is only as good as its baseline, the baseline capture is itself
+  constrained (FR-044): same machine, same scene composition, same quality mode, same browser,
+  measured over a sustained window rather than an instant, and recorded in the PR so the
+  comparison is reproducible rather than asserted. Without that, a noisy baseline run makes any
+  later regression pass.
+
+- Q: What happens when a peer is selected and then disappears from the `/api/n2n` feed? → A:
+  **Retain and mark as gone.** Keep the panel showing that peer's last known detail, explicitly
+  flagged as no longer present in the feed, and drop the node's selected treatment in the scene.
+  This is Q1's principle one level down: blanking the panel discards what the operator was
+  reading mid-investigation, while keeping it live and unlabelled is the FR-006 defect in a new
+  place. Peers genuinely do leave the feed — Hermes was re-enrolled under a new AS on
+  2026-07-23, and spec 100's `forget_peer_endpoint` mutates rows under a running HUD.
+
+- Q: How do SC-002 and SC-003 pass or fail, given "an observer can correctly identify/sort" is
+  self-graded? → A: **Declared channels plus screenshot evidence.** The design must name the
+  specific visual channels carrying each state (e.g. outline, rim, opacity, badge, label
+  affix), and acceptance is a screenshot in which each declared channel is present and distinct
+  per state. Self-checkable with the `chrome-devtools-mcp` already in use, needs no second
+  observer, and converts a judgement into a check. A pixel-diff fixture harness (the fully
+  objective option) was rejected as tooling this repo has never had and does not need for four
+  states.
+
+- Q: Which three.js version is the FR-044 performance baseline captured against, given US5
+  bumps mid-feature? → A: **Two baselines.** Capture at `0.170.0`; land the bump alone and
+  re-measure, gating its own frame-time delta at 10%; then measure US2/US3/US4 against the
+  post-bump baseline.
+
+  Without this, a baseline at 0.170 followed by both a bump and new animation makes a
+  regression unattributable, defeating the falsifiability Q2 was chosen to create. It also
+  gives US5 a performance gate it otherwise lacks entirely — FR-025 only required the upgrade
+  preserve *visual* behavior, so nothing checked whether it cost frame time.
+
+  **Sequencing consequence**: US5 must land **alone and before** US2/US3/US4 are measured, even
+  though it is P2 by operator value. Priority orders *value*; this orders *measurement*.
+
 ### Decisions taken without asking (reasonable defaults, recorded)
 
 - **The version bump is decoupled from the renderer choice.** Verified free at build level
@@ -103,6 +150,9 @@ with no other story implemented.
    detail renders — both entry points are affected by the defect and both must be fixed.
 5. **Given** a peer with in-flight delegated tasks, **When** it is selected, **Then** those
    tasks are listed.
+6. **Given** a peer is selected, **When** it disappears from `/api/n2n` on the next poll,
+   **Then** the panel still shows its last known detail marked as no longer present, and the
+   node is no longer drawn as selected.
 
 ---
 
@@ -200,6 +250,9 @@ unchanged scene.
    normal access path.
 5. **Given** `THIRD_PARTY_NOTICES.md` or the HUD README cites a three.js version, **Then**
    they are updated (Principle XII).
+6. **Given** the pre-bump and post-bump FR-044 baselines, **When** they are compared, **Then**
+   the upgrade's own median frame-time increase is within 10% — the bump is gated on cost, not
+   only on looking unchanged.
 
 ---
 
@@ -210,12 +263,16 @@ unchanged scene.
 - What happens when two peers share a `display_name` (the live "Hermes" case, two identities)?
   Feature 072's `disambiguateLabels` handles the label; US1's inspector must show the
   *identity*, not just the label, or the panel is ambiguous.
-- What happens on a browser with neither WebGPU nor adequate WebGL 2?
 - What happens if `channel_state` is `"unknown"` — genuinely unknown, or not yet polled? US3
   must not render "unknown" as "dead".
-- What happens to the CSS2D label layer under `WebGPURenderer`? Labels are DOM overlays and
-  should be unaffected, but this is unverified.
-- What happens when a peer is selected and then disappears from the feed?
+- **Resolved (Clarifications):** what happens when the `/api/n2n` poll fails outright? The
+  scene freezes on last known good state and is flagged stale with the age of the last
+  successful poll (FR-041/042/043). Per-peer liveness is never mutated by a failed fetch.
+- What happens on a browser without adequate WebGL 2? (The WebGPU variant of this question was
+  removed with the renderer clarification — this feature stays on `WebGLRenderer`.)
+- **Resolved (Clarifications):** a selected peer disappearing from the feed retains its last
+  known detail in the panel, explicitly flagged as no longer present, and loses its selected
+  treatment in the scene (FR-045).
 
 ## Requirements *(mandatory)*
 
@@ -234,6 +291,10 @@ unchanged scene.
 - **FR-006**: No `setDetail` kind may fall through to the default overview branch. An
   unrecognised kind MUST fail loudly in development rather than silently rendering another
   subject's content — this silent fallthrough *is* the defect.
+- **FR-045**: If the selected peer disappears from the feed, the inspector MUST retain that
+  peer's last known detail and MUST label it as no longer present, and the scene MUST drop that
+  node's selected treatment. The panel MUST NOT silently continue to read as current, and MUST
+  NOT be blanked — the operator may be mid-investigation.
 
 ### Selection (US2)
 
@@ -256,6 +317,14 @@ unchanged scene.
 - **FR-016**: `unknown` state MUST be rendered as distinct from both healthy and dead.
 - **FR-017**: The encoding MUST NOT overstate confidence — a peer that is merely unpolled must
   not read as failed.
+- **FR-041**: A failed, errored, or unparseable `/api/n2n` poll MUST NOT mutate any peer's or
+  member's liveness encoding. The last known good state MUST be retained. Absence of data is
+  not evidence of failure, and rendering it as failure would fabricate an outage.
+- **FR-042**: While the last poll is failing, the HUD MUST indicate at scene level that the
+  data is stale, including the age of the last successful poll, so the operator can distinguish
+  "this is current" from "this is what I last knew."
+- **FR-043**: On recovery, the scene MUST return to normal indication on the next successful
+  poll with no reload and no manual acknowledgement.
 
 ### Link flow (US4)
 
@@ -263,7 +332,8 @@ unchanged scene.
   peers MUST NOT.
 - **FR-019**: Flow direction MUST correspond to something real, or MUST be non-directional.
 - **FR-020**: Flow MUST respect reduced-motion preference.
-- **FR-021**: Flow MUST NOT measurably regress frame rate at current scene scale.
+- **FR-021**: Flow MUST NOT increase median frame time by more than **10%** versus the
+  pre-change baseline captured per FR-044, at current scene scale with all effects enabled.
 
 ### Version upgrade (US5)
 
@@ -287,6 +357,21 @@ unchanged scene.
   scene renders.
 - **FR-036**: Any new pure logic MUST be unit-tested on the `src/orgchart/` side of feature
   072's pure/render split, which forbids importing three.js.
+- **FR-046**: The design MUST declare, per state, which visual channels carry it — selected vs
+  unselected, and live vs unknown vs stale vs severed. Each state MUST map to a combination
+  distinct from every other state's, and no state may be carried by color alone (FR-014).
+  SC-002 and SC-003 are checked against this declaration, so an undeclared channel set makes
+  them unverifiable.
+- **FR-044**: **Two** performance baselines MUST be captured and recorded in the PR: one at
+  `three@0.170.0` before any change, and one at `three@0.185.1` after the bump lands alone.
+  Each MUST state machine, browser, scene composition (node counts by band), quality mode, and
+  median frame time over a sustained window — not an instantaneous reading. An uncaptured or
+  unreproducible baseline makes FR-021, FR-047 and SC-005 unverifiable and blocks their
+  acceptance.
+- **FR-047**: The version bump's own frame-time delta MUST be measured between the two FR-044
+  baselines and MUST NOT exceed 10%. US2/US3/US4 are then measured against the **post-bump**
+  baseline, so a regression is attributable to the upgrade or to the feature work, never
+  ambiguous between them.
 
 ### Preservation
 
@@ -301,19 +386,26 @@ unchanged scene.
 
 - **SC-001**: An operator can click any of the 7 peers and see that peer's own detail — 7/7,
   where today it is 0/7.
-- **SC-002**: In a screenshot with no panel visible, an observer can correctly identify which
-  node is selected.
-- **SC-003**: In a screenshot, an observer can correctly sort peers into live / stale /
-  severed without clicking.
+- **SC-002**: A screenshot with no panel visible shows the selected node carrying every
+  channel declared for selection (FR-046), each visibly distinct from the unselected treatment
+  of the same node type.
+- **SC-003**: A single screenshot containing a live, a stale, and a severed peer shows three
+  mutually distinct combinations of the declared channels (FR-046) — no two states share an
+  identical rendering.
 - **SC-004**: The HUD runs on `0.185.1` with zero console errors and no visual regression.
-- **SC-005**: Frame rate at current scene scale is no worse than before, measured the same way
-  before and after.
+- **SC-005**: Median frame time at current scene scale is within **110%** of the **post-bump**
+  FR-044 baseline, and the bump's own delta from the pre-bump baseline is also within 110%
+  (FR-047). All three numbers are recorded in the PR. A run that cannot produce them fails this
+  criterion rather than passing by default.
 - **SC-006**: No `setDetail` call can silently render the wrong subject — an unhandled kind is
   detectable rather than plausible.
 - **SC-007**: Bundle growth from the upgrade stays within ~10% of today's 753 kB.
   the WebGPU-only capabilities absent rather than broken.
 - **SC-009**: Every claim of "verified" in this feature is backed by a build result, a
   screenshot, or a test — not by inspection alone.
+- **SC-010**: With the mesh daemon stopped, no peer's appearance changes to indicate failure,
+  and the scene reports stale data with the age of the last successful poll. Directly testable
+  by stopping `netclaw-mesh.service` with the HUD open.
 
 ## Assumptions
 

--- a/specs/101-hud-threejs-modernization/spec.md
+++ b/specs/101-hud-threejs-modernization/spec.md
@@ -1,0 +1,408 @@
+# Feature Specification: HUD three.js Modernization — 0.170 → 0.185.1, plus legibility and selection work
+
+**Feature Branch**: `101-hud-threejs-modernization`
+**Created**: 2026-08-06
+**Status**: Draft — awaiting clarification on the renderer decision (see Clarifications)
+**Input**: Operator request, 2026-08-06 — "I can't click on Nate / eN2N netclaws in the HUD for details, they are not clickable"; then "anything else you think the HUD needs work on especially using three.js latest and greatest stuff"; then "proceed with fix, and 2-5; and bring in some really showboat three.js stuff we couldn't do in .170 with .185.1".
+
+## Problem Statement
+
+Three separate things are wrong with the HUD, and only one of them is about three.js.
+
+1. **A federated peer cannot be inspected.** Clicking "Nate" repaints the detail panel with
+   the generic overview instead of peer detail, because the click path passes a `setDetail`
+   kind that has no branch. Root-caused in [research.md](./research.md) R7.
+2. **The HUD ignores data it already has.** `/api/n2n` carries `channel_state`, `stale`, and
+   `inventory_received_at` per peer. Nate (live channel, fresh inventory) and Byrn (stale
+   since 2026-07-25) render essentially alike. Selection is `emissiveIntensity = 1.8` plus a
+   scale bump, which is easy to miss in a bloom-heavy scene — there is no `OutlinePass` at all.
+3. **The renderer is eighteen months behind.** `three@^0.170.0` against a current `0.185.1`,
+   fifteen releases. This is the *least* urgent of the three, and the research shows it is
+   also the cheapest to fix.
+
+The framing that matters: the two improvements with the highest payoff need **no upgrade at
+all**, and the two most impressive capabilities need a **renderer migration** that the version
+bump alone does not deliver. Conflating "upgrade three.js" with "get the new toys" is the main
+way this work could go wrong.
+
+## Measured state (2026-08-06, verified — see research.md)
+
+| Quantity | Value |
+|---|---|
+Installed three.js | `0.170.0` |
+Latest three.js | **`0.185.1`** (2026-07-01), 15 releases ahead |
+r171–r185 breaking changes affecting this HUD | **0** (grepped every deprecated/removed API) |
+Build at `0.185.1` with zero code changes | **passes** (exit 0) |
+Bundle delta | 753.22 kB → 798.95 kB, **+45.73 kB (+6.1%)** |
+Test files importing three.js | **0** — the 85 passing tests prove nothing about rendering |
+Modules importing three.js | **7**, all with **zero** test coverage |
+`ShaderMaterial` instances (GLSL, would need TSL port) | **4** |
+`onBeforeCompile` hooks (worst part of a WebGPU port) | **0** |
+`EffectComposer` passes in the chain | **7** |
+Scene size | ~40 nodes (7 peers + 30 members + Border + edges) |
+
+## Clarifications
+
+### Needed before Phase 1 — the renderer decision
+
+- **Q: Migrate to `WebGPURenderer`, or stay on `WebGLRenderer`?** → **[NEEDS CLARIFICATION]**
+
+  This is the only genuinely open question and it gates User Stories 6–7 entirely.
+  `WebGPURenderer` does **not** support `ShaderMaterial` with raw GLSL, and does **not**
+  support `EffectComposer` — both must be ported (4 shaders, one 7-pass chain). In exchange it
+  is the *only* way to get compute-shader particles, `ClusteredLighting`, and node-based
+  post-processing. It falls back to WebGL 2 automatically, but the fallback does **not**
+  restore the WebGPU-only capabilities, so anything built on them is a progressive
+  enhancement that the HUD must look correct without.
+
+  The spec is written so US1–US5 are renderer-agnostic and shippable either way, and US6–US7
+  are explicitly gated on this answer.
+
+### Decisions taken without asking (reasonable defaults, recorded)
+
+- **The version bump is decoupled from the renderer choice.** Verified free at build level
+  (research R2), so it lands first and alone regardless of how the renderer question resolves.
+  Bundling them would make a zero-risk change hostage to a large one.
+- **Verification is visual, via the already-integrated `chrome-devtools-mcp`** (feature 048),
+  not a new headless-GL harness. The seven three.js modules have no tests and a rendering
+  regression is visual by nature (research R6). No new dependency.
+- **The peer inspector is written against the `/api/n2n` shape, not `/api/graph`.** It is the
+  richer source and already carries the staleness fields US3 needs (research R7).
+- **Compute-shader particles are scoped to link flow only.** The >1M-unit headline is
+  irrelevant at 40 nodes; as packet flow along federation links it is informative rather than
+  decorative (research R5).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Inspect a federated peer (Priority: P1)
+
+An operator clicks an eN2N peer in the org chart and sees that peer's federation detail:
+identity, channel state, inventory freshness, chat enablement, and in-flight delegated tasks.
+
+**Why this priority**: it is the reported defect, it is a genuine bug rather than an
+enhancement, and it is currently misleading — the panel repaints with plausible-looking
+content for a *different* subject, which is worse than doing nothing visible.
+
+**Independent Test**: click each of the 7 peers; each shows its own detail. Fully testable
+with no other story implemented.
+
+**Acceptance Scenarios**:
+
+1. **Given** the HUD is loaded with live `/api/n2n` data, **When** the operator clicks the
+   peer node "Nate", **Then** the detail panel shows Nate's identity, state, channel state
+   and inventory freshness — not the generic "This NetClaw" overview.
+2. **Given** a peer with `stale: true` and an inventory from 12 days ago, **When** it is
+   selected, **Then** the panel states the staleness explicitly rather than showing a bare
+   timestamp the operator must date-arithmetic themselves.
+3. **Given** a `severed` peer, **When** it is selected, **Then** the panel shows the severed
+   state and does not present it as reachable.
+4. **Given** keyboard navigation to a peer node, **When** it is activated, **Then** the same
+   detail renders — both entry points are affected by the defect and both must be fixed.
+5. **Given** a peer with in-flight delegated tasks, **When** it is selected, **Then** those
+   tasks are listed.
+
+---
+
+### User Story 2 — Selection is unmistakable (Priority: P1)
+
+An operator can always tell which node is currently selected, at any zoom, against a
+bloom-heavy scene.
+
+**Why this priority**: cheapest meaningful improvement in the whole feature, needs no upgrade
+and no renderer decision, and it compounds with US1 — a detail panel is only useful if the
+operator is confident *which* node it describes.
+
+**Independent Test**: select nodes across bands and confirm the treatment is visible in a
+screenshot without needing the panel to disambiguate.
+
+**Acceptance Scenarios**:
+
+1. **Given** any node is selected, **When** the operator looks at the scene, **Then** the
+   selected node is distinguishable from every unselected node by a treatment that does not
+   rely on emissive intensity alone.
+2. **Given** a selected node in a cluster of cold members, **When** bloom is at its
+   configured strength, **Then** the selection is still legible.
+3. **Given** the selection changes, **Then** the previous node returns fully to its
+   unselected appearance with no residue.
+4. **Given** reduced-motion is preferred, **Then** the treatment is static rather than animated.
+
+---
+
+### User Story 3 — Liveness and staleness are readable from the scene (Priority: P1)
+
+An operator can tell, without clicking anything, which peers and members are actually live and
+which are stale or unreachable.
+
+**Why this priority**: the biggest legibility win available, and it needs no upgrade. The data
+is already fetched and already ignored. This is the difference between a topology picture and
+an operational display.
+
+**Independent Test**: with one live peer, one stale peer and one severed peer in the feed, all
+three read differently in a screenshot.
+
+**Acceptance Scenarios**:
+
+1. **Given** Nate (`channel_state: "up"`, fresh inventory) and Byrn (`channel_state:
+   "unknown"`, `stale: true`), **When** both render, **Then** they are visually distinct.
+2. **Given** a peer whose inventory has never arrived (`inventory_received_at: null`),
+   **Then** it is distinguishable from one with fresh inventory.
+3. **Given** a member with `live: false` and `state: "provisioned"`, **Then** it is demoted
+   relative to a live member, consistent with feature 072's existing visual-weight rules.
+4. **Given** a peer transitions from live to stale while the HUD is open, **Then** the change
+   is reflected on the next poll without a reload.
+5. **Given** the encoding, **Then** it does not rely on color alone (accessibility — feature
+   072 established an a11y tree that must stay coherent).
+
+---
+
+### User Story 4 — Federation links show flow (Priority: P2)
+
+Links to live peers visibly carry traffic; links to stale or dead peers are visibly static.
+
+**Why this priority**: this is where the "showboat" quality and genuine information coincide.
+Deliberately P2 rather than P1 because it is an *addition* to US3's encoding rather than a
+prerequisite for reading the scene. Achievable in the existing GLSL — no renderer decision.
+
+**Independent Test**: one live and one stale peer; the live link animates, the stale one does not.
+
+**Acceptance Scenarios**:
+
+1. **Given** a peer with a live channel, **Then** its link to the Border shows directional flow.
+2. **Given** a stale or severed peer, **Then** its link shows no flow.
+3. **Given** reduced-motion is preferred, **Then** flow is conveyed without continuous animation.
+4. **Given** ~40 nodes and their links, **Then** frame rate does not regress measurably.
+
+---
+
+### User Story 5 — Upgrade to 0.185.1 without regression (Priority: P2)
+
+The HUD runs on `three@0.185.1` and looks and behaves exactly as it does today.
+
+**Why this priority**: verified free at build level, so it is low-risk — but it delivers **no
+visible operator value on its own**, which is precisely why it is P2 and not P1. It is
+enabling work and honesty requires labelling it as such.
+
+**Independent Test**: bump, build, load the HUD, confirm zero console errors and a visually
+unchanged scene.
+
+**Acceptance Scenarios**:
+
+1. **Given** the dependency is `0.185.1`, **When** the project builds, **Then** it succeeds
+   with no source change (already verified in an isolated probe — research R2).
+2. **Given** the HUD is loaded in a browser, **Then** the console shows no errors and no
+   three.js deprecation warnings.
+3. **Given** the upgraded HUD, **Then** the org-chart bands, labels, links, selection and the
+   full post-processing chain are visually intact.
+4. **Given** the bundle grows ~6%, **Then** initial load remains acceptable on the operator's
+   normal access path.
+5. **Given** `THIRD_PARTY_NOTICES.md` or the HUD README cites a three.js version, **Then**
+   they are updated (Principle XII).
+
+---
+
+### User Story 6 — Node-based post-processing on WebGPU (Priority: P3) 🔒
+
+The post-processing chain runs on the modern node stack, enabling per-object selective bloom.
+
+**Why this priority**: P3 and **gated on the renderer clarification**. It requires porting 4
+`ShaderMaterial`s to TSL and rebuilding a 7-pass chain — bounded but real. Its main payoff is
+making US2's selection treatment cleaner, which US2 already achieves acceptably without it.
+
+**Independent Test**: the HUD renders identically on the node stack, and selective bloom
+applies to one object without affecting its neighbours.
+
+**Acceptance Scenarios**:
+
+1. **Given** `WebGPURenderer`, **Then** the four custom materials render as they do today.
+2. **Given** the node post-processing stack, **Then** bloom, SMAA, vignette, RGB-shift,
+   afterimage, film and glitch equivalents are all present or a deliberate, recorded omission.
+3. **Given** a WebGL-only browser, **Then** the HUD still renders correctly via fallback.
+4. **Given** selective bloom, **Then** the selected node can bloom without its neighbours doing so.
+
+---
+
+### User Story 7 — Capabilities impossible at 0.170 (Priority: P3) 🔒
+
+The HUD uses genuinely new r185 capabilities: `ClusteredLighting` for per-claw lighting, and
+compute-shader particles for link flow.
+
+**Why this priority**: P3, **gated on the renderer clarification**, and explicitly a
+progressive enhancement — the WebGL fallback cannot provide these, so the HUD must be correct
+without them. This is the most visually impressive story and the least operationally necessary,
+and the priority reflects that honestly rather than rewarding novelty.
+
+**Independent Test**: on a WebGPU browser, per-claw lights and particle flow are present; on a
+WebGL-only browser, the HUD still reads correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** `ClusteredLighting` and one light per live claw, **Then** dozens of dynamic lights
+   render without the frame-rate collapse this would cause at 0.170.
+2. **Given** compute-shader particle flow on federation links, **Then** live links carry
+   visible packet flow and dead links do not.
+3. **Given** a WebGL-only browser, **Then** these degrade to US3/US4's non-WebGPU treatments
+   with no broken or empty visuals.
+4. **Given** either capability, **Then** it conveys real state — never decoration that could
+   mislead an operator about liveness.
+
+---
+
+### Edge Cases
+
+- What happens when `/api/n2n` returns zero peers (fresh install)? US3's encoding must have an
+  empty state — feature 072 already defines first-run behavior that must not regress.
+- What happens when two peers share a `display_name` (the live "Hermes" case, two identities)?
+  Feature 072's `disambiguateLabels` handles the label; US1's inspector must show the
+  *identity*, not just the label, or the panel is ambiguous.
+- What happens on a browser with neither WebGPU nor adequate WebGL 2?
+- What happens if `channel_state` is `"unknown"` — genuinely unknown, or not yet polled? US3
+  must not render "unknown" as "dead".
+- What happens to the CSS2D label layer under `WebGPURenderer`? Labels are DOM overlays and
+  should be unaffected, but this is unverified.
+- What happens when a peer is selected and then disappears from the feed?
+
+## Requirements *(mandatory)*
+
+### Peer inspection (US1)
+
+- **FR-001**: Clicking or keyboard-activating any eN2N peer node MUST render that peer's own
+  federation detail.
+- **FR-002**: The inspector MUST be driven by the `/api/n2n` peer shape, and MUST NOT be
+  implemented by routing peers to the existing BGP-session renderer, whose payload contract
+  differs and would render undefined fields.
+- **FR-003**: The inspector MUST show, at minimum: identity, display name, state, channel
+  state, inventory freshness, chat enablement, and in-flight delegated tasks.
+- **FR-004**: Inventory freshness MUST be expressed in operator terms (relative age and an
+  explicit stale/fresh judgement), not as a raw timestamp alone.
+- **FR-005**: Both the pointer and the keyboard/accessibility activation paths MUST be fixed.
+- **FR-006**: No `setDetail` kind may fall through to the default overview branch. An
+  unrecognised kind MUST fail loudly in development rather than silently rendering another
+  subject's content — this silent fallthrough *is* the defect.
+
+### Selection (US2)
+
+- **FR-007**: The selected node MUST be distinguishable by a treatment that does not depend on
+  emissive intensity alone.
+- **FR-008**: Deselection MUST fully restore the prior appearance.
+- **FR-009**: Exactly one node MUST read as selected at a time.
+- **FR-010**: The selection treatment MUST respect reduced-motion preference.
+- **FR-011**: Selection MUST remain legible at the extremes of the existing camera's
+  configured zoom range.
+
+### Liveness encoding (US3)
+
+- **FR-012**: Peers MUST be visually differentiated by channel state and inventory staleness.
+- **FR-013**: Members MUST be visually differentiated by `live` state, consistent with feature
+  072's existing visual-weight rules rather than inventing a competing scheme.
+- **FR-014**: The encoding MUST NOT rely on color alone, and MUST remain coherent with the
+  existing a11y tree.
+- **FR-015**: A state change MUST be reflected on the next poll without a reload.
+- **FR-016**: `unknown` state MUST be rendered as distinct from both healthy and dead.
+- **FR-017**: The encoding MUST NOT overstate confidence — a peer that is merely unpolled must
+  not read as failed.
+
+### Link flow (US4)
+
+- **FR-018**: Links to live-channel peers MUST show directional flow; links to stale or severed
+  peers MUST NOT.
+- **FR-019**: Flow direction MUST correspond to something real, or MUST be non-directional.
+- **FR-020**: Flow MUST respect reduced-motion preference.
+- **FR-021**: Flow MUST NOT measurably regress frame rate at current scene scale.
+
+### Version upgrade (US5)
+
+- **FR-022**: The HUD MUST run on `three@0.185.1`.
+- **FR-023**: The upgrade MUST NOT require changes to HUD source (verified at build level;
+  runtime is what US5's acceptance covers).
+- **FR-024**: After upgrade the HUD MUST load with zero console errors and zero three.js
+  deprecation warnings.
+- **FR-025**: All existing visual behavior MUST be preserved — bands, labels, links,
+  selection, camera, and every post-processing pass.
+- **FR-026**: Documentation citing a three.js version MUST be updated (Principle XII).
+- **FR-027**: `scripts/reconcile-mcp.py` MUST exit 0 (CLAUDE.md; CI gate).
+- **FR-028**: The upgrade MUST be verifiable without disturbing the running
+  `netclaw-hud.service`, or the disruption MUST be an explicit confirmed step.
+
+### Renderer migration (US6/US7) — gated
+
+- **FR-029**: If `WebGPURenderer` is adopted, all four `ShaderMaterial`s MUST be ported to node
+  materials/TSL with no visual regression.
+- **FR-030**: If adopted, the 7-pass `EffectComposer` chain MUST be rebuilt on the node stack,
+  and any effect deliberately dropped MUST be recorded as a decision rather than silently lost.
+- **FR-031**: If adopted, the HUD MUST render correctly on a WebGL-only browser via fallback.
+- **FR-032**: WebGPU-only capabilities MUST be progressive enhancements. The HUD MUST NOT
+  depend on them for conveying any operational state.
+- **FR-033**: Any new visual channel MUST encode real state, never decoration that could be
+  misread as liveness.
+
+### Verification
+
+- **FR-034**: Runtime verification MUST be visual, using the existing `chrome-devtools-mcp`
+  integration, and MUST NOT introduce a new test dependency.
+- **FR-035**: Verification MUST cover zero console errors plus a screenshot confirming the
+  scene renders.
+- **FR-036**: Any new pure logic MUST be unit-tested on the `src/orgchart/` side of feature
+  072's pure/render split, which forbids importing three.js.
+
+### Preservation
+
+- **FR-037**: The chat interface and the right-hand information bar MUST NOT be altered —
+  carried forward from feature 072's explicit operator constraint.
+- **FR-038**: Feature 072's layout stability guarantees MUST hold: no sibling node moves as a
+  result of selection or expansion.
+- **FR-039**: `server.js` and the `/api/n2n` contract MUST NOT change. This is a client-side feature.
+- **FR-040**: The existing a11y tree and keyboard navigation MUST remain functional.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: An operator can click any of the 7 peers and see that peer's own detail — 7/7,
+  where today it is 0/7.
+- **SC-002**: In a screenshot with no panel visible, an observer can correctly identify which
+  node is selected.
+- **SC-003**: In a screenshot, an observer can correctly sort peers into live / stale /
+  severed without clicking.
+- **SC-004**: The HUD runs on `0.185.1` with zero console errors and no visual regression.
+- **SC-005**: Frame rate at current scene scale is no worse than before, measured the same way
+  before and after.
+- **SC-006**: No `setDetail` call can silently render the wrong subject — an unhandled kind is
+  detectable rather than plausible.
+- **SC-007**: Bundle growth from the upgrade stays within ~10% of today's 753 kB.
+- **SC-008**: If WebGPU is adopted, the HUD renders correctly on a WebGL-only browser, with
+  the WebGPU-only capabilities absent rather than broken.
+- **SC-009**: Every claim of "verified" in this feature is backed by a build result, a
+  screenshot, or a test — not by inspection alone.
+
+## Assumptions
+
+- The operator's browser supports WebGL 2 today; WebGPU availability is not assumed.
+- `/api/n2n` remains the source of truth for federation state, unchanged by this work.
+- Feature 072's pure/render split, band layout, camera constraints and a11y tree are the
+  foundation to build on, not to revisit.
+- The ~40-node scale holds. Nothing here is designed for thousands of nodes, and the research
+  explicitly rejects capabilities justified only at that scale.
+- `chrome-devtools-mcp` (feature 048) is installed and usable against `localhost:3000`.
+- `netclaw-hud.service` runs a live Vite dev server from the working tree, so dependency
+  changes are operationally visible and must be sequenced deliberately.
+- The 4 `ShaderMaterial`s and 0 `onBeforeCompile` hooks measured in research R4 are the
+  complete custom-shader surface.
+
+## Out of Scope
+
+- **WebXR / VR walkthrough of the mesh.** Newly possible with WebGPU in r185 and genuinely
+  interesting, but a distinct feature with its own interaction design.
+- **Rendering thousands of nodes.** Compute particles and instancing headlines target a scale
+  this HUD does not have; scoped in R5 to link flow only.
+- **Replacing CSS2D labels with SDF text** (`troika-three-text`). Current labels are crisp and
+  selectable; the only gain is depth-correct occlusion, which has not been reported as a problem.
+- **Changing `server.js`, `/api/n2n`, or any MCP server.** Client-side only.
+- **The chat interface and right-hand info bar** (FR-037).
+- **Revisiting feature 072's layout algorithm.**
+- **Upgrading to r186+.** Unreleased at spec time; its `Object3D.dispose()` change is noted in
+  research R3 as a future consideration.
+
+## Dependencies
+
+- `three@0.185.1` from npm.
+- Feature 072's org-chart modules (`src/orgchart/`, `src/orgchart-render/`).
+- Feature 048's `chrome-devtools-mcp` for runtime verification.
+- The `/api/n2n` endpoint as it exists today.

--- a/specs/101-hud-threejs-modernization/spec.md
+++ b/specs/101-hud-threejs-modernization/spec.md
@@ -344,7 +344,11 @@ unchanged scene.
   deprecation warnings.
 - **FR-025**: All existing visual behavior MUST be preserved — bands, labels, links,
   selection, camera, and every post-processing pass.
-- **FR-026**: Documentation citing a three.js version MUST be updated (Principle XII).
+- **FR-026**: The renderer stack version MUST be recorded in `ui/netclaw-visual/README.md`
+  (Principle XII — documentation must accurately reflect current state). **Verified during
+  analysis: neither `README.md` nor `THIRD_PARTY_NOTICES.md` currently cites a three.js
+  version at all**, so this is an addition, not an edit. `THIRD_PARTY_NOTICES.md` is out of
+  scope — it covers adapted third-party *source* (Jack Rabbit), not dependency versions.
 - **FR-027**: `scripts/reconcile-mcp.py` MUST exit 0 (CLAUDE.md; CI gate).
 - **FR-028**: The upgrade MUST be verifiable without disturbing the running
   `netclaw-hud.service`, or the disruption MUST be an explicit confirmed step.
@@ -389,9 +393,11 @@ unchanged scene.
 - **SC-002**: A screenshot with no panel visible shows the selected node carrying every
   channel declared for selection (FR-046), each visibly distinct from the unselected treatment
   of the same node type.
-- **SC-003**: A single screenshot containing a live, a stale, and a severed peer shows three
-  mutually distinct combinations of the declared channels (FR-046) — no two states share an
-  identical rendering.
+- **SC-003**: A screenshot set covering **all six** declared peer states (`LIVE`, `IDLE`,
+  `STALE`, `UNKNOWN`, `UNREACHABLE`, `SEVERED`) shows six mutually distinct combinations of
+  the declared channels (FR-046) — no two states share an identical rendering. Covering only
+  live/stale/severed would leave FR-016's `UNKNOWN`-is-distinct requirement unverified
+  visually, which is exactly the state five of seven live peers occupy.
 - **SC-004**: The HUD runs on `0.185.1` with zero console errors and no visual regression.
 - **SC-005**: Median frame time at current scene scale is within **110%** of the **post-bump**
   FR-044 baseline, and the bump's own delta from the pre-bump baseline is also within 110%

--- a/specs/101-hud-threejs-modernization/tasks.md
+++ b/specs/101-hud-threejs-modernization/tasks.md
@@ -37,7 +37,7 @@ before a selection treatment must stay distinguishable against it.
 ## Phase 1: Setup
 
 - [ ] T001 Capture the **pre-bump** performance baseline at `three@0.170.0` per [quickstart.md](./quickstart.md) §0 — machine, browser + version, scene composition from `/api/n2n`, quality mode, median frame time over a sustained window. **This cannot be recreated once the bump lands** and FR-047/SC-005 are unverifiable without it. Record verbatim in the PR.
-- [ ] T002 [P] Confirm the current suite is green before any change: `cd ui/netclaw-visual && npm test >/dev/null 2>&1; echo $?` → `0`, so later failures are attributable to this work.
+- [ ] T002 [P] Confirm the current suite is green before any change (attribution baseline for FR-036): `cd ui/netclaw-visual && npm test >/dev/null 2>&1; echo $?` → `0`, so later failures are attributable to this work.
 - [ ] T003 [P] Record the live peer-state distribution as the fixture basis for US3, confirming data-model §1's finding that 5 of 7 peers hit `colorForStructural`'s healthy default: `curl -s localhost:3001/api/n2n | python3 -c "import json,sys;d=json.load(sys.stdin);[print(p['display_name'], p['state'], p['channel_state'], p['stale'], p['inventory_received_at']) for p in d['peers']]"`
 
 **Checkpoint**: baseline captured and unreproducible-later data secured; suite green.
@@ -47,15 +47,15 @@ before a selection treatment must stay distinguishable against it.
 ## Phase 2: Foundational (Blocking Prerequisites)
 
 **⚠️ Blocks US1, US3, US4.** These are the pure modules that hold every decision the render layer
-must not make. All four are independent of one another → all `[P]`.
+must not make. All eight tasks are independent of one another → all `[P]`.
 
 - [ ] T004 [P] Create `ui/netclaw-visual/src/orgchart/freshness.js` implementing `FreshnessView` per [data-model.md](./data-model.md) §3: `receivedAt`, `ageSeconds`, `ageText`, `judgement` (`fresh`/`aging`/`stale`/`never`). `ageSeconds === null` (never received) MUST NOT render as `0` (just now) — that conflation is the FR-004 defect.
-- [ ] T005 [P] Create `ui/netclaw-visual/src/orgchart/freshness.test.js`: never-received yields `never` and `null` age, not `0`; `judgement` derives from age AND honors the API `stale` flag with the pessimistic reading winning; `ageText` renders minutes/hours/days in operator terms.
+- [ ] T005 [P] Create `ui/netclaw-visual/src/orgchart/freshness.test.js` (FR-004, FR-036): never-received yields `never` and `null` age, not `0`; `judgement` derives from age AND honors the API `stale` flag with the pessimistic reading winning; `ageText` renders minutes/hours/days in operator terms.
 - [ ] T006 [P] Create `ui/netclaw-visual/src/orgchart/liveness.js` implementing `PeerViewState` per data-model §2 — six states with top-down precedence, `LIVE` checked first. Must read `stale` and treat `channel_state: "unknown"` as its own case, which `colorForStructural` never does.
-- [ ] T007 [P] Create `ui/netclaw-visual/src/orgchart/liveness.test.js` driven by T003's real distribution: Nate → `LIVE`; Byrn/Nicholas/Hermes(`as65008`) → `STALE` and **not** the same state as Nate (the defect); AB/Carapace → `UNKNOWN`, distinct from both healthy and dead (FR-016/017); Hermes(`as65007`) → `SEVERED`; precedence means a severed peer is never `LIVE` regardless of other fields (FR-017).
+- [ ] T007 [P] Create `ui/netclaw-visual/src/orgchart/liveness.test.js` driven by T003's real distribution: Nate → `LIVE`; Byrn/Nicholas/Hermes(`as65008`) → `STALE` and **not** the same state as Nate (the defect); AB/Carapace → `UNKNOWN`, distinct from both healthy and dead (FR-016, FR-017); Hermes(`as65007`) → `SEVERED`; precedence means a severed peer is never `LIVE` regardless of other fields (FR-017).
 - [ ] T008 [P] Create `ui/netclaw-visual/src/orgchart/feed-state.js` implementing `FeedState` per data-model §5 — freeze-and-flag: retain `lastGood`, never recompute liveness on a failed poll (FR-041), expose `degraded` + age of `lastGoodAt` (FR-042), clear on next success with no reload (FR-043).
-- [ ] T009 [P] Create `ui/netclaw-visual/src/orgchart/feed-state.test.js`: a throw, a non-2xx, and unparseable JSON are each failures that leave `lastGood` untouched; **a successful poll with zero peers is NOT a failure** but a renderable empty state; recovery clears `degraded` without acknowledgement. This is the test that stops the HUD fabricating an outage.
-- [ ] T010 [P] Create `ui/netclaw-visual/src/orgchart/peer-detail.js` mapping a `/api/n2n` peer row to the panel view-model per [contracts/visual-contract.md](./contracts/visual-contract.md) §6, including `identity` (not just `label`) and `presentInFeed`.
+- [ ] T009 [P] Create `ui/netclaw-visual/src/orgchart/feed-state.test.js` (FR-041, FR-042, FR-043, FR-036): a throw, a non-2xx, and unparseable JSON are each failures that leave `lastGood` untouched; **a successful poll with zero peers is NOT a failure** but a renderable empty state; recovery clears `degraded` without acknowledgement. This is the test that stops the HUD fabricating an outage.
+- [ ] T010 [P] Create `ui/netclaw-visual/src/orgchart/peer-detail.js` (FR-002, FR-003) mapping a `/api/n2n` peer row to the panel view-model per [contracts/visual-contract.md](./contracts/visual-contract.md) §6, including `identity` (not just `label`) and `presentInFeed`.
 - [ ] T011 [P] Create `ui/netclaw-visual/src/orgchart/peer-detail.test.js`: every row either has a value or an explicit placeholder — **never `undefined`** (P2); both Hermes rows produce distinguishable view-models because `identity` is present; empty `in_flight_tasks` yields an explicit "none".
 
 **Checkpoint**: every state/staleness/failure decision is implemented and unit-tested on the pure side, before any three.js file is touched.
@@ -70,11 +70,11 @@ must not make. All four are independent of one another → all `[P]`.
 
 > Runs before the P1 stories for measurement reasons only (plan.md). It ships no visible value.
 
-- [ ] T012 [US5] Bump `three` to `0.185.1` in `ui/netclaw-visual/package.json`. **No source change is required** — verified by isolated probe (research R2/R3), which found zero of the r171–r185 deprecated APIs in use.
-- [ ] T013 [US5] Build and test: `cd ui/netclaw-visual && npm run build >/dev/null 2>&1; echo $?` → `0`; `npm test >/dev/null 2>&1; echo $?` → `0`. Confirm bundle within ~10% of 753 kB (SC-007; expect ~799 kB).
+- [ ] T012 [US5] Decide and record the verification route per FR-028 **before** bumping: either the isolated-probe technique (research R2 — copy `src/`, `index.html`, `canvas.html`, `vite.config.js` to a scratch dir with its own `node_modules`, mirroring the `<project>/../../specs/...` fixture path) or an explicit, confirmed `systemctl --user restart netclaw-hud.service`. `netclaw-hud.service` runs Vite from the working tree, so a dependency change is immediately visible to anyone watching the HUD. Then bump `three` to `0.185.1` in `ui/netclaw-visual/package.json`. **No source change is required** (FR-022, FR-023) — verified by isolated probe (research R2/R3), which found zero of the r171–r185 deprecated APIs in use.
+- [ ] T013 [US5] Build and test (FR-022, FR-023, SC-004, SC-007): `cd ui/netclaw-visual && npm run build >/dev/null 2>&1; echo $?` → `0`; `npm test >/dev/null 2>&1; echo $?` → `0`. Confirm bundle within ~10% of 753 kB (SC-007; expect ~799 kB).
 - [ ] T014 [US5] Capture the **post-bump** baseline at `0.185.1` (FR-044) and assert the delta from T001 is **≤10%** (FR-047). Same machine, browser, scene and quality mode, or the comparison is void.
-- [ ] T015 [US5] Verify visually via `chrome-devtools-mcp` (FR-034/035): HUD loads with **zero console errors** and no three.js deprecation warnings; screenshot confirms bands, labels, links, camera framing and all seven post-processing passes intact (FR-025).
-- [ ] T016 [P] [US5] Update the three.js version reference in `ui/netclaw-visual/README.md` and `ui/netclaw-visual/THIRD_PARTY_NOTICES.md` (FR-026, Principle XII).
+- [ ] T015 [US5] Verify visually via `chrome-devtools-mcp` (FR-024, FR-034, FR-035, SC-004): HUD loads with **zero console errors** and no three.js deprecation warnings; screenshot confirms bands, labels, links, camera framing and all seven post-processing passes intact (FR-025).
+- [ ] T016 [P] [US5] Record the renderer stack version (`three@0.185.1`, `WebGLRenderer`) in `ui/netclaw-visual/README.md` (FR-026, Principle XII). **Analysis found neither `README.md` nor `THIRD_PARTY_NOTICES.md` cites a three.js version today**, so this is an addition rather than an edit — do not "update" a string that is not there. `THIRD_PARTY_NOTICES.md` is deliberately untouched: it documents adapted third-party *source* (Jack Rabbit), not dependency versions.
 
 **Checkpoint**: HUD on 0.185.1, visually identical, upgrade cost measured and gated. All later measurements now have a valid reference.
 
@@ -86,8 +86,8 @@ must not make. All four are independent of one another → all `[P]`.
 
 **Independent test**: click each of the 7 peers; each shows its own detail. Needs no other story.
 
-- [ ] T017 [US1] Add the `federation-peer` branch to `setDetail` in `ui/netclaw-visual/src/main.js`, rendering from T010's view-model per visual-contract §6. This is the missing seventh branch — the click path at `main.js:2180` and `:2765` already passes this kind and it currently falls through to the default overview.
-- [ ] T018 [US1] Add the FR-006 guard in `ui/netclaw-visual/src/main.js`: an unrecognised `setDetail` kind MUST NOT reach the default overview branch and MUST fail loudly in development. **The silent fallthrough is the defect** — it repaints with a different subject's content, which is why it read as "not clickable" while the mesh was pickable and hover-scaling.
+- [ ] T017 [US1] Add the `federation-peer` branch to `setDetail` (FR-001, FR-002, FR-003) in `ui/netclaw-visual/src/main.js`, rendering from T010's view-model per visual-contract §6. This is the missing seventh branch — the click path at `main.js:2180` and `:2765` already passes this kind and it currently falls through to the default overview.
+- [ ] T018 [US1] Add the FR-006 guard (also SC-006) in `ui/netclaw-visual/src/main.js`: an unrecognised `setDetail` kind MUST NOT reach the default overview branch and MUST fail loudly in development. **The silent fallthrough is the defect** — it repaints with a different subject's content, which is why it read as "not clickable" while the mesh was pickable and hover-scaling.
 - [ ] T019 [US1] Verify both activation paths reach the new branch (FR-005): pointer (`main.js:2180`) and keyboard/a11y (`main.js:2765`). Both were broken.
 - [ ] T020 [US1] Implement the not-in-feed behaviour (FR-045) in `ui/netclaw-visual/src/main.js`: a selected peer that disappears retains its last known detail with an explicit banner, and the scene drops its selected treatment. Neither blank the panel nor let it read as current.
 - [ ] T021 [US1] Walk [quickstart.md](./quickstart.md) §3 against the running HUD: all 7 peers, both Hermes rows distinguishable, AB/Carapace show "never seen" not "0s ago", severed not presented as reachable, no row renders `undefined`, and the FR-045 case verified with spec 100's `forget_peer_endpoint`.
@@ -104,13 +104,14 @@ must not make. All four are independent of one another → all `[P]`.
 
 > Precedes US2 so the declared channels exist before selection must stay distinct against them.
 
-- [ ] T022 [US3] Extend `ui/netclaw-visual/src/orgchart-render/nodes.js` with a peer-state treatment table per visual-contract §3, consuming T006's `PeerViewState`. Replaces `colorForStructural`'s two-branch logic, which never reads `stale` and lets `channel_state: "unknown"` reach the healthy default — the reason 5 of 7 peers look identical to Nate.
+- [ ] T022 [US3] Extend `ui/netclaw-visual/src/orgchart-render/nodes.js` (FR-012) with a peer-state treatment table per visual-contract §3, consuming T006's `PeerViewState`. Replaces `colorForStructural`'s two-branch logic, which never reads `stale` and lets `channel_state: "unknown"` reach the healthy default — the reason 5 of 7 peers look identical to Nate.
 - [ ] T023 [US3] In `ui/netclaw-visual/src/orgchart-render/nodes.js`, keep peers recognisable as peers (R4): state MUST modulate the existing `geometries.peer` octahedron silhouette, never substitute a member shape from `TREATMENTS`, so band membership still reads at a glance.
-- [ ] T024 [US3] Add label affixes as channel 4 per visual-contract §3 (`· stale 12d`, `· never seen`, `· unreachable`, `· severed`), extending — never replacing — the label from `resolveLabel`/`disambiguateLabels` (R5). This is the channel that survives greyscale, reduced-motion and colour-blindness simultaneously.
+- [ ] T024 [US3] Add label affixes as channel 4 (FR-014) per visual-contract §3 (`· stale 12d`, `· never seen`, `· unreachable`, `· severed`), extending — never replacing — the label from `resolveLabel`/`disambiguateLabels` (R5). This is the channel that survives greyscale, reduced-motion and colour-blindness simultaneously.
 - [ ] T025 [US3] Create `ui/netclaw-visual/src/orgchart-render/peer-treatments.test.js` asserting visual-contract R1/R2/R3 on the declared constants: every pair of the six peer states differs by **≥18** ITU-R BT.709 luminance (reusing `treatments.test.js`'s exact metric and threshold); `LIVE`/`IDLE` vs `STALE` checked explicitly; `UNKNOWN` is **not** in the alarm hue family.
-- [ ] T026 [US3] Wire freeze-and-flag into the poll path in `ui/netclaw-visual/src/main.js` using T008's `FeedState` (FR-041/042/043): a failed poll must not mutate any liveness, and the scene shows a stale-data indicator with the age of the last good poll.
-- [ ] T027 [US3] Confirm members are untouched (FR-013): `HOT`/`WARM`/`COLD`/`FAULT` render exactly as before and `treatments.test.js` still passes unmodified.
-- [ ] T028 [US3] Walk [quickstart.md](./quickstart.md) §4: SC-003 screenshot, greyscale screenshot, reduced-motion screenshot, and the zero-peers empty state. Then verify SC-010 by stopping `netclaw-mesh.service` with the HUD open — **no peer may change to a failure appearance**.
+- [ ] T026 [US3] Wire freeze-and-flag into the poll path in `ui/netclaw-visual/src/main.js` using T008's `FeedState` (FR-041, FR-042, FR-043): a failed poll must not mutate any liveness, and the scene shows a stale-data indicator with the age of the last good poll.
+- [ ] T027 [US3] Verify liveness is **live**, not one-shot (FR-015): a peer's state change is reflected on the next successful poll with no reload. Test by flipping a real peer — retire an endpoint with spec 100's `n2n_forget_endpoint`, or stop and restart a member — and confirm the treatment changes within one poll interval. **Analysis found FR-015 had zero task coverage**; without this, US3 could ship as a static picture that is correct only at page load.
+- [ ] T028 [US3] Confirm members are untouched (FR-013): `HOT`/`WARM`/`COLD`/`FAULT` render exactly as before and `treatments.test.js` still passes unmodified.
+- [ ] T029 [US3] Walk [quickstart.md](./quickstart.md) §4 with screenshots covering **all six** peer states, not just live/stale/severed (SC-003 as widened by analysis): plus greyscale (FR-014), reduced-motion, and the zero-peers empty state. `UNKNOWN` needs explicit visual proof it is distinct from both healthy and dead (FR-016, FR-017) — it is the state five of seven live peers occupy. Then verify SC-010 by stopping `netclaw-mesh.service` with the HUD open — **no peer may change to a failure appearance**.
 
 **Checkpoint**: SC-003 and SC-010 met. Byrn and Nicholas no longer masquerade as healthy.
 
@@ -122,12 +123,12 @@ must not make. All four are independent of one another → all `[P]`.
 
 **Independent test**: select nodes across bands; the treatment is visible in a screenshot without the panel disambiguating.
 
-- [ ] T029 [US2] Implement selection as **channel 5 only** in `ui/netclaw-visual/src/orgchart-render/nodes.js` per visual-contract §2 — an outline or rim outside the silhouette. It MUST NOT raise `emissiveIntensity`, or change colour, form or scale.
-- [ ] T030 [US2] Remove the old treatment (`emissiveIntensity = 1.8` + scale bump) from `ui/netclaw-visual/src/main.js`. It reuses **state** channels, so selecting a dim node brightens it toward the healthy treatment — the concrete FR-007 failure mode.
-- [ ] T031 [US2] In `ui/netclaw-visual/src/main.js`, enforce the single-selection invariant (FR-009) via `clearSelection()` and guarantee full restoration on deselect with no residue (FR-008) — the current `scale.setScalar(1)` hover-reset pattern is the precedent to follow.
-- [ ] T032 [US2] Respect `prefers-reduced-motion` (FR-010): the treatment is static, not animated.
-- [ ] T033 [US2] Verify against the **bloom-enabled** scene, not a bare one — additive glow can wash out an outline. Check both extremes of the camera's configured zoom range (FR-011).
-- [ ] T034 [US2] Walk [quickstart.md](./quickstart.md) §5, including the collision case plan.md names as the primary risk: select a `STALE` peer and a `COLD` member and confirm selection is legible on dim nodes **without** the node reading as healthy.
+- [ ] T030 [US2] Implement selection as **channel 5 only** in `ui/netclaw-visual/src/orgchart-render/nodes.js` per visual-contract §2 — an outline or rim outside the silhouette. It MUST NOT raise `emissiveIntensity`, or change colour, form or scale.
+- [ ] T031 [US2] Remove the old treatment (`emissiveIntensity = 1.8` + scale bump) from `ui/netclaw-visual/src/main.js`. It reuses **state** channels, so selecting a dim node brightens it toward the healthy treatment — the concrete FR-007 failure mode.
+- [ ] T032 [US2] In `ui/netclaw-visual/src/main.js`, enforce the single-selection invariant (FR-009) via `clearSelection()` and guarantee full restoration on deselect with no residue (FR-008) — the current `scale.setScalar(1)` hover-reset pattern is the precedent to follow.
+- [ ] T033 [US2] Respect `prefers-reduced-motion` (FR-010): the treatment is static, not animated.
+- [ ] T034 [US2] Verify against the **bloom-enabled** scene, not a bare one — additive glow can wash out an outline. Check both extremes of the camera's configured zoom range (FR-011).
+- [ ] T035 [US2] Walk [quickstart.md](./quickstart.md) §5, including the collision case plan.md names as the primary risk: select a `STALE` peer and a `COLD` member and confirm selection is legible on dim nodes **without** the node reading as healthy.
 
 **Checkpoint**: SC-002 met, and selection is provably orthogonal to state.
 
@@ -141,10 +142,10 @@ must not make. All four are independent of one another → all `[P]`.
 
 > Last, because it is the only story with real perf risk and should be measured against a scene already carrying US2 and US3.
 
-- [ ] T035 [US4] Add flow animation to `ui/netclaw-visual/src/orgchart-render/links.js`, gated on `PeerViewState === LIVE` per visual-contract §5. Only `LIVE` flows; `IDLE`, `STALE`, `UNKNOWN`, `UNREACHABLE`, `SEVERED` do not.
-- [ ] T036 [US4] Record the direction decision in code (FR-019): absent a real per-link direction signal in `/api/n2n`, flow renders Border-ward to represent inbound capability availability. Do not imply a direction the data does not support.
-- [ ] T037 [US4] Respect `prefers-reduced-motion` (FR-020): the live/not-live distinction must survive with motion suppressed, since flow is redundant with US3's channels.
-- [ ] T038 [US4] Measure median frame time against the **post-bump** T014 baseline and assert **≤110%** (FR-021, SC-005), same machine/browser/scene/quality mode.
+- [ ] T036 [US4] Add flow animation to `ui/netclaw-visual/src/orgchart-render/links.js` (FR-018), gated on `PeerViewState === LIVE` per visual-contract §5. Only `LIVE` flows; `IDLE`, `STALE`, `UNKNOWN`, `UNREACHABLE`, `SEVERED` do not.
+- [ ] T037 [US4] Record the direction decision in code (FR-019): absent a real per-link direction signal in `/api/n2n`, flow renders Border-ward to represent inbound capability availability. Do not imply a direction the data does not support.
+- [ ] T038 [US4] Respect `prefers-reduced-motion` (FR-020): the live/not-live distinction must survive with motion suppressed, since flow is redundant with US3's channels.
+- [ ] T039 [US4] Measure median frame time against the **post-bump** T014 baseline and assert **≤110%** (FR-021, SC-005), same machine/browser/scene/quality mode.
 
 **Checkpoint**: all five stories independently functional; SC-005 satisfied with all three numbers recorded.
 
@@ -152,12 +153,12 @@ must not make. All four are independent of one another → all `[P]`.
 
 ## Phase 8: Polish & Cross-Cutting Concerns
 
-- [ ] T039 [P] Verify preservation constraints per [quickstart.md](./quickstart.md) §7: chat interface untouched (FR-037), right-hand info bar untouched (FR-037), no sibling moves on select/expand (FR-038), `git diff --stat -- ui/netclaw-visual/server.js` **empty** (FR-039), a11y tree and keyboard nav functional with `aria-expanded` in step (FR-040).
-- [ ] T040 [P] Run `python3 scripts/reconcile-mcp.py >/dev/null 2>&1; echo $?` → `0` (FR-027). CI runs the same command and fails the merge on non-zero. **Never read this exit code through a pipe** (CLAUDE.md).
-- [ ] T041 [P] Confirm `tests/n2n/` is unaffected: `/usr/bin/python3 -m pytest tests/n2n/ -q` stays green — this feature touches no Python.
-- [ ] T042 Confirm every requirement has evidence (SC-009): a build result, a screenshot, or a test — never inspection alone. Any requirement without evidence is not done.
-- [ ] T043 Draft the Principle XVII milestone blog post as `docs/blog/2026-08-XX-hud-threejs-modernization.md`, following the existing `docs/blog/` convention. **Offer it — never publish unprompted** (Principle XIV).
-- [ ] T044 Verify the branch is still `101-hud-threejs-modernization` before committing — other agents switch branches in this shared checkout. Then commit and open the PR including all three frame-time numbers so SC-005 is evidenced, not claimed.
+- [ ] T040 [P] Verify preservation constraints per [quickstart.md](./quickstart.md) §7: chat interface untouched (FR-037), right-hand info bar untouched (FR-037), no sibling moves on select/expand (FR-038), `git diff --stat -- ui/netclaw-visual/server.js` **empty** (FR-039), a11y tree and keyboard nav functional with `aria-expanded` in step (FR-040).
+- [ ] T041 [P] Run `python3 scripts/reconcile-mcp.py >/dev/null 2>&1; echo $?` → `0` (FR-027). CI runs the same command and fails the merge on non-zero. **Never read this exit code through a pipe** (CLAUDE.md).
+- [ ] T042 [P] Confirm `tests/n2n/` is unaffected: `/usr/bin/python3 -m pytest tests/n2n/ -q` stays green — this feature touches no Python.
+- [ ] T043 Confirm every requirement has evidence (SC-009): a build result, a screenshot, or a test — never inspection alone. Any requirement without evidence is not done.
+- [ ] T044 Draft the Principle XVII milestone blog post as `docs/blog/2026-08-XX-hud-threejs-modernization.md`, following the existing `docs/blog/` convention. **Offer it — never publish unprompted** (Principle XIV).
+- [ ] T045 Verify the branch is still `101-hud-threejs-modernization` before committing — other agents switch branches in this shared checkout. Then commit and open the PR including all three frame-time numbers so SC-005 is evidenced, not claimed.
 
 ---
 
@@ -180,9 +181,9 @@ Phases 3-7 ──► Phase 8 (polish)
 ### Critical orderings
 
 - **T001 blocks everything.** The pre-bump baseline cannot be recreated after T012.
-- **T012 (bump) before T014, and T014 before T038.** US2/US3/US4 measure against the post-bump baseline.
-- **T006 blocks T022, T035.** The render layer consumes `PeerViewState`; it must not re-derive it.
-- **T022/T024 block T029.** Selection must be shown distinct from the declared state channels.
+- **T012 (bump) before T014, and T014 before T039.** US2/US3/US4 measure against the post-bump baseline.
+- **T006 blocks T022, T036.** The render layer consumes `PeerViewState`; it must not re-derive it.
+- **T022/T024 block T030.** Selection must be shown distinct from the declared state channels.
 - **T008 blocks T026.** Freeze-and-flag logic before wiring it to the poll.
 - **T017 blocks T018, T020, T021.**
 
@@ -201,7 +202,7 @@ US4 (link flow) | Phase 2 (T006), US5 (baseline) | Yes |
 - **T004–T011** — all eight Phase 2 tasks are different files with no interdependency. The largest parallel block in the feature.
 - **T002, T003** alongside T001.
 - **T016** alongside any Phase 3 task (docs only).
-- **T039, T040, T041** all parallel in Phase 8.
+- **T040, T041, T042** all parallel in Phase 8.
 - **Phase 4 (US1) and Phase 5 (US3) can run in parallel** once Phase 2 is done — US1 touches `main.js`'s `setDetail`, US3 touches `nodes.js` treatments. Only their `main.js` edits (T020, T026) need coordinating.
 
 ## Implementation strategy

--- a/specs/101-hud-threejs-modernization/tasks.md
+++ b/specs/101-hud-threejs-modernization/tasks.md
@@ -1,0 +1,220 @@
+# Tasks: HUD three.js Modernization
+
+**Feature**: `101-hud-threejs-modernization` | **Date**: 2026-08-06
+**Input**: [spec.md](./spec.md), [plan.md](./plan.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/visual-contract.md](./contracts/visual-contract.md), [quickstart.md](./quickstart.md)
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]** — parallelizable (different file, no incomplete dependency)
+- **[US1..US5]** — user story this task serves
+
+## Path Conventions
+
+All paths relative to repo root. The frontend package is `ui/netclaw-visual/`.
+`src/orgchart/` is **pure** and must never import three.js (feature 072's rule);
+`src/orgchart-render/` owns all three.js contact.
+
+## Tests
+
+Test tasks **are** included — required by FR-036 and FR-046, not a default. Two specific reasons:
+
+1. **The existing suite cannot see rendering.** No test file imports three.js, and the 7 modules
+   that do have zero coverage (research R2). Every requirement about *what a state means* must be
+   testable on the pure side or it is untested entirely.
+2. **FR-046's separability rules are properties of design constants, not of one frame.** Feature
+   072 proved this matters: its `treatments.test.js` caught a real collision where COLD landed
+   within 10 luminance of FAULT. A screenshot would have passed.
+
+## Ordering rationale — measurement, not priority
+
+plan.md sequences by **measurement dependency**. US5 is P2 by operator value but runs early
+because FR-047 gates the upgrade's own frame-time delta between two baselines, and US2/US3/US4 are
+measured against the post-bump one. US3 precedes US2 so the per-state channel declaration exists
+before a selection treatment must stay distinguishable against it.
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Capture the **pre-bump** performance baseline at `three@0.170.0` per [quickstart.md](./quickstart.md) §0 — machine, browser + version, scene composition from `/api/n2n`, quality mode, median frame time over a sustained window. **This cannot be recreated once the bump lands** and FR-047/SC-005 are unverifiable without it. Record verbatim in the PR.
+- [ ] T002 [P] Confirm the current suite is green before any change: `cd ui/netclaw-visual && npm test >/dev/null 2>&1; echo $?` → `0`, so later failures are attributable to this work.
+- [ ] T003 [P] Record the live peer-state distribution as the fixture basis for US3, confirming data-model §1's finding that 5 of 7 peers hit `colorForStructural`'s healthy default: `curl -s localhost:3001/api/n2n | python3 -c "import json,sys;d=json.load(sys.stdin);[print(p['display_name'], p['state'], p['channel_state'], p['stale'], p['inventory_received_at']) for p in d['peers']]"`
+
+**Checkpoint**: baseline captured and unreproducible-later data secured; suite green.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**⚠️ Blocks US1, US3, US4.** These are the pure modules that hold every decision the render layer
+must not make. All four are independent of one another → all `[P]`.
+
+- [ ] T004 [P] Create `ui/netclaw-visual/src/orgchart/freshness.js` implementing `FreshnessView` per [data-model.md](./data-model.md) §3: `receivedAt`, `ageSeconds`, `ageText`, `judgement` (`fresh`/`aging`/`stale`/`never`). `ageSeconds === null` (never received) MUST NOT render as `0` (just now) — that conflation is the FR-004 defect.
+- [ ] T005 [P] Create `ui/netclaw-visual/src/orgchart/freshness.test.js`: never-received yields `never` and `null` age, not `0`; `judgement` derives from age AND honors the API `stale` flag with the pessimistic reading winning; `ageText` renders minutes/hours/days in operator terms.
+- [ ] T006 [P] Create `ui/netclaw-visual/src/orgchart/liveness.js` implementing `PeerViewState` per data-model §2 — six states with top-down precedence, `LIVE` checked first. Must read `stale` and treat `channel_state: "unknown"` as its own case, which `colorForStructural` never does.
+- [ ] T007 [P] Create `ui/netclaw-visual/src/orgchart/liveness.test.js` driven by T003's real distribution: Nate → `LIVE`; Byrn/Nicholas/Hermes(`as65008`) → `STALE` and **not** the same state as Nate (the defect); AB/Carapace → `UNKNOWN`, distinct from both healthy and dead (FR-016/017); Hermes(`as65007`) → `SEVERED`; precedence means a severed peer is never `LIVE` regardless of other fields (FR-017).
+- [ ] T008 [P] Create `ui/netclaw-visual/src/orgchart/feed-state.js` implementing `FeedState` per data-model §5 — freeze-and-flag: retain `lastGood`, never recompute liveness on a failed poll (FR-041), expose `degraded` + age of `lastGoodAt` (FR-042), clear on next success with no reload (FR-043).
+- [ ] T009 [P] Create `ui/netclaw-visual/src/orgchart/feed-state.test.js`: a throw, a non-2xx, and unparseable JSON are each failures that leave `lastGood` untouched; **a successful poll with zero peers is NOT a failure** but a renderable empty state; recovery clears `degraded` without acknowledgement. This is the test that stops the HUD fabricating an outage.
+- [ ] T010 [P] Create `ui/netclaw-visual/src/orgchart/peer-detail.js` mapping a `/api/n2n` peer row to the panel view-model per [contracts/visual-contract.md](./contracts/visual-contract.md) §6, including `identity` (not just `label`) and `presentInFeed`.
+- [ ] T011 [P] Create `ui/netclaw-visual/src/orgchart/peer-detail.test.js`: every row either has a value or an explicit placeholder — **never `undefined`** (P2); both Hermes rows produce distinguishable view-models because `identity` is present; empty `in_flight_tasks` yields an explicit "none".
+
+**Checkpoint**: every state/staleness/failure decision is implemented and unit-tested on the pure side, before any three.js file is touched.
+
+---
+
+## Phase 3: User Story 5 — Upgrade to 0.185.1 (Priority: P2) ⏱️ RUNS FIRST
+
+**Goal**: the HUD runs on `three@0.185.1`, visually unchanged, with its own frame-time cost measured.
+
+**Independent test**: bump, build, load the HUD, confirm zero console errors and an unchanged scene.
+
+> Runs before the P1 stories for measurement reasons only (plan.md). It ships no visible value.
+
+- [ ] T012 [US5] Bump `three` to `0.185.1` in `ui/netclaw-visual/package.json`. **No source change is required** — verified by isolated probe (research R2/R3), which found zero of the r171–r185 deprecated APIs in use.
+- [ ] T013 [US5] Build and test: `cd ui/netclaw-visual && npm run build >/dev/null 2>&1; echo $?` → `0`; `npm test >/dev/null 2>&1; echo $?` → `0`. Confirm bundle within ~10% of 753 kB (SC-007; expect ~799 kB).
+- [ ] T014 [US5] Capture the **post-bump** baseline at `0.185.1` (FR-044) and assert the delta from T001 is **≤10%** (FR-047). Same machine, browser, scene and quality mode, or the comparison is void.
+- [ ] T015 [US5] Verify visually via `chrome-devtools-mcp` (FR-034/035): HUD loads with **zero console errors** and no three.js deprecation warnings; screenshot confirms bands, labels, links, camera framing and all seven post-processing passes intact (FR-025).
+- [ ] T016 [P] [US5] Update the three.js version reference in `ui/netclaw-visual/README.md` and `ui/netclaw-visual/THIRD_PARTY_NOTICES.md` (FR-026, Principle XII).
+
+**Checkpoint**: HUD on 0.185.1, visually identical, upgrade cost measured and gated. All later measurements now have a valid reference.
+
+---
+
+## Phase 4: User Story 1 — Inspect a federated peer (Priority: P1) 🎯 MVP
+
+**Goal**: clicking any eN2N peer shows that peer's own federation detail.
+
+**Independent test**: click each of the 7 peers; each shows its own detail. Needs no other story.
+
+- [ ] T017 [US1] Add the `federation-peer` branch to `setDetail` in `ui/netclaw-visual/src/main.js`, rendering from T010's view-model per visual-contract §6. This is the missing seventh branch — the click path at `main.js:2180` and `:2765` already passes this kind and it currently falls through to the default overview.
+- [ ] T018 [US1] Add the FR-006 guard in `ui/netclaw-visual/src/main.js`: an unrecognised `setDetail` kind MUST NOT reach the default overview branch and MUST fail loudly in development. **The silent fallthrough is the defect** — it repaints with a different subject's content, which is why it read as "not clickable" while the mesh was pickable and hover-scaling.
+- [ ] T019 [US1] Verify both activation paths reach the new branch (FR-005): pointer (`main.js:2180`) and keyboard/a11y (`main.js:2765`). Both were broken.
+- [ ] T020 [US1] Implement the not-in-feed behaviour (FR-045) in `ui/netclaw-visual/src/main.js`: a selected peer that disappears retains its last known detail with an explicit banner, and the scene drops its selected treatment. Neither blank the panel nor let it read as current.
+- [ ] T021 [US1] Walk [quickstart.md](./quickstart.md) §3 against the running HUD: all 7 peers, both Hermes rows distinguishable, AB/Carapace show "never seen" not "0s ago", severed not presented as reachable, no row renders `undefined`, and the FR-045 case verified with spec 100's `forget_peer_endpoint`.
+
+**Checkpoint**: SC-001 met — 7/7 peers inspectable, where today it is 0/7. This alone is a shippable MVP that fixes the reported defect.
+
+---
+
+## Phase 5: User Story 3 — Liveness and staleness readable (Priority: P1)
+
+**Goal**: an operator can sort peers into live / stale / severed without clicking anything.
+
+**Independent test**: one live, one stale, one severed peer in the feed all read differently in a screenshot.
+
+> Precedes US2 so the declared channels exist before selection must stay distinct against them.
+
+- [ ] T022 [US3] Extend `ui/netclaw-visual/src/orgchart-render/nodes.js` with a peer-state treatment table per visual-contract §3, consuming T006's `PeerViewState`. Replaces `colorForStructural`'s two-branch logic, which never reads `stale` and lets `channel_state: "unknown"` reach the healthy default — the reason 5 of 7 peers look identical to Nate.
+- [ ] T023 [US3] In `ui/netclaw-visual/src/orgchart-render/nodes.js`, keep peers recognisable as peers (R4): state MUST modulate the existing `geometries.peer` octahedron silhouette, never substitute a member shape from `TREATMENTS`, so band membership still reads at a glance.
+- [ ] T024 [US3] Add label affixes as channel 4 per visual-contract §3 (`· stale 12d`, `· never seen`, `· unreachable`, `· severed`), extending — never replacing — the label from `resolveLabel`/`disambiguateLabels` (R5). This is the channel that survives greyscale, reduced-motion and colour-blindness simultaneously.
+- [ ] T025 [US3] Create `ui/netclaw-visual/src/orgchart-render/peer-treatments.test.js` asserting visual-contract R1/R2/R3 on the declared constants: every pair of the six peer states differs by **≥18** ITU-R BT.709 luminance (reusing `treatments.test.js`'s exact metric and threshold); `LIVE`/`IDLE` vs `STALE` checked explicitly; `UNKNOWN` is **not** in the alarm hue family.
+- [ ] T026 [US3] Wire freeze-and-flag into the poll path in `ui/netclaw-visual/src/main.js` using T008's `FeedState` (FR-041/042/043): a failed poll must not mutate any liveness, and the scene shows a stale-data indicator with the age of the last good poll.
+- [ ] T027 [US3] Confirm members are untouched (FR-013): `HOT`/`WARM`/`COLD`/`FAULT` render exactly as before and `treatments.test.js` still passes unmodified.
+- [ ] T028 [US3] Walk [quickstart.md](./quickstart.md) §4: SC-003 screenshot, greyscale screenshot, reduced-motion screenshot, and the zero-peers empty state. Then verify SC-010 by stopping `netclaw-mesh.service` with the HUD open — **no peer may change to a failure appearance**.
+
+**Checkpoint**: SC-003 and SC-010 met. Byrn and Nicholas no longer masquerade as healthy.
+
+---
+
+## Phase 6: User Story 2 — Selection is unmistakable (Priority: P1)
+
+**Goal**: the selected node is always identifiable, at any zoom, against a bloom-heavy scene.
+
+**Independent test**: select nodes across bands; the treatment is visible in a screenshot without the panel disambiguating.
+
+- [ ] T029 [US2] Implement selection as **channel 5 only** in `ui/netclaw-visual/src/orgchart-render/nodes.js` per visual-contract §2 — an outline or rim outside the silhouette. It MUST NOT raise `emissiveIntensity`, or change colour, form or scale.
+- [ ] T030 [US2] Remove the old treatment (`emissiveIntensity = 1.8` + scale bump) from `ui/netclaw-visual/src/main.js`. It reuses **state** channels, so selecting a dim node brightens it toward the healthy treatment — the concrete FR-007 failure mode.
+- [ ] T031 [US2] In `ui/netclaw-visual/src/main.js`, enforce the single-selection invariant (FR-009) via `clearSelection()` and guarantee full restoration on deselect with no residue (FR-008) — the current `scale.setScalar(1)` hover-reset pattern is the precedent to follow.
+- [ ] T032 [US2] Respect `prefers-reduced-motion` (FR-010): the treatment is static, not animated.
+- [ ] T033 [US2] Verify against the **bloom-enabled** scene, not a bare one — additive glow can wash out an outline. Check both extremes of the camera's configured zoom range (FR-011).
+- [ ] T034 [US2] Walk [quickstart.md](./quickstart.md) §5, including the collision case plan.md names as the primary risk: select a `STALE` peer and a `COLD` member and confirm selection is legible on dim nodes **without** the node reading as healthy.
+
+**Checkpoint**: SC-002 met, and selection is provably orthogonal to state.
+
+---
+
+## Phase 7: User Story 4 — Federation links show flow (Priority: P2)
+
+**Goal**: live links visibly carry traffic; stale and dead links are visibly static.
+
+**Independent test**: one live and one stale peer — the live link animates, the stale one does not.
+
+> Last, because it is the only story with real perf risk and should be measured against a scene already carrying US2 and US3.
+
+- [ ] T035 [US4] Add flow animation to `ui/netclaw-visual/src/orgchart-render/links.js`, gated on `PeerViewState === LIVE` per visual-contract §5. Only `LIVE` flows; `IDLE`, `STALE`, `UNKNOWN`, `UNREACHABLE`, `SEVERED` do not.
+- [ ] T036 [US4] Record the direction decision in code (FR-019): absent a real per-link direction signal in `/api/n2n`, flow renders Border-ward to represent inbound capability availability. Do not imply a direction the data does not support.
+- [ ] T037 [US4] Respect `prefers-reduced-motion` (FR-020): the live/not-live distinction must survive with motion suppressed, since flow is redundant with US3's channels.
+- [ ] T038 [US4] Measure median frame time against the **post-bump** T014 baseline and assert **≤110%** (FR-021, SC-005), same machine/browser/scene/quality mode.
+
+**Checkpoint**: all five stories independently functional; SC-005 satisfied with all three numbers recorded.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+- [ ] T039 [P] Verify preservation constraints per [quickstart.md](./quickstart.md) §7: chat interface untouched (FR-037), right-hand info bar untouched (FR-037), no sibling moves on select/expand (FR-038), `git diff --stat -- ui/netclaw-visual/server.js` **empty** (FR-039), a11y tree and keyboard nav functional with `aria-expanded` in step (FR-040).
+- [ ] T040 [P] Run `python3 scripts/reconcile-mcp.py >/dev/null 2>&1; echo $?` → `0` (FR-027). CI runs the same command and fails the merge on non-zero. **Never read this exit code through a pipe** (CLAUDE.md).
+- [ ] T041 [P] Confirm `tests/n2n/` is unaffected: `/usr/bin/python3 -m pytest tests/n2n/ -q` stays green — this feature touches no Python.
+- [ ] T042 Confirm every requirement has evidence (SC-009): a build result, a screenshot, or a test — never inspection alone. Any requirement without evidence is not done.
+- [ ] T043 Draft the Principle XVII milestone blog post as `docs/blog/2026-08-XX-hud-threejs-modernization.md`, following the existing `docs/blog/` convention. **Offer it — never publish unprompted** (Principle XIV).
+- [ ] T044 Verify the branch is still `101-hud-threejs-modernization` before committing — other agents switch branches in this shared checkout. Then commit and open the PR including all three frame-time numbers so SC-005 is evidenced, not claimed.
+
+---
+
+## Dependencies
+
+### Phase dependencies
+
+```
+Phase 1 (setup) ──► Phase 2 (pure modules) ──┬──► Phase 4 (US1)  needs T010/T011
+                                             ├──► Phase 5 (US3)  needs T004/T006/T008
+                                             └──► Phase 7 (US4)  needs T006
+        │
+        └──► Phase 3 (US5, the bump) ──► valid baseline for Phases 5-7
+
+Phase 5 (US3) ──► Phase 6 (US2)      channels declared before selection must contrast
+Phase 6 (US2) ──► Phase 7 (US4)      perf measured on the fully-loaded scene
+Phases 3-7 ──► Phase 8 (polish)
+```
+
+### Critical orderings
+
+- **T001 blocks everything.** The pre-bump baseline cannot be recreated after T012.
+- **T012 (bump) before T014, and T014 before T038.** US2/US3/US4 measure against the post-bump baseline.
+- **T006 blocks T022, T035.** The render layer consumes `PeerViewState`; it must not re-derive it.
+- **T022/T024 block T029.** Selection must be shown distinct from the declared state channels.
+- **T008 blocks T026.** Freeze-and-flag logic before wiring it to the poll.
+- **T017 blocks T018, T020, T021.**
+
+### Story independence
+
+| Story | Depends on | Independently shippable? |
+|---|---|---|
+US5 (bump) | Phase 1 only | Yes — ships nothing visible, but is complete and verifiable |
+US1 (peer inspector) | Phase 2 (T010/T011) | **Yes — this is the MVP** |
+US3 (liveness) | Phase 2 (T004/T006/T008) | Yes |
+US2 (selection) | US3 (channel declaration) | Only after US3, to avoid channel collision |
+US4 (link flow) | Phase 2 (T006), US5 (baseline) | Yes |
+
+## Parallel opportunities
+
+- **T004–T011** — all eight Phase 2 tasks are different files with no interdependency. The largest parallel block in the feature.
+- **T002, T003** alongside T001.
+- **T016** alongside any Phase 3 task (docs only).
+- **T039, T040, T041** all parallel in Phase 8.
+- **Phase 4 (US1) and Phase 5 (US3) can run in parallel** once Phase 2 is done — US1 touches `main.js`'s `setDetail`, US3 touches `nodes.js` treatments. Only their `main.js` edits (T020, T026) need coordinating.
+
+## Implementation strategy
+
+**MVP = Phase 1 + Phase 2 + Phase 4 (US1).** That fixes the reported defect — the one thing the
+operator actually complained about — and delivers 7/7 peer inspection where today it is 0/7.
+Everything after it is improvement rather than repair.
+
+**Incremental delivery**: US5 → US1 → US3 → US2 → US4, which is the measurement order, not the
+value order. If work stops after any story, the HUD is in a coherent state: the bump alone is
+invisible-but-correct, US1 alone fixes the bug, US3 alone makes the scene honest.
+
+**Do not reorder US3 and US2.** Selection and state both add channels to the same nodes on a scene
+already running seven post-processing passes. Choosing a selection treatment before the state
+channels are declared is how the two collide, and the collision is invisible until you select a
+dim node (plan.md primary risk).

--- a/ui/netclaw-visual/README.md
+++ b/ui/netclaw-visual/README.md
@@ -458,6 +458,21 @@ Keep that boundary; the test suite runs in bare Node and will fail if it breaks.
 
 ## Architecture
 
+### Renderer stack
+
+| Component | Version / choice | Notes |
+|---|---|---|
+| `three` | **0.185.1** | Bumped from `0.170.0` by spec 101. Fifteen releases; zero source changes were required, because every breaking change in r171–r185 lands in TSL / WebGPU node materials, which this HUD does not use. |
+| Renderer | `WebGLRenderer` | **Not** `WebGPURenderer`. That migration is spec 102: `WebGPURenderer` supports neither raw-GLSL `ShaderMaterial` (this HUD has 4) nor `EffectComposer` (this HUD has a 7-pass chain), so it is an either/or rather than an upgrade. |
+| Post-processing | `EffectComposer` | `RenderPass` → `UnrealBloomPass` → `ShaderPass`×2 (vignette, RGB-shift) → `AfterimagePass` → `FilmPass` → `GlitchPass` → `SMAAPass` → `OutputPass`. |
+| Labels | `CSS2DRenderer` | DOM overlay, so labels stay crisp and selectable. |
+| Camera | `OrbitControls`, zoom `0.35`–`6.0` | Constrained by spec 072 so the org-chart hierarchy always reads. |
+
+`src/orgchart/` is **pure logic and must never import three.js**; `src/orgchart-render/`
+owns every three.js contact. That split (spec 072) is what makes the layout, health
+classification, liveness and staleness rules unit-testable — the render modules have no
+automated coverage, so anything that can be a decision belongs on the pure side.
+
 ```
 Browser (Visual HUD + Canvas Chat @ localhost:3000)
     |

--- a/ui/netclaw-visual/package-lock.json
+++ b/ui/netclaw-visual/package-lock.json
@@ -17,7 +17,7 @@
         "multer": "^2.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "three": "^0.170.0",
+        "three": "^0.185.1",
         "ws": "^8.16.0"
       },
       "devDependencies": {
@@ -57,6 +57,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1343,6 +1344,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.44",
         "caniuse-lite": "^1.0.30001806",
@@ -2392,6 +2394,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2763,9 +2766,9 @@
       }
     },
     "node_modules/three": {
-      "version": "0.170.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
-      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
       "license": "MIT"
     },
     "node_modules/toidentifier": {
@@ -2883,6 +2886,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/ui/netclaw-visual/package.json
+++ b/ui/netclaw-visual/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netclaw-hud",
   "version": "1.0.0",
-  "description": "NetClaw Three.js HUD \u2014 futuristic network operations dashboard",
+  "description": "NetClaw Three.js HUD — futuristic network operations dashboard",
   "type": "module",
   "scripts": {
     "dev": "concurrently \"node server.js\" \"vite --host\"",
@@ -20,7 +20,7 @@
     "multer": "^2.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "three": "^0.170.0",
+    "three": "^0.185.1",
     "ws": "^8.16.0"
   },
   "devDependencies": {

--- a/ui/netclaw-visual/src/main.js
+++ b/ui/netclaw-visual/src/main.js
@@ -22,6 +22,14 @@ import {
 import {
   createChartCamera, createChartControls, resizeChartCamera, frameChart,
 } from './orgchart-render/camera.js';
+// Feature 101: pure view-model + poll-outcome logic. These live under orgchart/
+// (never importing three.js) precisely so the decisions they make — what a peer's
+// state means, how stale is stale, whether a failed poll is an outage — are
+// unit-tested. The render modules here have no automated coverage.
+import { peerDetailView } from './orgchart/peer-detail.js';
+import {
+  createFeedState, recordSuccess, recordFailure, staleIndicator, renderablePayload,
+} from './orgchart/feed-state.js';
 import { VignetteShader } from 'three/addons/shaders/VignetteShader.js';
 import { CSS2DRenderer, CSS2DObject } from 'three/addons/renderers/CSS2DRenderer.js';
 import gsap from 'gsap';
@@ -1310,6 +1318,66 @@ function setDetail(kind, payload, related = []) {
     return;
   }
 
+  // ── Feature 101 (US1): the eN2N peer inspector ──────────────────────────
+  //
+  // THE DEFECT THIS FIXES. The org-chart click path already passed
+  // 'federation-peer' from two places (the pointer handler and the keyboard/a11y
+  // handler), but no branch existed for it — so it fell past all six branches
+  // into the default overview below and repainted the panel with the GENERIC
+  // "This NetClaw" summary. The click registered, the panel repainted, and it
+  // showed a different subject's content. That is why it read as "not clickable"
+  // even though the mesh is pickable and hover-scales correctly.
+  //
+  // Deliberately NOT routed through 'peer-core': that branch expects a
+  // /api/graph BGP-session payload (peer.as, routerId, peerIp, routesReceived,
+  // adjRibIn) which is absent from the /api/n2n shape the org chart carries, so
+  // reusing it would render a panel of undefineds. The /api/n2n shape is also
+  // the richer one for federation.
+  if (kind === 'federation-peer') {
+    const nowEpochS = Math.floor(Date.now() / 1000);
+    const v = peerDetailView(payload, nowEpochS, {
+      label: payload?.__label,
+      presentInFeed: payload?.__presentInFeed !== false,
+    });
+
+    const taskRows = v.inFlightTasks.map((t) => `
+      <div class="detail-row"><span>${t.task_id || t.target_name || 'task'}</span>
+        <strong>${t.state || '—'}${t.progress ? ` · ${t.progress}` : ''}</strong></div>
+    `).join('');
+
+    dom.detailPanel.innerHTML = `
+      <h2>Peer Claw</h2>
+      <p>${v.heading}</p>
+      ${v.notInFeedNotice
+        ? `<div class="n2n-state-not-federated" style="padding:6px 0">${v.notInFeedNotice}</div>`
+        : ''}
+      <div class="detail-grid">
+        <div class="detail-row"><span>Identity</span><strong>${v.identity}</strong></div>
+        <div class="detail-row"><span>State</span><strong class="n2n-state-${v.state.toLowerCase()}">${v.state}</strong></div>
+        <div class="detail-row"><span>Meaning</span><strong>${v.stateSummary}</strong></div>
+        <div class="detail-row"><span>Channel</span><strong>${v.channelState}</strong></div>
+        <div class="detail-row"><span>Inventory</span><strong>${v.inventoryAge} · ${v.inventoryJudgement}</strong></div>
+        <div class="detail-row"><span>Chat</span><strong>${v.chatText}</strong></div>
+        <div class="detail-row"><span>In-flight tasks</span><strong>${v.inFlightText}</strong></div>
+      </div>
+      ${taskRows ? `<div class="detail-grid">${taskRows}</div>` : ''}
+    `;
+    return;
+  }
+
+  // FR-006: no kind may reach the default overview by accident.
+  //
+  // The silent fallthrough IS the bug fixed above — it renders a plausible panel
+  // for the wrong subject, which is strictly worse than rendering nothing,
+  // because the operator has no signal that anything went wrong. Anything not
+  // explicitly handled is a programming error and must be loud, not plausible.
+  if (kind !== undefined && kind !== null && kind !== 'overview') {
+    const msg = `setDetail: unhandled kind '${kind}' — falling through to the generic
+      overview would show another subject's content (feature 101 FR-006)`;
+    if (import.meta?.env?.DEV) throw new Error(msg);
+    console.error(msg);
+  }
+
   // Default: overview with BGP summary if available
   const bgpSummary = state.bgp?.available ? `
     <div class="bgp-overview-section">
@@ -2177,7 +2245,9 @@ function onClick(event) {
         setDetail('local-core');
         state.selected = { kind: 'local-core' };
       } else if (node.kind === 'peer') {
-        setDetail('federation-peer', node.payload);
+        // Pass the layout node's label: disambiguation is a whole-list operation
+        // (two peers legitimately share "Hermes") and normalize.js already did it.
+        setDetail('federation-peer', { ...node.payload, __label: node.label });
         state.selected = { kind: 'federation-peer', peer: node.id };
       } else {
         setDetail('member-core', node.payload);
@@ -2762,7 +2832,7 @@ async function boot() {
     mountA11y(document.getElementById('scene-root'), {
       onSelect: (node) => {
         if (node.kind === 'border') { setDetail('local-core'); state.selected = { kind: 'local-core' }; }
-        else if (node.kind === 'peer') { setDetail('federation-peer', node.payload); state.selected = { kind: 'federation-peer', peer: node.id }; }
+        else if (node.kind === 'peer') { setDetail('federation-peer', { ...node.payload, __label: node.label }); state.selected = { kind: 'federation-peer', peer: node.id }; }
         else { setDetail('member-core', node.payload); state.selected = { kind: 'member-core', member: node.id }; }
       },
       onToggle: (node) => toggleNodeExpansion(node.id, makeLabel),

--- a/ui/netclaw-visual/src/main.js
+++ b/ui/netclaw-visual/src/main.js
@@ -18,6 +18,7 @@ import {
   mountOrgChart, updateOrgChart, searchOrgChart,
   pickableObjects, chartNodes, tickOrgChart, activateNode,
   mountA11y, toggleNodeExpansion,
+  setSelectedNode, clearSelectedNode,
 } from './orgchart-render/index.js';
 import {
   createChartCamera, createChartControls, resizeChartCamera, frameChart,
@@ -73,6 +74,8 @@ const state = {
     view: 'integrations',
   },
   mouse: new THREE.Vector2(),
+  // Feature 101 (FR-041/042/043): poll-outcome memory for freeze-and-flag.
+  feed: createFeedState(),
   raycaster: new THREE.Raycaster(),
   socket: null,
   clock: new THREE.Clock(),
@@ -1177,6 +1180,29 @@ function wireFederationChat(peer) {
   input.addEventListener('keydown', (e) => { if (e.key === 'Enter') send(); });
 }
 
+/**
+ * Scene-level stale-data indicator (feature 101, FR-042).
+ *
+ * Deliberately a banner rather than a per-node treatment: the peers are not
+ * individually stale, our VIEW of all of them is. Marking each node would be the
+ * very confusion FR-041 exists to prevent.
+ */
+function renderStaleBanner(ind) {
+  let el = document.getElementById('feed-stale-banner');
+  if (!ind.degraded) { el?.remove(); return; }
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'feed-stale-banner';
+    el.style.cssText = 'position:fixed;top:8px;left:50%;transform:translateX(-50%);'
+      + 'z-index:9999;padding:6px 14px;border-radius:6px;font:12px/1.4 ui-monospace,monospace;'
+      + 'background:rgba(120,80,20,.92);color:#ffe9c2;border:1px solid #d9a94a;'
+      + 'pointer-events:none;letter-spacing:.04em';
+    document.body.appendChild(el);
+  }
+  el.textContent = `⚠ ${ind.message}`
+    + (ind.consecutiveFailures > 1 ? ` (${ind.consecutiveFailures} failed polls)` : '');
+}
+
 function setDetail(kind, payload, related = []) {
   if (kind === 'local-core') {
     dom.detailPanel.innerHTML = `
@@ -2035,6 +2061,10 @@ function clearSelection() {
     restoreTracePath();
   }
   state.selected = null;
+  // Feature 101 (FR-008): selection is a scene channel now, so clearing the
+  // selection must clear it there too — otherwise the ring is left orphaned
+  // on a node the panel no longer describes.
+  clearSelectedNode();
   setDetail('overview');
   state.integrations.forEach((entry) => {
     entry.node.material.uniforms.uBrightness.value = 1.0;
@@ -2241,6 +2271,8 @@ function onClick(event) {
     const node = activateNode(chartHit.object, makeLabel);
     if (node) {
       clearSelection();
+      // Feature 101 (US2): channel 5. Set AFTER clearSelection, which clears it.
+      setSelectedNode(node.id);
       if (node.kind === 'border') {
         setDetail('local-core');
         state.selected = { kind: 'local-core' };
@@ -2303,7 +2335,7 @@ function animate() {
   // HUD 2.0 node pulses. Motion is a redundant channel (R8) — the four health
   // states are already separable by form and colour — so honouring reduced
   // motion simply skips it without weakening the encoding.
-  tickOrgChart(elapsed);
+  tickOrgChart(elapsed, state.camera);
 
   // Track time offset for freeze: when frozen, hold rotations at the moment of freeze
   if (frozen && state._frozenAt == null) state._frozenAt = elapsed;
@@ -2791,8 +2823,16 @@ async function boot() {
       const url = state.fixtureName
         ? `/fixtures/${state.fixtureName}.json`
         : '/api/n2n';
-      state.n2n = await (await fetch(url)).json();
-    } catch { state.n2n = null; }
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      recordSuccess(state.feed, await res.json(), Date.now());
+      state.n2n = renderablePayload(state.feed);
+    } catch (e) {
+      // First load failed: nothing to freeze. state.n2n stays null and the
+      // existing empty/first-run path renders — NOT a fabricated outage.
+      recordFailure(state.feed, e, Date.now());
+      state.n2n = null;
+    }
     if (state.fixtureName) markFixtureMode(state.fixtureName);
 
     setLoading(36, 'Spinning up scene');
@@ -2866,7 +2906,43 @@ async function boot() {
     setInterval(checkGatewayStatus, 15000);
     // Refresh N2N federation state so claw nodes reflect consent/inventory/sever (FR-026)
     setInterval(async () => {
-      try { state.n2n = await (await fetch('/api/n2n')).json(); } catch { /* keep last */ }
+      // Feature 101 (FR-041/042/043): freeze and flag.
+      //
+      // The pre-101 `catch { /* keep last */ }` froze by accident but never SAID
+      // so, and it could not detect a 200 carrying a wrongly-shaped body. A
+      // failed poll must never recompute liveness — if it did, the mesh daemon
+      // going down would render all seven peers dead and send an operator
+      // chasing an outage that does not exist. The decision logic lives in the
+      // tested pure module; this is only the wiring.
+      const nowMs = Date.now();
+      try {
+        const res = await fetch('/api/n2n');
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        recordSuccess(state.feed, await res.json(), nowMs);
+      } catch (e) {
+        recordFailure(state.feed, e, nowMs);
+      }
+      // Only ever adopt a payload that actually succeeded. While degraded this
+      // keeps returning the last good one, which is the freeze half.
+      const frozen = renderablePayload(state.feed);
+      if (frozen) {
+        // FR-045: a peer selected when its row disappears keeps its panel, marked
+        // as gone, and loses its scene selection. Detected here because it needs
+        // the previous poll for comparison.
+        const before = new Set((state.n2n?.peers || []).map((p) => p.identity));
+        const after = new Set((frozen.peers || []).map((p) => p.identity));
+        if (state.selected?.kind === 'federation-peer'
+            && before.has(state.selected.peer) && !after.has(state.selected.peer)) {
+          const gone = (state.n2n.peers || []).find((p) => p.identity === state.selected.peer);
+          if (gone) {
+            setDetail('federation-peer', { ...gone, __presentInFeed: false });
+            clearSelection();
+            state.selected = { kind: 'federation-peer', peer: gone.identity, stillPresent: false };
+          }
+        }
+        state.n2n = frozen;
+      }
+      renderStaleBanner(staleIndicator(state.feed, nowMs));
       // The detail panel only renders on click (setDetail is never called
       // again just because state.n2n refreshed) -- if "This NetClaw" is the
       // panel currently open, re-render it in place so edge-node liveness/

--- a/ui/netclaw-visual/src/orgchart-render/index.js
+++ b/ui/netclaw-visual/src/orgchart-render/index.js
@@ -16,7 +16,7 @@ import * as THREE from 'three';
 import { computeLayout, appendMember } from '../orgchart/layout.js';
 import { buildNodes, animateNodes, applyHighlight, TREATMENTS } from './nodes.js';
 import { buildBands } from './bands.js';
-import { buildLinks } from './links.js';
+import { buildLinks, animateFlows } from './links.js';
 import { classifyHealth } from '../orgchart/health.js';
 import { toggleExpansion, collapseAll, isExpanded, expandedCount } from './expansion.js';
 import { buildA11yOverlay } from './a11y.js';
@@ -33,6 +33,11 @@ const chart = {
   catalog: [],
   entries: [],
   search: '',
+  // Feature 101 (US2): the single selection marker. ONE mesh moved between
+  // nodes rather than a per-node treatment, which makes FR-009 (exactly one
+  // node reads as selected) structural instead of something to remember.
+  selectionMarker: null,
+  selectedNodeId: null,
 };
 
 export function prefersReducedMotion() {
@@ -224,6 +229,83 @@ export function collapseAllExpansions() {
 
 export { isExpanded, expandedCount };
 
-export function tickOrgChart(elapsed) {
+/**
+ * Selection as its own visual channel (feature 101, US2 — visual-contract §2).
+ *
+ * ## Why an outline and not brightness
+ *
+ * The org chart had NO selection treatment at all — clicking set the detail panel
+ * and nothing else, so the only feedback was the panel itself. The legacy orbit
+ * scene used `emissiveIntensity = 1.8` plus a scale bump, and copying that here
+ * would have reused STATE channels: brightening a dim node pushes it toward the
+ * healthy treatment, so a selected STALE peer would look like a live one. That is
+ * the concrete failure FR-007 names.
+ *
+ * So selection lives outside the silhouette, in space no state channel uses:
+ * a ring drawn around the node, in a neutral colour that belongs to no state.
+ *
+ * Additive blending is deliberately NOT used — the scene already runs
+ * UnrealBloomPass, and an additive ring washes out into the glow it is supposed
+ * to stand against.
+ */
+const SELECTION_COLOR = 0xffffff;
+
+function ensureSelectionMarker() {
+  if (chart.selectionMarker) return chart.selectionMarker;
+  const geo = new THREE.TorusGeometry(1, 0.075, 8, 48);
+  const mat = new THREE.MeshBasicMaterial({
+    color: SELECTION_COLOR, transparent: true, opacity: 0.95,
+    depthTest: false,          // always legible, even behind a nearer node
+    toneMapped: false,         // keep it pure white through the tone-mapped chain
+  });
+  const ring = new THREE.Mesh(geo, mat);
+  ring.renderOrder = 999;
+  ring.visible = false;
+  ring.name = 'orgchart-selection';
+  chart.selectionMarker = ring;
+  if (chart.root) chart.root.add(ring);
+  return ring;
+}
+
+/**
+ * Mark one node as selected, or clear when nodeId is falsy.
+ *
+ * @param {string|null} nodeId layout node id
+ */
+export function setSelectedNode(nodeId) {
+  const ring = ensureSelectionMarker();
+  if (chart.root && ring.parent !== chart.root) chart.root.add(ring);
+
+  const entry = nodeId ? chart.entries.find((e) => e.node.id === nodeId) : null;
+  if (!entry) {
+    ring.visible = false;
+    chart.selectedNodeId = null;
+    return;
+  }
+
+  // Sized from the node's own base scale so it reads at every zoom (FR-011) and
+  // never depends on the pulse-modulated live scale.
+  const r = entry.baseScale * 1.9 + 0.9;
+  ring.scale.setScalar(r);
+  ring.position.set(entry.node.position.x, entry.node.position.y, entry.node.position.z);
+  ring.visible = true;
+  chart.selectedNodeId = nodeId;
+}
+
+/** FR-008: full restoration on deselect, with no residue. */
+export function clearSelectedNode() {
+  setSelectedNode(null);
+}
+
+export function selectedNodeId() {
+  return chart.selectedNodeId;
+}
+
+export function tickOrgChart(elapsed, camera) {
   animateNodes(chart.entries, elapsed, prefersReducedMotion());
+  // Feature 101 (US4): flow markers on LIVE peer links only.
+  animateFlows(chart.links?.flows, elapsed, prefersReducedMotion());
+  // Billboard the selection ring: an unrotated torus seen edge-on collapses to
+  // a line and the selection appears to vanish at some camera angles.
+  if (camera && chart.selectionMarker?.visible) chart.selectionMarker.quaternion.copy(camera.quaternion);
 }

--- a/ui/netclaw-visual/src/orgchart-render/links.js
+++ b/ui/netclaw-visual/src/orgchart-render/links.js
@@ -56,7 +56,10 @@ export function buildLinks(layoutNodes, categories) {
 
   const nodes = layoutNodes || [];
   const border = nodes.find((n) => n.kind === 'border');
-  if (!border) return { group, dispose() {} };
+  if (!border) return { group, dispose() {}, flows: [] };
+
+  // Feature 101 (US4): flow markers for peers with a LIVE channel only.
+  const flows = [];
 
   const origin = new THREE.Vector3(border.position.x, border.position.y, border.position.z);
 
@@ -90,12 +93,56 @@ export function buildLinks(layoutNodes, categories) {
 
     group.add(makeLine(points, style, disposables));
     if (style.arrow) group.add(makeArrow(origin, target, style, disposables));
+
+    // Feature 101 (US4/FR-018): only a LIVE channel flows. IDLE, STALE, UNKNOWN,
+    // UNREACHABLE and SEVERED are all static, so motion means exactly one thing:
+    // this link is carrying capability right now.
+    //
+    // FR-019: /api/n2n exposes no per-link direction, so flow runs peer -> Border
+    // to represent inbound capability availability, and that choice is recorded
+    // here rather than left for a reader to infer from the animation.
+    if (node.kind === 'peer' && node.peerState === 'LIVE') {
+      const geo = new THREE.SphereGeometry(0.42, 10, 8);
+      const mat = new THREE.MeshBasicMaterial({
+        color: style.color, transparent: true, opacity: 0.95, toneMapped: false,
+      });
+      disposables.push(geo, mat);
+      for (let i = 0; i < 3; i += 1) {
+        const dot = new THREE.Mesh(geo, mat);
+        dot.renderOrder = 2;
+        group.add(dot);
+        // `phase` staggers the three dots so the link reads as a stream rather
+        // than one dot looping.
+        flows.push({ dot, from: target.clone(), to: origin.clone(), phase: i / 3 });
+      }
+    }
   }
 
   return {
     group,
+    flows,
     dispose() { for (const d of disposables) d.dispose?.(); },
   };
+}
+
+/**
+ * Advance the flow markers (feature 101, US4).
+ *
+ * FR-020: with reduced motion preferred the dots are PARKED at fixed points along
+ * the link instead of hidden. A viewer who cannot see motion still sees that this
+ * link is marked and the stale ones are not, so the live/not-live distinction
+ * survives — which is what makes flow a redundant channel rather than the only
+ * one carrying liveness.
+ *
+ * @param {Array<object>} flows from buildLinks().flows
+ * @param {number} elapsed seconds
+ * @param {boolean} reducedMotion
+ */
+export function animateFlows(flows, elapsed, reducedMotion) {
+  for (const f of flows || []) {
+    const t = reducedMotion ? (0.2 + f.phase * 0.3) : ((elapsed * 0.35 + f.phase) % 1);
+    f.dot.position.lerpVectors(f.from, f.to, t);
+  }
 }
 
 function makeLine(points, style, disposables) {

--- a/ui/netclaw-visual/src/orgchart-render/nodes.js
+++ b/ui/netclaw-visual/src/orgchart-render/nodes.js
@@ -70,6 +70,65 @@ export const TREATMENTS = {
   },
 };
 
+/**
+ * Peer state treatments (feature 101, US3 — visual-contract.md §3).
+ *
+ * ## What this replaces, and why
+ *
+ * Peers used to be "structural": one fixed octahedron, no motion, and a colour
+ * from `colorForStructural()` that branched on only two things — `severed`, and
+ * `channel_state ∈ {unreachable, reconnecting}`. Everything else fell through to
+ * a single healthy blue. It **never read `stale`**, and `channel_state: "unknown"`
+ * is not in that set, so against the live feed FIVE of seven peers landed in the
+ * catch-all: Byrn (stale 12d), Nicholas (stale 19d), Hermes (stale 14d), AB and
+ * Carapace (never seen) all rendered identically to a live Nate. Confirmed
+ * visually in the pre-change screenshot, not just in source.
+ *
+ * ## The encoding rule (inherited from TREATMENTS above)
+ *
+ * Each state differs in FORM, COLOUR TEMPERATURE and (where present) MOTION at
+ * once — never opacity alone, never colour alone. `scaleMul` and `affix` are
+ * additional redundant channels. Motion is deliberately redundant so suppressing
+ * it for prefers-reduced-motion cannot collapse the encoding.
+ *
+ * `lum` is the ITU-R BT.709 luminance of `color`, kept as a comment so the
+ * ≥18-delta requirement is auditable by eye as well as by peer-treatments.test.js.
+ */
+export const PEER_TREATMENTS = {
+  // Channel up right now. Brightest, alive, gentle breathing.
+  LIVE: {
+    shape: 'peer', color: 0x7ff0d0, emissive: 0x1fbf9b, emissiveIntensity: 1.6,
+    scaleMul: 1.08, pulse: 0.09, affix: '', label: 'Channel up now',
+  }, // lum ≈ 205
+  // Federated, idle, inventory fresh. Normal steady state — nothing is wrong.
+  IDLE: {
+    shape: 'peer', color: 0x8ad6ff, emissive: 0x2f6da8, emissiveIntensity: 1.1,
+    scaleMul: 1.0, pulse: 0.0, affix: '', label: 'Federated, idle',
+  }, // lum ≈ 201 — nearly equal to LIVE, so MOTION + form carry this pair (R2)
+  // Federated, but what we know is old.
+  STALE: {
+    shape: 'peerWorn', color: 0xb8a878, emissive: 0x5a4f2e, emissiveIntensity: 0.7,
+    scaleMul: 0.92, pulse: 0.0, affix: 'stale', label: 'Data is old',
+  }, // lum ≈ 168
+  // Never sent an inventory. NOT a failure (FR-016/017) — deliberately cool and
+  // hollow rather than warm/alarming, so "never heard from AB" cannot read as
+  // "AB is broken".
+  UNKNOWN: {
+    shape: 'peerHollow', color: 0x6f7f96, emissive: 0x2a3440, emissiveIntensity: 0.45,
+    scaleMul: 0.88, pulse: 0.0, affix: 'never seen', label: 'Never sent an inventory',
+  }, // lum ≈ 126
+  // Was reachable, is not now. Actionable — urgent pulse, broken outline.
+  UNREACHABLE: {
+    shape: 'ring', color: 0xff9d6e, emissive: 0xc2481a, emissiveIntensity: 2.0,
+    scaleMul: 1.12, pulse: 0.2, affix: 'unreachable', label: 'Was reachable, now not',
+  }, // lum ≈ 175 — separated from STALE by form (ring vs worn) + motion + affix
+  // Deliberately cut. Darkest, inert.
+  SEVERED: {
+    shape: 'peerCut', color: 0x8a4a52, emissive: 0x3a1c20, emissiveIntensity: 0.5,
+    scaleMul: 0.85, pulse: 0.0, affix: 'severed', label: 'Deliberately severed',
+  }, // lum ≈ 92
+};
+
 export const KIND_SCALE = { border: 2.2, peer: 1.35, member: 1.0, edge: 1.15 };
 
 /** Shared geometries — created once, reused across every node (FR-029a). */
@@ -82,6 +141,16 @@ function buildGeometries() {
     border: new THREE.IcosahedronGeometry(2.4, 1),
     peer: new THREE.OctahedronGeometry(1.8, 0),
     edge: new THREE.BoxGeometry(1.5, 2.6, 0.5),
+    // Feature 101 (US3, visual-contract R4): peer STATE modulates the octahedron
+    // silhouette rather than replacing it with a member shape, so band membership
+    // still reads at a glance while state reads on top of it.
+    //   peerWorn   — lower-detail octahedron: same family, visibly degraded
+    //   peerHollow — smaller octahedron rendered as a wireframe (see material
+    //                below): present but empty, for "we have never heard from it"
+    //   peerCut    — a half-height octahedron: the silhouette, truncated
+    peerWorn: new THREE.OctahedronGeometry(1.7, 0),
+    peerHollow: new THREE.OctahedronGeometry(1.75, 0),
+    peerCut: new THREE.OctahedronGeometry(1.8, 0).scale(1, 0.45, 1),
   };
 }
 
@@ -102,26 +171,41 @@ export function buildNodes(layoutNodes, makeLabel) {
   for (const node of layoutNodes || []) {
     const treatment = TREATMENTS[node.health] || TREATMENTS.COLD;
 
+    // Feature 101 (US3): peers now carry a state treatment of their own instead
+    // of being lumped in with the Border as "structural". Only the Border remains
+    // structural — it has no state to convey, it IS the centre.
+    const peerT = node.kind === 'peer'
+      ? (PEER_TREATMENTS[node.peerState] || PEER_TREATMENTS.IDLE)
+      : null;
+
     let geometry;
     if (node.kind === 'border') geometry = geometries.border;
-    else if (node.kind === 'peer') geometry = geometries.peer;
+    else if (peerT) geometry = geometries[peerT.shape] || geometries.peer;
     else if (node.kind === 'edge') geometry = geometries.edge;
     else geometry = geometries[treatment.shape] || geometries.sphere;
 
-    const isStructural = node.kind === 'border' || node.kind === 'peer';
-    const color = isStructural ? colorForStructural(node) : treatment.color;
+    const isStructural = node.kind === 'border';
+    let color;
+    if (isStructural) color = colorForStructural(node);
+    else if (peerT) color = peerT.color;
+    else color = treatment.color;
 
     const material = new THREE.MeshStandardMaterial({
       color,
-      emissive: isStructural ? 0x102030 : treatment.emissive,
-      emissiveIntensity: isStructural ? 1.1 : (treatment.emissiveIntensity ?? 1.0),
+      emissive: isStructural ? 0x102030 : (peerT ? peerT.emissive : treatment.emissive),
+      emissiveIntensity: isStructural ? 1.1
+        : (peerT ? peerT.emissiveIntensity : (treatment.emissiveIntensity ?? 1.0)),
       roughness: node.health === 'COLD' ? 0.8 : 0.28,
       metalness: node.health === 'COLD' ? 0.1 : 0.5,
+      // UNKNOWN renders hollow: present, but visibly containing nothing. A third
+      // form channel that survives greyscale and reduced motion alike.
+      wireframe: peerT?.shape === 'peerHollow',
     });
     materials.push(material);
 
     const mesh = new THREE.Mesh(geometry, material);
-    const scale = (KIND_SCALE[node.kind] || 1) * (isStructural ? 1 : treatment.scale);
+    const scale = (KIND_SCALE[node.kind] || 1)
+      * (isStructural ? 1 : (peerT ? peerT.scaleMul : treatment.scale));
     mesh.scale.setScalar(scale);
     mesh.position.set(node.position.x, node.position.y, node.position.z);
     mesh.userData = { nodeId: node.id, kind: node.kind, payload: node.payload, node };
@@ -130,6 +214,12 @@ export function buildNodes(layoutNodes, makeLabel) {
     let text = node.label;
     if (node.kind === 'member' && node.toolCount > 0) text += `  ·${node.toolCount}`;
     if (node.kind === 'edge' && node.heartbeatAgeS != null) text += `  ${formatAge(node.heartbeatAgeS)}`;
+    // Feature 101 (US3, visual-contract R5): the state affix is ADDITIVE — it
+    // extends the label normalize.js already disambiguated, never replaces it.
+    // This is the only channel that survives greyscale, reduced motion and
+    // colour-blindness simultaneously, so a state with an affix is never
+    // conveyed by rendering alone.
+    if (peerT && peerT.affix) text += `  · ${peerT.affix}`;
 
     // The label is a sibling of the mesh, NOT a child. Parenting it to the mesh
     // made it inherit the pulse scale, so every HOT and FAULT label drifted a
@@ -144,7 +234,10 @@ export function buildNodes(layoutNodes, makeLabel) {
 
     group.add(mesh);
     group.add(label);
-    entries.push({ node, mesh, material, label, baseScale: scale, pulse: treatment.pulse });
+    entries.push({
+      node, mesh, material, label, baseScale: scale,
+      pulse: peerT ? peerT.pulse : treatment.pulse,
+    });
   }
 
   return {
@@ -193,7 +286,10 @@ export function animateNodes(entries, elapsed, reducedMotion) {
   for (const e of entries) {
     if (!e.pulse) continue;
     // FAULT beats faster than HOT: urgency reads differently from liveness.
-    const rate = e.node.health === 'FAULT' ? 4.2 : 1.6;
+    // Feature 101: UNREACHABLE is the peer-side equivalent of FAULT and gets the
+    // same urgent rate, so 'needs attention' reads identically in both bands.
+    const urgent = e.node.health === 'FAULT' || e.node.peerState === 'UNREACHABLE';
+    const rate = urgent ? 4.2 : 1.6;
     const factor = 1 + Math.sin(elapsed * rate) * e.pulse;
     e.mesh.scale.setScalar(e.baseScale * factor);
   }

--- a/ui/netclaw-visual/src/orgchart-render/peer-treatments.test.js
+++ b/ui/netclaw-visual/src/orgchart-render/peer-treatments.test.js
@@ -1,0 +1,161 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { PEER_TREATMENTS, TREATMENTS } from './nodes.js';
+import { PEER_STATES } from '../orgchart/liveness.js';
+
+/**
+ * visual-contract.md §3 rules R1–R5, as a permanent test rather than a screenshot.
+ *
+ * These are properties of the design constants, so they hold on every run instead
+ * of for one build on one machine. Feature 072 proved the value: its
+ * treatments.test.js caught COLD landing within 10 luminance of FAULT, a
+ * collision a screenshot review had passed.
+ */
+
+/** ITU-R BT.709 relative luminance — what a greyscale conversion produces. */
+function luminance(hex) {
+  const r = (hex >> 16) & 0xff;
+  const g = (hex >> 8) & 0xff;
+  const b = hex & 0xff;
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/** Same threshold feature 072 settled on. */
+const MIN_DELTA = 18;
+
+test('every classified peer state has a treatment', () => {
+  for (const s of PEER_STATES) {
+    assert.ok(PEER_TREATMENTS[s], `no treatment for ${s}`);
+  }
+  assert.equal(Object.keys(PEER_TREATMENTS).length, PEER_STATES.length);
+});
+
+test('R1: no two states are conveyed by the same channel combination', () => {
+  // The real requirement. Six states cannot all clear >=18 luminance within one
+  // usable range, so the contract says form and affix must carry the difference
+  // where colour cannot — this asserts the COMBINATION is unique, which is what
+  // an operator actually distinguishes.
+  const seen = new Map();
+  for (const [state, t] of Object.entries(PEER_TREATMENTS)) {
+    const key = `${t.shape}|${t.color}|${t.pulse > 0}|${t.affix}`;
+    assert.ok(!seen.has(key),
+      `${state} and ${seen.get(key)} are visually identical (${key})`);
+    seen.set(key, state);
+  }
+});
+
+test('R1: states sharing a form are separable by luminance alone', () => {
+  // Where form does NOT distinguish two states, colour must — otherwise the pair
+  // collapses in greyscale with nothing else to fall back on.
+  const byShape = new Map();
+  for (const [state, t] of Object.entries(PEER_TREATMENTS)) {
+    if (!byShape.has(t.shape)) byShape.set(t.shape, []);
+    byShape.get(t.shape).push(state);
+  }
+  for (const [shape, states] of byShape) {
+    for (let i = 0; i < states.length; i += 1) {
+      for (let j = i + 1; j < states.length; j += 1) {
+        const a = states[i]; const b = states[j];
+        const delta = Math.abs(
+          luminance(PEER_TREATMENTS[a].color) - luminance(PEER_TREATMENTS[b].color));
+        const motionDiffers = (PEER_TREATMENTS[a].pulse > 0) !== (PEER_TREATMENTS[b].pulse > 0);
+        assert.ok(delta >= MIN_DELTA || motionDiffers,
+          `${a} and ${b} share form '${shape}', differ by only ${delta.toFixed(1)} `
+          + 'luminance, and neither pulses — indistinguishable in a greyscale still');
+      }
+    }
+  }
+});
+
+test('R2: LIVE and IDLE are each distinguishable from STALE', () => {
+  // The pairs an operator acts on, checked explicitly rather than only as part of
+  // the sweep: mistaking stale data for a live channel is the whole defect.
+  for (const good of ['LIVE', 'IDLE']) {
+    const delta = Math.abs(
+      luminance(PEER_TREATMENTS[good].color) - luminance(PEER_TREATMENTS.STALE.color));
+    assert.ok(delta >= MIN_DELTA,
+      `${good} vs STALE differ by only ${delta.toFixed(1)} luminance`);
+    assert.notEqual(PEER_TREATMENTS[good].shape, PEER_TREATMENTS.STALE.shape);
+    assert.equal(PEER_TREATMENTS.STALE.affix, 'stale', 'STALE must carry a text affix');
+  }
+});
+
+test('R2: LIVE and IDLE are distinguishable from each other', () => {
+  // These two are deliberately close in colour (both healthy) — so motion and
+  // scale must separate them, or a live channel looks merely idle.
+  const a = PEER_TREATMENTS.LIVE; const b = PEER_TREATMENTS.IDLE;
+  assert.ok(a.pulse > 0 && b.pulse === 0, 'LIVE must pulse and IDLE must not');
+  assert.notEqual(a.scaleMul, b.scaleMul);
+});
+
+test('R3: UNKNOWN is not in the alarm hue family', () => {
+  // FR-016/017. "We have never heard from AB" must not read as "AB is broken".
+  const u = PEER_TREATMENTS.UNKNOWN;
+  const r = (u.color >> 16) & 0xff;
+  const g = (u.color >> 8) & 0xff;
+  const b = u.color & 0xff;
+  assert.ok(b >= r, `UNKNOWN colour is warm (r=${r} > b=${b}) — reads as alarm`);
+  assert.equal(u.pulse, 0, 'UNKNOWN must not pulse — pulsing signals urgency');
+  assert.ok(u.affix.includes('never'), 'the affix must say never, not failed');
+});
+
+test('R3: the actionable states ARE warm and urgent', () => {
+  // The converse of the rule above: if nothing is warm, the encoding cannot
+  // signal "act on this" at all.
+  for (const s of ['UNREACHABLE', 'SEVERED']) {
+    const t = PEER_TREATMENTS[s];
+    const r = (t.color >> 16) & 0xff;
+    const b = t.color & 0xff;
+    assert.ok(r > b, `${s} should read warm/alarming (r=${r}, b=${b})`);
+  }
+  assert.ok(PEER_TREATMENTS.UNREACHABLE.pulse > 0, 'UNREACHABLE is urgent — it pulses');
+});
+
+test('R4: every peer state keeps a peer-family silhouette', () => {
+  // Band membership must still read at a glance; state modulates the octahedron
+  // rather than borrowing a member shape.
+  const memberShapes = new Set(Object.values(TREATMENTS).map((t) => t.shape));
+  for (const [state, t] of Object.entries(PEER_TREATMENTS)) {
+    if (t.shape === 'ring') continue;   // ring is shared with FAULT ON PURPOSE:
+                                        // "needs attention" should look the same
+                                        // in both bands (see the pulse-rate note
+                                        // in animateNodes).
+    assert.ok(t.shape.startsWith('peer'),
+      `${state} uses '${t.shape}', which is not a peer-family silhouette`);
+    assert.ok(!memberShapes.has(t.shape) || t.shape === 'ring',
+      `${state} borrows the member shape '${t.shape}'`);
+  }
+});
+
+test('R5: affixes are short, lowercase, and only on non-healthy states', () => {
+  assert.equal(PEER_TREATMENTS.LIVE.affix, '', 'a healthy peer needs no affix');
+  assert.equal(PEER_TREATMENTS.IDLE.affix, '', 'idle is normal — no affix');
+  for (const s of ['STALE', 'UNKNOWN', 'UNREACHABLE', 'SEVERED']) {
+    const a = PEER_TREATMENTS[s].affix;
+    assert.ok(a.length > 0 && a.length <= 12, `${s} affix '${a}' is not concise`);
+    assert.equal(a, a.toLowerCase());
+  }
+});
+
+test('FR-014: no state is carried by colour alone', () => {
+  // Strip colour entirely and every state must still be unique.
+  const keys = Object.entries(PEER_TREATMENTS)
+    .map(([, t]) => `${t.shape}|${t.pulse > 0}|${t.affix}|${t.scaleMul}`);
+  assert.equal(new Set(keys).size, keys.length,
+    'two states become identical once colour is removed');
+});
+
+test('every treatment carries a human-readable label', () => {
+  for (const [s, t] of Object.entries(PEER_TREATMENTS)) {
+    assert.ok(t.label && t.label.length > 3, `${s} has no usable label`);
+  }
+});
+
+test('member TREATMENTS are untouched by this feature (FR-013)', () => {
+  // Regression guard: US3 must extend, not replace, feature 072's scheme.
+  assert.deepEqual(Object.keys(TREATMENTS), ['HOT', 'WARM', 'COLD', 'FAULT']);
+  assert.equal(TREATMENTS.HOT.color, 0x4dff9b);
+  assert.equal(TREATMENTS.COLD.color, 0x5f6d80);
+  assert.equal(TREATMENTS.FAULT.color, 0xff7a7a);
+});

--- a/ui/netclaw-visual/src/orgchart/feed-state.js
+++ b/ui/netclaw-visual/src/orgchart/feed-state.js
@@ -1,0 +1,140 @@
+/**
+ * Poll outcome tracking — freeze and flag (feature 101, FR-041/042/043).
+ *
+ * Pure: no imports, no clock, no fetch. Times are injected; the caller owns the
+ * network. That is what makes the dangerous case testable.
+ *
+ * ## Why this is a separate module and not three lines in main.js
+ *
+ * The decision "is this a failure, and what do we show" is the most dangerous
+ * logic in the feature. If a failed poll were allowed to recompute liveness, the
+ * mesh daemon going down would render all seven peers as dead — an operator
+ * would see a total outage that does not exist and go chasing it. A failed poll
+ * is not evidence about peers; conflating "I cannot see" with "they are down" is
+ * exactly the inversion this guards against.
+ *
+ * So it lives here, on the pure side, where it is unit-tested — the render layer
+ * has no automated coverage at all.
+ *
+ * The symmetric error matters too: a **successful** poll returning zero peers is
+ * a real, renderable state (fresh install), not a failure. Treating it as one
+ * would be the same class of mistake in the opposite direction.
+ */
+
+export function createFeedState() {
+  return {
+    lastGood: null,
+    lastGoodAt: null,
+    consecutiveFailures: 0,
+    degraded: false,
+    lastError: null,
+  };
+}
+
+/**
+ * Is this payload a usable /api/n2n response?
+ *
+ * Requires `peers` to be an array. An empty array passes — that is the fresh
+ * install case and it must reach the empty-state path, not the failure path.
+ *
+ * @param {*} payload
+ * @returns {boolean}
+ */
+export function isUsablePayload(payload) {
+  return !!payload && typeof payload === 'object' && Array.isArray(payload.peers);
+}
+
+/**
+ * Record a successful poll.
+ *
+ * @param {object} feed state from createFeedState()
+ * @param {object} payload parsed /api/n2n body
+ * @param {number} nowMs injected clock
+ * @returns {object} the same feed object, mutated
+ */
+export function recordSuccess(feed, payload, nowMs) {
+  if (!isUsablePayload(payload)) {
+    // Shaped wrong => treat as a failure rather than caching garbage that would
+    // then be frozen and shown as authoritative.
+    return recordFailure(feed, new Error('unusable payload shape'), nowMs);
+  }
+  feed.lastGood = payload;
+  feed.lastGoodAt = nowMs;
+  feed.consecutiveFailures = 0;
+  feed.degraded = false;        // FR-043: recovery needs no reload, no acknowledgement
+  feed.lastError = null;
+  return feed;
+}
+
+/**
+ * Record a failed poll — a throw, a non-2xx, or unparseable body.
+ *
+ * **Deliberately does not touch `lastGood`** (FR-041). The scene keeps rendering
+ * the last known good state and no per-entity liveness is recomputed.
+ *
+ * @param {object} feed
+ * @param {Error|string} error
+ * @param {number} nowMs injected clock
+ * @returns {object} the same feed object, mutated
+ */
+export function recordFailure(feed, error, nowMs) {
+  feed.consecutiveFailures += 1;
+  feed.degraded = true;
+  feed.lastError = error instanceof Error ? error.message : String(error || 'unknown');
+  // lastGood and lastGoodAt are untouched on purpose.
+  return feed;
+}
+
+/**
+ * What the scene-level indicator should say (FR-042).
+ *
+ * @param {object} feed
+ * @param {number} nowMs injected clock
+ * @returns {{degraded: boolean, staleForSeconds: number|null, everSucceeded: boolean,
+ *            consecutiveFailures: number, message: string|null}}
+ */
+export function staleIndicator(feed, nowMs) {
+  if (!feed.degraded) {
+    return {
+      degraded: false,
+      staleForSeconds: null,
+      everSucceeded: feed.lastGoodAt !== null,
+      consecutiveFailures: 0,
+      message: null,
+    };
+  }
+
+  const everSucceeded = feed.lastGoodAt !== null;
+  const staleForSeconds = everSucceeded
+    ? Math.max(0, Math.floor((nowMs - feed.lastGoodAt) / 1000))
+    : null;
+
+  // Distinguish "we had data and lost contact" from "we never had any". The
+  // second is a first-run/misconfiguration story, not a stale-data story, and
+  // showing an age of 0 for it would be a fabricated reassurance.
+  const message = everSucceeded
+    ? `stale data — last good poll ${staleForSeconds}s ago`
+    : 'no data — never reached the mesh daemon';
+
+  return {
+    degraded: true,
+    staleForSeconds,
+    everSucceeded,
+    consecutiveFailures: feed.consecutiveFailures,
+    message,
+  };
+}
+
+/**
+ * The payload the scene should render right now.
+ *
+ * Returns `lastGood` while degraded — that is the freeze half of freeze-and-flag.
+ * Returns null only when nothing has ever succeeded, which the caller renders as
+ * an empty/first-run state rather than as failure.
+ *
+ * @param {object} feed
+ * @returns {object|null}
+ */
+export function renderablePayload(feed) {
+  return feed.lastGood;
+}

--- a/ui/netclaw-visual/src/orgchart/feed-state.test.js
+++ b/ui/netclaw-visual/src/orgchart/feed-state.test.js
@@ -1,0 +1,119 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createFeedState, isUsablePayload, recordFailure, recordSuccess,
+  renderablePayload, staleIndicator,
+} from './feed-state.js';
+
+/**
+ * FR-041/042/043 — freeze and flag.
+ *
+ * This is the file that stops the HUD fabricating an outage. If a failed poll
+ * were allowed to recompute liveness, the mesh daemon going down would render all
+ * seven peers as dead and send an operator chasing a total outage that does not
+ * exist.
+ *
+ * The symmetric error is tested too: a SUCCESSFUL poll with zero peers is a real
+ * empty state, not a failure.
+ */
+
+const T0 = 1786060000000;
+const GOOD = { identity: 'as65001-4.4.4.4', peers: [{ identity: 'as65006-6.6.6.6' }], members: [] };
+
+test('a successful poll caches the payload and clears degraded', () => {
+  const f = recordSuccess(createFeedState(), GOOD, T0);
+  assert.equal(f.lastGood, GOOD);
+  assert.equal(f.lastGoodAt, T0);
+  assert.equal(f.degraded, false);
+  assert.equal(f.consecutiveFailures, 0);
+});
+
+test('FR-041: a failed poll does NOT touch lastGood', () => {
+  const f = recordSuccess(createFeedState(), GOOD, T0);
+  recordFailure(f, new Error('ECONNREFUSED'), T0 + 5000);
+  assert.equal(f.lastGood, GOOD, 'the frozen payload must survive the failure');
+  assert.equal(f.lastGoodAt, T0, 'the age reference must not move');
+  assert.equal(f.degraded, true);
+});
+
+test('FR-041: the scene keeps rendering the last good payload while degraded', () => {
+  const f = recordSuccess(createFeedState(), GOOD, T0);
+  recordFailure(f, 'daemon down', T0 + 1000);
+  assert.equal(renderablePayload(f), GOOD);
+});
+
+test('every failure mode is a failure: throw, non-2xx, unparseable', () => {
+  for (const err of [new Error('fetch failed'), 'HTTP 502', new SyntaxError('Unexpected token')]) {
+    const f = recordSuccess(createFeedState(), GOOD, T0);
+    recordFailure(f, err, T0 + 1000);
+    assert.equal(f.degraded, true);
+    assert.equal(f.lastGood, GOOD);
+  }
+});
+
+test('a wrongly-shaped 200 response is treated as a failure, not cached', () => {
+  // Caching garbage would then freeze it and present it as authoritative.
+  const f = recordSuccess(createFeedState(), GOOD, T0);
+  recordSuccess(f, { peers: 'not-an-array' }, T0 + 1000);
+  assert.equal(f.degraded, true);
+  assert.equal(f.lastGood, GOOD, 'the previous good payload must be kept');
+});
+
+test('ZERO PEERS on a successful poll is NOT a failure', () => {
+  // The symmetric error: conflating "the daemon says nothing is federated" with
+  // "I could not reach the daemon" is the same class of mistake inverted.
+  const empty = { identity: 'as65001-4.4.4.4', peers: [], members: [] };
+  assert.equal(isUsablePayload(empty), true);
+  const f = recordSuccess(createFeedState(), empty, T0);
+  assert.equal(f.degraded, false);
+  assert.equal(renderablePayload(f), empty);
+  assert.equal(staleIndicator(f, T0).message, null, 'an empty fleet must not be flagged as stale');
+});
+
+test('consecutive failures accumulate and reset on success (FR-043)', () => {
+  const f = recordSuccess(createFeedState(), GOOD, T0);
+  recordFailure(f, 'x', T0 + 1000);
+  recordFailure(f, 'x', T0 + 2000);
+  recordFailure(f, 'x', T0 + 3000);
+  assert.equal(f.consecutiveFailures, 3);
+
+  recordSuccess(f, GOOD, T0 + 4000);
+  assert.equal(f.consecutiveFailures, 0);
+  assert.equal(f.degraded, false, 'FR-043: recovery needs no reload and no acknowledgement');
+});
+
+test('FR-042: the indicator reports the age of the last good poll', () => {
+  const f = recordSuccess(createFeedState(), GOOD, T0);
+  recordFailure(f, 'down', T0 + 90000);
+  const ind = staleIndicator(f, T0 + 90000);
+  assert.equal(ind.degraded, true);
+  assert.equal(ind.staleForSeconds, 90);
+  assert.equal(ind.everSucceeded, true);
+  assert.match(ind.message, /90s ago/);
+});
+
+test('never-succeeded is reported differently from lost-contact', () => {
+  // Showing an age of 0 for "we never reached the daemon" would be a fabricated
+  // reassurance — it is a first-run/misconfiguration story, not a staleness one.
+  const f = recordFailure(createFeedState(), 'ECONNREFUSED', T0);
+  const ind = staleIndicator(f, T0);
+  assert.equal(ind.everSucceeded, false);
+  assert.equal(ind.staleForSeconds, null);
+  assert.match(ind.message, /never reached/);
+  assert.equal(renderablePayload(f), null, 'nothing to freeze — caller renders an empty state');
+});
+
+test('a healthy feed produces no indicator at all', () => {
+  const f = recordSuccess(createFeedState(), GOOD, T0);
+  const ind = staleIndicator(f, T0 + 1000);
+  assert.equal(ind.degraded, false);
+  assert.equal(ind.message, null);
+});
+
+test('isUsablePayload accepts only an object with a peers array', () => {
+  assert.equal(isUsablePayload({ peers: [] }), true);
+  for (const bad of [null, undefined, 42, 'x', {}, { peers: null }, { peers: {} }, []]) {
+    assert.equal(isUsablePayload(bad), false, JSON.stringify(bad));
+  }
+});

--- a/ui/netclaw-visual/src/orgchart/freshness.js
+++ b/ui/netclaw-visual/src/orgchart/freshness.js
@@ -1,0 +1,102 @@
+/**
+ * Inventory freshness in operator terms (feature 101, FR-004).
+ *
+ * Pure: no imports, no clock. `nowEpochS` is injected, never read from
+ * Date.now() — otherwise every boundary here is untestable, the same reason
+ * health.js takes it as a parameter.
+ *
+ * FR-004 forbids showing a bare timestamp. An operator should not have to do
+ * date arithmetic to learn a peer went quiet twelve days ago, and
+ * "2026-07-25T16:43:51Z" requires exactly that.
+ *
+ * The distinction that matters most here is **never vs zero**. A peer that has
+ * never sent an inventory (AB, Carapace) has `inventory_received_at: null`. If
+ * that renders as "just now" it reads as the healthiest possible value, which
+ * is the inverse of the truth. So `ageSeconds` is `null`, not `0`, and
+ * `judgement` is its own state.
+ */
+
+/** Age above which a peer is *aging* — visible before the daemon flips `stale`. */
+export const AGING_THRESHOLD_S = 3600;        // 1 hour
+
+/** Age above which we call it stale regardless of what the API flag says. */
+export const STALE_THRESHOLD_S = 86400;       // 24 hours
+
+export const FRESH = 'fresh';
+export const AGING = 'aging';
+export const STALE = 'stale';
+export const NEVER = 'never';
+
+/**
+ * Parse an ISO-8601 `...Z` timestamp to epoch seconds.
+ *
+ * Deliberately narrow: the only producer is the daemon's `_now()`, which always
+ * emits `%Y-%m-%dT%H:%M:%SZ`. Anything else is treated as absent rather than
+ * guessed at, because a silently mis-parsed date would produce a confident wrong
+ * age — worse than admitting we do not know.
+ *
+ * @param {string|null|undefined} iso
+ * @returns {number|null} epoch seconds, or null if unusable
+ */
+export function parseStamp(iso) {
+  if (typeof iso !== 'string' || iso.trim() === '') return null;
+  const ms = Date.parse(iso);
+  return Number.isFinite(ms) ? Math.floor(ms / 1000) : null;
+}
+
+/**
+ * Render an age as something an operator reads at a glance.
+ *
+ * @param {number|null} seconds
+ * @returns {string}
+ */
+export function formatAge(seconds) {
+  if (seconds === null || !Number.isFinite(seconds)) return 'never';
+  const s = Math.max(0, Math.floor(seconds));
+  if (s < 45) return 'just now';
+  if (s < 3600) return `${Math.round(s / 60)}m ago`;
+  if (s < 86400) return `${Math.round(s / 3600)}h ago`;
+  return `${Math.round(s / 86400)}d ago`;
+}
+
+/**
+ * Build the FreshnessView for one peer (data-model.md §3).
+ *
+ * `judgement` combines two inputs and takes the **pessimistic** reading:
+ *   - derived age (so the HUD can say "aging" before the daemon flips `stale`)
+ *   - the API's own `stale` flag (authoritative when set — the daemon knows
+ *     things we do not, e.g. that a channel dropped)
+ *
+ * Pessimistic-wins mirrors normalize.js's `STATE_RESTRICTIVENESS`: claiming a
+ * stale peer is fresh is the dangerous direction of the error.
+ *
+ * @param {object} peer a peer row from /api/n2n peers[]
+ * @param {number} nowEpochS current time in epoch seconds (injected)
+ * @returns {{receivedAt: string|null, ageSeconds: number|null, ageText: string,
+ *            judgement: 'fresh'|'aging'|'stale'|'never'}}
+ */
+export function freshnessOf(peer, nowEpochS) {
+  const row = peer && typeof peer === 'object' ? peer : {};
+  const receivedAt = typeof row.inventory_received_at === 'string'
+    ? row.inventory_received_at
+    : null;
+
+  const stamp = parseStamp(receivedAt);
+  if (stamp === null) {
+    // Never received, or a timestamp we refuse to guess at. Either way we have
+    // no age — and `null` must never collapse to 0 (FR-004).
+    return { receivedAt, ageSeconds: null, ageText: 'never', judgement: NEVER };
+  }
+
+  const ageSeconds = Math.max(0, nowEpochS - stamp);
+
+  let judgement;
+  if (ageSeconds >= STALE_THRESHOLD_S) judgement = STALE;
+  else if (ageSeconds >= AGING_THRESHOLD_S) judgement = AGING;
+  else judgement = FRESH;
+
+  // The API flag can only make it worse, never better.
+  if (row.stale === true && judgement !== STALE) judgement = STALE;
+
+  return { receivedAt, ageSeconds, ageText: formatAge(ageSeconds), judgement };
+}

--- a/ui/netclaw-visual/src/orgchart/freshness.test.js
+++ b/ui/netclaw-visual/src/orgchart/freshness.test.js
@@ -1,0 +1,99 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  AGING_THRESHOLD_S, STALE_THRESHOLD_S,
+  formatAge, freshnessOf, parseStamp,
+} from './freshness.js';
+
+/**
+ * FR-004: inventory freshness in operator terms, never a bare timestamp.
+ *
+ * The assertion that matters most is never-vs-zero. A peer that has never sent an
+ * inventory rendering as "just now" would read as the healthiest possible value
+ * while meaning the opposite — and two of seven live peers (AB, Carapace) are in
+ * exactly that state.
+ */
+
+const NOW = 1786060000;   // fixed injected clock
+
+test('never-received yields null age and the never judgement, not zero', () => {
+  const f = freshnessOf({ inventory_received_at: null }, NOW);
+  assert.equal(f.ageSeconds, null, 'null must not collapse to 0');
+  assert.equal(f.judgement, 'never');
+  assert.equal(f.ageText, 'never');
+  assert.notEqual(f.ageText, 'just now', 'never must never read as the freshest value');
+});
+
+test('a missing field is treated the same as null', () => {
+  assert.equal(freshnessOf({}, NOW).judgement, 'never');
+  assert.equal(freshnessOf(undefined, NOW).judgement, 'never');
+});
+
+test('an unparseable timestamp is never guessed at', () => {
+  // A silently mis-parsed date produces a confident wrong age, which is worse
+  // than admitting we do not know.
+  for (const bad of ['not-a-date', '', '   ', '2026-13-45T99:99:99Z']) {
+    assert.equal(freshnessOf({ inventory_received_at: bad }, NOW).judgement, 'never', bad);
+  }
+});
+
+test('parseStamp returns epoch seconds for the daemon format', () => {
+  assert.equal(parseStamp('2026-08-06T20:12:08Z'), Math.floor(Date.parse('2026-08-06T20:12:08Z') / 1000));
+  assert.equal(parseStamp(null), null);
+  assert.equal(parseStamp(42), null);
+});
+
+test('judgement derives from age across both thresholds', () => {
+  const at = (age) => {
+    const iso = new Date((NOW - age) * 1000).toISOString().replace(/\.\d{3}Z$/, 'Z');
+    return freshnessOf({ inventory_received_at: iso }, NOW).judgement;
+  };
+  assert.equal(at(60), 'fresh');
+  assert.equal(at(AGING_THRESHOLD_S - 10), 'fresh');
+  assert.equal(at(AGING_THRESHOLD_S + 10), 'aging');
+  assert.equal(at(STALE_THRESHOLD_S - 10), 'aging');
+  assert.equal(at(STALE_THRESHOLD_S + 10), 'stale');
+});
+
+test('the API stale flag can only make the judgement worse, never better', () => {
+  const iso = new Date((NOW - 60) * 1000).toISOString().replace(/\.\d{3}Z$/, 'Z');
+  // Fresh by age, but the daemon says stale — the daemon knows things we do not
+  // (e.g. a dropped channel), and claiming a stale peer is fresh is the dangerous
+  // direction of the error.
+  assert.equal(freshnessOf({ inventory_received_at: iso, stale: true }, NOW).judgement, 'stale');
+  // And it cannot rescue a genuinely old inventory.
+  const old = new Date((NOW - STALE_THRESHOLD_S - 100) * 1000).toISOString().replace(/\.\d{3}Z$/, 'Z');
+  assert.equal(freshnessOf({ inventory_received_at: old, stale: false }, NOW).judgement, 'stale');
+});
+
+test('formatAge renders operator terms across every band', () => {
+  assert.equal(formatAge(null), 'never');
+  assert.equal(formatAge(0), 'just now');
+  assert.equal(formatAge(44), 'just now');
+  assert.equal(formatAge(600), '10m ago');
+  assert.equal(formatAge(7200), '2h ago');
+  assert.equal(formatAge(86400 * 12), '12d ago');
+});
+
+test('formatAge never emits a bare ISO timestamp', () => {
+  for (const s of [0, 100, 10000, 1000000]) {
+    assert.ok(!/\d{4}-\d{2}-\d{2}/.test(formatAge(s)), `FR-004 violated for ${s}`);
+  }
+});
+
+test('a future timestamp clamps to zero rather than going negative', () => {
+  const future = new Date((NOW + 5000) * 1000).toISOString().replace(/\.\d{3}Z$/, 'Z');
+  const f = freshnessOf({ inventory_received_at: future }, NOW);
+  assert.equal(f.ageSeconds, 0);
+  assert.equal(f.ageText, 'just now');
+});
+
+test('the real Byrn row reads as stale, not fresh', () => {
+  // Live data 2026-08-06: inventory from 2026-07-25, stale flag set.
+  const f = freshnessOf(
+    { inventory_received_at: '2026-07-25T16:43:51Z', stale: true },
+    Math.floor(Date.parse('2026-08-06T23:00:00Z') / 1000));
+  assert.equal(f.judgement, 'stale');
+  assert.match(f.ageText, /\d+d ago/, 'twelve days must render in days, not seconds');
+});

--- a/ui/netclaw-visual/src/orgchart/layout.js
+++ b/ui/netclaw-visual/src/orgchart/layout.js
@@ -28,12 +28,19 @@ import { classifyHealth } from './health.js';
 import { orderCategories, orderMembers } from './ordering.js';
 import { resolveLabel, disambiguateLabels, dedupePeers } from './normalize.js';
 import { categorizeMembers } from './categorize.js';
+import { classifyPeer } from './liveness.js';
 
 /** Layout constants. Named, not scattered as literals. */
 export const LAYOUT = {
   boundaryY: 18,
   externalY: 40,
-  externalSpacingX: 34,
+  // Feature 101 (US3): widened from 34. The state affixes ("· never seen",
+  // "· unreachable") made peer labels roughly twice as wide, and at 34 they
+  // collided — "Nicholas" overlapped "Hermes (as65008)" and Carapace was clipped
+  // to "ace · never seen". Caught by screenshot review; no unit test can see it,
+  // because label collision is a rendered-geometry property and the labels are
+  // DOM overlays positioned in world space.
+  externalSpacingX: 58,
   borderY: 0,
   internalTopY: -20,
   // The internal band fans WIDE. Members are the bulk of the chart and the
@@ -87,6 +94,12 @@ export function computeLayout(n2n, integrationCatalog, nowEpochS, opts = {}) {
       state: entity.state || 'unknown',
       channelState: entity.channel_state || 'unknown',
       severed: String(entity.state).toLowerCase() === 'severed',
+      // Feature 101 (US3/FR-012): the six-state classification the render layer
+      // consumes. Computed here, on the pure side, so the render layer never
+      // re-derives it — `colorForStructural` re-deriving it from two fields is
+      // exactly how `stale` came to be ignored and five of seven peers ended up
+      // rendering as healthy.
+      peerState: classifyPeer(entity, nowEpochS),
       payload: entity,
       position: { x: -peerSpan / 2 + i * cfg.externalSpacingX, y: cfg.externalY, z: 0 },
     });

--- a/ui/netclaw-visual/src/orgchart/liveness.js
+++ b/ui/netclaw-visual/src/orgchart/liveness.js
@@ -1,0 +1,119 @@
+/**
+ * Peer liveness classification (feature 101, US3 — FR-012/016/017).
+ *
+ * Pure: no imports beyond freshness (also pure), no clock. `nowEpochS` injected.
+ *
+ * ## The defect this exists to fix
+ *
+ * `orgchart-render/nodes.js` treats peers as *structural*, so they skip the
+ * four-state member treatment entirely and take their colour from
+ * `colorForStructural()`:
+ *
+ *     if (node.severed) return 0xa85c5c;
+ *     if (channelState === 'unreachable' || channelState === 'reconnecting')
+ *                        return 0x86a9cc;
+ *     return 0x8ad6ff;                       // <- the catch-all
+ *
+ * Three colours, one fixed form, no motion. It **never reads `stale`**, and
+ * `channel_state: "unknown"` falls straight through to the healthy default.
+ * Measured against the live feed, five of seven peers land in that catch-all —
+ * Byrn, Nicholas, Hermes, AB and Carapace all render identically to a healthy
+ * Nate. An operator cannot tell a peer that has been quiet for twelve days from
+ * one with a live channel.
+ *
+ * Six states rather than three, because the catch-all was hiding three genuinely
+ * different situations: normal-and-idle, gone-stale, and never-heard-from.
+ */
+
+import { freshnessOf, NEVER, STALE as STALE_JUDGEMENT } from './freshness.js';
+
+export const LIVE = 'LIVE';
+export const IDLE = 'IDLE';
+export const STALE = 'STALE';
+export const UNKNOWN = 'UNKNOWN';
+export const UNREACHABLE = 'UNREACHABLE';
+export const SEVERED = 'SEVERED';
+
+/** Declared order, most-known-good first. Used by tests and by the render table. */
+export const PEER_STATES = [LIVE, IDLE, STALE, UNKNOWN, UNREACHABLE, SEVERED];
+
+/** Channel states meaning "was reachable, is not now". */
+const UNREACHABLE_CHANNELS = new Set(['unreachable', 'reconnecting']);
+
+/**
+ * Classify a peer into exactly one of the six states.
+ *
+ * Precedence is strict and evaluated top-down. The order encodes two rules the
+ * spec insists on:
+ *
+ *   1. SEVERED first — a severed peer is NEVER reported as anything else,
+ *      whatever its other fields say (FR-017). Claiming a severed peer is live
+ *      is the dangerous direction of the error.
+ *   2. LIVE beats staleness — an `up` channel is direct evidence of reachability
+ *      now, which outranks an old inventory. A peer can legitimately have a live
+ *      channel and a stale inventory.
+ *
+ * UNKNOWN sits between STALE and UNREACHABLE deliberately: "we have never heard
+ * from this peer" is not a failure (FR-016/017). AB and Carapace are in this
+ * state and nothing is known to be wrong with either.
+ *
+ * @param {object} peer a peer row from /api/n2n peers[]
+ * @param {number} nowEpochS current time in epoch seconds (injected)
+ * @returns {'LIVE'|'IDLE'|'STALE'|'UNKNOWN'|'UNREACHABLE'|'SEVERED'}
+ */
+export function classifyPeer(peer, nowEpochS) {
+  const row = peer && typeof peer === 'object' ? peer : {};
+  const state = String(row.state || '').toLowerCase();
+  const channel = String(row.channel_state || '').toLowerCase();
+
+  // 1. Deliberately cut. Terminal until re-enrolled.
+  if (state === 'severed') return SEVERED;
+
+  // 2. A live channel is present-tense evidence and outranks inventory age.
+  if (channel === 'up') return LIVE;
+
+  // 3. Was reachable, is not now. Actionable.
+  if (UNREACHABLE_CHANNELS.has(channel)) return UNREACHABLE;
+
+  const fresh = freshnessOf(row, nowEpochS);
+
+  // 4. Never told us anything — NOT a failure (FR-016/017).
+  if (fresh.judgement === NEVER) return UNKNOWN;
+
+  // 5. Federated, but what we know is old.
+  if (fresh.judgement === STALE_JUDGEMENT) return STALE;
+
+  // 6. Normal steady state: federated, no live channel, inventory fresh.
+  return IDLE;
+}
+
+/**
+ * Full view state for one peer (data-model.md §2).
+ *
+ * `label` is passed in rather than derived, because disambiguation is a
+ * whole-list operation (two peers legitimately share "Hermes") and belongs to
+ * normalize.js, which already owns it.
+ *
+ * @param {object} peer a peer row from /api/n2n peers[]
+ * @param {number} nowEpochS injected clock
+ * @param {object} [opts]
+ * @param {string} [opts.label] pre-disambiguated label
+ * @param {boolean} [opts.presentInFeed=true] false once the row vanishes (FR-045)
+ */
+export function peerViewState(peer, nowEpochS, opts = {}) {
+  const row = peer && typeof peer === 'object' ? peer : {};
+  return {
+    identity: typeof row.identity === 'string' ? row.identity : '',
+    label: opts.label || row.display_name || row.identity || 'unknown',
+    state: classifyPeer(row, nowEpochS),
+    freshness: freshnessOf(row, nowEpochS),
+    chatEnabled: row.chat_enabled === true || row.chat_enabled === 1,
+    inFlightTasks: Array.isArray(row.in_flight_tasks) ? row.in_flight_tasks : [],
+    presentInFeed: opts.presentInFeed !== false,
+  };
+}
+
+/** True when this state means an operator may need to act. */
+export function isActionable(state) {
+  return state === UNREACHABLE || state === SEVERED;
+}

--- a/ui/netclaw-visual/src/orgchart/liveness.test.js
+++ b/ui/netclaw-visual/src/orgchart/liveness.test.js
@@ -1,0 +1,156 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  IDLE, LIVE, PEER_STATES, SEVERED, STALE, UNKNOWN, UNREACHABLE,
+  classifyPeer, isActionable, peerViewState,
+} from './liveness.js';
+
+/**
+ * US3 / FR-012/016/017.
+ *
+ * Driven by the REAL live feed as of 2026-08-06, because the defect is only
+ * visible against real data: five of seven peers fall into
+ * `colorForStructural`'s healthy catch-all and render identically to Nate. Each
+ * of those five is asserted here by name.
+ */
+
+const NOW = Math.floor(Date.parse('2026-08-06T23:00:00Z') / 1000);
+
+/** The live /api/n2n peers[] rows, trimmed to the fields classification reads. */
+const FEED = {
+  nate: {
+    identity: 'as65006-6.6.6.6', display_name: 'Nate', state: 'federated',
+    channel_state: 'up', stale: false, inventory_received_at: '2026-08-06T20:12:06Z',
+  },
+  byrn: {
+    identity: 'as65099-10.255.255.1', display_name: 'Byrn', state: 'federated',
+    channel_state: 'unknown', stale: true, inventory_received_at: '2026-07-25T16:43:51Z',
+  },
+  nicholas: {
+    identity: 'as65007-7.7.7.7', display_name: 'Nicholas', state: 'federated',
+    channel_state: 'unknown', stale: true, inventory_received_at: '2026-07-18T17:04:37Z',
+  },
+  hermesFederated: {
+    identity: 'as65008-8.8.8.8', display_name: 'Hermes', state: 'federated',
+    channel_state: 'unknown', stale: true, inventory_received_at: '2026-07-23T00:34:20Z',
+  },
+  hermesSevered: {
+    identity: 'as65007-8.8.8.8', display_name: 'Hermes', state: 'severed',
+    channel_state: 'unknown', stale: null, inventory_received_at: null,
+  },
+  ab: {
+    identity: 'as65003-3.3.3.3', display_name: 'AB', state: 'federated',
+    channel_state: 'unknown', stale: null, inventory_received_at: null,
+  },
+  carapace: {
+    identity: 'as65100-10.0.0.1', display_name: 'Carapace', state: 'federated',
+    channel_state: 'unknown', stale: null, inventory_received_at: null,
+  },
+};
+
+test('all six states are declared', () => {
+  assert.equal(PEER_STATES.length, 6);
+  for (const s of [LIVE, IDLE, STALE, UNKNOWN, UNREACHABLE, SEVERED]) {
+    assert.ok(PEER_STATES.includes(s), s);
+  }
+});
+
+test('the live feed classifies into four distinct states', () => {
+  assert.equal(classifyPeer(FEED.nate, NOW), LIVE);
+  assert.equal(classifyPeer(FEED.byrn, NOW), STALE);
+  assert.equal(classifyPeer(FEED.nicholas, NOW), STALE);
+  assert.equal(classifyPeer(FEED.hermesFederated, NOW), STALE);
+  assert.equal(classifyPeer(FEED.hermesSevered, NOW), SEVERED);
+  assert.equal(classifyPeer(FEED.ab, NOW), UNKNOWN);
+  assert.equal(classifyPeer(FEED.carapace, NOW), UNKNOWN);
+});
+
+test('THE DEFECT: the five catch-all peers no longer match healthy Nate', () => {
+  // Every one of these hit `return 0x8ad6ff` in colorForStructural and rendered
+  // identically to a peer with a live channel.
+  const nate = classifyPeer(FEED.nate, NOW);
+  for (const [name, row] of Object.entries({
+    byrn: FEED.byrn, nicholas: FEED.nicholas, hermes: FEED.hermesFederated,
+    ab: FEED.ab, carapace: FEED.carapace,
+  })) {
+    assert.notEqual(classifyPeer(row, NOW), nate,
+      `${name} still classifies the same as healthy Nate — the defect is not fixed`);
+  }
+});
+
+test('FR-016/017: UNKNOWN is distinct from both healthy and dead', () => {
+  const unknown = classifyPeer(FEED.ab, NOW);
+  assert.notEqual(unknown, LIVE);
+  assert.notEqual(unknown, IDLE);
+  assert.notEqual(unknown, UNREACHABLE);
+  assert.notEqual(unknown, SEVERED);
+  assert.equal(unknown, UNKNOWN);
+});
+
+test('FR-017: UNKNOWN is not actionable — never heard from is not a fault', () => {
+  assert.equal(isActionable(UNKNOWN), false);
+  assert.equal(isActionable(STALE), false);
+  assert.equal(isActionable(UNREACHABLE), true);
+  assert.equal(isActionable(SEVERED), true);
+});
+
+test('FR-017: a severed peer is never reported as anything else', () => {
+  // Severed wins over every other signal, including a live channel — claiming a
+  // severed peer is live is the dangerous direction of the error.
+  const contradictory = {
+    ...FEED.nate, state: 'severed', channel_state: 'up', stale: false,
+  };
+  assert.equal(classifyPeer(contradictory, NOW), SEVERED);
+});
+
+test('a live channel outranks a stale inventory', () => {
+  // Legitimate combination: channel came up before the inventory refreshed.
+  const row = { ...FEED.byrn, channel_state: 'up' };
+  assert.equal(classifyPeer(row, NOW), LIVE);
+});
+
+test('unreachable and reconnecting both classify as UNREACHABLE', () => {
+  for (const channel of ['unreachable', 'reconnecting']) {
+    assert.equal(classifyPeer({ ...FEED.byrn, channel_state: channel }, NOW), UNREACHABLE);
+  }
+});
+
+test('IDLE is the normal steady state, not an error', () => {
+  const row = {
+    identity: 'as65010-10.10.10.10', state: 'federated', channel_state: 'unknown',
+    stale: false, inventory_received_at: '2026-08-06T22:55:00Z',
+  };
+  assert.equal(classifyPeer(row, NOW), IDLE);
+});
+
+test('classification is case-insensitive on API strings', () => {
+  assert.equal(classifyPeer({ ...FEED.nate, channel_state: 'UP' }, NOW), LIVE);
+  assert.equal(classifyPeer({ ...FEED.hermesSevered, state: 'SEVERED' }, NOW), SEVERED);
+});
+
+test('a malformed row does not throw', () => {
+  for (const bad of [undefined, null, {}, 42, 'peer']) {
+    assert.doesNotThrow(() => classifyPeer(bad, NOW));
+  }
+});
+
+test('peerViewState carries identity separately from label', () => {
+  // Two peers share the display name "Hermes"; the panel needs identity to tell
+  // them apart.
+  const a = peerViewState(FEED.hermesFederated, NOW, { label: 'Hermes (as65008)' });
+  const b = peerViewState(FEED.hermesSevered, NOW, { label: 'Hermes (as65007)' });
+  assert.notEqual(a.identity, b.identity);
+  assert.notEqual(a.state, b.state);
+});
+
+test('peerViewState defaults presentInFeed true and honours false (FR-045)', () => {
+  assert.equal(peerViewState(FEED.nate, NOW).presentInFeed, true);
+  assert.equal(peerViewState(FEED.nate, NOW, { presentInFeed: false }).presentInFeed, false);
+});
+
+test('chat_enabled accepts both boolean and SQLite integer forms', () => {
+  assert.equal(peerViewState({ ...FEED.nate, chat_enabled: 1 }, NOW).chatEnabled, true);
+  assert.equal(peerViewState({ ...FEED.nate, chat_enabled: 0 }, NOW).chatEnabled, false);
+  assert.equal(peerViewState({ ...FEED.nate, chat_enabled: true }, NOW).chatEnabled, true);
+});

--- a/ui/netclaw-visual/src/orgchart/peer-detail.js
+++ b/ui/netclaw-visual/src/orgchart/peer-detail.js
@@ -1,0 +1,100 @@
+/**
+ * Peer detail panel view-model (feature 101, US1 — FR-002/003/004).
+ *
+ * Pure: no imports beyond liveness/freshness (both pure), no clock, no DOM.
+ *
+ * ## The defect
+ *
+ * `setDetail()` in main.js branches on six kinds — local-core, member-core,
+ * integration, device, skill, peer-core — and the org-chart click path passes a
+ * **seventh that does not exist**:
+ *
+ *     } else if (node.kind === 'peer') {
+ *       setDetail('federation-peer', node.payload);   // no such branch
+ *
+ * It falls past all six into the `// Default: overview` block and renders the
+ * generic "This NetClaw" summary. So the click *registers* and the panel *does*
+ * repaint — with a different subject's content. That is why it reads as "not
+ * clickable" even though the mesh is pickable and hover-scales correctly.
+ *
+ * ## Why not just point it at `peer-core`
+ *
+ * `peer-core` expects a BGP-session payload from /api/graph — `peer.as`,
+ * `peer.routerId`, `peer.peerIp`, `peer.routesReceived`, `peer.adjRibIn`. The
+ * org chart carries the /api/n2n shape instead (`identity`, `channel_state`,
+ * `inventory_received_at`, `stale`, `in_flight_tasks`). Renaming the kind would
+ * render a panel of `undefined`s. The /api/n2n shape is also the *richer* one for
+ * federation, which is why the panel is built against it.
+ *
+ * Every field resolves to a value or an explicit placeholder — never `undefined`.
+ */
+
+import { peerViewState } from './liveness.js';
+
+/** Shown instead of an empty cell, so a blank always means "we know it is empty". */
+export const PLACEHOLDER = '—';
+
+/** Human sentence per state. The panel says what the state *means*, not just its name. */
+export const STATE_SUMMARY = {
+  LIVE: 'Channel up now',
+  IDLE: 'Federated, idle — nothing wrong',
+  STALE: 'Federated, but what we know is old',
+  UNKNOWN: 'Never sent an inventory — not a failure',
+  UNREACHABLE: 'Was reachable, not now — may need attention',
+  SEVERED: 'Deliberately severed',
+};
+
+function orPlaceholder(value) {
+  if (value === null || value === undefined) return PLACEHOLDER;
+  const s = String(value).trim();
+  return s === '' ? PLACEHOLDER : s;
+}
+
+/**
+ * Build the panel view-model for one peer.
+ *
+ * @param {object} peer a peer row from /api/n2n peers[]
+ * @param {number} nowEpochS injected clock
+ * @param {object} [opts]
+ * @param {string} [opts.label] pre-disambiguated label from normalize.js
+ * @param {boolean} [opts.presentInFeed=true] false once the row vanishes (FR-045)
+ * @returns {object} view-model with no undefined values
+ */
+export function peerDetailView(peer, nowEpochS, opts = {}) {
+  const view = peerViewState(peer, nowEpochS, opts);
+  const row = peer && typeof peer === 'object' ? peer : {};
+
+  return {
+    // Heading uses the disambiguated label, but `identity` is always shown as its
+    // own row: two peers legitimately share the display name "Hermes", so the
+    // label alone cannot tell them apart.
+    heading: orPlaceholder(view.label),
+    identity: orPlaceholder(view.identity),
+
+    state: view.state,
+    stateSummary: STATE_SUMMARY[view.state] || PLACEHOLDER,
+    // Raw channel_state kept alongside, so an operator can cross-reference the
+    // panel against `n2n_health` output without translating.
+    channelState: orPlaceholder(row.channel_state),
+
+    inventoryAge: view.freshness.ageText,
+    inventoryJudgement: view.freshness.judgement,
+    inventoryReceivedAt: orPlaceholder(view.freshness.receivedAt),
+
+    chatEnabled: view.chatEnabled,
+    chatText: view.chatEnabled ? 'enabled' : 'disabled',
+
+    // An empty task list renders as an explicit "none", never as a blank region
+    // that could read as "failed to load".
+    inFlightTasks: view.inFlightTasks,
+    inFlightText: view.inFlightTasks.length === 0
+      ? 'none'
+      : `${view.inFlightTasks.length} in flight`,
+
+    presentInFeed: view.presentInFeed,
+    // FR-045: retained-but-gone must be stated, not implied by staleness.
+    notInFeedNotice: view.presentInFeed
+      ? null
+      : 'No longer present in the feed — this is the last known state',
+  };
+}

--- a/ui/netclaw-visual/src/orgchart/peer-detail.test.js
+++ b/ui/netclaw-visual/src/orgchart/peer-detail.test.js
@@ -1,0 +1,145 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { PLACEHOLDER, STATE_SUMMARY, peerDetailView } from './peer-detail.js';
+import { PEER_STATES } from './liveness.js';
+
+/**
+ * US1 / FR-002/003/004 and visual-contract §6 rule P2.
+ *
+ * The binding rule is **never render `undefined`**. That is not a style
+ * preference: routing peers to the existing `peer-core` branch would have
+ * produced exactly that, because it expects a /api/graph BGP payload
+ * (peer.as, peer.routerId, peer.peerIp, peer.routesReceived) which is absent
+ * from the /api/n2n shape the org chart carries.
+ */
+
+const NOW = Math.floor(Date.parse('2026-08-06T23:00:00Z') / 1000);
+
+const NATE = {
+  identity: 'as65006-6.6.6.6', display_name: 'Nate', state: 'federated',
+  channel_state: 'up', stale: false, chat_enabled: 1,
+  inventory_received_at: '2026-08-06T20:12:06Z', in_flight_tasks: [],
+};
+
+/** Walk every value in the view-model. */
+function values(view) {
+  return Object.entries(view).flatMap(([k, v]) =>
+    Array.isArray(v) ? v.map((x, i) => [`${k}[${i}]`, x]) : [[k, v]]);
+}
+
+test('P2: no field is ever undefined, for any input', () => {
+  const inputs = [
+    NATE,
+    {},                                   // entirely empty row
+    undefined,                            // no row at all
+    { identity: 'as65003-3.3.3.3' },      // identity only
+    { ...NATE, channel_state: null, inventory_received_at: null, in_flight_tasks: null },
+  ];
+  for (const row of inputs) {
+    const view = peerDetailView(row, NOW);
+    for (const [key, v] of values(view)) {
+      assert.notEqual(v, undefined, `${key} is undefined for input ${JSON.stringify(row)}`);
+    }
+  }
+});
+
+test('empty values render as an explicit placeholder, not a blank', () => {
+  const view = peerDetailView({}, NOW);
+  assert.equal(view.identity, PLACEHOLDER);
+  assert.equal(view.channelState, PLACEHOLDER);
+  assert.equal(view.inventoryReceivedAt, PLACEHOLDER);
+});
+
+test('FR-003: every required row is present', () => {
+  const view = peerDetailView(NATE, NOW, { label: 'Nate' });
+  for (const key of ['heading', 'identity', 'state', 'channelState',
+                     'inventoryAge', 'inventoryJudgement', 'chatEnabled', 'inFlightTasks']) {
+    assert.ok(key in view, `missing required row: ${key}`);
+  }
+  assert.equal(view.heading, 'Nate');
+  assert.equal(view.identity, 'as65006-6.6.6.6');
+  assert.equal(view.state, 'LIVE');
+});
+
+test('identity is shown separately so the two Hermes rows are distinguishable', () => {
+  const fed = peerDetailView(
+    { identity: 'as65008-8.8.8.8', display_name: 'Hermes', state: 'federated',
+      channel_state: 'unknown', stale: true, inventory_received_at: '2026-07-23T00:34:20Z' },
+    NOW, { label: 'Hermes (as65008)' });
+  const sev = peerDetailView(
+    { identity: 'as65007-8.8.8.8', display_name: 'Hermes', state: 'severed',
+      channel_state: 'unknown', inventory_received_at: null },
+    NOW, { label: 'Hermes (as65007)' });
+
+  assert.notEqual(fed.identity, sev.identity);
+  assert.notEqual(fed.state, sev.state);
+  assert.notEqual(fed.heading, sev.heading);
+});
+
+test('FR-004: inventory age is operator-readable, never a bare timestamp', () => {
+  const byrn = peerDetailView(
+    { identity: 'as65099-10.255.255.1', state: 'federated', channel_state: 'unknown',
+      stale: true, inventory_received_at: '2026-07-25T16:43:51Z' }, NOW);
+  assert.match(byrn.inventoryAge, /\d+d ago/);
+  assert.equal(byrn.inventoryJudgement, 'stale');
+  assert.ok(!/^\d{4}-\d{2}-\d{2}/.test(byrn.inventoryAge), 'must not be a raw timestamp');
+});
+
+test('never-received reads as never, not as zero', () => {
+  const ab = peerDetailView(
+    { identity: 'as65003-3.3.3.3', state: 'federated', channel_state: 'unknown',
+      inventory_received_at: null }, NOW);
+  assert.equal(ab.inventoryAge, 'never');
+  assert.equal(ab.inventoryJudgement, 'never');
+  assert.equal(ab.state, 'UNKNOWN');
+});
+
+test('an empty task list renders an explicit "none"', () => {
+  // A blank region could read as "failed to load" rather than "there are none".
+  assert.equal(peerDetailView(NATE, NOW).inFlightText, 'none');
+  const busy = peerDetailView(
+    { ...NATE, in_flight_tasks: [{ task_id: 'a' }, { task_id: 'b' }] }, NOW);
+  assert.equal(busy.inFlightText, '2 in flight');
+});
+
+test('chat state renders as words, not a raw integer', () => {
+  assert.equal(peerDetailView({ ...NATE, chat_enabled: 1 }, NOW).chatText, 'enabled');
+  assert.equal(peerDetailView({ ...NATE, chat_enabled: 0 }, NOW).chatText, 'disabled');
+});
+
+test('every state has a human summary — the panel says what it MEANS', () => {
+  for (const s of PEER_STATES) {
+    assert.ok(STATE_SUMMARY[s], `no summary for ${s}`);
+    assert.notEqual(STATE_SUMMARY[s], PLACEHOLDER);
+  }
+});
+
+test('FR-016/017: the UNKNOWN summary does not read as a failure', () => {
+  assert.match(STATE_SUMMARY.UNKNOWN, /not a failure/i);
+});
+
+test('FR-045: a vanished peer carries an explicit notice', () => {
+  const gone = peerDetailView(NATE, NOW, { presentInFeed: false });
+  assert.equal(gone.presentInFeed, false);
+  assert.ok(gone.notInFeedNotice, 'must state it is no longer present');
+  assert.match(gone.notInFeedNotice, /last known/i);
+
+  const here = peerDetailView(NATE, NOW);
+  assert.equal(here.notInFeedNotice, null, 'no notice when the peer is present');
+});
+
+test('a malformed row does not throw', () => {
+  for (const bad of [undefined, null, {}, 42, 'peer', []]) {
+    assert.doesNotThrow(() => peerDetailView(bad, NOW));
+  }
+});
+
+test('the view-model contains no BGP-shaped fields', () => {
+  // Guards against someone "unifying" this with peer-core, which is what would
+  // reintroduce the undefined-panel defect.
+  const view = peerDetailView(NATE, NOW);
+  for (const leaked of ['as', 'routerId', 'peerIp', 'routesReceived', 'adjRibIn']) {
+    assert.ok(!(leaked in view), `${leaked} belongs to the /api/graph shape, not this panel`);
+  }
+});


### PR DESCRIPTION
Five stories on `WebGLRenderer`. The WebGPU migration was deliberately split to spec 102 during clarification.

## The reported defect, fixed

`setDetail()` had six branches and the org-chart click path passed a **seventh that did not exist** (`federation-peer`), so it fell through to the default overview and repainted the panel with the generic "This NetClaw" summary. The click registered and the panel repainted — with *another subject's content*, which is why it read as "not clickable" while the mesh was pickable and hover-scaling correctly. Both the pointer and keyboard paths were affected.

Not fixable by pointing peers at `peer-core`: that branch expects a `/api/graph` BGP payload absent from the `/api/n2n` shape the org chart carries, so it would render a panel of `undefined`s. Added an FR-006 guard so no kind can silently reach the generic overview again.

## A second defect found on the way

`nodes.js` treated peers as "structural", so `colorForStructural()` gave them three colours and one fixed form. It **never read `stale`**, and `channel_state: "unknown"` fell through to the healthy default — so **five of seven peers rendered identically to a live Nate**: Byrn (stale 12d), Nicholas (19d), Hermes (14d), AB and Carapace (never seen). Confirmed visually, not just in source.

Now six states across four channels (form, colour, motion, label affix). Peers stopped being structural; only the Border is, since it has no state to convey.

## Upgrade

`three@0.185.1`, **zero source changes required** — every breaking change in r171–r185 lands in TSL/WebGPU node materials this HUD does not use. Bundle 753.22 → 798.80 kB (+6.05%). Frame time 749.9 ms vs a 758 ms post-bump baseline: three stories of new rendering cost nothing measurable.

## Evidence, and its limits

| | |
|---|---|
Tests | **145** (85 pre-existing + 60 new) |
`reconcile-mcp.py` | exit 0 |
`server.js` | unchanged (FR-039) |
Baselines | `evidence/` + reproducible probe script |

Measurements come from a **GPU-less host** — 700–760 ms medians under SwiftShader software rasterization, ~1.4 fps. The relative comparison holds (same machine, browser, scene) but nothing about *perceived* performance transfers to real hardware.

**FR-024 is not met**: one console error at both versions, traced to a missing `/favicon.ico`. Cosmetic, pre-existing, not introduced here — recorded rather than waved away.

**A regression I introduced and fixed**, findable only by screenshot: the state affixes made peer labels ~2× wider and they collided — "Nicholas" overlapped "Hermes (as65008)", Carapace clipped to `ace · never seen`. Widened band spacing. No unit test can see this; label collision is a rendered-geometry property of DOM overlays. Residual: the two longest labels still overlap slightly and the peer span now exceeds the band graphic.

## Process notes worth keeping

- `/speckit.analyze` found 0 critical issues; all 7 findings fixed. Two were real: **FR-026/T016 were a no-op** (neither README nor THIRD_PARTY_NOTICES cited a three.js version at all), and **FR-015 had zero task coverage**.
- Spec 048 (Chrome DevTools) had merged as an installable component but was **never enabled** — no package, no profile, no browser binary. Provisioned it to get any runtime evidence at all.
- I bumped before capturing the pre-bump baseline, which T001 existed to prevent. Recovered by temporarily reinstalling 0.170.0 on the same machine and scene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)