### PR TITLE
feat(105): make mobile Border onboarding self-diagnosing

### DIFF
--- a/mcp-servers/protocol-mcp/bgp-daemon-v2.py
+++ b/mcp-servers/protocol-mcp/bgp-daemon-v2.py
@@ -487,8 +487,12 @@ async def handle_n2n(method, path, body):
                     "push_platform": m.get("push_platform"),
                     "queued": fed.edge_queue.depth(m["member_id"]),
                 })
+            # Spec 105: the listener's own state, not just the devices behind it.
+            # `_start_edge` runs as a task, so a bare attribute read can race
+            # startup — absent means "not yet decided", not "healthy".
+            edge_status = getattr(fed, "edge_status", {"state": "starting"})
             return 200, {"identity": fed.local_identity, "peers": peers,
-                         "edge_nodes": edge}
+                         "edge_nodes": edge, "edge_listener": edge_status}
 
         if path == "/n2n/peers/forget-endpoint" and method == "POST":
             # Feature 100 (US4/FR-021/026): retire a stale dial endpoint without shell
@@ -914,13 +918,30 @@ async def _start_edge(fed):
     same domain-verified/self-signed credential as eN2N/iN2N via
     host_credential() + tls.server_context() (research D1) — deliberately NOT
     internal_channel.build_ssl_contexts, which is the older risk-CA/self-signed
-    path and does not carry the domain-verified cert."""
+    path and does not carry the domain-verified cert.
+
+    Every exit path records why on `fed.edge_status` (spec 105). Before that, a
+    listener that never bound left no trace outside one journal line, and the
+    only user-facing symptom was `risk token --edge` refusing to mint —
+    reported as "only a Border can issue enrollment tokens", which points at
+    the role even when the role is correct and the real cause is a missing
+    dependency. First real-world install lost hours to exactly that."""
+    def _status(state, **kw):
+        fed.edge_status = {"state": state, **kw}
+
     try:
-        if not (fed.risk.is_border() and fed.risk.stack_enabled("in2n")):
+        if not fed.risk.is_border():
+            _status("not_border", role=fed.risk.role(),
+                    hint="promote this claw: netclaw risk role border <risk-name>")
+            return
+        if not fed.risk.stack_enabled("in2n"):
+            _status("stack_disabled", enabled_stacks=fed.risk.get_risk().get("enabled_stacks"),
+                    hint="enable the in2n stack: netclaw risk role border <risk-name> in2n")
             return
         port = int(os.environ.get("N2N_EDGE_WS_PORT", "0") or 0)
         if not port:
             logger.info("Edge (NetClaw Mobile): set N2N_EDGE_WS_PORT to accept phone dial-ins")
+            _status("no_port", hint="set N2N_EDGE_WS_PORT=8443 in ~/.openclaw/.env")
             return
         import websockets
         from bgp.federation import tls as _tls
@@ -962,10 +983,27 @@ async def _start_edge(fed):
             max_size=NCFED_MAX_MESSAGE,
         )
         fed._edge_server = server  # keep a ref
+        _status("listening", port=port,
+                domain=os.environ.get("N2N_CLAW_DOMAIN") or None)
         logger.info("Edge (NetClaw Mobile) WS listener on 0.0.0.0:%d (risk=%s)",
                    port, fed.risk.get_risk().get("risk_name"))
+    except ModuleNotFoundError as e:
+        # The single most likely first-install failure, and the one whose
+        # surface error is most misleading. `websockets` is declared in
+        # protocol-mcp/requirements.txt, but that file is only installed by the
+        # optional `protocol` component — selecting N2N without it yields a mesh
+        # daemon that cannot bind the edge listener. Name the remedy here rather
+        # than leaving the operator to infer it from an ImportError.
+        mod = getattr(e, "name", None) or str(e)
+        hint = (f"python3 -m pip install --break-system-packages {mod}"
+                f"   (or: apt install python3-{mod})")
+        logger.error("Edge WS start FAILED — missing Python module %r for %s. Remedy: %s",
+                     mod, sys.executable, hint)
+        _status("failed", port=port, error=f"missing module {mod!r}",
+                interpreter=sys.executable, hint=hint)
     except Exception as e:
         logger.error("Edge WS start error: %s", e)
+        _status("failed", port=port, error=str(e))
 
 
 async def _start_cert_lifecycle(fed):

--- a/mobile/netclaw-mobile/MOBILE-ONBOARDING.md
+++ b/mobile/netclaw-mobile/MOBILE-ONBOARDING.md
@@ -36,6 +36,20 @@ phone is exactly as privileged as the scope you grant it and no more.
 | **Revocation** | Removing the member unpins the key. The Border then answers that device with `-32023` (not trusted), which drops the app back to its enrollment screen instead of retrying forever. |
 | **Audit** | Every request a phone originates is recorded in the Border's normal GAIT audit trail, attributed to that member ID. |
 
