### PR TITLE
fix(106): treat a platform push as a wake signal, not a delivery

### DIFF
--- a/mcp-servers/protocol-mcp/bgp-daemon-v2.py
+++ b/mcp-servers/protocol-mcp/bgp-daemon-v2.py
@@ -801,33 +801,85 @@ async def handle_n2n(method, path, body):
                 "designated_by": "agent",
                 "pushed_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             }
+            # Spec 106. The three delivery tiers below used to be mutually
+            # exclusive, and two of the three exits lost the message outright:
+            #
+            #  1. A platform push counted as *delivery*, so it never enqueued.
+            #     But a push notification only draws the OS banner — the sole
+            #     writer to the phone's MessageFeedStore is the WS handler for
+            #     `n2n/edge/message`, and nothing on the device persists an
+            #     FCM data payload. So the operator saw a notification, opened
+            #     the app, and found an empty feed: `queued=0` on the Border and
+            #     no `Replaying` line, because the content was never written
+            #     down anywhere. Reported from production 2026-08-13.
+            #
+            #  2. Only ValueError fell through to the fallback. `push_to_edge`
+            #     raises ValueError just for "not connected" — a channel that
+            #     exists but whose device is suspended raises
+            #     RpcError(ERR_EXECUTION_TIMEOUT) after the 30s call timeout,
+            #     and a closed socket raises a websockets error. Both escaped to
+            #     the outer handler as a 500: no push, no queue, message gone.
+            #     That is the common case for an iOS device, which holds a
+            #     registered channel for seconds after backgrounding.
+            #
+            # A platform push is now treated as a WAKE SIGNAL, not a delivery:
+            # every path that does not confirm live in-app delivery also
+            # persists, and replay on next connect is what actually populates
+            # the feed. Bounded already — EdgeQueue enforces a per-member depth
+            # cap and TTL on every enqueue (newest-wins), so this cannot grow
+            # federation.db without limit.
+            live_failure = None
             try:
                 result = await fed.push_to_edge(member_id, push)
                 return 200, {"delivered": True, "member_id": member_id, "result": result}
-            except ValueError:
-                # Not connected -- platform push-notification fallback
-                # (FR-011, US3/T031).
-                from bgp.federation import push_notify
-                member = fed.risk.get_member(member_id)
-                if not member:
-                    return 404, {"error": f"unknown member {member_id}"}
+            except ValueError as e:
+                live_failure = f"not connected ({e})"
+            except Exception as e:
+                # Registered but unreachable: call timeout, closed socket, RPC
+                # error from the device. Falling through is strictly better than
+                # a 500 — the operator's message survives either way.
+                live_failure = f"live delivery failed ({type(e).__name__}: {e})"
+                logger.warning("Edge live push to %s failed, falling back: %s",
+                               member_id, e)
+
+            from bgp.federation import push_notify
+            member = fed.risk.get_member(member_id)
+            if not member:
+                return 404, {"error": f"unknown member {member_id}"}
+
+            def _persist(reason):
+                """Enqueue for replay. Never let a bookkeeping failure convert an
+                otherwise-successful push into a 500."""
                 try:
