### PR TITLE
Add Lantronix Percepxion + SLC out-of-band console management (spec 104)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -850,3 +850,27 @@ CATALYST_CENTER_PASSWORD=
 # TLS verification. Defaults to true. The DevNet sandboxes use self-signed
 # certificates, so a lab needs false — never disable it against production.
 CATALYST_CENTER_VERIFY_SSL=
+
+# ─────────────────────────────────────────────────────────────────────
+# Lantronix Percepxion + SLC — spec 104. External/on-demand, not vendored:
+# both are Lantronix's own actively co-developed repos. See
+# specs/104-percepxion-oob-integration/spec.md and workspace/skills/
+# percepxion-oob/SKILL.md for the full env var reference and install steps.
+# ─────────────────────────────────────────────────────────────────────
+# percepxion-mcp-server: fleet-wide OOB console-server SaaS
+PERCEPXION_USERNAME=
+PERCEPXION_PASSWORD=
+# Default: https://api.percepxion.ai/api. Use api.gopercepxion.ai only for the
+# Lantronix internal sandbox — the wrong domain causes silent auth failures.
+PERCEPXION_API_URL=
+
+# slc-mcp-server: direct, synchronous single-device OOB console-server access.
+# {KEY} is the device identifier, uppercased, non-alphanumeric replaced with
+# `_` (e.g. device_id "slc9000-dc-a" -> SLC_SLC9000_DC_A_IP). SLC_DEFAULT_IP/
+# USERNAME/PASSWORD below apply when device_id isn't in the per-device set.
+SLC_DEFAULT_IP=
+SLC_USERNAME=
+SLC_PASSWORD=
+# SLC_{KEY}_IP=
+# SLC_{KEY}_USERNAME=
+# SLC_{KEY}_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # NetClaw
 