+### What this exposes
+
+Be deliberate about it: enrolling a phone means **a public inbound TLS listener
+into whatever network segment the Border sits on**. That is a posture change, not
+a default, and it deserves a decision rather than a shrug.
+
+What carries it: domain-verified TLS the app validates with no bypass; single-use
+enrollment tokens stored only as hashes; and hardware-rooted device identity
+whose private key cannot be exported. What you should still do: tighten the
+firewall's source addresses if the client population is predictable, audit the
+WAN policy logs periodically, and after any host-level change (a kernel reboot
+especially) confirm the mesh service, Border role, port forward, and listener all
+came back — `netclaw risk edge-check` covers the last three.
+
 **The enrollment token is the one genuinely sensitive artifact in this flow.**
 It is bearer credentials: anyone who has it before your tester does can enroll
 their own device in their place. Treat it like a password — see *Handing over
@@ -43,7 +57,95 @@ the token* below.
 
 ---
 
+## Fast path
+
+If you just want the commands, in order. Every one of these is a step a real
+first install got stuck on — the long-form sections below explain why.
+
+```bash
+netclaw risk edge-check                      # 0. what's missing? (checks all of the below)
+netclaw risk role border <risk-name> in2n    # 1. standalone → Border, in2n stack on
+systemctl --user restart netclaw-mesh.service # 2. apply
+netclaw risk edge-check                      # 3. confirm green before going further
+netclaw risk token --edge <device-label>     # 4. mint the QR
+netclaw risk members                         # 5. verify the device that claimed it
+```
+
+`netclaw risk edge-check` is the one command worth remembering. It checks role,
+stack, both env vars, the mesh daemon's Python dependencies, whether the
+listener actually bound, the live socket, and DNS — and prints the remedy for
+whatever is wrong. It exists because the first real-world install cleared **five
+independent blockers, each of which masked the next**, and none of which named
+itself in its own error message.
+
+---
+
 ## Claw side (Border operator)
+
+### 0. One-time: you must be a Border, with the `in2n` stack enabled
+
+At install you chose **standalone**, **Border**, or **Member**. Only a Border
+issues mobile enrollment tokens:
+
+```bash
+netclaw risk status
+#   role : standalone
+netclaw risk token --edge my-phone
+#   error: only a Border can issue enrollment tokens
+```
+
+> **"Standalone is a risk of one, its own Border" does not mean Border features
+> work.** Standalone is its own Border for federation *identity* only. It issues
+> no enrollment tokens and starts no mobile edge listener. This wording has
+> misled at least one installer; `risk status` now says so explicitly.
+
+Promote in place — **no reinstall is needed**, the role is a field in the
+federation database:
+
+```bash
+netclaw risk role border <risk-name> in2n
+systemctl --user restart netclaw-mesh.service
+netclaw risk status          # role : border
+```
+
+**The `in2n` stack matters as much as the role.** The edge listener is gated on
+`is_border()` **and** `stack_enabled("in2n")` — a Border with no stack enabled
+starts no listener, so the promote looks successful and the phone still cannot
+connect. `netclaw risk role border <name>` defaults the stack to `in2n` for
+exactly this reason; pass `both` instead if you also want external (eN2N)
+federation peering.
+
+> **Historical note — if you are following an older copy of these instructions:**
+> there was no `netclaw risk role` subcommand, and the documented promote was a
+> raw `curl` against `/n2n/risk`. Written without the scheme and port
+> (`127.0.0.1/n2n/risk` rather than `http://127.0.0.1:8179/n2n/risk`) it never
+> reaches the daemon and **silently no-ops** — no error, role unchanged. If you
+> must use curl, use `-i` so a missing `200` is visible. The subcommand exists
+> so you don't have to.
+
+### 0b. The mesh daemon needs `websockets` and `qrcode`
+
+The edge listener imports `websockets`; the token command renders with `qrcode`.
+Both are declared in `mcp-servers/protocol-mcp/requirements.txt`, but that file
+is installed by the optional **Protocol** component — so an install that
+selected N2N without it gets a mesh daemon that starts, looks healthy, and
+cannot bind the edge listener. (Fixed in the installer as of spec 105; this
+section is for boxes installed before that.)
+
+The trap is *which* interpreter: the mesh runs under the `ExecStart` in
+`netclaw-mesh.service`, which is `/usr/bin/python3` — a virtualenv will not be
+consulted, and on modern Ubuntu a plain `pip install` there is refused by
+PEP 668 (`externally-managed-environment`).
+
+```bash
+/usr/bin/python3 -c "import websockets, qrcode"        # the only test that counts
+sudo apt install -y python3-websockets python3-qrcode  # PEP-668-clean
+# or: /usr/bin/python3 -m pip install --break-system-packages websockets qrcode
+systemctl --user restart netclaw-mesh.service
+```
+
+`netclaw risk edge-check` performs this import test against the interpreter it
+reads out of the unit file, not against whatever `python3` means in your shell.
 
 ### 1. One-time: expose the edge listener
 
@@ -57,20 +159,105 @@ N2N_CLAW_DOMAIN=border.example.com   # must match your TLS certificate
 N2N_EDGE_WS_PORT=8443
 ```
 
-Restart the daemon, then confirm the listener came up:
+Restart the daemon, then confirm the listener came up — **and read the port in
+the log line, don't assume it**:
 
 ```bash
 systemctl --user restart netclaw-mesh.service