-                    result = await push_notify.send_push_notification(member, push)
-                    return 200, {"delivered": True, "via": "push_notification",
-                                "member_id": member_id, "result": result}
-                except Exception as e:
-                    # Third tier: neither live WS nor a platform push could
-                    # reach the device. Persist instead of dropping, and replay
-                    # on its next connect (_flush_edge_queue). This is the only
-                    # delivery path for an iOS device with no APNs credentials,
-                    # where the OS suspends the socket on background and there
-                    # is nothing that can wake the app.
-                    logger.warning("Push-notification fallback failed for %s: %s", member_id, e)
-                    queue_id = fed.edge_queue.enqueue(member_id, push, reason=str(e))
-                    return 200, {"delivered": False, "queued": True,
-                                 "queue_id": queue_id,
-                                 "queue_depth": fed.edge_queue.depth(member_id),
-                                 "reason": str(e), "member_id": member_id}
+                    return fed.edge_queue.enqueue(member_id, push, reason=reason)
+                except Exception as qe:
+                    logger.error("Edge queue enqueue failed for %s: %s", member_id, qe)
+                    return None
+
+            try:
+                result = await push_notify.send_push_notification(member, push)
+            except Exception as e:
+                # Neither live WS nor a platform push could reach the device.
+                # The only delivery path for a device with no working push
+                # credentials, where the OS suspends the socket on background
+                # and nothing can wake the app.
+                logger.warning("Push-notification fallback failed for %s: %s", member_id, e)
+                queue_id = _persist(f"{live_failure}; push notification failed ({e})")
+                return 200, {"delivered": False, "queued": queue_id is not None,
+                             "queue_id": queue_id,
+                             "queue_depth": fed.edge_queue.depth(member_id),
+                             "reason": str(e), "member_id": member_id}
+
+            # Push accepted by the platform. That wakes the device; it does NOT
+            # put the content in the app. Persist so the next connect replays it.
+            queue_id = _persist(f"{live_failure}; wake-signal push sent, awaiting reconnect")
+            return 200, {"delivered": True, "via": "push_notification",
+                         "member_id": member_id, "result": result,
+                         # Explicit so a caller can tell a banner-only wake from
+                         # confirmed in-app delivery.
+                         "in_app_delivery": "pending_replay",
+                         "queued": queue_id is not None, "queue_id": queue_id,
+                         "queue_depth": fed.edge_queue.depth(member_id)}
 
         return 404, {"error": f"unknown n2n route {path}"}
     except Exception as e:

--- a/mcp-servers/protocol-mcp/bgp/federation/service.py
+++ b/mcp-servers/protocol-mcp/bgp/federation/service.py
@@ -1567,6 +1567,17 @@ class FederationService:
         channel.peer_identity = member_id
         channel.trusted = True
         self._register_edge_channel(member_id, channel)
+        # Spec 106: a successful reconnect used to log NOTHING, so the journal
+        # showed "Accepted edge WS dial-in (awaiting device auth)" followed by a
+        # channel close with nothing in between — indistinguishable from an auth
+        # that never completed. A phone that authenticates and drops seconds
+        # later (iOS suspending a backgrounded socket) is a real, recurring
+        # state, and diagnosing it needs both ends of the channel's life
+        # recorded. The queue depth is here because it decides whether the
+        # replay that follows has anything to send.
+        logger.info("Edge node %s authenticated (source=%s, %d queued)",
+                    member_id, self._edge_channel_source(channel),
+                    self.edge_queue.depth(member_id))
         return {"risk": self.risk.get_risk().get("risk_name"), "trusted": True,
                "member_state": "active"}
 

--- a/tests/n2n/test_edge_push.py
+++ b/tests/n2n/test_edge_push.py
@@ -212,20 +212,28 @@ async def _send_push_notification_dispatches(tmp_path, monkeypatch):
     async def _fake_send_fcm(token, content):
         return {"via": "fcm", "token": token}
 
-    async def _fake_send_apns(token, content):
-        return {"via": "apns", "token": token}
-
     monkeypatch.setattr(push_notify, "send_fcm", _fake_send_fcm)
-    monkeypatch.setattr(push_notify, "send_apns", _fake_send_apns)
-
+    # No send_apns to patch: spec 103 consolidated iOS onto the FCM path, since
+    # the client registers an FCM registration token rather than the raw APNs
+    # device token api.push.apple.com requires. This test had kept patching a
+    # send_apns that no longer exists and had been failing on main ever since;
+    # it now asserts the consolidation instead of the removed function.
     fcm_member = {"member_id": "risk/phone1", "push_platform": "fcm", "push_token": "tok-fcm"}
     apns_member = {"member_id": "risk/phone2", "push_platform": "apns", "push_token": "tok-apns"}
     unregistered = {"member_id": "risk/phone3", "push_platform": None, "push_token": None}
 
     assert (await push_notify.send_push_notification(fcm_member, {"content_type": "text"}))["via"] == "fcm"
-    assert (await push_notify.send_push_notification(apns_member, {"content_type": "text"}))["via"] == "apns"
+    # platform='apns' still routes through FCM — accepted so devices enrolled
+    # before that decision keep working without re-registering.
+    assert (await push_notify.send_push_notification(apns_member, {"content_type": "text"}))["via"] == "fcm"
     with pytest.raises(RuntimeError):
         await push_notify.send_push_notification(unregistered, {"content_type": "text"})