-A CCIE-level AI network engineering coworker. Built on [OpenClaw](https://github.com/openclaw/openclaw) with Anthropic Claude, 221 skills, and 163 MCP integrations for complete network automation with ITSM gating, source-of-truth reconciliation, immutable audit trails, gNMI streaming telemetry, NetFlow/IPFIX flow telemetry, Canvas/A2UI inline network visualizations, packet capture analysis, GitHub config-as-code, GitLab DevOps (issues, merge requests, pipelines, repositories, wikis), Jenkins CI/CD (job monitoring, build triggering, log analysis, SCM tracking), Chrome DevTools browser automation (visualization render QA, controller GUI gap-filling, undocumented API discovery, headless or watchable-headed), Computer Use full-desktop automation (legacy desktop-only tools with no browser or API path, virtual XFCE desktop with VNC/noVNC Watch Mode), Cisco CML lab simulation, ContainerLab containerized network labs, Cisco NSO orchestration, Cisco SD-WAN vManage monitoring, Grafana observability (dashboards, Prometheus, Loki, alerting, incidents), Prometheus direct PromQL monitoring, Kubeshark Kubernetes traffic analysis, Cisco Meraki Dashboard management, Cisco ThousandEyes network intelligence, AWS and Azure cloud networking, Cisco Secure Firewall policy auditing, Check Point Security (15 MCPs: policy, threat intel, gateway, SASE, malware), Itential network orchestration, Juniper JunOS device automation, Arista CloudVision Portal monitoring, F5 BIG-IP pyATS iControl REST coverage, Infoblox DDI, Palo Alto Panorama, FortiManager, Batfish offline configuration analysis, UML diagram generation, EVPN/VXLAN fabric workflows, live BGP/OSPF control-plane participation, nmap network scanning, gtrace path analysis and IP enrichment, Slack-native operations, Cisco WebEx-native operations, Microsoft 365 integration, Twilio voice/SMS, Twitter/X integration, Claroty OT/IoT asset management, Forward Networks digital twin, Ollama local LLM routing, an offline agentic RAG document knowledge base (cited answers from user-uploaded vendor guides and standards), layered Memory MCP, and MemPalace persistent AI memory.
+A CCIE-level AI network engineering coworker. Built on [OpenClaw](https://github.com/openclaw/openclaw) with Anthropic Claude, 222 skills, and 165 MCP integrations for complete network automation with ITSM gating, source-of-truth reconciliation, immutable audit trails, gNMI streaming telemetry, NetFlow/IPFIX flow telemetry, Canvas/A2UI inline network visualizations, packet capture analysis, GitHub config-as-code, GitLab DevOps (issues, merge requests, pipelines, repositories, wikis), Jenkins CI/CD (job monitoring, build triggering, log analysis, SCM tracking), Chrome DevTools browser automation (visualization render QA, controller GUI gap-filling, undocumented API discovery, headless or watchable-headed), Computer Use full-desktop automation (legacy desktop-only tools with no browser or API path, virtual XFCE desktop with VNC/noVNC Watch Mode), Cisco CML lab simulation, ContainerLab containerized network labs, Cisco NSO orchestration, Cisco SD-WAN vManage monitoring, Grafana observability (dashboards, Prometheus, Loki, alerting, incidents), Prometheus direct PromQL monitoring, Kubeshark Kubernetes traffic analysis, Cisco Meraki Dashboard management, Cisco ThousandEyes network intelligence, AWS and Azure cloud networking, Cisco Secure Firewall policy auditing, Check Point Security (15 MCPs: policy, threat intel, gateway, SASE, malware), Itential network orchestration, Juniper JunOS device automation, Arista CloudVision Portal monitoring, F5 BIG-IP pyATS iControl REST coverage, Infoblox DDI, Palo Alto Panorama, FortiManager, Batfish offline configuration analysis, UML diagram generation, EVPN/VXLAN fabric workflows, live BGP/OSPF control-plane participation, nmap network scanning, gtrace path analysis and IP enrichment, Slack-native operations, Cisco WebEx-native operations, Microsoft 365 integration, Twilio voice/SMS, Twitter/X integration, Claroty OT/IoT asset management, Forward Networks digital twin, Ollama local LLM routing, an offline agentic RAG document knowledge base (cited answers from user-uploaded vendor guides and standards), layered Memory MCP, MemPalace persistent AI memory, and Lantronix Percepxion/SLC out-of-band console-server management (fleet-wide and direct single-device).
 
 ## Resources
 
@@ -239,7 +239,7 @@ claw
   <img src="ui/netclaw-visual/logos/netclawvisualhud.png" alt="NetClaw Visual HUD — 3D Network Operations Dashboard" width="800">
 </p>
 
-NetClaw includes a Three.js 3D operations dashboard that computes its integration and skill inventory live from the codebase (currently 163 MCP integrations and 221 skills) each time it's opened, alongside your device fleet and live BGP peering topology — so the dashboard never drifts out of sync with what's actually installed. Chat with NetClaw directly from the browser, watch integrations light up as tools execute, and inspect every node in the graph. The Canvas/A2UI visualization skill renders inline topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards directly in the chat interface.
+NetClaw includes a Three.js 3D operations dashboard that computes its integration and skill inventory live from the codebase (currently 165 MCP integrations and 222 skills) each time it's opened, alongside your device fleet and live BGP peering topology — so the dashboard never drifts out of sync with what's actually installed. Chat with NetClaw directly from the browser, watch integrations light up as tools execute, and inspect every node in the graph. The Canvas/A2UI visualization skill renders inline topology maps, health dashboards, alert cards, change timelines, config diffs, path traces, and health scorecards directly in the chat interface.
 
 ```bash
 cd ui/netclaw-visual
@@ -518,7 +518,7 @@ NetClaw ships with the full set of OpenClaw workspace markdown files. These are 
 
 ---
 
-## MCP Servers (163)
+## MCP Servers (165)
 
 > Adding one? Follow **[docs/ADDING-AN-MCP.md](docs/ADDING-AN-MCP.md)** and run
 > `python3 scripts/reconcile-mcp.py` before pushing — CI enforces it.
@@ -636,6 +636,8 @@ NetClaw ships with the full set of OpenClaw workspace markdown files. These are 
 | 124 | Zeek + Suricata NSM | NetClaw-authored (`mcp-servers/nsm-mcp`) | stdio (Python) | **Offline PCAP network-security monitoring, read-only** — Zeek 8.2.1 session/protocol metadata and Suricata 8.0.6 signature alerting, both from digest-pinned containers. 6 tools / 934 tokens. Every response carries detection posture: Suricata reporting 0 alerts with 0 signatures loaded is reported as an inert detector, never as clean traffic |
 | 125 | DuckDB Analysis | NetClaw-authored (`mcp-servers/analysis-mcp`) | stdio (Python) | **Read-only SQL over exported network data** — Zeek logs, Suricata `eve.json`, generated reports. 3 tools. Sandboxed by DuckDB itself: datasets are materialised, then `enable_external_access=false` + `lock_configuration=true` close every filesystem and network path irreversibly, so the memory, RAG, federation and GAIT stores are unreachable by construction rather than by pattern matching |
 | 126 | Redfish BMC | NetClaw-authored (`mcp-servers/redfish-mcp`) | stdio (Python) | **Out-of-band hardware visibility, read-only** — power state, component health, thermal and power, BMC firmware, SEL logs across iDRAC/iLO/XClarity/Supermicro. 6 tools / 728 tokens. Answers "is the box dead or is it the network": every response carries a verdict stating what the reading establishes, and an unreachable BMC can never be reported as a downed host. No power control — `#ComputerSystem.Reset` is deliberately unimplemented |
+| 127 | Lantronix Percepxion | [Lantronix/percepxion-mcp-server](https://github.com/Lantronix/percepxion-mcp-server) | stdio (Python, dedicated venv) | **Fleet-wide OOB console-server management, external/on-demand** — device inventory, firmware compliance/rollout, config mgmt, Smart Groups, security audit, async CLI dispatch with output retrieval across the Percepxion SaaS platform (37 tools). Actively co-developed by Lantronix, not vendored — see [spec 104](specs/104-percepxion-oob-integration/spec.md) |
+| 128 | Lantronix SLC direct | [Lantronix/slc-mcp-server](https://github.com/Lantronix/slc-mcp-server) | stdio (Python, dedicated venv) | **Direct, synchronous single-device OOB console-server access, external/on-demand** — port status, session management, synchronous CLI output, cellular status against individual SLC9000/SLC8000 console servers (37 tools). Same repo family and venv reasoning as Percepxion above — see [spec 104](specs/104-percepxion-oob-integration/spec.md) |
 ### Additional Server Notes
 
 All MCP servers communicate via stdio (JSON-RPC 2.0) through `scripts/mcp-call.py`, except where noted below (HTTP/remote endpoints).
@@ -672,7 +674,7 @@ All MCP servers communicate via stdio (JSON-RPC 2.0) through `scripts/mcp-call.p
 
 ---
 
-## Skills (221)
+## Skills (222)
 
 ### pyATS Device Skills (9)
 
@@ -934,6 +936,12 @@ All MCP servers communicate via stdio (JSON-RPC 2.0) through `scripts/mcp-call.p
 | Skill | What It Does |
 |-------|-------------|
 | **suzieq-observability** | SuzieQ network observability (5 read-only tools): query current and historical network state from 20+ tables (`suzieq_show`), get aggregated statistics and summary views (`suzieq_summarize`), run validation assertions for BGP/OSPF/interface/EVPN health (`suzieq_assert`), discover distinct values and distributions for any column (`suzieq_unique`), trace hop-by-hop forwarding paths between endpoints (`suzieq_path`). Supports time-travel queries via start_time/end_time for historical analysis. Wraps SuzieQ REST API via async httpx client with stdio transport. GAIT audit trail. |
+
+### Lantronix OOB Skills (1)
+
+| Skill | What It Does |
+|-------|-------------|
+| **percepxion-oob** | Out-of-band console-server management via two external Lantronix MCP servers: fleet-wide operations through Percepxion SaaS (device inventory, firmware compliance/rollout, config mgmt, Smart Groups, security audit, async CLI dispatch with output retrieval) and direct, synchronous single-device access via slc-mcp-server (port status, session management, sync CLI output, cellular status). Disambiguates "OOB device" (the Lantronix console server) from "managed device" (the router/switch/firewall cabled to its serial port) before routing any tool call — the two device-identity spaces are not interchangeable. Read-only CLI policy default on both servers, `PERCEPXION_CLI_WRITE_ENABLED`/write-mode opt-in explicit. See [spec 104](specs/104-percepxion-oob-integration/spec.md). |
 
 ### Cisco Meraki Skills (5)
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -12,7 +12,7 @@ Every time you learn something about how I work or what I need, update the relev
 
 ## Your Skills
 
-You interact with the network through **221 skills** backed by 163 MCP servers:
+You interact with the network through **222 skills** backed by 165 MCP servers:
 
 ### Device Automation (9)
 pyats-network, pyats-health-check, pyats-routing, pyats-security, pyats-topology, pyats-config-mgmt, pyats-troubleshoot, pyats-dynamic-test, pyats-parallel-ops
@@ -639,6 +639,18 @@ Configure in `~/.openclaw/voice/alert_triggers.json` to receive outbound calls f
 ### Auvik Network Monitoring Skills (4)
 auvik-inventory, auvik-network-alerts, auvik-lifecycle, auvik-performance
 
+### Lantronix OOB Skills (1)
+percepxion-oob
+
+Out-of-band console-server management — the path to a device when its primary network path is down —
+through two external Lantronix MCP servers: Percepxion (fleet-wide SaaS, device inventory, firmware
+compliance/rollout, config management, Smart Groups, security audit, async CLI dispatch with output
+retrieval) and slc-mcp-server (direct, synchronous single-device access, port status, session
+management, sync CLI output, cellular status). Always disambiguate "OOB device" (the Lantronix console
+server) from "managed device" (the router/switch/firewall cabled to its serial port) before routing any
+tool call — the two device-identity spaces are not interchangeable and confusing them sends a command to
+the wrong hardware. Read-only CLI policy default on both servers.
+
 ---
 
 ## How You Work
@@ -702,7 +714,7 @@ The knowledge base is not memory: RAG holds user-supplied documents (`~/.opencla
 
 For **detailed skill procedures**, read `SOUL-SKILLS.md`:
 - Use when executing any skill that needs step-by-step guidance
-- Contains operational workflows, commands, and best practices for all 221 skills
+- Contains operational workflows, commands, and best practices for all 222 skills
 - Load with: `read("~/.openclaw/workspace/SOUL-SKILLS.md")`
 
 For **technical knowledge**, read `SOUL-EXPERTISE.md`:

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -718,3 +718,44 @@ NetClaw MCP is stdio), and **a container** needed only to isolate the first. Dep
 
 `pyats`/`multivendor-cli` read the device (and win on disagreement) · `netbox`/`nautobot` hold intent, this
 reports discovery · `devnet-catalyst-search` reads docs, this queries an appliance.
+
+## Lantronix Percepxion + SLC, out-of-band console management (`percepxion-mcp-server`, `slc-mcp-server`)
+
+**Spec 104.** Two external, actively co-developed Lantronix repos, not vendored, not registered in
+`config/openclaw.json`, external/on-demand install (dedicated venv per server, see
+`component_install_percepxion`/`component_install_slc` in `scripts/lib/install-steps.sh`). 37 tools each.
+Full install steps, environment variables, and workflows in `workspace/skills/percepxion-oob/SKILL.md`.
+
+| Server | Repository | Answers |
+|---|---|---|
+| `percepxion-mcp-server` | [Lantronix/percepxion-mcp-server](https://github.com/Lantronix/percepxion-mcp-server) | Fleet-wide, async — firmware compliance across many devices, bulk config push, security audit, CLI dispatch through the cloud (job group create, poll, then `get_cli_command_output` for text) |
+| `slc-mcp-server` | [Lantronix/slc-mcp-server](https://github.com/Lantronix/slc-mcp-server) | One device, sync — direct port status, session management, CLI output with no polling, cellular status |
+
+### Why two servers, not one
+
+They're not redundant — the highest-value content is the routing rule between them. Percepxion has no
+single-device sync path; slc-mcp-server has no fleet concept. A device reachable only through Percepxion's
+cloud path has no direct-network alternative via slc-mcp-server, and vice versa for a device with no cloud
+enrollment. The skill's "Key Terms" and "CLI Command Routing" sections encode this as tool-routing rules.
+
+### Behaviour worth knowing
+
+- **`get_job_group` never returns CLI command output text** — only job status and metadata. A live root-cause
+  finding (pre-v1.1.0) traced actual output retrieval to a second, undocumented REST call
+  (`POST /v1/telemetry/result/search`), absent from Percepxion's own OpenAPI spec. Shipped as
+  `get_cli_command_output` in `percepxion-mcp-server` v1.1.0.
+- **Percepxion's `organization_id` requirement is role-dependent.** Required for Project Admin sessions on
+  job/telemetry/content/Smart-Group/audit calls; optional (auto-scoped) for Tenant Admin/Tenant User.
+  Omitting it as a Project Admin previously surfaced as an opaque `400 ACCESS_DENIED: "Invalid access to
+  tenant."`; v1.1.0+ raises a clear error naming the missing parameter instead.
+- **"OOB device" and "managed device" are not the same identity space.** The OOB device is the Lantronix
+  console server; the managed device is the router/switch/firewall cabled to its serial port. Confusing the
+  two sends a command to the wrong hardware, not a soft error.
+- Both servers pin `fastmcp>=3.1.0,<4.0`, the same conflict shape as `zabbix-mcp` (five NetClaw servers pin
+  `fastmcp<3`), hence the dedicated venv rather than the shared installer interpreter.
+
+### Boundaries
+
+`redfish-mcp` reads BMC/hardware health on a server chassis, this reads OOB console-server/managed-device
+state — disjoint hardware classes · neither `pyats` nor `multivendor-cli` reaches a device through a serial
+console port, this closes that gap when the primary network path is down.

--- a/scripts/lib/catalog.sh
+++ b/scripts/lib/catalog.sh
@@ -15,6 +15,9 @@ CATALOG=(
     "radkit|Device Automation|Cisco RADKit|Cloud-relayed remote CLI, SNMP, inventory (5 tools)"
     "multivendor-cli|Device Automation|Multivendor CLI Driver|Nornir/NAPALM/Netmiko — ~90 platform families Cisco/Juniper servers cannot reach (read-only)"
 
+    "percepxion|Out-of-Band|Lantronix Percepxion|Fleet-wide OOB console-server SaaS — device inventory, firmware compliance/rollout, config mgmt, Smart Groups, security audit, async CLI dispatch (37 tools, external/on-demand)"
+    "slc|Out-of-Band|Lantronix SLC direct|Direct, synchronous single-device OOB console-server access — port status, session mgmt, sync CLI output, cellular status (37 tools, external/on-demand)"
+
     "netbox|Source of Truth|NetBox|DCIM/IPAM source of truth (read-write)"
     "nautobot|Source of Truth|Nautobot|IPAM — IPs, prefixes, VRF/tenant/site (5 tools)"
     "nautobot-golden-config|Source of Truth|Nautobot Golden Config|Golden-config compliance job runner for Nautobot"
@@ -152,7 +155,7 @@ PROFILE_CISCO="pyats gait netbox servicenow aci ise catc meraki sdwan cml fmc \
 radkit te-community te-official nvd-cve cisco-psirt subnet-calc drawio-rfc uml packet-buddy"
 
 PROFILE_MULTIVENDOR="pyats junos anta arista-cvp aruba-cx f5 fortinet multivendor-cli netbox nautobot gait servicenow \
-fwrule subnet-calc drawio-rfc uml packet-buddy"
+fwrule subnet-calc drawio-rfc uml packet-buddy percepxion slc"
 
 PROFILE_CLOUD="aws azure gcp cloudflare terraform vault github gait drawio-rfc uml subnet-calc"
 

--- a/scripts/lib/install-steps.sh
+++ b/scripts/lib/install-steps.sh
@@ -4121,3 +4121,103 @@ log_info "Budget note: cost = probe count. limit:20 spends 20 of 500 per hour."
 
 echo ""
 }
+
+# ── Step 53: Lantronix Percepxion MCP Server (OOB fleet management) ─
+component_install_percepxion() {
+log_step "Installing Lantronix Percepxion MCP Server..."
+echo "  Source: https://github.com/Lantronix/percepxion-mcp-server"
+echo "  Fleet-wide OOB console-server SaaS — device inventory, firmware compliance/rollout,"
+echo "  config mgmt, Smart Groups, security audit, async CLI dispatch (37 tools)"
+echo "  Actively co-developed by Lantronix, not a frozen third-party target — see"
+echo "  specs/104-percepxion-oob-integration/spec.md for why this is external, not vendored."
+
+PERCEPXION_MCP_DIR="$MCP_DIR/percepxion-mcp-server"
+clone_or_pull "$PERCEPXION_MCP_DIR" "https://github.com/Lantronix/percepxion-mcp-server.git"
+
+if [ -d "$PERCEPXION_MCP_DIR" ]; then
+    # DEDICATED VIRTUALENV — NOT OPTIONAL, DO NOT "SIMPLIFY" THIS AWAY.
+    # This server pins fastmcp>=3.1.0,<4.0. Five NetClaw servers pin fastmcp<3:
+    # netbox-mcp-server, CiscoFMC-MCP-server-community, Wikipedia_MCP, rag-mcp,
+    # ISE_MCP. A shared install breaks all five — the same conflict shape as
+    # component_install_zabbix() (spec 076's cryptography incident), which is
+    # why this follows Zabbix's dedicated-venv pattern instead of pyATS/JunOS's
+    # shared-interpreter pattern (neither of those pins fastmcp at all).
+    echo "  Creating a dedicated virtualenv (fastmcp 3.x conflicts with five other servers)"
+
+    if command -v netclaw_venv_create >/dev/null 2>&1; then
+        netclaw_venv_create "$PERCEPXION_MCP_DIR/.venv" || log_warn "Percepxion MCP venv creation failed"
+    elif command -v uv >/dev/null 2>&1; then
+        uv venv "$PERCEPXION_MCP_DIR/.venv" >/dev/null 2>&1 || log_warn "Percepxion MCP venv creation failed (uv)"
+    else
+        log_warn "Neither netclaw_venv_create nor uv available — cannot build the Percepxion venv."
+        log_warn "Do NOT fall back to 'python3 -m venv': ensurepip is unavailable on some hosts,"
+        log_warn "and installing into the system interpreter would break five other servers."
+    fi
+
+    if [ -x "$PERCEPXION_MCP_DIR/.venv/bin/python" ]; then
+        # Install into the VENV interpreter, named explicitly. Deliberately NOT
+        # netclaw_pip_install: that targets the system interpreter, which is the
+        # exact thing this venv exists to protect.
+        ( cd "$PERCEPXION_MCP_DIR" && \
+          uv pip install -q --python "$PERCEPXION_MCP_DIR/.venv/bin/python" -r requirements.txt ) 2>/dev/null || \
+            log_warn "Percepxion MCP dependency install failed (fastmcp, requests, python-dotenv)"
+        log_info "Percepxion MCP prepared: $PERCEPXION_MCP_DIR (isolated venv)"
+    fi
+else
+    log_warn "Percepxion MCP clone failed"
+fi
+
+# No config/openclaw.json entry — the installed path is user-specific (external/
+# on-demand classification, spec 104). Register manually per workspace/skills/
+# percepxion-oob/SKILL.md's "MCP Server" section, and set PERCEPXION_USERNAME /
+# PERCEPXION_PASSWORD (or a Vault/AWS/CyberArk provider) in .env first.
+log_info "Not auto-registered in openclaw.json — see workspace/skills/percepxion-oob/SKILL.md"
+log_info "  to register (stdio, runs from the venv above) and for required env vars."
+
+echo ""
+}
+
+# ── Step 54: Lantronix SLC MCP Server (direct OOB console access) ─
+component_install_slc() {
+log_step "Installing Lantronix SLC MCP Server..."
+echo "  Source: https://github.com/Lantronix/slc-mcp-server"
+echo "  Direct, synchronous single-device OOB console-server access — port status,"
+echo "  session mgmt, sync CLI output, cellular status (37 tools)"
+echo "  Actively co-developed by Lantronix, not a frozen third-party target — see"
+echo "  specs/104-percepxion-oob-integration/spec.md for why this is external, not vendored."
+
+SLC_MCP_DIR="$MCP_DIR/slc-mcp-server"
+clone_or_pull "$SLC_MCP_DIR" "https://github.com/Lantronix/slc-mcp-server.git"
+
+if [ -d "$SLC_MCP_DIR" ]; then
+    # DEDICATED VIRTUALENV — same fastmcp>=3.1.0,<4.0 conflict as percepxion-mcp-server
+    # above. See that function's comment for the full explanation; identical reasoning.
+    echo "  Creating a dedicated virtualenv (fastmcp 3.x conflicts with five other servers)"
+
+    if command -v netclaw_venv_create >/dev/null 2>&1; then
+        netclaw_venv_create "$SLC_MCP_DIR/.venv" || log_warn "SLC MCP venv creation failed"
+    elif command -v uv >/dev/null 2>&1; then
+        uv venv "$SLC_MCP_DIR/.venv" >/dev/null 2>&1 || log_warn "SLC MCP venv creation failed (uv)"
+    else
+        log_warn "Neither netclaw_venv_create nor uv available — cannot build the SLC venv."
+        log_warn "Do NOT fall back to 'python3 -m venv': ensurepip is unavailable on some hosts,"
+        log_warn "and installing into the system interpreter would break five other servers."
+    fi
+
+    if [ -x "$SLC_MCP_DIR/.venv/bin/python" ]; then
+        ( cd "$SLC_MCP_DIR" && \
+          uv pip install -q --python "$SLC_MCP_DIR/.venv/bin/python" -r requirements.txt ) 2>/dev/null || \
+            log_warn "SLC MCP dependency install failed (fastmcp, requests, hvac, boto3, pyotp)"
+        log_info "SLC MCP prepared: $SLC_MCP_DIR (isolated venv)"
+    fi
+else
+    log_warn "SLC MCP clone failed"
+fi
+
+# No config/openclaw.json entry — same external/on-demand classification as
+# percepxion-mcp-server above (spec 104).
+log_info "Not auto-registered in openclaw.json — see workspace/skills/percepxion-oob/SKILL.md"
+log_info "  to register (stdio, runs from the venv above) and for required env vars (SLC_{KEY}_*)."
+
+echo ""
+}

--- a/scripts/verify-inventory-counts.py
+++ b/scripts/verify-inventory-counts.py
@@ -93,6 +93,12 @@ EXTERNAL_INTEGRATIONS = [
     "Red Hat Docs",
     "fwrule",
     "HumanRail",
+    # Spec 104: Lantronix's own actively co-developed repos, not a frozen
+    # third-party target -- vendoring would go stale on the first upstream
+    # release. git-clone + pip-install into $MCP_DIR, no config/openclaw.json
+    # entry (installed path is user-specific). See specs/104-percepxion-oob-integration/spec.md.
+    "Percepxion (Lantronix OOB fleet management)",
+    "SLC (Lantronix OOB console server, direct)",
     # Vendored under mcp-servers/ but, as of 2026-07-07, undocumented in
     # README.md's MCP Servers table entirely -- see spec 047 User Story 2.
     "IPFIX/NetFlow",

--- a/specs/104-percepxion-oob-integration/plan.md
+++ b/specs/104-percepxion-oob-integration/plan.md
@@ -1,0 +1,139 @@
+# Implementation Plan + Tasks: Lantronix Percepxion OOB integration
+
+**Branch**: `104-percepxion-oob-integration` | **Date**: 2026-08-13 | **Spec**: [spec.md](./spec.md)
+**Roadmap**: new coverage area
+
+> **Note on form.** Plan and tasks are combined in one document, following spec 084's precedent. The
+> skill body already existed as a working draft, iterated against both servers' actual source over
+> several prior sessions (including two live root-cause findings, see spec.md), rather than
+> speculatively authored here. A separate tasks.md would restate that work rather than add to it.
+
+## Summary
+
+Two external MCP servers (`percepxion-mcp-server`, `slc-mcp-server`), one skill
+(`workspace/skills/percepxion-oob/SKILL.md`). Neither server is vendored, built, or modified by
+this change, both already exist as complete, tested, actively-maintained Lantronix repositories.
+This spec's work is integration: classify correctly, register per `docs/ADDING-AN-MCP.md`, add
+installer coverage with the dependency isolation both servers require, and reconcile every
+documentation surface.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ for both servers (FastMCP 3.x, stdio transport).
+
+**Dependencies**: `percepxion-mcp-server`: `fastmcp>=3.1.0,<4.0`, `requests>=2.32.0,<3.0`,
+`python-dotenv>=1.2.0,<2.0`. `slc-mcp-server`: the same three plus `hvac>=2.4.0,<3`,
+`boto3>=1.43.10,<2`, `pyotp>=2.9.0,<3`. All upper-bounded; verified directly against each repo's
+current `pyproject.toml` (2026-08-12).
+
+**Storage**: none in NetClaw. Each server holds its own session token in memory for the process
+lifetime; credentials come from `PERCEPXION_USERNAME`/`PERCEPXION_PASSWORD` (or Vault/AWS/CyberArk)
+and `SLC_{KEY}_*` env vars respectively.
+
+**Testing**: both servers carry their own test suites (93 tests, `percepxion-mcp-server`; 127
+tests, `slc-mcp-server`), run and passing as of 2026-08-12. Nothing in this integration adds
+NetClaw-side test surface, there is no NetClaw code in the call path (Principle XV shape, same as
+spec 084's static-binary reasoning, here because both servers are external processes NetClaw
+never imports).
+
+**Constraints**: dedicated virtualenv per server, not the installer's shared interpreter (both
+pin `fastmcp` 3.x, which conflicts with five vendored servers pinning `fastmcp<3`, see spec 076
+and the Zabbix install function). No `config/openclaw.json` entry (external/on-demand
+classification, see spec.md).
+
+## Constitution Check
+
+| Principle | Status | How |
+|---|---|---|
+| **I. Safety-First** | ✅ | Both servers read-only by default; `percepxion-mcp-server`'s CLI policy defaults `PERCEPXION_CLI_WRITE_ENABLED=false` with a built-in deny list; `slc-mcp-server`'s `cli_policy.py` does the same for `apply_config_commands` |
+| **II. Read-Before-Write** | ✅ | Skill's Golden Rule section: confirm device identity and port state (`get_security_telemetry`/`get_port_telemetry`) before any write or CLI dispatch |
+| **III. ITSM-Gated Changes** | ✅ | Skill requires explicit operator confirmation before `send_direct_cli_command` (write mode), `update_firmware_by_smart_group`, `reboot_device`, `remove_device_from_platform`; W8 (closed-loop remediation) requires an upstream incident ID recorded in every mutating call's `description` field |
+| **IV. Immutable Audit Trail** | ✅ | Both platforms log independently of NetClaw: Percepxion's own audit trail (`investigate_audit_logs`, job group records) and slc-mcp-server's audit logging on device-modifying tools. No NetClaw-side GAIT gap the way spec 084 carries one, both upstream servers already audit at the platform layer |
+| **V. MCP-Native** | ✅ | stdio, both servers |
+| **VI. Multi-Vendor Neutrality** | ✅ n/a | Lantronix-specific by design, this is the OOB/console-server category, comparable to how `redfish-mcp` is BMC-specific |
+| **VII. Skill Modularity** | ✅ | Skill's "Integration with Other NetClaw Skills" section states explicit boundaries against `pagerduty-incidents`, `servicenow-change-workflow`, `netbox-source-of-truth`, `itential-orchestration`, `gait-session-tracking`, `grafana-observability` |
+| **VIII. Verify After Change** | ✅ | W8 Step 8 requires post-action audit-log confirmation; W2 preflight requires port-state verification before any automated sequence |
+| **IX. Security by Default** | ✅ | Read-only CLI policy default on both servers; credentials never logged; `PERCEPXION_CLI_YOLO`/full bypass explicitly opt-in and flagged "use with extreme caution" in the skill |
+| **X. Observability** | ✅ | Skill requires every diagnostic/remediation call to carry a `description` field identifying the actor and reason (W8 governance note) |
+| **XI. Artifact Coherence** | ✅ | This plan's Phase 5 |
+| **XII. Documentation-as-Code** | ✅ | spec.md, this plan, `SKILL.md`, upstream repos' own `README.md`/`CHANGELOG.md` (already current, this session) |
+| **XIII. Credential Safety** | ✅ | Skill states explicitly: never expose `PERCEPXION_USERNAME`/`PASSWORD`, `VAULT_TOKEN`, or session tokens in logs, chat output, or error messages |
+| **XIV. External Comms** | ✅ n/a | No external comms (Slack/email/etc.) initiated by this skill |
+| **XV. Backwards Compatibility** | ✅ | External processes, no NetClaw code imports either server; a Lantronix release cannot break NetClaw's own codebase |
+| **XVI. Spec-Driven** | ✅ | specify → plan/tasks (this document) → implement |
+| **XVII. Blog** | ⏭️ waived | Standing operator decision |
+
+## Complexity Tracking
+
+| Deviation | Why | Alternative rejected because |
+|---|---|---|
+| **Two MCP servers behind one skill** | Percepxion and slc-mcp-server answer genuinely different questions (fleet-wide async vs. single-device sync, see spec.md's routing table) and an operator/agent needs both to cover OOB end-to-end. Splitting into two skills (`percepxion-fleet-ops` + `slc-console-ops`) was considered and rejected: the highest-value content is the *routing rule between them* (Key Terms, CLI Command Routing sections), which would either duplicate across two skills or live awkwardly in just one, orphaning the other. | A single skill with an explicit disambiguation section (matches `zabbix-availability`/`zabbix-metrics-history`'s sibling-skill precedent, but inline rather than cross-file, since the routing decision itself is the content) |
+| **No `mcp-servers/<name>/README.md`** | That artifact is for vendored copies (see spec.md's "External, not vendored" section); `aap-automation` (the closest precedent, also external/on-demand) has none either | Writing one anyway would create a second, driftable copy of documentation that already lives correctly in each upstream repo's own `README.md` |
+
+## Tasks
+
+### Phase 1, Classify and verify (BLOCKING)
+
+- [X] T001 Confirm neither server is vendorable-in-good-conscience-as-frozen: both are actively
+      co-developed by the same author submitting this integration, not a stable third-party
+      target (FR of spec.md's "External, not vendored" section)
+- [X] T002 Verify both `pyproject.toml` dependency pins directly against the current repos, no
+      unbounded pin on an imported submodule (FR-007)
+- [X] T003 Confirm both servers' own test suites pass on current `main` (93 tests
+      `percepxion-mcp-server`, 127 tests `slc-mcp-server`), recorded rather than assumed
+
+### Phase 2, Skill (P1, this is the integration's substance)
+
+- [X] T004 Add `workspace/skills/percepxion-oob/SKILL.md`, `name:` field matching the directory
+      exactly (every real skill in the repo does this, our source draft's frontmatter did not)
+- [X] T005 Add `user-invocable: true` to frontmatter, matching the majority convention (111 of
+      ~230 sampled skills)
+- [X] T006 Verify the CLI-output-retrieval correction (FR-002): `get_job_group` returns status and
+      metadata only, `get_cli_command_output` (percepxion-mcp-server v1.1.0+) returns the actual
+      text, corrected at all 8 sites in the skill body where the prior draft conflated them
+- [X] T007 Verify the role-based `organization_id` requirement (FR-005) is documented at the point
+      an agent would first hit it (multi-tenant discovery) and in the Platform Security
+      Configuration section as the authoritative statement
+
+### Phase 3, Installer coverage (P1)
+
+- [X] T008 Add `percepxion` and `slc` entries to `EXTERNAL_INTEGRATIONS` in
+      `scripts/verify-inventory-counts.py` with a reason comment
+- [X] T009 Add `scripts/lib/catalog.sh` entries for both, `Category` = a new "Out-of-Band" grouping
+- [X] T010 Add `component_install_percepxion()` and `component_install_slc()` to
+      `scripts/lib/install-steps.sh`: `clone_or_pull` into `$MCP_DIR`, then a **dedicated venv**
+      per FR-006 (`netclaw_venv_create` with `uv venv` fallback, install with `--python` targeting
+      the venv explicitly, never `netclaw_pip_install`, matching the Zabbix precedent's exact
+      justification since both packages pin `fastmcp` 3.x)
+- [X] T011 Add both to `PROFILE_MULTIVENDOR` (per the R1/spec-076-adjacent lesson that a component
+      absent from every named profile is easy to miss, see `docs/ADDING-AN-MCP.md`'s "Two
+      artifacts that are easy to miss")
+
+### Phase 4, Documentation surfaces + counts (P1)
+
+- [X] T012 `README.md`: description in the integrations prose paragraph, and the count line
+      (163 → 165 MCP integrations, 221 → 222 skills)
+- [X] T013 `SOUL.md`: capability summary describing what OOB coverage now means for the agent, not
+      only the count (per `docs/ADDING-AN-MCP.md`'s "Two artifacts that are easy to miss" #3)
+- [X] T014 `.env.example`: `PERCEPXION_USERNAME`, `PERCEPXION_PASSWORD`, `PERCEPXION_API_URL`, and
+      `SLC_{KEY}_IP`/`SLC_{KEY}_USERNAME`/`SLC_{KEY}_PASSWORD` (names and a comment only, no
+      values)
+- [X] T015 `TOOLS.md`: infrastructure reference entry for both servers
+- [X] T016 `python3 scripts/verify-inventory-counts.py` exits with the documentation check PASS
+      and the exact predicted delta (spec.md Verification)
+
+### Phase 5, Reconcile and verify
+
+- [X] T017 `scripts/reconcile-mcp.py --surface catalog` clean
+- [X] T018 `scripts/reconcile-mcp.py --surface portability` clean (no machine-specific paths, this
+      integration introduces none since it writes no `config/openclaw.json` entry)
+- [X] T019 `scripts/reconcile-mcp.py --surface dependencies` clean (FR-007, already verified in
+      Phase 1, re-checked here against the gate's own static scan)
+- [X] T020 `scripts/reconcile-mcp.py` (all surfaces) exits 0
+- [X] T021 `scripts/verify-spec-artifacts.py` passes against this spec directory
+
+## Dependencies
+
+Phase 1 blocks Phase 2 (no point documenting tools against an unverified server state). Phase 2
+blocks Phase 3 (installer coverage references the skill's own install instructions). Phases 3 and
+4 can run in parallel. Phase 5 depends on all prior phases landing.

--- a/specs/104-percepxion-oob-integration/research.md
+++ b/specs/104-percepxion-oob-integration/research.md
@@ -1,0 +1,81 @@
+# Phase 0 Research, Lantronix Percepxion OOB integration
+
+## R1, Vendor, or external/on-demand?
+
+Checked `docs/ADDING-AN-MCP.md`'s classification table against both repos. "Vendored,
+pre-registered" fits a stable third-party target adopted and pinned (`zabbix-mcp`: frozen source
+under `mcp-servers/zabbix-mcp/vendor/`, pinned to commit `0722f48`, "adopted unmodified"). Neither
+Percepxion nor SLC fits that shape: both are Lantronix's own repos, under active co-development
+by the author submitting this integration. Confirmed directly, both took real commits in the
+week this spec was written (a permission-model bug fix, a new CLI-output-retrieval endpoint, a
+dependency lockfile refresh, on `percepxion-mcp-server`; a matching dependency refresh and a
+documentation correction on `slc-mcp-server`). Vendoring a frozen copy would be stale before the
+PR merges.
+
+**Decision: external/on-demand**, same classification as `pyats` and `aap-automation`. Verified
+`aap-automation`'s `SKILL.md` as the closest real precedent, external GitHub repo, `git clone` +
+`uv sync`/`pip install -e .`, no `config/openclaw.json` entry, no `specs/` directory (predates
+the spec-driven requirement, but structurally identical to what this integration needs).
+
+## R2, One skill or two?
+
+Considered splitting into `percepxion-fleet-ops` (Percepxion only) and `slc-console-ops`
+(slc-mcp-server only), mirroring how Auvik's four capability slices
+(`auvik-inventory`/`auvik-lifecycle`/`auvik-network-alerts`/`auvik-performance`) are split per
+capability rather than bundled.
+
+Rejected: Auvik's split works because each slice is a self-contained capability against **one**
+MCP server. Here, the highest-value content is not either server's tool list individually, it's
+the **routing rule between them**, when a question needs Percepxion's fleet-wide async view
+versus slc-mcp-server's single-device synchronous view, and the connection-string computation
+that bridges "I need to reach a managed device attached to this console server" from Percepxion's
+device/port model to slc-mcp-server's direct-SSH model. Splitting the skill would either duplicate
+that routing content in both files or strand it in one, leaving the other skill silent about a
+distinction that determines correctness (a wrong tool choice here sends a live command to the
+wrong device via a serial port, not a soft error).
+
+**Decision: one skill**, explicit disambiguation section up front (Key Terms), matching how
+`zabbix-availability` handles its sibling relationship with `zabbix-metrics-history` in spirit,
+inline here rather than cross-file since the routing decision itself is the content, not a
+side-note.
+
+## R3, The dedicated-venv requirement
+
+Both servers pin `fastmcp>=3.1.0,<4.0`. `scripts/lib/install-steps.sh`'s `component_install_zabbix()`
+documents that five vendored servers pin `fastmcp<3`
+(`netbox-mcp-server`, `CiscoFMC-MCP-server-community`, `Wikipedia_MCP`, `rag-mcp`, `ISE_MCP`) and
+a shared install breaks all five, explicitly citing spec 076's cryptography incident as the same
+failure shape recurring. Zabbix's install function solves it with a dedicated venv
+(`netclaw_venv_create`, `uv venv` fallback, packages installed with `--python` naming the venv
+interpreter explicitly, never `netclaw_pip_install` which targets the shared interpreter this
+exists to protect).
+
+**Decision:** both `component_install_percepxion()` and `component_install_slc()` follow the same
+pattern. Unlike Zabbix, these are external/on-demand (clone into `$MCP_DIR`, not
+`mcp-servers/<name>/`), but the isolation reasoning is identical, the version conflict is about
+`fastmcp` 3.x versus five other servers, not about vendored-versus-external classification.
+
+## R4, Does `pyats`'s shared-install pattern apply instead?
+
+`component_install_pyats()` and `component_install_junos()` (also external/on-demand) install via
+`netclaw_pip_install` into the shared interpreter, no dedicated venv. Checked whether that's the
+right template instead of Zabbix's.
+
+**Rejected as the template.** Neither pyATS nor JunOS pins `fastmcp` at all (pyATS's dependency
+set is `pyats[full] mcp pydantic python-dotenv`, unconstrained on `fastmcp`; JunOS MCP's
+`requirements.txt` has no `fastmcp` entry). They don't carry the conflict Zabbix's comment warns
+about, so their shared-install pattern is safe for them and would not be for Percepxion/SLC,
+which do pin `fastmcp` 3.x. The two external-install patterns already coexisting in
+`install-steps.sh` (shared-interpreter for no-conflict packages, dedicated-venv for
+version-conflicting ones) settled which one applies here by inspection, not by guessing.
+
+## R5, A live root-cause finding folded into the skill, not just this spec
+
+While preparing this integration, live testing against `percepxion-mcp-server` (pre-v1.1.0)
+found that `get_job_group` never returns CLI command output text, only job status and metadata,
+contrary to what the skill's original draft assumed throughout. Traced to the actual mechanism:
+Percepxion's own WebUI console-editor fetches output via a second, undocumented REST call
+(`POST /v1/telemetry/result/search`), absent from both local copies of Percepxion's OpenAPI spec.
+This became `get_cli_command_output`, shipped in `percepxion-mcp-server` v1.1.0 the same week.
+Corrected at all 8 sites in the skill body where the prior draft's "retrieve the output with
+`get_job_group`" instruction appeared, this is spec.md's FR-002.

--- a/specs/104-percepxion-oob-integration/spec.md
+++ b/specs/104-percepxion-oob-integration/spec.md
@@ -1,0 +1,114 @@
+# Spec 104, Lantronix Percepxion OOB integration
+
+**Status**: implemented
+**Branch**: `104-percepxion-oob-integration`
+**Date**: 2026-08-13
+**Roadmap**: new coverage area, out-of-band (OOB) console-server management
+
+## Summary
+
+Adds a `percepxion-oob` skill covering out-of-band (OOB) console-server management via two
+external, actively-maintained Lantronix MCP servers:
+
+- **`percepxion-mcp-server`** (37 tools), fleet-wide operations through the Percepxion SaaS
+  platform: device inventory, firmware compliance and rollout, config management, Smart Groups,
+  security audit, and asynchronous CLI command dispatch with output retrieval.
+- **`slc-mcp-server`** (37 tools), direct, synchronous device-level operations against
+  individual SLC9000/SLC8000 console servers: port status, session management, synchronous CLI
+  output, cellular status, and the Percepxion client lifecycle running on the device itself.
+
+OOB is a real coverage gap NetClaw had no answer for: **the primary network path is exactly what
+console-server access exists to work around.** When a device is unreachable in-band, an OOB path
+through its serial console (often over an independent cellular WAN) is the only way to diagnose
+or recover it without a truck roll. None of NetClaw's 163 existing MCP integrations reach a
+device's console port; this closes that gap.
+
+## Why two servers, one skill
+
+Percepxion and slc-mcp-server are not redundant, they answer different questions and the
+distinction is the skill's spine, the same way spec 094's BMC-vs-host distinction is the spine of
+`redfish-mcp`:
+
+| Question | Answer via | Why not the other |
+|---|---|---|
+| Fleet-wide firmware compliance, bulk config push, security audit across many devices | Percepxion | slc-mcp-server has no fleet concept, it talks to one device at a time |
+| Synchronous CLI output from one device, right now, no polling | slc-mcp-server (`apply_config_commands`) | Percepxion's `send_direct_cli_command` is async, job group create, then a separate `get_cli_command_output` fetch once status reaches `"Completed"` |
+| A device reachable only through Percepxion's cloud path (no direct network route) | Percepxion | slc-mcp-server needs a direct IP/jump-host path to the device |
+
+The skill's own "Key Terms" and "CLI Command Routing" sections (ported from an existing internal
+draft, see Verification) encode this distinction as tool-routing rules, not prose the caller has
+to infer.
+
+## External, not vendored, and why
+
+Both servers are Lantronix's own actively co-developed repositories
+([`percepxion-mcp-server`](https://github.com/Lantronix/percepxion-mcp-server),
+[`slc-mcp-server`](https://github.com/Lantronix/slc-mcp-server)), not a frozen third-party target
+to adopt and pin. Both shipped real fixes in the week this spec was written, a permission-model
+bug, a new CLI-output-retrieval capability, a dependency refresh. Vendoring a frozen copy under
+`mcp-servers/` (spec 083's Zabbix pattern) would go stale on the first upstream release and
+require a manual re-sync on every Lantronix change; that maintenance shape fits an adopted
+third-party tool, not two repos under active co-development by the same author submitting this
+integration.
+
+Classified per `docs/ADDING-AN-MCP.md`'s table as **installed on demand (pip/git)**, the same
+shape as `pyats` and `aap-automation`: `git clone` + `pip install -e .` into
+`$NETCLAW_DIR/mcp-servers/`, recorded in `EXTERNAL_INTEGRATIONS`, no `config/openclaw.json`
+entry (the installed path is user-specific, not a fixed repo-relative path).
+
+## Requirements
+
+- **FR-001** The skill MUST disambiguate "OOB device" (the Lantronix console server) from
+  "managed device" (the router/switch/firewall cabled to its serial port) before routing any
+  tool call, the two device-identity spaces are not interchangeable and confusing them sends a
+  command to the wrong hardware.
+- **FR-002** CLI output retrieval MUST be documented as the two-call pattern it actually is:
+  poll `get_job_group`/`search_job_groups` for status, then `get_cli_command_output` for text.
+  `get_job_group` alone never returns command output, documenting it as sufficient produces an
+  agent that reports empty output as "the command produced nothing."
+- **FR-003** Destructive and write operations (`send_direct_cli_command` in write mode,
+  `update_firmware_by_smart_group`, `reboot_device`, `remove_device_from_platform`) MUST require
+  explicit operator confirmation before invocation, consistent with Constitution Principle III.
+- **FR-004** The skill MUST document that Percepxion enforces its own server-side CLI policy
+  (read-only default, deny-list, `PERCEPXION_CLI_WRITE_ENABLED`) which the calling agent cannot
+  override at runtime, this is server configuration, not a tool parameter.
+- **FR-005** The skill MUST document Percepxion's role-based `organization_id` requirement:
+  required for Project Admin sessions on job/telemetry/content/Smart-Group/audit calls, optional
+  (auto-scoped) for Tenant Admin/Tenant User. Omitting this context produces confusing
+  `ACCESS_DENIED` failures with no indication of the actual cause.
+- **FR-006** Both servers MUST be installed into a dedicated virtualenv, never the installer's
+  shared interpreter. Both pin `fastmcp>=3.1.0,<4.0`; spec 076's cryptography incident and the
+  Zabbix install function's fastmcp-3-vs-five-servers-pinning-fastmcp<3 conflict are the same
+  failure shape this sidesteps.
+- **FR-007** Neither server's `requirements.txt`/`pyproject.toml` may carry an unbounded pin on a
+  package whose submodule is imported (spec 077). Verified directly against both repos' current
+  `pyproject.toml`, see Verification.
+
+## Verification
+
+- Both servers' `pyproject.toml` dependency pins checked directly: `fastmcp>=3.1.0,<4.0`,
+  `requests>=2.32.0,<3.0`, `python-dotenv>=1.2.0,<2.0` (`percepxion-mcp-server`); the same three
+  plus `hvac`, `boto3`, `pyotp`, all upper-bounded (`slc-mcp-server`). No unbounded pin on any
+  package with an imported submodule.
+- `scripts/reconcile-mcp.py` run against this branch (see plan.md Phase 4 for the exact command
+  and result).
+- `python3 scripts/verify-inventory-counts.py` confirms the count delta: 221 → 222 skills,
+  163 → 165 MCP integrations (60 → 62 external, 103 config-registered unchanged, since neither
+  server gets a `config/openclaw.json` entry).
+- The skill body (workflows, tool routing, CLI output correction) was drafted and iterated
+  against both servers' actual source over several sessions of hands-on use, including a live
+  root-cause finding that `get_job_group` never returns CLI output text (only
+  `get_cli_command_output`, added upstream in `percepxion-mcp-server` v1.1.0, does), rather than
+  written from the servers' documentation alone.
+
+## Out of scope
+
+- **Vendoring either server.** See "External, not vendored, and why" above.
+- **A NetClaw-side CLI policy layer.** Both servers already enforce their own (Percepxion
+  server-side env vars; slc-mcp-server's `cli_policy.py`). Duplicating it in the skill would be
+  two sources of truth for the same rule.
+- **iN2N federation artifacts.** No request to expose this to a federated member as of this
+  spec; the five-artifact federation checklist in `docs/ADDING-AN-MCP.md` is not executed here.
+- **A dedicated `mcp-servers/<name>/README.md`.** That artifact is for vendored copies; an
+  external/on-demand integration's install and tool documentation lives in the skill itself and
+  in each upstream repo's own README, consistent with `aap-automation`'s precedent.

--- a/workspace/skills/percepxion-oob/SKILL.md
+++ b/workspace/skills/percepxion-oob/SKILL.md
@@ -1,0 +1,1101 @@
+---
+name: percepxion-oob
+description: "Manage Lantronix out-of-band (OOB) infrastructure via Percepxion central management platform: device inventory, serial port inspection via SLC CLI, firmware compliance, config management, security auditing, and closed-loop incident remediation. Use during outages, maintenance windows, compliance cycles, and AI-assisted automation workflows."
+version: 1.0.0
+license: Apache-2.0
+user-invocable: true
+tags: [lantronix, percepxion, oob, out-of-band, console-server, slc9000, slc8000, emg7500, emg8500, network-ops, serial-console, network-automation, aoob, naf, closed-loop, fleet-management, incident-remediation]
+metadata:
+  { "openclaw": { "requires": { "bins": ["python3", "uv"], "env": ["PERCEPXION_USERNAME", "PERCEPXION_PASSWORD"] } } }
+---
+
+# Percepxion OOB Skill
+
+## What Is Out-of-Band Management?
+
+Out-of-Band (OOB) management is a dedicated secondary path to the console port of every network device in your infrastructure. When a switch, router, firewall, or server becomes unreachable via its production (in-band) network interface, OOB gives you serial console access through an independent control plane, often with a resilient cellular network WAN connection,  so you can, Day-0 provision, diagnose, recover, or remediate even when the production network is completely dark.
+
+OOB turns a midnight outage that would require a truck roll into a routine remote session.
+
+**Lantronix hardware in this stack:**
+
+| Device | Role | Ports | Cellular | Status |
+|--------|------|-------|--------|--------|
+| **SLC9000** | Console server, current gen. Serial or USB console ports and Ethernet switch ports. Dual power, redundant management interfaces, Percepxion-native, OpenAPI 3.1. | 16-48 | Optional 5G | Announced June 1st, 2026 |
+| **SLC8000** | Console server, previous gen. Still widely deployed in enterprise and carrier networks. Full Percepxion support. | 8-48 | - | Shipping until December 31st, 2026 |
+| **EMG series** | Compact console server for small closets or remote edge sites. | 4-8 | Optional 4G | Production |
+
+**Percepxion** is the SaaS-native management platform that aggregates these devices into a single API surface. It handles device ZTP, authentication, session brokering, firmware lifecycle, configuration management, access logging, and multi-tenant operations across thousands of devices. The Percepxion MCP server exposes 37 tools against this API.
+
+---
+
+## Key Terms: OOB Device vs. Managed Device
+
+This skill operates on two distinct device types. Confusing them causes wrong tool calls and unwanted outcomes.
+
+| Term | What it is | Examples | How you reference it |
+|------|-----------|---------|---------------------|
+| **OOB device** (also: console server) | The Lantronix hardware managed by Percepxion. Has serial ports that cable to managed devices. | SLC9000, SLC8000, EMG7500, EMG8500 | By `device_id` in most MCP tool calls |
+| **Managed device** (also: attached device, target device) | The network device whose console port is physically cabled to a serial port on the OOB device. NOT managed by Percepxion directly. | Cisco switch, Juniper router, Palo Alto firewall, OOB-connected server | Via `get_security_telemetry` (full inventory: hostname, model, serial, IP, OS) or `get_port_telemetry` (single port). `list_device_ports` returns port state only, not managed-device identity. |
+
+**Tool routing for port and managed-device queries:**
+
+| Question | Correct tool | Notes |
+|----------|-------------|-------|
+| What ports does this OOB device have? | `list_device_ports` | Returns port names, numbers, and connection state. Does NOT return managed-device hostname, model, serial, or IP. |
+| What managed devices are attached to this OOB device? | `get_security_telemetry` | Source of truth for managed-device inventory. Returns per-port `dp_info` records: hostname, model, serial, IP, OS version, uptime, CPU/memory/flash. Also includes console manager, firmware, network, and audit records. |
+| What is on a specific port (e.g. port 2)? | `get_port_telemetry` | Single-port filtered view. Returns structured managed-device object for that port only. Cheaper than `get_security_telemetry` for targeted single-port questions. |
+| What port is a named managed device on? | `list_device_ports` with device name as `device_id` | Searches port index by label/name. Returns `parent_device_id` and `port_number` for computing SSH connection string. |
+
+**The key distinction for tool calling:**
+
+- All Percepxion MCP tools, `get_device_list`, `get_device_details`, `get_device_config`, `firmware_compliance_report`, `reboot_device`, and `send_direct_cli_command`, operate on the **OOB device**. The `device_id` in every tool call is the OOB device ID from `get_device_list` or `get_device_details`.
+- `send_direct_cli_command` runs commands on the SLC's own management CLI (Linux shell), not on managed devices attached via serial. Valid commands are SLC-native: `show deviceport names`, `show deviceport port N`, `connect direct deviceport N`,`show sysstatus`, `admin version`, `diag ping <ip>`, `diag traceroute <ip>`. Cisco/Juniper/Arista CLI syntax will not work here. Full CLI command reference in Users Guide [cdn.lantronix.com/wp-content/uploads/pdf/900-704-RBD-SLC-UG.pdf](https://cdn.lantronix.com/wp-content/uploads/pdf/900-704-RBD-SLC-UG.pdf) beginning in chapter "15: Command Reference".
+- There is no Percepxion MCP tool that provides an interactive managed-device CLI session over serial. However, the MCP can compute the direct SSH connection string you need, see the "When to ask for clarification" section below. For a fully interactive terminal session rather than a connection string, SSH directly to the SLC (`ssh sysadmin@<slc-ip>`) and use `connect direct deviceport N` from the SLC shell. That is a human-in-the-loop operation outside this MCP server's scope.
+
+**When to ask for clarification:**
+
+If the operator says "I need to run a command on the device," ask:
+- "Do you mean the OOB console server (the SLC itself), or a managed device attached to one of its serial ports?"
+
+If they mean the SLC, proceed with `send_direct_cli_command` using SLC CLI syntax.
+
+If they mean an attached managed device, do not stop at "SSH to the SLC directly." Instead, proactively look up the connection details they need:
+
+1. `list_device_ports(device_id=<managed_device_name_or_port_label>)`, search port records by the managed device name or partial port label. The `device_id` parameter functions as a search string against the Percepxion port index, the same search the WebUI Device Ports view uses. Results include `parent_device_id` (which SLC hosts this port) and `port_number`.
+2. From the matching port record, read `parent_device_id` and `port_number`. If the port status shows disconnected or no carrier detect, flag it before returning the connection string.
+3. `get_device_details(device_id=parent_device_id)`, retrieve the SLC's management IP address.
+4. Calculate the SSH direct-connect port: **3000 + port number** (port 2 → TCP 3002, port 16 → TCP 3016)
+5. Return the ready-to-use connection string:
+   ```
+   ssh -p <3000+N> <username>@<slc-management-ip>
+   ```
+
+The username is typically the operator's Percepxion/SLC credential. If unknown, surface the SLC IP and port and note they will be prompted for credentials on connect.
+
+This saves the operator from logging into Percepxion to find port assignments manually.
+
+This disambiguation drives every tool choice in this skill.
+
+---
+
+## When to Use This Skill
+
+Proactive use is as important as reactive use. The Percepxion MCP is not a break-glass tool, it's the management plane for the OOB infrastructure at all times. Use it before incidents happen, not only during them.
+
+| Trigger | OOB Role | Workflows / Tools |
+|---------|----------|-------------------|
+| Production network outage, device unreachable | Diagnose via SLC CLI, assess serial port state, capture evidence | W2 preflight + W3 diagnostics + W8 closed-loop |
+| Maintenance window, fleet firmware update | Compliance scan + bulk upgrade via Smart Groups | W4: `firmware_compliance_report`, `update_firmware_by_smart_group` |
+| Proactive compliance run | Config drift detection, template enforcement | W6: `get_device_config`, `clone_device_config`, `list_templates` |
+| PagerDuty / Itential event fires | Closed-loop automated remediation with audit trail | W8 full flow |
+| Security audit / access review | Who accessed what, when, from where | W5: `investigate_audit_logs`, `get_security_telemetry` |
+| New site onboarding | Bulk device import and config clone | W7: `import_and_assign_devices`, `clone_device_config` |
+| AI automation pre/post validation | Verify OOB path is healthy before and after primary-network changes | W2: `get_device_details`, `list_device_ports` or `send_direct_cli_command` |
+
+**If a user asks about fleet health, firmware currency, config drift, or access history, pull the relevant Percepxion data immediately.** Do not wait for an incident to justify the query.
+
+---
+
+## Golden Rule
+
+**Never send CLI commands to a managed device or push firmware to an OOB device without explicit operator confirmation.** `send_direct_cli_command` reaches live network infrastructure through a serial port, a wrong port number sends your command to the wrong managed device entirely. `update_firmware_by_smart_group` pushes firmware to OOB devices and is irreversible while in progress. All mutating actions require human confirmation before invocation.
+
+**Always call `login_with_env` first.** Every session requires authentication. No other tool will succeed without an active session. This is not optional.
+
+**Read before you write.** Call `get_device_list` or `get_device_details` to confirm the OOB device. Call `get_security_telemetry` (or `get_port_telemetry` for a single port) to confirm which port reaches the target managed device and verify it shows a connected managed device. `list_device_ports` returns port state only, it does not surface managed-device hostname, model, or serial. Never skip these steps.
+
+---
+
+## MCP Server
+
+This skill uses the **percepxion-mcp-server**, a Python/FastMCP server that wraps the Percepxion REST API.
+
+- **Repository:** https://github.com/Lantronix/percepxion-mcp-server
+- **Transport:** stdio
+- **Python version:** 3.11+
+
+**Install:**
+```bash
+git clone https://github.com/Lantronix/percepxion-mcp-server.git
+cd percepxion-mcp-server
+uv venv && uv pip install -r requirements.txt
+```
+
+**Register in openclaw.json (stdio transport):**
+```json
+{
+  "percepxion": {
+    "type": "stdio",
+    "command": "uv",
+    "args": ["run", "--directory", "/path/to/percepxion-mcp-server", "python", "percepxion_mcp.py"],
+    "env": {
+      "PERCEPXION_USERNAME": "${PERCEPXION_USERNAME}",
+      "PERCEPXION_PASSWORD": "${PERCEPXION_PASSWORD}",
+      "PERCEPXION_API_URL": "${PERCEPXION_API_URL}"
+    }
+  }
+}
+```
+
+**Version requirement:** this skill was written based on percepxion-mcp-server v1.1.0. If not at this version or later, update the server from the repository above, in particular `get_cli_command_output` (retrieve actual CLI output text) and role-aware `organization_id` enforcement (see Platform Security Configuration) were both added in v1.1.0 and this skill assumes they're present.
+
+---
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `PERCEPXION_USERNAME` | Yes | | Percepxion login username |
+| `PERCEPXION_PASSWORD` | Yes | | Percepxion login password |
+| `PERCEPXION_API_URL` | No | `https://api.percepxion.ai/api` | API base URL. Use `https://api.gopercepxion.ai/api` for the Lantronix internal sandbox. |
+| `PERCEPXION_CREDENTIAL_PROVIDER` | No | `env` | Credential backend: `env` (default), `vault`, `aws`, or `cyberark`. See Platform Security Configuration. |
+| `PERCEPXION_DEFAULT_ORGANIZATION_ID` | No | | Default organization ID used when callers omit `organization_id`. Useful for single-organization deployments. Primary name; `PERCEPXION_DEFAULT_TENANT_ID` still works as a deprecated alias. |
+| `PERCEPXION_REQUEST_TIMEOUT` | No | `45` | HTTP timeout in seconds. Raise to `120` or higher for large log downloads or slow links. |
+| `PERCEPXION_FIRMWARE_DIR` | No | | If set, firmware uploads are restricted to files in this directory. Recommended for shared or automated deployments. |
+
+> **Important:** Use `https://api.percepxion.ai/api`, not `api.gopercepxion.ai` which is a sandbox environment unless explicitly instructed by the user. The wrong domain causes silent auth failures.
+
+---
+
+## SLC MCP Server
+
+Workflow 3 (SLC Console Diagnostics) and any direct, synchronous single-device access use the **slc-mcp-server**, a separate Python/FastMCP server that talks to an SLC9000/SLC8000 console server directly, not through Percepxion's cloud.
+
+- **Repository:** https://github.com/Lantronix/slc-mcp-server
+- **Transport:** stdio
+- **Python version:** 3.11+
+
+**Install:**
+```bash
+git clone https://github.com/Lantronix/slc-mcp-server.git
+cd slc-mcp-server
+uv venv && uv pip install -r requirements.txt
+```
+
+**Register in openclaw.json (stdio transport):**
+```json
+{
+  "slc": {
+    "type": "stdio",
+    "command": "uv",
+    "args": ["run", "--directory", "/path/to/slc-mcp-server", "python", "slc_mcp.py"],
+    "env": {
+      "SLC_DEFAULT_IP": "${SLC_DEFAULT_IP}",
+      "SLC_USERNAME": "${SLC_USERNAME}",
+      "SLC_PASSWORD": "${SLC_PASSWORD}"
+    }
+  }
+}
+```
+
+### SLC Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `SLC_DEFAULT_IP` | No | | Default device IP, used when `device_id` isn't in the per-device registry |
+| `SLC_USERNAME` | No | `sysadmin` | Default username |
+| `SLC_PASSWORD` | No | | Default password |
+| `SLC_TOTP_SECRET` | No | | Default TOTP secret for 2FA-enabled devices |
+| `SLC_{KEY}_IP` / `SLC_{KEY}_USERNAME` / `SLC_{KEY}_PASSWORD` / `SLC_{KEY}_TOTP_SECRET` | No | | Per-device credentials, `{KEY}` is the device identifier uppercased with non-alphanumeric characters replaced by `_` (e.g. `device_id` `slc9000-dc-a` becomes `SLC_SLC9000_DC_A_IP`) |
+| `SLC_VERIFY_SSL` | No | `true` | Set to `false` only for lab devices with self-signed certificates. Never disable in production. |
+| `SLC_CREDENTIAL_PROVIDER` | No | `env` | Credential backend: `env` (default), `vault`, `aws`, `percepxion`, or `cyberark`. The `percepxion` provider looks up device IP from the Percepxion device registry (requires `PERCEPXION_API_URL`/`PERCEPXION_USERNAME`/`PERCEPXION_PASSWORD` above) while SLC credentials still come from `SLC_{KEY}_*`. |
+| `SLC_CLI_WRITE_ENABLED` | No | `false` | Allow write commands via `apply_config_commands` and px client tools |
+| `SLC_CLI_YOLO` | No | `false` | Disable all CLI policy filtering. Never use in production. |
+
+Read-only commands (`show`, `diag`, `ping`, `traceroute`, etc.) are always permitted regardless of `SLC_CLI_WRITE_ENABLED`. A built-in deny list (`factory-reset`, `write erase`, `erase startup-config`, `erase flash`, `reload`, `reboot`, `format`, `shutdown`, `power off`, `reset system`, `init 0`, `halt`) always blocks unless `SLC_CLI_YOLO=true`.
+
+---
+
+## Workflow 1: Session Auth + Device Discovery (P1, Required First Step)
+
+Every session starts here. You must authenticate before any other tool will succeed.
+
+### Step 1: Authenticate
+
+```
+Tool: login_with_env
+Parameters: {}
+```
+
+Returns a session token stored in memory for the server process lifetime. Confirm the response shows `"ok": true` before proceeding.
+
+### Step 2: List All OOB Devices
+
+`get_device_list` returns OOB devices (the Lantronix console servers), not managed devices. All are optional parameters.
+
+```
+Tool: get_device_list
+Parameters: {
+  "search_query": "*",
+  "limit": 25,
+  "sort": "device_name",
+  "order": "asc"
+}
+```
+
+Returns all OOB console servers managed by your Percepxion account. Note device IDs, you'll need them for every subsequent tool call. Use `search_query` to filter by hostname or model.
+
+### Step 3: (Multi-tenant) List Organizations and Filter by Org
+
+If the account manages multiple customer organizations:
+
+```
+Tool: list_organizations
+Parameters: {}
+```
+
+(`list_tenants` still works as a deprecated alias for `list_organizations`. `organization_id` is the primary parameter name across all tools; `tenant_id` still works everywhere as a deprecated alias.)
+
+Then filter by organization:
+
+```
+Tool: get_devices_by_organization
+Parameters: {
+  "organization_id": "org-abc123"
+}
+```
+
+**If the authenticated account is a Percepxion Project Admin**, `organization_id` is *required*, not optional, on job/telemetry/content/Smart-Group/audit calls (`send_direct_cli_command`, `get_cli_command_output`, `search_job_groups`, `get_job_group`, `update_device_config`, `reboot_device`, `request_device_syslog_upload`, smart group and firmware tools, audit tools, and more). A Project Admin's access spans every organization in their project, so Percepxion can't infer a single default the way it does for Tenant Admin/Tenant User accounts (auto-scoped to their one organization, `organization_id` optional for those). Omitting it as a Project Admin raises a clear error naming the missing parameter (percepxion-mcp-server v1.1.0+); before that fix it surfaced as an opaque `400 ACCESS_DENIED: "Invalid access to tenant."` Call `list_organizations` first if you don't already have the ID to pass. Device-inventory tools (`get_device_list`, `get_device_details`, `list_device_ports`) don't require it for any role. See Platform Security Configuration for the full rule.
+
+### Step 4: Get Details for a Specific OOB Device
+
+Look up by device ID or serial number, at least one is required.
+
+```
+Tool: get_device_details
+Parameters: {
+  "device_id": "device-abc123"
+}
+```
+
+Or by serial number if device ID is unknown:
+
+```
+Tool: get_device_details
+Parameters: {
+  "serial_num": "SLC9016-XXXXXX"
+}
+```
+
+Returns hostname, firmware version, model, IP address, last check-in time, and status for the **OOB device**.
+
+### Example Prompts
+- "Show all OOB devices managed by Percepxion"
+- "List all console servers in org org-abc123"
+- "Get details for device device-abc123"
+- "What firmware version is each SLC9000 running?"
+- "Which devices haven't checked in recently?"
+
+---
+
+## Workflow 2: Preflight, Validate OOB Path Before Automation (P2, Run Before Any Automated Action)
+
+Before triggering automated remediation, maintenance tasks, or configuration changes, confirm the OOB device is reachable and the target serial port shows an active connection. A failed preflight stops you before committing to an operation on a dead or misidentified console path.
+
+### Step 1: Confirm the OOB Device is Online
+
+```
+Tool: get_device_details
+Parameters: {
+  "device_id": "device-abc123"
+}
+```
+
+Check status is `online` and last check-in is recent. If the OOB device is offline, the serial path is unavailable. Stop and alert the operator.
+
+### Step 2: List Device Ports
+
+`list_device_ports` returns port names, numbers, and connection state. `get_security_telemetry` returns full managed-device inventory per port (hostname, model, serial, IP, OS version). Use both: `list_device_ports` to enumerate ports and confirm connection state, `get_security_telemetry` (or `get_port_telemetry` for a single port) to confirm the right managed device is present on the target port. A `list_device_ports` result of `total: 0` or an empty port status does not mean no managed devices are attached, the telemetry endpoint is authoritative for that question.
+
+```
+Tool: list_device_ports
+Parameters: {
+  "device_id": "device-abc123",
+  "limit": 100
+}
+```
+
+Confirm the port status shows `connected`. Then verify managed-device identity:
+
+```
+Tool: get_port_telemetry
+Parameters: {
+  "device_id": "device-abc123",
+  "port_number": 4
+}
+```
+
+Or for all ports at once:
+
+```
+Tool: get_security_telemetry
+Parameters: {
+  "device_id": "device-abc123"
+}
+```
+
+Confirm the target port's `managed_device` shows `Managed Device Attached: Yes` and the hostname or model matches the expected device. If the port shows no device in either tool, the serial cable may be unplugged or the managed device is powered off. Warn the operator and stop unless they explicitly override.
+
+For richer per-port detail (carrier detect state, baud rate, bytes transferred), supplement with a CLI call:
+
+```
+Tool: send_direct_cli_command
+Parameters: {
+  "device_id": "device-abc123",
+  "command": "show deviceport port 4",
+  "description": "W2 preflight, detailed port 4 inspection"
+}
+```
+
+Poll `get_job_group` (or `search_job_groups`) with the returned `job_group_id` until status reaches `"Completed"`, then call `get_cli_command_output` with that same `job_group_id` and `device_id` for the actual command output text. `get_job_group` alone returns status and metadata only, never the output text, see the Async Operations section below.
+
+### Step 3: Proceed, Abort, or Override
+
+- **Pass:** OOB device online, target port connected with carrier detect. Proceed to the calling workflow.
+- **Fail:** Report the specific failure reason (OOB offline / port disconnected / no carrier detect). Stop by default.
+- **Operator override:** If the operator explicitly acknowledges the failure and authorizes proceeding, record their acknowledgment in the `description` field of all subsequent tool calls: `"description": "Operator authorized: proceeding despite [reason]"`. This creates an auditable record. The operator's override cannot bypass server-side CLI policy (see Platform Security Configuration).
+
+### Example Prompts
+- "Run a preflight check on the OOB path before we start the maintenance window"
+- "Verify the serial port for Chicago-WAN-01 is connected and has carrier"
+- "Check all OOB console paths in this window are reachable before we start"
+- "Preflight failed on port 4, the operator acknowledges the risk and says proceed"
+
+---
+
+## Workflow 3: SLC Console Diagnostics and Device Port Inspection (P3)
+
+Use `send_direct_cli_command` to run diagnostic commands on the SLC's own management CLI. This is how you assess port state, check SLC system health, and collect evidence before or during an incident. All commands target the SLC itself, not managed devices attached via serial.
+
+**What `send_direct_cli_command` does:** Submits a command to the SLC's native Linux/management shell and returns a job group ID. The SLC executes the command and reports what it observes, including the state of each serial port (carrier detect, baud rate, bytes transferred). The `device_id` is always the OOB device (SLC) ID.
+
+**What it does NOT do:** Pass commands through to managed devices (Cisco switch, Juniper router, Arista switch). Commands like `show ip interface brief` or `show ip bgp summary` are Cisco IOS syntax and will not work here. If the operator needs to reach a managed device CLI, the MCP can compute the direct SSH connection string (`ssh -p <3000+N> <user>@<slc-ip>`) using `get_device_details` and `list_device_ports`, see "When to ask for clarification" in the Key Terms section. For a fully interactive terminal session, SSH directly to the SLC (`ssh admin@<slc-ip>`) and use `connect direct deviceport N` from the SLC shell. That is a human-in-the-loop operation outside this MCP server's scope.
+
+All `send_direct_cli_command` calls are asynchronous, and returning the actual output text is a two-step follow-up, not one. Poll status first, then fetch output:
+
+```
+Tool: get_job_group
+Parameters: { "job_group_id": "<id from send_direct_cli_command response>" }
+```
+
+Once status reaches `"Completed"`:
+
+```
+Tool: get_cli_command_output
+Parameters: {
+  "job_group_id": "<same id>",
+  "device_id": "<same device_id>"
+}
+```
+
+`get_job_group` alone never returns CLI output text, only job status and metadata (device, command string, timestamps). Calling `get_cli_command_output` before the job completes returns `total_results: 0`, not an error, retry after a short delay. (percepxion-mcp-server v1.1.0+; earlier versions had no working way to retrieve CLI output text via the API at all, only job status via MQTT.)
+
+### Step 1: Check SLC System Health
+
+```
+Tool: send_direct_cli_command
+Parameters: {
+  "device_id": "device-abc123",
+  "command": "show sysstatus",
+  "description": "SLC health check, pre-incident diagnostics"
+}
+```
+
+```
+Tool: get_job_group
+Parameters: {
+  "job_group_id": "<id from send_direct_cli_command response>"
+}
+```
+
+Once `"status": "Completed"`:
+
+```
+Tool: get_cli_command_output
+Parameters: {
+  "job_group_id": "<id from send_direct_cli_command response>",
+  "device_id": "device-abc123"
+}
+```
+
+### Step 2: Inspect a Specific Serial Port
+
+```
+Tool: send_direct_cli_command
+Parameters: {
+  "device_id": "device-abc123",
+  "command": "show deviceport port 4",
+  "description": "Port 4 inspection, checking carrier detect and connection state"
+}
+```
+
+Poll `get_job_group` for status, then `get_cli_command_output` (same `job_group_id` + `device_id`) for the actual text. Output includes: baud rate, carrier detect (yes/no), connection state, bytes sent/received since last session. A `no carrier` result means the attached device is powered off or the cable is disconnected.
+
+### Step 3: Survey All Ports
+
+```
+Tool: send_direct_cli_command
+Parameters: {
+  "device_id": "device-abc123",
+  "command": "show portstatus",
+  "description": "Full port survey, pre-maintenance audit"
+}
+```
+
+Poll `get_job_group` for status, then `get_cli_command_output` for the actual text. Returns the mode and state of every device port. Useful for inventory checks and preflight before bulk operations.
+
+### Step 4: Test Network Reachability from the SLC
+
+```
+Tool: send_direct_cli_command
+Parameters: {
+  "device_id": "device-abc123",
+  "command": "diag ping 192.168.1.50",
+  "description": "Reachability test to managed device management IP from SLC local network"
+}
+```
+
+Poll `get_job_group` for status, then `get_cli_command_output` for the actual text. Tests whether the managed device is reachable via its management IP from the SLC's network path. Confirms whether the failure is in-band (unreachable from the SLC too) or isolated to the production network.
+
+### Step 5: Collect SLC Evidence After Diagnostics
+
+After any diagnostic session, capture OOB device logs for the audit trail:
+
+```
+Tool: get_device_syslogs
+Parameters: {
+  "device_id": "device-abc123"
+}
+```
+
+```
+Tool: query_device_access_log
+Parameters: {
+  "device_id": "device-abc123",
+  "query": "session opened"
+}
+```
+
+### Example Prompts
+- "Check the health status of the SLC at device-abc123"
+- "What does port 4 look like on device-abc123, is it connected and does it have carrier detect?"
+- "Survey all serial ports on device-abc123 to find which ones are active"
+- "Run diag ping 192.168.1.50 from the SLC to test if the managed device is reachable via OOB network path"
+- "Get the syslogs from device-abc123 after the diagnostic session"
+
+---
+
+## Workflow 4: Firmware Compliance and Updates (P4)
+
+Use before maintenance windows, for quarterly compliance reviews, or when CVEs require a coordinated patch across the fleet.
+
+### Step 1: Check Firmware Status for One Device
+
+```
+Tool: get_device_firmware_status
+Parameters: {
+  "device_id": "device-abc123"
+}
+```
+
+### Step 2: Run a Fleet-Wide Compliance Report
+
+`expected_firmware_version` is required. Use `model_filter` to scope to one device family.
+
+```
+Tool: firmware_compliance_report
+Parameters: {
+  "expected_firmware_version": "9.7.0.0R11",
+  "model_filter": "SLC9000",
+  "limit": 1000
+}
+```
+
+Returns compliant, non-compliant, and unknown devices for the OOB fleet against the specified version.
+
+### Step 3: List Available Firmware Packages
+
+```
+Tool: list_firmware_content
+Parameters: {}
+```
+
+Returns firmware packages available in Percepxion for your OOB device models (SLC9000, SLC8000, EMG).
+
+### Step 4: Create a Smart Group for Non-Compliant Devices
+
+Use a `query` filter string OR an explicit `device_ids` list, not both. Use `temporary: true` for one-off operations.
+
+```
+Tool: create_smart_group
+Parameters: {
+  "name": "slc9000-non-compliant-q2",
+  "query": "firmware_ver:9.7.0.0R7 AND model:SLC9000",
+  "description": "Non-compliant SLC9000s for Q2 patch cycle",
+  "temporary": true
+}
+```
+
+Returns a smart group ID. Smart groups re-evaluate membership at execution time.
+
+### Step 5: Confirm Scope with Operator
+
+Present: smart group name, member count, current firmware versions, target firmware version, and the local firmware file path that will be uploaded. Wait for explicit confirmation.
+
+### Step 6: Push Firmware Update
+
+`update_firmware_by_smart_group` uploads a local firmware file to Percepxion and targets one or more smart groups. You must have the firmware file on disk before calling this. `smart_group_ids` is an array.
+
+```
+Tool: update_firmware_by_smart_group
+Parameters: {
+  "firmware_file_path": "/path/to/SLC9000-9.7.0.0R11.bin",
+  "smart_group_ids": ["sg-abc123"],
+  "content_name": "SLC9000-9.7.0.0R11",
+  "version": "9.7.0.0R11",
+  "description": "Q2 compliance patch, operator authorized",
+  "enable": true
+}
+```
+
+This is asynchronous and maps to a multipart/form-data upload. Returns a job group ID immediately.
+
+### Step 7: Monitor Job Status
+
+```
+Tool: get_job_group
+Parameters: {
+  "job_group_id": "jg-xyz789"
+}
+```
+
+Or search recent jobs:
+
+```
+Tool: search_job_groups
+Parameters: {
+  "query": "firmware update",
+  "limit": 10
+}
+```
+
+Poll until status is `completed` or `failed`. On `failed`, surface the error reason to the operator.
+
+For a per-device breakdown across the Smart Group (which devices succeeded, which failed) rather than just the overall job status, use `get_job_results_by_device(job_group_id)` instead of, or alongside, `get_job_group`.
+
+### Step 8: Clean Up the Smart Group
+
+```
+Tool: delete_smart_group
+Parameters: {
+  "smart_group_id": "sg-abc123"
+}
+```
+
+### Example Prompts
+- "Run a firmware compliance report for all devices"
+- "Which SLC9000s are not on firmware 9.7.0.0R11?"
+- "Push firmware 9.7.0.0R11 to all non-compliant SLC9000s"
+- "What's the status of this morning's firmware update job?"
+- "List available firmware for SLC8000"
+
+---
+
+## Workflow 5: Security Audit and Access Investigation (P5)
+
+Use for post-incident access reviews, compliance audits, or when a security team needs to reconstruct who accessed which OOB devices during a specific window.
+
+### Step 1: Get Security Telemetry for a Specific OOB Device
+
+`device_id` is required, this is scoped to one OOB device, not fleet-wide.
+
+```
+Tool: get_security_telemetry
+Parameters: {
+  "device_id": "device-abc123",
+  "selected": true
+}
+```
+
+Returns telemetry statistics useful for security analysis on that OOB device.
+
+### Step 2: Investigate Audit Logs by Time Window and Search String
+
+`investigate_audit_logs` has no `device_id` parameter. Filter by device using `search_string`. Date parameters are `from_date` and `to_date`, not `start_time`/`end_time`. If dates are omitted, the default range is effectively all history.
+
+```
+Tool: investigate_audit_logs
+Parameters: {
+  "search_string": "device-abc123",
+  "from_date": "2026-06-01",
+  "to_date": "2026-06-02",
+  "limit": 50,
+  "order": "desc"
+}
+```
+
+To filter by specific users, pass a list to `usernames`:
+
+```
+Tool: investigate_audit_logs
+Parameters: {
+  "usernames": ["jsmith@example.com", "kwilson@example.com"],
+  "from_date": "2026-06-01",
+  "to_date": "2026-06-02",
+  "limit": 50
+}
+```
+
+### Step 3: Search User Audit Records
+
+`investigate_user_audit_logs` returns user records with last audit action summaries. Filter with `user_filter` string, there are no date range parameters on this tool.
+
+```
+Tool: investigate_user_audit_logs
+Parameters: {
+  "user_filter": "jsmith@example.com",
+  "limit": 50,
+  "order": "asc"
+}
+```
+
+### Step 4: Download Raw Access Log for Forensic Export
+
+For SIEM ingestion or evidence preservation:
+
+```
+Tool: download_device_access_log
+Parameters: {
+  "device_id": "device-abc123"
+}
+```
+
+### Step 5: Query Access Log for Specific Events
+
+```
+Tool: query_device_access_log
+Parameters: {
+  "device_id": "device-abc123",
+  "query": "session opened port 8"
+}
+```
+
+### Example Prompts
+- "Who accessed device-abc123 during the outage window on June 1?"
+- "Show all OOB actions by user jsmith@example.com in the last 7 days"
+- "Get the fleet security telemetry summary"
+- "Download the access log for device-abc123 for forensic export"
+- "Were there any failed login attempts on OOB devices in the last 24 hours?"
+
+---
+
+## Workflow 6: Configuration Management (P6)
+
+Use for baseline config distribution, config audit, or onboarding new OOB devices (console servers) with a standard configuration. All tools in this workflow operate on the OOB device, not on managed devices attached to it.
+
+### Step 1: Read Current Device Config
+
+```
+Tool: get_device_config
+Parameters: {
+  "device_id": "device-abc123"
+}
+```
+
+### Step 2: Update a Config Parameter
+
+**Requires operator confirmation.** Present the proposed change before applying.
+
+Use either `property_name` + `new_value` for a single change, or `items` for multiple changes at once. `apply_now: true` (default) saves and immediately creates a config pull job.
+
+```
+Tool: update_device_config
+Parameters: {
+  "device_id": "device-abc123",
+  "property_name": "syslog_server",
+  "new_value": "192.168.1.100",
+  "apply_now": true
+}
+```
+
+Multiple changes at once using `items`:
+
+```
+Tool: update_device_config
+Parameters: {
+  "device_id": "device-abc123",
+  "items": [
+    {"name": "hostname", "value": "slc9000-chicago-01"},
+    {"name": "banner", "value": "Authorized access only. All sessions are logged."}
+  ],
+  "apply_now": true
+}
+```
+
+### Step 3: Clone Config from One Device to Another
+
+`record_names` is required, it specifies which config record names to copy from the source. Read the source config first with `get_device_config` to identify the record names.
+
+1. Read source config: `get_device_config` on the baseline device
+2. Identify `record_names` from the response
+3. Confirm source and target device IDs with the operator
+
+```
+Tool: clone_device_config
+Parameters: {
+  "source_device_id": "device-abc123",
+  "target_device_id": "device-def456",
+  "record_names": ["network", "services", "authentication"],
+  "template_name": "Chicago-Baseline-v2"
+}
+```
+
+### Step 4: List Config Templates
+
+```
+Tool: list_templates
+Parameters: {}
+```
+
+### Example Prompts
+- "Get the current config for device-abc123"
+- "Clone the config from our baseline device device-abc123 to newly racked device-def456"
+- "Update the syslog server on device-abc123 to 192.168.1.100"
+- "List all config templates in Percepxion"
+
+---
+
+## Workflow 7: OOB Device Lifecycle Operations (P7)
+
+For onboarding new Lantronix hardware into Percepxion, offboarding decommissioned OOB devices, or rotating the credentials Percepxion uses to authenticate to each OOB device.
+
+### Import and Assign New Devices
+
+```
+Tool: import_and_assign_devices
+Parameters: {
+  "devices": [
+    {"device_id": "device-new-001", "device_name": "slc9000-chicago-02", "serial_num": "SLC9016-XXXXXX"},
+    {"device_id": "device-new-002", "device_name": "slc9000-chicago-03", "serial_num": "SLC9016-YYYYYY"}
+  ],
+  "organization_id": "org-abc123"
+}
+```
+
+Each entry in `devices` must include `device_id`, `device_name`, and `serial_num`. A fourth optional field `device_description`can be used for additional context. `organization_id` is required here for Project Admin sessions, see Platform Security Configuration.
+
+### Reboot an OOB Device
+
+**Requires operator confirmation.** A reboot of the OOB device causes a brief loss of serial console access to all managed devices on its ports. Confirm the maintenance window is acceptable.
+
+1. Confirm OOB device ID and hostname via `get_device_details`
+2. Confirm operator accepts the access loss window
+3. Execute:
+
+```
+Tool: reboot_device
+Parameters: {
+  "device_id": "device-abc123",
+  "description": "Scheduled reboot, maintenance window approved by operator"
+}
+```
+
+### Remove a Decommissioned OOB Device
+
+**Irreversible.** Confirm before executing.
+
+```
+Tool: remove_device_from_platform
+Parameters: {
+  "device_id": "device-abc123"
+}
+```
+
+Or unassign from a tenant without removing from the platform:
+
+```
+Tool: unassign_devices
+Parameters: {
+  "device_ids": ["device-abc123"]
+}
+```
+
+### Upload Syslog from OOB Device to Percepxion
+
+Request the OOB device to upload its current syslog buffer for retrieval:
+
+```
+Tool: request_device_syslog_upload
+Parameters: {
+  "device_id": "device-abc123"
+}
+```
+
+### Example Prompts
+- "Add two new SLC9000s to tenant org-abc123"
+- "Reboot OOB device device-abc123, it's been unresponsive to management pings"
+- "Remove device-abc123 from Percepxion, it's been decommissioned"
+- "Upload the syslog from device-abc123 so I can review it"
+
+---
+
+## Workflow 8: Closed-Loop Incident Remediation (P8)
+
+**Trigger:** An upstream orchestrator (PagerDuty, Itential FlowAI, monitoring webhook) signals that a device is unreachable via the primary network. This workflow gives the orchestrator a complete OOB response: diagnostic evidence, optional remediation, and a traceable audit trail to close the incident ticket.
+
+**Write access prerequisite:** Steps 7-8 (remediation commands) require `PERCEPXION_CLI_WRITE_ENABLED=true` on the MCP server. Steps 1-6 and 9 are read-only and always available.
+
+### Step 1: Authenticate
+
+```
+Tool: login_with_env
+Parameters: {}
+```
+
+Skip if already authenticated in this session.
+
+### Step 2: Locate the OOB Device
+
+```
+Tool: get_device_list
+Parameters: {
+  "search_query": "<site-name or managed-device-name>"
+}
+```
+
+Returns the Lantronix OOB device (SLC console server) managing the affected infrastructure at that site.
+
+### Step 3: Confirm OOB Device is Reachable
+
+```
+Tool: get_device_details
+Parameters: {
+  "device_id": "<oob_device_id>"
+}
+```
+
+**Critical branch:** If the OOB device itself is unreachable (`online: false`), OOB access is unavailable. Stop and escalate to a human. Do not proceed.
+
+### Step 4: W2 Preflight, Verify Port State
+
+Run Workflow 2 to confirm the managed device is connected at the serial layer. Check `show deviceport port <N>` via `send_direct_cli_command` for carrier detect and connection state.
+
+If the port shows no carrier or a disconnected state, log this as a finding in the incident record and decide with the operator whether to continue.
+
+### Step 5: Collect Pre-Action Evidence
+
+```
+Tool: get_device_syslogs
+Parameters: {
+  "device_id": "<oob_device_id>"
+}
+```
+
+Captures the OOB device syslog before any action. This is the before-state evidence.
+
+### Step 6: Run Diagnostic Commands
+
+```
+Tool: send_direct_cli_command
+Parameters: {
+  "device_id": "<oob_device_id>",
+  "command": "show sysstatus",
+  "description": "Automated incident response, incident-id: <upstream-incident-id>, diagnostics phase"
+}
+```
+
+Run SLC-native diagnostics as needed (`show sysstatus`, `show deviceport port <N>`, `diag ping <ip>`). Always include the upstream incident ID in the `description` field. Poll `get_job_group` for status, then call `get_cli_command_output` with the same `job_group_id` and `device_id` for the actual diagnostic text, that's what goes into the incident record, `get_job_group` alone has no output.
+
+### Step 7: Execute Remediation (Write Access Required)
+
+**Only if `PERCEPXION_CLI_WRITE_ENABLED=true`.** Present the proposed command to the operator or upstream orchestrator before executing.
+
+```
+Tool: send_direct_cli_command
+Parameters: {
+  "device_id": "<oob_device_id>",
+  "command": "<recovery-command>",
+  "description": "Automated remediation, incident-id: <upstream-incident-id>, approved by: <orchestrator-or-operator>"
+}
+```
+
+Confirm status via `get_job_group`, then confirm actual output via `get_cli_command_output` with the same `job_group_id` and `device_id`. Do not report remediation as successful based on job status alone, verify the device's own response text.
+
+### Step 8: Collect Post-Action Audit Evidence
+
+```
+Tool: investigate_audit_logs
+Parameters: {
+  "search_string": "<oob-device-name-or-ip>"
+}
+```
+
+Confirms the OOB action is in Percepxion's audit trail. Include the audit log excerpt in the incident closure report.
+
+### Step 9: Report to Upstream Orchestrator
+
+Return a structured outcome to the calling system (Itential, PagerDuty, ServiceNow):
+
+- Job group ID from Step 7 (or Step 6 if no remediation was performed)
+- Pre-action syslog summary from Step 5
+- Post-action audit log entry from Step 8
+- Final status: `remediated`, `diagnosed-only`, or `escalate-to-human`
+
+### Governance Note
+
+AI-initiated OOB access carries the same audit trail as human access. The `description` field on every `send_direct_cli_command` call is the machine's justification. Treat it like a change ticket number. Percepxion logs who authenticated, what commands ran, and when, regardless of whether a human or an AI agent initiated the session.
+
+### Example Prompts
+- "A PagerDuty alert fired on core-switch-nyc-01, it's unreachable via primary network. Run an OOB diagnostic."
+- "Itential FlowAI is executing incident INC-4821. Open an OOB session to the SLC managing router-chi-03 and collect evidence."
+- "Run automated OOB remediation on device-abc123, incident ID INC-4821, write access is enabled."
+
+---
+
+## Platform Security Configuration
+
+### MCP Server Credential Providers
+
+`login_with_env` supports four credential backends, selected by the `PERCEPXION_CREDENTIAL_PROVIDER` environment variable on the server:
+
+| Provider | Env var to set | When to use |
+|----------|---------------|-------------|
+| `env` (default) | `PERCEPXION_USERNAME` + `PERCEPXION_PASSWORD` | Dev, local testing, simple deployments |
+| `vault` | `VAULT_ADDR`, `VAULT_TOKEN`, `VAULT_SECRET_PATH` | Production, HashiCorp Vault for secret management |
+| `aws` | `AWS_SECRET_NAME`, `AWS_REGION` | Production, AWS Secrets Manager |
+| `cyberark` | `CYBERARK_URL`, `CYBERARK_APP_ID`, `CYBERARK_SAFE`, `CYBERARK_OBJECT` | Enterprise deployments already running CyberArk Central Credential Provider (CCP) |
+
+To switch providers at runtime, use `reconfigure_credentials` then re-authenticate:
+
+```
+Tool: reconfigure_credentials
+Parameters: {
+  "provider": "vault"
+}
+```
+
+Valid values: `"env"`, `"vault"`, `"aws"`, `"cyberark"`. After calling this, always follow with `login_with_env` to re-authenticate with the new provider. This is NOT per-device credential rotation, it changes which secret store the MCP server itself uses for its Percepxion session credentials.
+
+### Role-Based `organization_id` Requirement (v1.1.0+)
+
+Percepxion's RBAC model has three roles, and their `organization_id`/`tenant_id` requirements differ:
+
+| Role | Scope | `organization_id` on job/telemetry/content/Smart-Group/audit calls |
+|------|-------|----------------------------------------------------------------|
+| Tenant User | One or more specific organizations, explicitly group-granted | Optional, auto-scoped |
+| Tenant Admin | One organization | Optional, auto-scoped |
+| Project Admin | Every organization in their project | **Required** |
+
+A Project Admin's access spans an entire Percepxion project (Percepxion's hierarchy is Project > Portal > Organization), and there's no API endpoint that enumerates a project's member organizations, so the server can't infer a single default the way it does for the other two roles. Omitting `organization_id` as a Project Admin now raises a clear error naming the missing parameter; before percepxion-mcp-server v1.1.0 this surfaced as an opaque `400 ACCESS_DENIED: "Invalid access to tenant."` with no indication why. **If a call fails with either error, check the authenticated account's role before assuming a bug**, call `list_organizations` to find the ID to pass. Device-inventory tools (`get_device_list`, `get_device_details`, `list_device_ports`) don't require it for any role.
+
+### MCP Server CLI Policy (Operator Override Controls)
+
+`send_direct_cli_command` enforces server-side CLI policy. These are environment variables set on the MCP server, not parameters in the tool call. **The AI cannot override these policies at runtime**, they must be configured by whoever starts the server.
+
+| Env var | Default | Effect |
+|---------|---------|--------|
+| `PERCEPXION_CLI_WRITE_ENABLED` | `false` | `true` enables write commands. Read-only (`show`, `get`, `ping`, `traceroute`) is the default. |
+| `PERCEPXION_CLI_MAX_LENGTH` | `512` | Maximum command length in characters. Automated workflows that build long commands will hit this silently. |
+| `PERCEPXION_CLI_DENY_COMMANDS` | built-in list | Comma-separated commands to block in addition to the built-in deny list |
+| `PERCEPXION_CLI_PERMIT_COMMANDS` | unset | Comma-separated explicit allowlist; if set, only these commands (and their subcommands) are allowed |
+| `PERCEPXION_CLI_YOLO` | `false` | `true` disables ALL filtering including the deny list. Use with extreme caution. |
+
+**Built-in deny list** (always blocked unless YOLO mode): `reload`, `factory-reset`, `write erase`, and similar destructive commands.
+
+**Operator override pattern:** If an operator explicitly accepts risk and needs to run a write command or a normally-blocked command:
+1. The server must be restarted with `PERCEPXION_CLI_WRITE_ENABLED=true` (or `PERCEPXION_CLI_YOLO=true` for full bypass)
+2. The AI records the operator's authorization in the `description` field of every `send_direct_cli_command` call: `"description": "Write access enabled, operator authorized: [reason]"`
+3. This creates an auditable record in the Percepxion job group log
+
+### Percepxion Platform RBAC
+
+User and device access permissions are configured in the Percepxion UI, not via this MCP server. A `send_direct_cli_command` failure with a permissions error means RBAC on the platform needs updating, there is nothing to change in the MCP call itself.
+
+### Command Filtering at the Platform Level
+
+Percepxion also supports per-port CLI command filtering configured in the platform UI (separate from the MCP server's CLI policy). If a command is allowed by the MCP server policy but blocked by Percepxion's own filtering, surface the error to the operator and advise reviewing the platform's command filter for that port.
+
+### Session Audit
+
+All MCP-initiated sessions are fully logged in Percepxion's audit trail: who authenticated, which commands ran, job group IDs, and session duration. Retrieve via `investigate_audit_logs`.
+
+---
+
+## Async Operations
+
+The following tools are asynchronous, they return a job group ID immediately and continue in the background:
+
+- `update_firmware_by_smart_group`
+- `request_device_syslog_upload`
+- `reboot_device`
+- `send_direct_cli_command` (always async, not conditional on firmware build)
+
+Always follow async calls with:
+
+```
+Tool: get_job_group
+Parameters: { "job_group_id": "<id returned by the async call>" }
+```
+
+Poll until status is `"Completed"` or `"Failed"`. On failure, surface the full error reason to the operator before suggesting next steps.
+
+**`get_job_group` and `search_job_groups` never return CLI output text**, only status and job metadata (device, command string, timestamps). For `send_direct_cli_command` jobs specifically, once status reaches `"Completed"`, call `get_cli_command_output(job_group_id, device_id)` for the actual device response text (percepxion-mcp-server v1.1.0+). For a multi-device job (e.g. a Smart Group firmware push or a CLI command sent to several devices at once), `get_job_results_by_device(job_group_id)` returns a per-device result rollup instead of one device at a time.
+
+---
+
+## Integration with Other NetClaw Skills
+
+- **pagerduty-incidents**, When an incident fires on an unreachable device, trigger this skill to open an OOB console session and gather diagnostic evidence before escalating to a human
+- **servicenow-change-workflow**, Reference ServiceNow change ticket IDs in audit records when performing governed OOB access during a change window
+- **netbox-source-of-truth**, Cross-reference Percepxion device IDs with NetBox CIs to confirm expected firmware version, rack position, site, and device owner before taking action
+- **itential-orchestration**, Itential FlowAI triggers W8 (closed-loop remediation); NetClaw executes the OOB session via Percepxion and returns a structured outcome (job group ID + audit evidence) to close the incident ticket. Pass the Itential workflow execution ID as the `description` value in every `send_direct_cli_command` call to create a traceable link between the automation record and the OOB action in Percepxion's audit log
+- **gait-session-tracking**, Log all Percepxion operations to the GAIT audit trail for compliance evidence and post-incident review
+- **grafana-observability**, Correlate Percepxion access events and telemetry with Grafana dashboard alerts when investigating device unreachability patterns
+
+---
+
+## Important Rules
+
+**Terminology**
+- When an operator says "the device," ask: OOB device (the Lantronix console server) or managed device (the router/switch/firewall attached to it)? Never assume.
+- `device_id` in all MCP tool calls is the **OOB device** ID from `get_device_list`. This is always the Lantronix SLC or EMG, never the managed device (router/switch/firewall) attached to it.
+
+**Authentication**
+- Always call `login_with_env` at the start of every session. No other tool works without it.
+- Never expose `PERCEPXION_USERNAME`, `PERCEPXION_PASSWORD`, `VAULT_TOKEN`, or session tokens in logs, chat output, or error messages.
+- Use `https://api.percepxion.ai/api` as the API URL. `api.gopercepxion.ai` causes silent auth failures unless the operator has confirmed their instance uses that domain.
+
+**Preflight before automation**
+- Run Workflow 2 before any automated sequence that sends configuration changes or destructive commands to a managed device.
+- If preflight fails at any step, stop by default. Only proceed if the operator explicitly acknowledges the failure and authorizes continuation, record their acknowledgment in the `description` field of every subsequent tool call.
+
+**SLC CLI scope**
+- `send_direct_cli_command` sends commands to the SLC's own management CLI (Linux/management shell), not to managed devices. Valid commands are SLC-native: `show sysstatus`, `show deviceport port <N>`, `show portstatus`, `diag ping <ip>`, `admin version`, etc.
+- Interactive managed-device CLI (typing into a router or switch prompt over serial) is not supported by this MCP. The MCP can compute the direct SSH connection string (`ssh -p <3000+N> <user>@<slc-ip>`), see "When to ask for clarification" in the Key Terms section. For a fully interactive terminal session, direct SSH to the SLC followed by `connect direct deviceport <N>` from the SLC shell is required. That is a human-in-the-loop operation outside MCP scope.
+- `send_direct_cli_command` is asynchronous. Poll `get_job_group` (or `search_job_groups`) for status, then call `get_cli_command_output` with the same `job_group_id` + `device_id` for the actual output text, `get_job_group` alone never returns it.
+- If the authenticated account is a Percepxion Project Admin, `organization_id` is required (not optional) on `send_direct_cli_command`, `get_cli_command_output`, and most other job/telemetry/content/audit tools, see Workflow 1 Step 3 and Platform Security Configuration.
+- Read-only by default (`PERCEPXION_CLI_WRITE_ENABLED=false`). Write commands require server reconfiguration. The AI cannot bypass CLI policy at runtime.
+
+**Firmware updates (OOB devices)**
+- `update_firmware_by_smart_group` requires a local firmware file (`firmware_file_path`) and targets `smart_group_ids` (array). Confirm the file path, group membership count, and target version before calling.
+- Always track the async job to completion via `get_job_group` or `search_job_groups`.
+
+**Credential provider**
+- `reconfigure_credentials` switches the MCP server's credential provider (`env`, `vault`, `aws`), it does NOT rotate per-device passwords. Always follow it with `login_with_env` to re-authenticate.
+
+**Destructive lifecycle operations**
+- For `remove_device_from_platform` and `reboot_device`, require the operator to confirm the OOB device hostname before executing.
+- `reboot_device` causes temporary loss of serial console access to all managed devices on the OOB device's ports.
+
+**Async tracking**
+- `send_direct_cli_command`, `update_firmware_by_smart_group`, `reboot_device`, and `request_device_syslog_upload` are all asynchronous. Never leave a job untracked, always poll to `completed` or `failed` and report the final status.
+
+**Proactive use**
+- Firmware compliance reports and config drift checks should run on a schedule, not just during incidents. When a user asks for fleet health, pull `firmware_compliance_report` and `get_device_config` across the fleet without waiting for a problem to surface.
+
+**Automation pipeline preflight (when OOB coverage exists)**
+- This rule only applies when Percepxion is available in the session. Before making primary-network changes, search `get_device_list` for the target device hostname or IP. If no OOB device is found, proceed normally, absent OOB coverage is expected and not a blocker. If an OOB device is found, run W2 preflight. A known OOB path that is unreachable is worth flagging before committing the change; an OOB path that simply doesn't exist is not.
+
+**Evidence always (W8 and any automated remediation)**
+- Every automated OOB action via W8 must call `get_device_syslogs` before and `investigate_audit_logs` after. This evidence is non-negotiable for compliance and incident closure. Do not skip these steps even if the remediation command fails.


### PR DESCRIPTION
## Summary

Adds a `percepxion-oob` skill covering out-of-band (OOB) console-server management, closing a real
coverage gap: none of NetClaw's existing MCP integrations reach a device's serial console, which is
exactly the path that exists to work around a dead in-band network.

Two external, actively co-developed Lantronix repos back the skill:

- **[`percepxion-mcp-server`](https://github.com/Lantronix/percepxion-mcp-server)** (37 tools) — fleet-wide operations through the Percepxion SaaS platform: device inventory, firmware compliance/rollout, config management, Smart Groups, security audit, async CLI dispatch with output retrieval.
- **[`slc-mcp-server`](https://github.com/Lantronix/slc-mcp-server)** (37 tools) — direct, synchronous single-device operations against individual SLC9000/SLC8000 console servers: port status, session management, sync CLI output, cellular status.

Classified **external/on-demand** (same shape as `pyats`/`aap-automation`), not vendored — both repos
took real commits in the week this spec was written, vendoring a frozen copy would go stale
immediately. Full reasoning in `specs/104-percepxion-oob-integration/research.md`.

## What's in this PR

- `specs/104-percepxion-oob-integration/{spec,plan,research}.md` — spec-driven artifacts per Principle XVI
- `workspace/skills/percepxion-oob/SKILL.md` — the skill itself, 8 workflows, iterated against both servers' actual source over several sessions of hands-on use, including two live root-cause findings (see below)
- `scripts/lib/catalog.sh` — new "Out-of-Band" category, `percepxion`/`slc` entries, added to `PROFILE_MULTIVENDOR`
- `scripts/lib/install-steps.sh` — `component_install_percepxion()`/`component_install_slc()`, dedicated-venv pattern (both servers pin `fastmcp>=3.1.0,<4.0`, the same conflict shape `component_install_zabbix()` guards against)
- `scripts/verify-inventory-counts.py` — `EXTERNAL_INTEGRATIONS` entries
- `README.md`, `SOUL.md`, `TOOLS.md`, `.env.example` — doc surfaces and count reconciliation (221→222 skills, 163→165 MCP integrations)

## Two live findings folded into the skill

1. **`get_job_group` never returns CLI command output text**, only job status/metadata — contrary to an earlier assumption. Traced to Percepxion's WebUI actually fetching output via a second, undocumented REST call. Shipped upstream as `get_cli_command_output` in `percepxion-mcp-server` v1.1.0, corrected at all 8 sites in the skill that assumed otherwise.
2. **Percepxion's `organization_id` requirement is role-dependent** — required for Project Admin sessions on job/telemetry/content/Smart-Group/audit calls, optional (auto-scoped) for Tenant Admin/Tenant User. Documented in the skill's Platform Security Configuration section; v1.1.0+ raises a clear error instead of an opaque `ACCESS_DENIED`.

## Test plan

- [x] `python3 scripts/verify-inventory-counts.py` — documentation check PASS, exact predicted delta (60→62 external, 103 config-registered unchanged)
- [x] `python3 scripts/verify-spec-artifacts.py` — PASS (90 specs checked)
- [x] `python3 scripts/reconcile-mcp.py --surface catalog` — PASS
- [x] `python3 scripts/reconcile-mcp.py --surface portability` — PASS
- [x] `python3 scripts/reconcile-mcp.py --surface dependencies` — PASS
- [x] `bash -n` on both modified installer scripts
- [x] Both servers' own test suites pass on current `main` (93 tests `percepxion-mcp-server`, 127 tests `slc-mcp-server`), and both `pyproject.toml` dependency pins verified directly, no unbounded pin on an imported submodule
- [ ] `scripts/reconcile-mcp.py` full run shows one unrelated pre-existing `startup` surface failure (missing Python modules for `gnmi-mcp`/`prisma-sdwan-mcp`/`rag-mcp`/`twilio-voice-mcp`/`twitter-mcp`) — confirmed present identically with this branch's changes stashed out, not introduced by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)