-journalctl --user -u netclaw-mesh.service -n 50 --no-pager | grep -i "Edge"
+journalctl --user -u netclaw-mesh.service --since "1 min ago" | grep -i "Edge"
 # → Edge (NetClaw Mobile) WS listener on 0.0.0.0:8443 (risk=<your-risk>)
+ss -tlnp | grep 8443          # the live socket, not a log claim
 ```
+
+Two things that have each cost real time here:
+
+- **Use `--since "1 min ago"`** (not `-n 50`). Old `ERROR` lines from before a
+  fix stay in the journal forever and read exactly like a current failure. More
+  than one already-solved problem has been re-chased this way.
+- **A transposed port survives a careless edit.** One install ran with
+  `N2N_EDGE_WS_PORT=1443` and bound `0.0.0.0:1443` perfectly happily while the
+  app dialled 8443. Check for a *duplicate* `N2N_EDGE_WS_PORT` line too — with
+  two lines the last one wins, and it may not be the one you just edited:
+  ```bash
+  grep -n N2N_EDGE_WS_PORT ~/.openclaw/.env    # expect exactly one line
+  ```
 
 `N2N_CLAW_DOMAIN` must resolve publicly and match the certificate the Border
 presents — phones validate it. A self-signed or mismatched cert fails the
 handshake with no override in the app, by design.
 
-Make sure the port is actually reachable from outside your network (firewall,
-NAT, security group). A phone on cellular is not on your LAN.
+```bash
+dig +short <your-claw-domain>     # must be the public IP the phone will reach
+```
+
+### 1b. Forward the port from the internet
+
+The listener binding `0.0.0.0:8443` proves nothing about reachability. **A phone
+on cellular is not on your LAN**, and a healthy listener behind an
+un-forwarded firewall port times out identically to a dead one — this is the
+blocker most likely to be mistaken for an app bug.
+
+Forward public `:8443` → `<box>:8443` however your edge device does it, then
+**verify with a live packet trace while the phone actually tries to connect**.
+A completed handshake (SYN in → SYN/ACK out → ACK → data) is the only proof:
+
+```bash
+# FortiGate
+diagnose sniffer packet <wan-interface> 'port 8443' 4
+```
+
+<details>
+<summary><b>FortiGate in Central NAT mode</b> — the VIP is not the policy's <code>dstaddr</code></summary>
+
+Check your mode first — if `show firewall central-snat-map` has entries, you are
+in Central NAT, and the usual "put the VIP in the policy's destination" recipe
+**will never work**. That is a policy-NAT-mode construct. In Central NAT the VIP
+carries the DNAT itself and the policy uses `dstaddr all`. Getting this wrong
+throws `entry not found in datasource` even after the VIP exists, which reads
+like a missing object rather than a mode mismatch.
+
+Order matters: the VIP must exist before any policy references it.
+
+```
+# 1. Service object
+config firewall service custom
+    edit "HTTPS_8443"
+        set tcp-portrange 8443
+    next
+end
+
+# 2. VIP — this is what performs the DNAT
+config firewall vip
+    edit "netclaw-mobile-8443"
+        set extip <WAN-IP>
+        set extintf "<wan-interface>"
+        set portforward enable
+        set protocol tcp
+        set extport 8443
+        set mappedip <box-internal-IP>
+        set mappedport 8443
+    next
+end
+
+# 3. Policy — dstaddr is ALL, *not* the VIP name
+config firewall policy
+    edit 0
+        set name "netclaw-mobile-in"
+        set srcintf "<wan-interface>"
+        set dstintf "<box-vlan-interface>"
+        set srcaddr "all"
+        set dstaddr "all"
+        set action accept
+        set schedule "always"
+        set service "HTTPS_8443"
+        set logtraffic all
+    next
+end
+```
+
+If the client population is predictable, tighten `srcaddr` rather than leaving
+it `all`.
+</details>
 
 ### 2. Per device: issue an enrollment token
 
@@ -183,11 +370,28 @@ member if it was already claimed, and issue a fresh one. Tokens are free.
 
 ## Troubleshooting
 
+**Start with `netclaw risk edge-check`.** It diagnoses every row in the first
+half of this table and prints the fix. The table is here for the reasoning.
+
 | Symptom | Cause |
 |---|---|
+| `error: only a Border can issue enrollment tokens` | Usually the literal truth — `netclaw risk status` shows `standalone`; promote with `netclaw risk role border <name> in2n`. **But this message has also appeared with the role already correct**, when the listener died for an unrelated reason (missing `websockets`). It names the role because that is the check the token route performs; it is not proof the role is wrong. Run `edge-check`. |
 | `netclaw risk token --edge` exits with no output | `N2N_CLAW_DOMAIN` or `N2N_EDGE_WS_PORT` missing from the runtime env — see step 1. |
-| `qrcode not installed` | `pip install -r mcp-servers/protocol-mcp/requirements.txt`. The JSON fallback and manual entry still work without it. |
-| Phone times out connecting | Port not reachable from outside your network, or the daemon's edge listener never started — check the `journalctl` line in step 1. |
-| TLS / certificate error on the phone | `N2N_CLAW_DOMAIN` doesn't match the served certificate, or the cert isn't publicly trusted. There is no bypass in the app. |
-| "Token already used" | Tokens are single-use. Issue a new one. |
+| Promote appeared to work but `risk status` still says `standalone` | A `curl` to `/n2n/risk` without `http://` and `:8179` never reaches the daemon and no-ops silently. Use `netclaw risk role`, or add `-i` to the curl. |
+| Listener bound, but on the wrong port | Mistyped or duplicated `N2N_EDGE_WS_PORT`. `grep -n N2N_EDGE_WS_PORT ~/.openclaw/.env` — expect one line. |
+| `ERROR Edge WS start error: No module named 'websockets'` | The mesh daemon's interpreter (`/usr/bin/python3`, per the unit's `ExecStart`) lacks it. `sudo apt install python3-websockets python3-qrcode`. A venv does not help — the unit calls the absolute path. |
+| `qrcode not installed` | Same interpreter problem as above. The JSON fallback and manual entry still work without it. |
+| Journal shows an error you already fixed | You are reading a stale line. Always `journalctl --user -u netclaw-mesh.service --since "1 min ago"`. |
+| Phone times out connecting | Listener not bound, or public `:8443` not forwarded to the box. Confirm the socket with `ss -tlnp \| grep 8443`, then prove reachability with a packet trace while the phone tries — see step 1b. |
+| FortiGate: `entry not found in datasource` on the policy | Central NAT mode — the VIP performs the DNAT and the policy's `dstaddr` must be `all`, not the VIP name. See step 1b. |
+| TLS / certificate error on the phone | `N2N_CLAW_DOMAIN` doesn't match the served certificate, or the cert isn't publicly trusted, or DNS points somewhere other than the forwarded public IP. There is no bypass in the app. |
+| "Token already used" | Tokens are single-use — a failed or partial attempt spends one. Issue a new one; they're free. |
 | App drops back to the enrollment screen | The Border revoked this device (`-32023`). Issue a fresh token to re-enroll. |