+    # A genuinely raw APNs device token must be rejected loudly rather than sent
+    # to FCM, where it would fail as an opaque vendor error.
+    with pytest.raises(RuntimeError, match="raw APNs"):
+        await push_notify.send_push_notification(
+            {"member_id": "risk/phone4", "push_platform": "apns", "push_token": "a" * 64},
+            {"content_type": "text"})
 
 
 def test_n2n_edge_message_has_no_inbound_handler(tmp_path):

--- a/tests/n2n/test_edge_push_wake_signal.py
+++ b/tests/n2n/test_edge_push_wake_signal.py
@@ -1,0 +1,90 @@
+"""A platform push is a wake signal, not a delivery (spec 106).
+
+Reported from production 2026-08-13: the operator saw notifications arrive on a
+real iPhone, tapped into the app, and found an empty feed. The Border reported
+`queued=0` and logged no `Replaying` line, because the content had never been
+written down anywhere.
+
+Two independent loss paths in the POST /n2n/edge/push route caused it:
+
+  1. A successful platform push RETURNED, without enqueueing. But a push
+     notification only draws the OS banner. The sole writer to the phone's
+     MessageFeedStore is the WS handler for `n2n/edge/message` — nothing on the
+     device persists an FCM data payload, and the notification-tap handler only
+     *searches* the store for an already-persisted match. So the content was
+     lost between the two tiers.
+
+  2. Only `ValueError` fell through to the fallback. `push_to_edge` raises
+     ValueError just for "not connected"; a channel that exists but whose device
+     is suspended raises `RpcError(ERR_EXECUTION_TIMEOUT)` after the 30s call
+     timeout, and a closed socket raises a websockets error. Both escaped as a
+     500 with no push and no queue — the common case for iOS, which holds a
+     registered channel for seconds after backgrounding.
+
+These are source-level assertions because bgp-daemon-v2.py is a script, not an
+importable module — the same convention as test_member_liveness_shared.py and
+test_edge_ws_frame_size.py. Weaker than a behavioural test, but sufficient to
+pin the specific regressions, and the route's tiering had no coverage at all
+before this, which is why the bug shipped.
+"""
+
+import os
+
+_DAEMON = os.path.join(os.path.dirname(__file__), "..", "..", "mcp-servers",
+                       "protocol-mcp", "bgp-daemon-v2.py")
+
+
+def _push_route_src():
+    """Just the POST /n2n/edge/push handler body."""
+    with open(_DAEMON) as f:
+        src = f.read()
+    start = src.index('if path == "/n2n/edge/push" and method == "POST":')
+    # The next route registration ends this one.
+    end = src.index('return 404, {"error": f"unknown n2n route {path}"}', start)
+    return src[start:end]
+
+
+def test_successful_platform_push_also_persists_for_replay():
+    """The reported bug: a banner counted as delivery and nothing was queued."""
+    route = _push_route_src()
+    via_push = route.index('"via": "push_notification"')
+    # Walk back to the enclosing success path and require a persist before it.
+    before = route[:via_push]
+    assert "_persist(" in before, (
+        "the successful push-notification path must enqueue for replay — a push "
+        "notification only wakes the device, it does not put content in the app. "
+        "Without this the message is lost between tiers 2 and 3.")
+
+
+def test_push_success_reports_in_app_delivery_as_pending():
+    """A caller must be able to tell a banner-only wake from real delivery."""
+    route = _push_route_src()
+    assert '"in_app_delivery": "pending_replay"' in route, (
+        'a push-notification response claiming {"delivered": true} without '
+        'qualification is what made this bug invisible to callers')
+
+
+def test_live_delivery_failure_falls_through_instead_of_500ing():
+    """A registered-but-suspended device must not lose the message."""
+    route = _push_route_src()
+    assert "except ValueError" in route, "the not-connected tier must still exist"
+    assert "except Exception" in route, (
+        "push_to_edge raises RpcError(ERR_EXECUTION_TIMEOUT) on a call timeout "
+        "and a websockets error on a closed socket — neither is a ValueError, so "
+        "catching only ValueError sends both to the outer handler as a 500 with "
+        "no push and no queue")
+    # The fallback must be reachable from the broad catch, i.e. the push_notify
+    # import cannot be nested inside the ValueError branch any more.
+    assert route.index("except Exception") < route.index("send_push_notification"), (
+        "the broad catch must precede the fallback so a live-delivery failure "
+        "reaches the platform push and the queue")
+
+
+def test_enqueue_failure_cannot_500_a_successful_push():
+    """Bookkeeping must not convert a delivered push into an error."""
+    route = _push_route_src()
+    persist = route[route.index("def _persist("):]
+    assert "except Exception" in persist[:persist.index("return 200")], (
+        "_persist must swallow and log an enqueue failure — the push already "
+        "left the Border, so raising here would report failure for a message "
+        "that was in fact sent")