+
+### Debugging posture
+
+The pattern that cleared all five first-install blockers: **stop trusting the
+surface error, find the actual state, fix the real cause.** Every one of them
+either failed silently or pointed at the wrong layer. Ask the system what it
+is — `risk status`, `ss -tlnp`, a packet trace, an `import` under the daemon's
+own interpreter — rather than inferring from the message you were given.

--- a/scripts/lib/install-steps.sh
+++ b/scripts/lib/install-steps.sh
@@ -1942,7 +1942,18 @@ if [ -d "$PROTOCOL_MCP_DIR" ]; then
     if [ -f "$PROTOCOL_MCP_DIR/requirements.txt" ]; then
         netclaw_pip_install -r "$PROTOCOL_MCP_DIR/requirements.txt" || {
             log_warn "Full Protocol MCP install failed — installing core deps..."
-            netclaw_pip_install scapy networkx mcp fastmcp || \
+            # Spec 105: websockets/qrcode/httpx/h2 belong in this fallback, not
+            # just in requirements.txt. They are the mesh daemon's own runtime
+            # deps (NCFED edge listener + enrollment QR + push), so omitting them
+            # here produced a daemon that starts, reports healthy, and cannot
+            # bind the mobile edge listener — diagnosed as a role problem.
+            #
+            # Two further corrections to this list, both from requirements.txt's
+            # own load-bearing comments: `mcp` MUST carry <2 (2.0.0 removed
+            # mcp.server.fastmcp, which this server imports, so a bare `mcp`
+            # resolves 2.x and dies at import), and `fastmcp` is deliberately NOT
+            # here — spec 077 removed it as a dead pin nothing imports.
+            netclaw_pip_install scapy networkx 'mcp>=1.0.0,<2' websockets qrcode httpx h2 || \
                 log_warn "Protocol MCP core deps install failed"
         }
     fi
@@ -1985,6 +1996,26 @@ if [ -d "$N2N_MCP_DIR" ]; then
         log_warn "n2n-mcp deps install failed — install httpx + fastmcp manually"
 else
     log_warn "n2n-mcp not found — it should be bundled at mcp-servers/n2n-mcp/"
+fi
+
+# Spec 105: N2N declares "Requires the mesh" above, and the mesh daemon IS
+# protocol-mcp/bgp-daemon-v2.py — but until now this step installed only
+# n2n-mcp's deps. Selecting N2N *without* the optional Protocol component
+# therefore produced a running mesh daemon missing its own runtime deps
+# (websockets → no NCFED edge listener, qrcode → no enrollment QR). The daemon
+# logged one ImportError and carried on; the operator-facing symptom was
+# `risk token --edge` answering "only a Border can issue enrollment tokens",
+# which points at the role rather than the missing module. That cost hours on
+# the first real-world mobile install.
+#
+# Idempotent: pip no-ops when the requirements are already satisfied, so this is
+# free when the Protocol component was selected too.
+PROTOCOL_MCP_REQS="$MCP_DIR/protocol-mcp/requirements.txt"
+if [ -f "$PROTOCOL_MCP_REQS" ]; then
+    log_info "Ensuring mesh daemon (protocol-mcp) dependencies — N2N runs on it..."
+    netclaw_pip_install -r "$PROTOCOL_MCP_REQS" || \
+        netclaw_pip_install websockets qrcode httpx h2 || \
+        log_warn "mesh daemon deps install failed — the NCFED edge listener will not bind"
 fi
 
 # Enable the federation layer in the OpenClaw .env

--- a/scripts/netclaw
+++ b/scripts/netclaw
@@ -11,6 +11,12 @@
 #   netclaw chats --watch    live-watch for new sessions/lines (Ctrl+C to stop)
 #   netclaw link            (re)create the ~/.local/bin/netclaw symlink
 #
+#   NetClaw Mobile (enrolling a phone against this claw):
+#   netclaw risk role border <risk-name> [in2n]   promote standalone → Border
+#   netclaw risk edge-check                       preflight every precondition
+#   netclaw risk token --edge <device-label>       mint the single-use QR
+#   See mobile/netclaw-mobile/MOBILE-ONBOARDING.md for the full procedure.
+#
 # Reads peering state from the mesh daemon HTTP API (bgp-daemon-v2.py,
 # default http://127.0.0.1:8179) and N2N chat transcripts from
 # ~/.openclaw/n2n/chats/. `peering up`/`down` start/stop the daemon
@@ -503,7 +509,13 @@ if d.get("role") == "border":
 elif d.get("role") == "member":
     print("    member_id    : %s" % (d.get("self_member_id") or "-"))
 else:
-    print("    (standalone — a risk of one, its own Border)")
+    # Spec 105: the old wording here was just "a risk of one, its own Border",
+    # which reads as "Border things will work" — they do not. Standalone is its
+    # own Border for federation *identity* only; it issues no enrollment tokens
+    # and starts no mobile edge listener. Say so where the operator looks.
+    print("    (standalone — its own Border for identity only)")
+    print("    note         : standalone cannot issue mobile enrollment tokens.")
+    print("                   To enroll a phone:  netclaw risk role border <risk-name>")
 '
 }
 
@@ -575,6 +587,204 @@ import json,sys; d=json.load(sys.stdin)
 print("    error:", d["error"]) if "error" in d else print("    token:", d["token"])'
 }
 