### PR DESCRIPTION
Reported from production 2026-08-13: notifications arrived on a real iPhone, but
tapping into the app showed an **empty feed**. The Border reported `queued=0` with
no `Replaying` line — the content had never been written down anywhere.

## Root cause

`POST /n2n/edge/push` treated its three delivery tiers as mutually exclusive, and
two of the three exits lost the operator's message outright.

**1. A successful platform push returned without enqueueing.** A push notification
only draws the OS banner. The sole writer to the phone's `MessageFeedStore` is the
WS handler for `n2n/edge/message`; there is no `FirebaseMessaging.onMessage` or
`onBackgroundMessage` handler anywhere in `lib/`, so nothing on the device
persists an FCM `data` payload, and `NotificationDeepLink._handleRemote` only
*searches* the store for an already-persisted match. Content was lost between
tiers 2 and 3.

This has been dropping tier-2 content for every device since 066 shipped. It went
unnoticed because tier 1 (app open, WS connected) works — which is exactly when
anyone looks.

**2. Only `ValueError` fell through to the fallback.** `push_to_edge` raises
`ValueError` just for "not connected". A channel that exists but whose device is
suspended raises `RpcError(ERR_EXECUTION_TIMEOUT)` after the 30s call timeout, and
a closed socket raises a websockets error. Both escaped to the outer handler as a
**500 — no push, no queue, message gone**. That is the common case for iOS, which
holds a registered channel for seconds after backgrounding, and matches the 5–10s
channel lifetimes observed on the reporting device.

## Change

A platform push is now a **wake signal, not a delivery**. Every path that does not
confirm live in-app delivery also persists, and replay on next connect is what
populates the feed.

- Responses distinguish a banner-only wake (`"in_app_delivery": "pending_replay"`)
  from confirmed delivery, so a caller can no longer read `{"delivered": true}` as
  "it's in the app".
- `EdgeQueue` already enforces a per-member depth cap and TTL on every enqueue
  (newest-wins), so this cannot grow `federation.db` without bound.
- An enqueue failure is logged, never converted into a 500 for a push that did
  leave the Border.

**No app change required** — which matters, because the iOS build is
TestFlight-gated.

## Observability

`_edge_on_hello` logged nothing on success, so the journal showed `Accepted edge WS
dial-in (awaiting device auth)` followed by a channel close with nothing in
between — indistinguishable from an auth that never completed. It now logs member,
remote source, and queue depth (the last decides whether the replay that follows
has anything to send).

## Known residual (app-side, not blocking)

Tapping the notification still will not *jump to* the item: `_handleRemote` searches
the store immediately on tap, but replay does not land until after WS auth plus the
3s `N2N_EDGE_REPLAY_SETTLE_S` settle. The message appears in the Feed tab
regardless. Fixing the jump needs either a re-run of the deep-link match after
replay, or persisting from the FCM `data` payload — and the latter requires a dedup
guard keyed on `pushed_at` first, since `MessageFeedStore.append` has no dedup and
would otherwise double every replayed message. Worth its own spec.

## Tests

- 4 source-level regression tests for the route's tiering, which had **no coverage
  at all** before this — which is why it shipped. All 4 verified failing against the
  old code and passing against the new.
- Repairs `test_edge_push`'s `send_push_notification` case, red on `main` since spec
  103 consolidated iOS onto FCM and removed `send_apns`.
- Full n2n suite: **445 passed**.

Verified live: mesh restarted on the maintainer's Border, edge listener rebound on
8443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)