+risk_role() {  # risk_role <standalone|border|member> [risk-name] [stacks]
+    # Spec 105. Before this, promoting a standalone claw to Border — the one
+    # step every mobile install needs — had no CLI at all, so the docs carried a
+    # raw curl. A curl written without the scheme and port silently no-ops
+    # (`127.0.0.1/n2n/risk` never reaches the daemon), which is exactly what
+    # happened on the first real-world install: no error, role unchanged.
+    local role="$1" name="${2:-}" stacks="${3:-}"
+    case "$role" in
+        standalone|border|member) ;;
+        *) echo "usage: netclaw risk role <standalone|border|member> [risk-name] [stacks]"
+           echo "  e.g. netclaw risk role border my-risk in2n     # enroll phones"
+           return 1 ;;
+    esac
+    if [ "$role" = "border" ]; then
+        # Carry forward what this claw already is when an argument is omitted.
+        # /n2n/risk overwrites every field it is given, so defaulting a blank
+        # `stacks` to "in2n" on a claw already running "both" would silently
+        # switch OFF external federation as a side effect of a mobile fix.
+        local cur_json cur_stacks cur_name
+        cur_json="$(api_get /n2n/risk)"
+        cur_stacks="$(printf '%s' "$cur_json" | python3 -c 'import json,sys
+try: print(json.load(sys.stdin).get("enabled_stacks") or "")
+except Exception: print("")' 2>/dev/null)"
+        cur_name="$(printf '%s' "$cur_json" | python3 -c 'import json,sys
+try: print(json.load(sys.stdin).get("risk_name") or "")
+except Exception: print("")' 2>/dev/null)"
+        name="${name:-$cur_name}"
+        [ -n "$name" ] || { echo "  a Border needs a risk name: netclaw risk role border <risk-name> [stacks]"; return 1; }
+        # in2n when there is nothing to preserve: the mobile edge listener is
+        # gated on the stack as well as the role, and a Border with no stack
+        # enabled starts no listener — a promote that looks successful and still
+        # cannot enroll a phone.
+        stacks="${stacks:-${cur_stacks:-in2n}}"
+        case "$stacks" in
+            in2n|both) ;;
+            *) echo "  note: enabled_stacks='$stacks' does not include in2n —"
+               echo "        the mobile edge listener will not start. Pass 'in2n' or 'both'." ;;
+        esac
+    fi
+    local body
+    body="$(python3 -c '
+import json, sys
+role, name, stacks = sys.argv[1], sys.argv[2], sys.argv[3]
+b = {"role": role}
+if name: b["risk_name"] = name
+if stacks: b["enabled_stacks"] = stacks
+print(json.dumps(b))' "$role" "$name" "$stacks")"
+    api_post /n2n/risk "$body" | python3 -c '
+import json, sys
+raw = sys.stdin.read().strip()
+if not raw:
+    print("    no response from the daemon API — is the mesh running?")
+    print("    check:  systemctl --user status netclaw-mesh.service")
+    sys.exit(1)
+try: d = json.loads(raw)
+except Exception: print("    unexpected response:", raw[:200]); sys.exit(1)
+if "error" in d:
+    print("    error:", d["error"]); sys.exit(1)
+print("    role  : %s" % d.get("role"))
+print("    risk  : %s" % (d.get("risk_name") or "-"))
+print("    %s" % d.get("note", ""))'
+    local rc=$?
+    [ "$rc" -eq 0 ] || return "$rc"
+    echo ""
+    echo "  Restart the mesh for the change to take effect, then verify:"
+    echo "      systemctl --user restart netclaw-mesh.service"
+    echo "      $(basename "$0") risk edge-check"
+}
+
+# Spec 105: one command that checks every precondition for enrolling a phone.
+# Written because the first real-world install cleared five independent
+# blockers, each of which masked the next and none of which named itself:
+# wrong role, disabled stack, a promote that silently no-op'd, a missing
+# Python module, a mistyped port, and an un-forwarded firewall port.
+risk_edge_check() {
+    echo ""
+    echo -e "  ${T_BOLD}NetClaw Mobile — edge enrollment preflight${T_NC}"
+    echo ""
+
+    local envf="$RUNTIME_HOME/.env" fail=0
+
+    # 1-2. Role + stack, straight from the daemon.
+    local risk_json; risk_json="$(api_get /n2n/risk)"
+    if [ -z "$risk_json" ]; then
+        echo "  ✗ daemon    : not reachable at $BGP_API"
+        echo "                systemctl --user status netclaw-mesh.service"
+        return 1
+    fi
+    local role stacks riskname
+    role="$(printf '%s' "$risk_json" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("role",""))' 2>/dev/null)"
+    stacks="$(printf '%s' "$risk_json" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("enabled_stacks") or "")' 2>/dev/null)"
+    riskname="$(printf '%s' "$risk_json" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("risk_name") or "")' 2>/dev/null)"
+
+    if [ "$role" = "border" ]; then
+        echo "  ✓ role      : border (risk=${riskname:--})"
+    else
+        echo "  ✗ role      : $role — only a Border can issue enrollment tokens"
+        echo "                netclaw risk role border <risk-name> in2n"
+        fail=1
+    fi
+    case "$stacks" in
+        in2n|both) echo "  ✓ stack     : $stacks (in2n enabled)" ;;
+        *) echo "  ✗ stack     : ${stacks:--} — the edge listener needs in2n"
+           echo "                netclaw risk role border ${riskname:-<risk-name>} in2n"
+           fail=1 ;;
+    esac
+
+    # 3. The two env vars, including the duplicate-line case that makes a
+    #    mistyped port survive a 'fix' (last line wins, and it may not be yours).
+    local domain port dupes
+    domain="$(env_get N2N_CLAW_DOMAIN)"; port="$(env_get N2N_EDGE_WS_PORT)"
+    if [ -n "$domain" ]; then echo "  ✓ domain    : $domain"
+    else echo "  ✗ domain    : N2N_CLAW_DOMAIN unset in $envf"; fail=1; fi
+    if [ -n "$port" ]; then echo "  ✓ port      : $port"
+    else echo "  ✗ port      : N2N_EDGE_WS_PORT unset in $envf"; fail=1; fi
+    if [ -f "$envf" ]; then
+        dupes="$(grep -cE '^[[:space:]]*N2N_EDGE_WS_PORT=' "$envf" 2>/dev/null || true)"
+        if [ "${dupes:-0}" -gt 1 ]; then
+            echo "  ! env       : N2N_EDGE_WS_PORT appears $dupes times in $envf (last wins)"
+        fi
+    fi
+
+    # 4. The daemon's own deps, under the interpreter systemd actually runs —
+    #    not whatever `python3` resolves to in this shell.
+    local mesh_py="/usr/bin/python3" unit="$HOME/.config/systemd/user/netclaw-mesh.service"
+    [ -f "$unit" ] && mesh_py="$(sed -n 's/^ExecStart=\([^ ]*\).*/\1/p' "$unit" | head -1)"
+    mesh_py="${mesh_py:-/usr/bin/python3}"
+    local missing=""
+    for mod in websockets qrcode; do
+        "$mesh_py" -c "import $mod" >/dev/null 2>&1 || missing="$missing $mod"
+    done
+    if [ -z "$missing" ]; then
+        echo "  ✓ deps      : websockets + qrcode importable by $mesh_py"
+    else
+        echo "  ✗ deps      :$missing missing for $mesh_py"
+        echo "                $mesh_py -m pip install --break-system-packages$missing"
+        echo "                (or: sudo apt install$(printf ' python3-%s' $missing))"
+        fail=1
+    fi
+
+    # 5. Did the listener actually bind? Ask the daemon, then confirm the socket.
+    local st; st="$(api_get /n2n/health | python3 -c '
+import json,sys
+try: d=json.load(sys.stdin)
+except Exception: print(""); sys.exit()
+e=d.get("edge_listener") or {}
+print("%s|%s|%s" % (e.get("state",""), e.get("error") or "", e.get("hint") or ""))' 2>/dev/null)"
+    # NB: separate statements, not one `local a=… b="${a}…"`. A single `local`
+    # expands every argument before assigning any, so the later references would
+    # read as unbound under `set -u`.
+    local lstate rest lerr lhint
+    lstate="${st%%|*}"; rest="${st#*|}"; lerr="${rest%%|*}"; lhint="${rest#*|}"
+    case "$lstate" in
+        listening) echo "  ✓ listener  : bound" ;;
+        "")        echo "  ! listener  : daemon reports no edge state (older daemon, or still starting)" ;;
+        *)         echo "  ✗ listener  : $lstate${lerr:+ — $lerr}"
+                   [ -n "$lhint" ] && echo "                $lhint"
+                   fail=1 ;;
+    esac
+    if [ -n "$port" ]; then
+        if ss -tlnH "sport = :$port" 2>/dev/null | grep -q .; then
+            echo "  ✓ socket    : something is listening on :$port"
+        else
+            echo "  ✗ socket    : nothing listening on :$port"
+            echo "                journalctl --user -u netclaw-mesh.service --since '2 min ago' | grep -i Edge"
+            fail=1
+        fi
+    fi
+
+    # 6. DNS must resolve the claw domain to the public IP the phone will hit,
+    #    or TLS cannot match no matter how the firewall is built.
+    if [ -n "$domain" ]; then
+        local resolved wan
+        resolved="$(getent ahostsv4 "$domain" 2>/dev/null | awk '{print $1; exit}')"
+        wan="$(curl -s --max-time 5 https://api.ipify.org 2>/dev/null || true)"
+        if [ -z "$resolved" ]; then
+            echo "  ✗ dns       : $domain does not resolve"; fail=1
+        elif [ -n "$wan" ] && [ "$resolved" != "$wan" ]; then
+            echo "  ! dns       : $domain → $resolved, but this host's public IP is $wan"
+            echo "                fine behind a NAT/VIP that forwards :$port — verify the forward"
+        else
+            echo "  ✓ dns       : $domain → $resolved"
+        fi
+    fi
+
+    echo ""
+    if [ "$fail" -eq 0 ]; then
+        echo "  All local checks passed. Inbound :$port must also be reachable from"
+        echo "  the internet — a phone on cellular is not on your LAN. Then:"
+        echo "      $(basename "$0") risk token --edge <device-label>"
+    else
+        echo "  Fix the ✗ lines above, restart the mesh, and re-run this check:"
+        echo "      systemctl --user restart netclaw-mesh.service"
+    fi
+    echo ""
+    return "$fail"
+}
+
 risk_edge_token() {  # risk_edge_token [label] — feature 066: NetClaw Mobile enrollment
     # Reuses the SAME bare-token route as risk_token(); node_type is set later,
     # server-side, by which listener (agent TCP vs edge WS) actually consumes
@@ -587,9 +797,27 @@ risk_edge_token() {  # risk_edge_token [label] — feature 066: NetClaw Mobile e
     if [ -z "$domain" ] || [ -z "$port" ]; then
         echo "  N2N_CLAW_DOMAIN and N2N_EDGE_WS_PORT must both be set in $RUNTIME_HOME/.env" >&2
         echo "  before issuing an edge (phone) enrollment QR." >&2
+        echo "  Run '$(basename "$0") risk edge-check' for the full preflight." >&2
         return 1
     fi
-    api_post /n2n/enroll/token "{\"label\":\"${1:-}\"}" | python3 -c "
+    # Spec 105: mint, but never report a bare API error without its remedy. The
+    # daemon answers a non-Border with "only a Border can issue enrollment
+    # tokens", which is true and yet points at the wrong layer whenever the role
+    # is right and the listener died for another reason — so route any failure
+    # through the preflight, which names the actual cause.
+    local resp; resp="$(api_post /n2n/enroll/token "{\"label\":\"${1:-}\"}")"
+    if [ -z "$resp" ] || printf '%s' "$resp" | grep -q '"error"'; then
+        printf '%s' "$resp" | python3 -c '
+import json, sys
+raw = sys.stdin.read().strip()
+try: print("  error:", json.loads(raw).get("error", raw[:200]))
+except Exception: print("  no response from the daemon API at the /n2n/enroll/token route")' >&2
+        echo "" >&2
+        echo "  Diagnosing — this is almost never really about the token:" >&2
+        risk_edge_check >&2
+        return 1
+    fi
+    printf '%s' "$resp" | python3 -c "
 import json, sys
 try:
     import qrcode
@@ -632,6 +860,7 @@ risk_menu() {
             "Member health (quarantine alerts)" \
             "Enrollment token (issue single-use)" \
             "Edge enrollment QR (NetClaw Mobile)" \
+            "Edge preflight (why can't I enroll a phone?)" \
             "← Back" || return 0
         case "$TUI_CHOICE" in
             0) risk_overview; pause ;;
@@ -639,7 +868,8 @@ risk_menu() {
             2) risk_health; pause ;;
             3) risk_token; pause ;;
             4) risk_edge_token; pause ;;
-            5) return 0 ;;
+            5) risk_edge_check; pause ;;
+            6) return 0 ;;
         esac
     done
 }
@@ -726,6 +956,8 @@ case "${1:-}" in
             health)   risk_health ;;
             add)      risk_add "${3:-}" "${4:-}" "${5:-}" ;;
             remove)   risk_remove "${3:-}" ;;
+            role)     risk_role "${3:-}" "${4:-}" "${5:-}" ;;
+            edge-check|edge_check|preflight) risk_edge_check ;;
             token)
                 if [ "${3:-}" = "--edge" ]; then
                     risk_edge_token "${4:-}"
@@ -733,7 +965,7 @@ case "${1:-}" in
                     risk_token "${3:-}"
                 fi ;;
             route)    risk_route "${3:-}" "${4:-}" ;;
-            *)        echo "Usage: netclaw risk [status|members|health|add|remove|token [--edge]|route]"; exit 1 ;;
+            *)        echo "Usage: netclaw risk [status|members|health|role|edge-check|add|remove|token [--edge]|route]"; exit 1 ;;
         esac ;;
     chats)
         if [ "${2:-}" = "--watch" ] || [ "${2:-}" = "watch" ]; then


### PR DESCRIPTION
First real-world NetClaw Mobile install against a third-party self-hosted Border
(Nate Howard's) cleared **five independent blockers, each masking the next**, none
of which named itself in its own error message. Every change here targets one.

## Root cause corrections

Two of the reported "bugs" pointed at the wrong layer:

- **`websockets`/`qrcode` were already declared** in `protocol-mcp/requirements.txt`,
  and `NETCLAW_PY` already defaults to `/usr/bin/python3` — the same interpreter the
  mesh unit's `ExecStart` uses — with PEP 668 already handled. The real cause:
  `requirements.txt` is installed only by the **optional Protocol component**, while
  `component_install_n2n` installs just n2n-mcp's deps despite the mesh daemon *being*
  `protocol-mcp/bgp-daemon-v2.py`. Selecting N2N without Protocol yielded a daemon that
  starts, reports healthy, and cannot bind the edge listener. Fixed at the source; the
  `apt install python3-websockets` remedy is documented only for already-broken boxes.
- No doc in this repo was found containing the scheme-less `127.0.0.1/n2n/risk`. The
  failure mode is real regardless (it silently no-ops), so the fix is a real subcommand.

## Code

- **`netclaw risk role <role> [name] [stacks]`** — promoting standalone → Border, the
  one step every mobile install needs, had no CLI, so instructions carried a raw curl.
  Preserves existing `risk_name`/`enabled_stacks` when omitted, so a mobile fix cannot
  switch off eN2N as a side effect.
- **`netclaw risk edge-check`** — one preflight for all five blockers: role, in2n stack,
  both env vars (including the duplicate-line case), the daemon's deps under the
  interpreter systemd actually runs, listener state, live socket, DNS vs public IP.
  Prints the remedy per failure and degrades to a warning against an older daemon
  rather than a false failure.
- **`_start_edge`** records every exit path on `fed.edge_status` (exposed at
  `/n2n/health.edge_listener`) instead of one journal line; `ModuleNotFoundError` names
  its remedy. A dead listener's only symptom used to be "only a Border can issue
  enrollment tokens" — which indicts the role even when the role is correct.
- **`risk token --edge`** routes failures through the preflight instead of echoing that
  misleading API error bare.
- **`risk status`** — "standalone — a risk of one, its own Border" now states that it
  issues no tokens and starts no edge listener. Its own Border for federation identity
  only; that wording misled an installer.

## Installer

- `component_install_n2n` now ensures `protocol-mcp/requirements.txt` (idempotent).
- Protocol fallback dep list gains `websockets`/`qrcode`/`httpx`/`h2`, pins `mcp<2` (a
  bare `mcp` resolves 2.x and dies on import, per requirements.txt's own comment), and
  drops `fastmcp` (spec 077 removed it as a dead pin).

## Docs — `MOBILE-ONBOARDING.md`

Fast path; standalone→Border section; the interpreter/PEP-668 dep trap; `--since "1 min
ago"` over `-n 50` (stale journal lines re-chased already-solved problems); mistyped and
duplicated port; port-forwarding with a packet trace as the only proof; FortiGate Central
NAT (the VIP performs the DNAT — policy `dstaddr` is `all`, not the VIP name); an
exposure/posture note; and a troubleshooting table rewritten around causes.

## Verification

`bash -n` clean on both shell files; `reconcile-mcp.py` and `check-dependency-pins.py`
exit 0. Mesh restarted on the maintainer's Border — all eight preflight checks green and
`/n2n/health.edge_listener` reports `{"state":"listening","port":8443}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)