### PR TITLE
feat(107): notification tap opens the message it names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # netclaw Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-08-08
+Auto-generated from all feature plans. Last updated: 2026-08-13
 
 ## Active Technologies
 - N/A (stateless server; subscription state held in-memory during runtime) (003-gnmi-mcp-server)
@@ -120,6 +120,8 @@ Auto-generated from all feature plans. Last updated: 2026-08-08
 - N/A — stateless client. All state from `GET /api/n2n` and `GET /api/graph`; nothing persisted. (101-hud-threejs-modernization)
 - JavaScript ES2022 (ESM), Node 22+ for tooling. No TypeScript. + `three@0.185.1` — **no new package**. New import surfaces: `three/webgpu` (`WebGPURenderer`, `PostProcessing`, `Lighting`), `three/tsl` (node functions), `three/addons/lighting/ClusteredLighting.js`, and `three/examples/jsm/tsl/display/*` (`BloomNode`, `RGBShiftNode`, `SMAANode`, `AfterImageNode`, `FilmNode`). Force-directed solver is hand-written, not a dependency (research R4). (102-hud-webgpu-interactive-layout)
 - **NEW** — a single JSON file written by `server.js` at a fixed path, holding per-preset node positions and camera pose. First persistent state the HUD client has ever had. `/api/n2n` and `/api/graph` unchanged (FR-032). (102-hud-webgpu-interactive-layout)
+- Dart 3.x / Flutter, SDK constraint `^3.12.2` (from `pubspec.yaml`) + No new packages. Reuses `firebase_messaging ^16.4.3`, `firebase_core ^4.12.1`, `flutter_local_notifications ^22.2.0`, all already present. Continues the 066–073 and 099 precedent of adding no dependency a story does not strictly require. (107-push-render-deeplink)
+- Existing on-device stores, extended not replaced — `MessageFeedStore` (JSON-Lines) and, unchanged, `ConversationStore`. No migration of stored history. (107-push-render-deeplink)
 
 - Python 3.10+ + FastMCP (MCP framework), grpcio + grpcio-tools (gRPC transport), pygnmi (gNMI client library), protobuf, cryptography (TLS handling) (003-gnmi-mcp-server)
 
@@ -139,9 +141,9 @@ cd src [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLO
 Python 3.10+: Follow standard conventions
 
 ## Recent Changes
+- 107-push-render-deeplink: Added Dart 3.x / Flutter, SDK constraint `^3.12.2` (from `pubspec.yaml`) + No new packages. Reuses `firebase_messaging ^16.4.3`, `firebase_core ^4.12.1`, `flutter_local_notifications ^22.2.0`, all already present. Continues the 066–073 and 099 precedent of adding no dependency a story does not strictly require.
 - 102-hud-webgpu-interactive-layout: Added JavaScript ES2022 (ESM), Node 22+ for tooling. No TypeScript. + `three@0.185.1` — **no new package**. New import surfaces: `three/webgpu` (`WebGPURenderer`, `PostProcessing`, `Lighting`), `three/tsl` (node functions), `three/addons/lighting/ClusteredLighting.js`, and `three/examples/jsm/tsl/display/*` (`BloomNode`, `RGBShiftNode`, `SMAANode`, `AfterImageNode`, `FilmNode`). Force-directed solver is hand-written, not a dependency (research R4).
 - 101-hud-threejs-modernization: Added JavaScript ES2022 (ESM), Node 22+ for tooling. No TypeScript in this package. + `three` 0.170.0 → **0.185.1** (the only dependency change); existing `gsap`, `lil-gui`, `vite` 5.4 unchanged. Addons consumed as-is: `OrbitControls`, `CSS2DRenderer`, `EffectComposer` + `RenderPass`/`UnrealBloomPass`/`ShaderPass`/`OutputPass`/`SMAAPass`/`AfterimagePass`/`FilmPass`/`GlitchPass`, `VignetteShader`, `RGBShiftShader`. **No new package.**
-- 099-mobile-prerelease-sweep: Added Dart 3.x / Flutter (SDK constraint `^3.12.2`, matching `mobile/netclaw-mobile/pubspec.yaml`); Swift 5.0 (existing `ios/Runner/*.swift`, `ios/WatchApp Watch App/*.swift`); Bash (CI workflow is declarative YAML, no new scripting language) + No new Dart packages — reuses `flutter_local_notifications`, `firebase_messaging`, `firebase_core`, `local_auth`, `app_links`, `web_socket_channel`, `flutter_secure_storage` already in `pubspec.yaml`. New native-only surface: Apple's **ActivityKit** (Live Activity, Story 7) and **WidgetKit** (watchOS complication, Story 8) — both system frameworks, zero new third-party dependencies, consistent with every prior mobile spec (066-073) adding no new packages beyond what a given story strictly needs.
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/mobile/netclaw-mobile/README.md
+++ b/mobile/netclaw-mobile/README.md
@@ -339,7 +339,14 @@ Border, not a dependency.
   `main.dart`'s `_tryRegisterPush()` swallows the resulting failure to a
   `debugPrint`, so **push silently does nothing rather than erroring** until those
   credentials exist. Notification-tap deep-linking is wired on the same success
-  path: it jumps to the Feed tab and highlights the referenced message.
+  path: it jumps to the Feed tab and highlights the referenced message. Since
+  spec 107 that works even when the message has not arrived yet — the tap records
+  a `PendingOpenIntent` (`lib/ncfed/pending_open_intent.dart`) which resolves when
+  the message lands, or gives up after 8s. Foreground pushes are also recorded
+  straight from their data payload (`lib/ncfed/push_message_ingest.dart`), so a
+  pushed message is readable without a live channel; `MessageFeedStore.append`
+  deduplicates on `pushed_at`, which is what stops that path and the Border's
+  replay from each storing their own copy.
 - Voice transcription (`speech_to_text`, feature 067 US4) and the device deep link
   (`app_links`, feature 067 US5) are wired in and pass their unit tests, but — like
   push notifications — haven't been exercised against a real microphone or a real

--- a/mobile/netclaw-mobile/TESTER-INSTRUCTIONS.md
+++ b/mobile/netclaw-mobile/TESTER-INSTRUCTIONS.md
@@ -141,7 +141,8 @@ Revocation is server-side; you don't need the phone back.
 |---|---|
 | Play Protect warns on install | Expected — unsigned-for-Play debug key |
 | No push notifications | Firebase project not configured yet. No longer *silent*: the Settings tab now says "Notifications unavailable" and explains why. Drop in `google-services.json` to enable — see `README.md`. |
-| Tapping a notification doesn't deep-link | Code is wired and tested; inert only until the Firebase config above exists |
+| Tapping a notification doesn't deep-link | **Fixed (spec 107)** — the tap now opens the message it names even when that message has not arrived yet. It used to search the local feed once, the instant the app opened, which could never win against the message's own arrival: a replayed message lands ~3s after channel auth (Border-side replay settle), and a cold launch from a tap finishes well inside that. The tap now records the message it wants and opens it on arrival, giving up after 8s. |
+| A pushed message wasn't visible until the app reconnected | **Fixed (spec 107)** — the push payload already carried the whole message; nothing on the device read it. Now recorded on receipt, so it renders without waiting for (or having) a live connection. Foreground only: background delivery is at the OS's discretion, and a push that arrives while backgrounded still reaches the feed via the Border's replay. |
 | Biometric approval untested on real hardware | Never exercised outside an emulator without enrolled biometrics |
 | Camera capture untested on real hardware | Emulator only produced a synthetic test pattern |
 | Voice input untested on real hardware | Never exercised against a real microphone |

--- a/mobile/netclaw-mobile/lib/main.dart
+++ b/mobile/netclaw-mobile/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:path_provider/path_provider.dart';
@@ -24,6 +25,7 @@ import 'ncfed/local_notifications.dart';
 import 'ncfed/message_feed.dart';
 import 'ncfed/notification_deep_link.dart';
 import 'ncfed/pending_approval_store.dart';
+import 'ncfed/push_message_ingest.dart';
 import 'ncfed/push_registration.dart';
 import 'ncfed/reconnect_supervisor.dart';
 import 'ncfed/turn_reconciler.dart';
@@ -310,6 +312,15 @@ class _HomeShellState extends State<HomeShell> {
           if (looksLikeDeviceHeartbeat(message)) {
             DeviceHeartbeatStore(dir).save(DeviceHeartbeatStatus.fromMessage(message));
           }
+          // Spec 107/US1: the feed just gained a message, so a notification tap
+          // still waiting for one may now be satisfiable. This is the signal that
+          // makes the pending-intent approach work without polling — replay lands
+          // seconds after a cold-start tap, and this is where that arrival is
+          // already observed. Late-bound through the field on purpose:
+          // `wireMessageFeed` is deliberately registered before the deep link is
+          // constructed (see the race comment above), so this must not capture a
+          // local that does not exist yet.
+          _notificationDeepLink?.messageArrived();
           if (!mounted) return;
           // Don't badge the tab the operator is already looking at.
           if (_tab != 2) { // Feed (099/FR-012: shifted by Dashboard at index 0)
@@ -367,6 +378,15 @@ class _HomeShellState extends State<HomeShell> {
             _tab = 1; // Chat (099/FR-012: shifted by Dashboard at index 0)
             _highlightTaskId = turn.taskId;
           });
+        },
+        // Spec 107/FR-003: the tapped message never turned up within the bound.
+        // Land the operator on the Feed rather than leaving them wherever the app
+        // happened to open — they tapped a notification about a message, so the
+        // feed is the least surprising place to be, and spec 106 means the
+        // message will appear there whenever it does arrive.
+        onOpenTimedOut: () {
+          if (!mounted) return;
+          setState(() => _tab = 2); // Feed
         },
       );
       await localNotifications.initialize(
@@ -502,6 +522,7 @@ class _HomeShellState extends State<HomeShell> {
       status = await PushRegistration(widget.client).registerCurrentToken();
       if (status == PushStatus.registered) {
         await _wireNotificationDeepLink();
+        _wireForegroundPushIngest();
       }
     } catch (e, stack) {
       status = classifyPushError(e);
@@ -528,6 +549,44 @@ class _HomeShellState extends State<HomeShell> {
   /// second, parallel dispatcher.
   Future<void> _wireNotificationDeepLink() async {
     await _notificationDeepLink?.wire();
+  }
+
+  /// Spec 107/US2: record a pushed message straight from its payload, so it is
+  /// readable without waiting for — or even having — a live channel.
+  ///
+  /// The sender has always included the full content beside the banner; nothing
+  /// consumed it until now, which is why a push to a disconnected device drew a
+  /// notification and left the feed empty.
+  ///
+  /// Safe only because [MessageFeedStore.append] deduplicates: this message will
+  /// also arrive over the live channel when the Border replays it, and without
+  /// dedup the operator would see two of everything.
+  ///
+  /// Foreground only, deliberately. Background execution for a data-carrying push
+  /// is at the OS's discretion on both platforms, so treating it as a delivery
+  /// guarantee would reintroduce the silent-loss class spec 106 removed. Spec 106's
+  /// queue-and-replay stays the guarantee; this is an acceleration of it, and a
+  /// push that arrives while backgrounded still lands in the feed via replay.
+  void _wireForegroundPushIngest() {
+    final store = _feedStore;
+    if (store == null) return;
+    FirebaseMessaging.onMessage.listen((remote) async {
+      final outcome = await ingestPushPayload(
+        remote.data,
+        store: store,
+        onApproval: (params) => _approvalClient?.receiveApproval(params),
+        onMessage: (_) {
+          _notificationDeepLink?.messageArrived();
+          if (!mounted) return;
+          if (_tab != 2) setState(() => _unreadFeed++);
+          _recomputeBadge();
+        },
+      );
+      if (outcome == PushIngestOutcome.rejected) {
+        // Not fatal: the Border still replays it over the live channel.
+        debugPrint('push payload not usable; awaiting replay instead');
+      }
+    });
   }
 
   @override

--- a/mobile/netclaw-mobile/lib/ncfed/message_feed.dart
+++ b/mobile/netclaw-mobile/lib/ncfed/message_feed.dart
@@ -5,6 +5,25 @@ import 'edge_client.dart';
 
 enum MessageContentType { text, voice, image }
 
+/// A message's identity, as an instant (spec 107, research R2, data-model.md).
+///
+/// Instant-based rather than raw `DateTime` equality on purpose: Dart's
+/// `DateTime.==` also requires both operands to agree on `isUtc`, so the same
+/// moment expressed as UTC and as local time compares unequal. Every path here
+/// happens to produce UTC today, but a dedup key that silently depends on that
+/// is a trap — two delivery paths disagreeing about zone would each store their
+/// own copy, which is precisely the bug dedup exists to prevent.
+///
+/// **Known limit, stated rather than hidden**: the Border stamps `pushed_at` at
+/// whole-second granularity (`%Y-%m-%dT%H:%M:%SZ`), so two genuinely distinct
+/// messages sent inside the same second collapse into one. Accepted because this
+/// path carries operator- and agent-initiated pushes, not a high-rate stream. If
+/// that stops being true the fix is a sender-assigned unique id — a Border
+/// change, and therefore a different spec. Do not work around it by adding a
+/// second, client-local identifier: that would break dedup *across* delivery
+/// paths, which is the entire point.
+int messageIdentity(DateTime pushedAt) => pushedAt.toUtc().microsecondsSinceEpoch;
+
 /// One message the Border explicitly pushed (US2/FR-008,
 /// contracts/edge-enrollment-and-push.md §3). `content` is plain text for
 /// `text`, base64-encoded media for `voice`/`image`.
@@ -31,6 +50,48 @@ class EdgeMessage {
         designatedBy: params['designated_by'] as String? ?? 'agent',
         pushedAt: DateTime.tryParse(params['pushed_at'] as String? ?? '') ?? DateTime.now().toUtc(),
       );
+
+  /// Strict counterpart to [fromWire], for the **untrusted** push-payload path
+  /// (spec 107, contract §3.3). Returns null instead of throwing or defaulting.
+  ///
+  /// Two differences from [fromWire], both load-bearing:
+  ///
+  /// 1. **A missing or unparseable `pushed_at` is rejected, not defaulted.**
+  ///    [fromWire] falls back to `DateTime.now()`, which is fine for the
+  ///    authenticated live channel (the Border always sets the field) but fatal
+  ///    here: a fresh `now()` on every delivery attempt mints a *new identity*
+  ///    each time, so the same message arriving twice would dedup against
+  ///    nothing and appear twice. Rejecting is safe — spec 106 guarantees replay
+  ///    will deliver it again over the live path.
+  /// 2. **Every value may have arrived as a String** (contract §3.1). The sender
+  ///    stringifies the whole content map (`{k: str(v) for k, v in ...}`), so no
+  ///    field can be assumed to have survived with its original type.
+  static EdgeMessage? tryFromWire(Map<String, dynamic> params) {
+    final rawPushedAt = params['pushed_at'];
+    if (rawPushedAt is! String) return null;
+    final pushedAt = DateTime.tryParse(rawPushedAt);
+    if (pushedAt == null) return null;
+
+    final rawType = params['content_type'];
+    if (rawType is! String) return null;
+    final contentType = MessageContentType.values
+        .where((t) => t.name == rawType)
+        .firstOrNull;
+    if (contentType == null) return null;
+
+    final rawContent = params['content'];
+    if (rawContent is! String) return null;
+
+    final rawDesignatedBy = params['designated_by'];
+    return EdgeMessage(
+      contentType: contentType,
+      content: rawContent,
+      designatedBy: rawDesignatedBy is String && rawDesignatedBy.isNotEmpty
+          ? rawDesignatedBy
+          : 'agent',
+      pushedAt: pushedAt,
+    );
+  }
 
   Map<String, dynamic> toJson() => {
         'content_type': contentType.name,
@@ -89,14 +150,43 @@ class MessageFeedStore {
     }
   }
 
-  Future<void> append(EdgeMessage message) async {
+  /// True if a message with this identity is already stored.
+  bool contains(DateTime pushedAt) {
+    final wanted = messageIdentity(pushedAt);
+    return _messages.any((m) => messageIdentity(m.pushedAt) == wanted);
+  }
+
+  /// Appends [message] unless one with the same identity is already stored.
+  ///
+  /// Returns **true if stored, false if declined** as a duplicate. Declining is
+  /// the expected outcome whenever two delivery paths carry the same message,
+  /// not an error (contract §2.4).
+  ///
+  /// This is the single enforcement point for message identity (spec 107,
+  /// research R3, contract §2.1) — callers must NOT pre-check. As of spec 107
+  /// there are two writers (the live channel handler and the push-payload ingest
+  /// path); putting the check here means a future third writer inherits it
+  /// without having to know it exists. Two implementations that must agree
+  /// forever is the drift pattern this repo already guards against elsewhere.
+  ///
+  /// A declined duplicate leaves the stored message completely untouched,
+  /// including its `acknowledged` state (FR-006, contract §2.2) — re-delivery
+  /// must never make a message the operator already read look unread again.
+  ///
+  /// The return value matters beyond bookkeeping: without it a caller would fire
+  /// its "arrived" side effect (unread badge, local notification) for every
+  /// replayed duplicate, so fixing double *entries* would leave double
+  /// *notifications* — a visibly identical bug one layer up (contract §2.3).
+  Future<bool> append(EdgeMessage message) async {
     await load();
+    if (contains(message.pushedAt)) return false;
     _messages.add(message);
     await _file().writeAsString(
       '${jsonEncode(message.toJson())}\n',
       mode: FileMode.append,
       flush: true,
     );
+    return true;
   }
 
   /// Rewrites the whole file from the in-memory list -- unlike [append],
@@ -164,8 +254,12 @@ void wireMessageFeed(
       return {'received': true};
     }
     final message = EdgeMessage.fromWire(params);
-    await store.append(message);
-    onMessage?.call(message);
+    // Spec 107: only announce it if it was actually new. A replayed message the
+    // push-ingest path already stored is declined here, and firing [onMessage]
+    // anyway would raise an unread badge and post a local notification for
+    // something the operator has already seen (contract §2.3).
+    final stored = await store.append(message);
+    if (stored) onMessage?.call(message);
     return {'received': true};
   });
 }

--- a/mobile/netclaw-mobile/lib/ncfed/notification_deep_link.dart
+++ b/mobile/netclaw-mobile/lib/ncfed/notification_deep_link.dart
@@ -8,6 +8,7 @@ import 'approval_confirmation.dart';
 import 'conversation_store.dart';
 import 'local_notifications.dart';
 import 'message_feed.dart';
+import 'pending_open_intent.dart';
 
 /// Finds the pushed message a notification's `data` payload refers to, by
 /// `pushed_at` — `push_notify.py`'s FCM/APNs `data` field always includes
@@ -64,12 +65,32 @@ class NotificationDeepLink {
   final ConversationStore? conversationStore;
   final void Function(ConversationTurn turn)? openChatTurn;
 
+  /// Fires when a tapped notification's message never turned up (FR-003), so the
+  /// caller can land the operator somewhere usable instead of leaving them
+  /// wherever the app happened to open.
+  final void Function()? onOpenTimedOut;
+
+  late final PendingOpenIntent _intent;
+
   NotificationDeepLink({
     required this.store,
     required this.openMessage,
     this.conversationStore,
     this.openChatTurn,
-  });
+    this.onOpenTimedOut,
+    Duration? intentTimeout,
+    PendingOpenIntent? intent,
+  }) {
+    _intent = intent ??
+        PendingOpenIntent(
+          onOpen: openMessage,
+          onExpire: onOpenTimedOut,
+          timeout: intentTimeout ?? PendingOpenIntent.defaultTimeout,
+        );
+  }
+
+  /// Visible for wiring and tests. Callers should prefer [messageArrived].
+  PendingOpenIntent get intent => _intent;
 
   Future<void> wire() async {
     FirebaseMessaging.onMessageOpenedApp.listen(_handleRemote);
@@ -78,10 +99,35 @@ class NotificationDeepLink {
   }
 
   Future<void> _handleRemote(RemoteMessage message) async {
-    await store.load();
-    final match = findMessageForNotificationData(store.messages, message.data);
-    if (match != null) openMessage(match);
+    final pushedAt = message.data['pushed_at'];
+    await recordTap(pushedAt is String ? pushedAt : null);
   }
+
+  /// Records that the operator tapped a notification naming the message with
+  /// this `pushed_at`, and resolves immediately if we already have it.
+  ///
+  /// Spec 107, research R1. This replaced a single `store.load()` +
+  /// [findMessageForNotificationData] read, which could not win the race against
+  /// the message's own arrival: a replayed message does not land until after
+  /// channel auth plus the Border's ~3s replay settle, and a cold app launch from
+  /// a tap finishes well inside that. The read therefore *always* missed on a
+  /// cold start, so the tap opened nothing and the operator had to go find the
+  /// message themselves once it appeared seconds later.
+  ///
+  /// A tap that names nothing records nothing — opening the app without a tap
+  /// must never force a message open (FR-011).
+  Future<void> recordTap(String? pushedAt) async {
+    if (pushedAt == null || pushedAt.isEmpty) return;
+    _intent.record(pushedAt);
+    await store.load();
+    _intent.tryResolve(store.messages);
+  }
+
+  /// Call whenever the feed gains a message, from any delivery path. Resolves a
+  /// pending tap if this is the message it was waiting for; otherwise a no-op.
+  void messageArrived() => _intent.tryResolve(store.messages);
+
+  void dispose() => _intent.dispose();
 
   /// Handles a tap on a locally-posted notification -- the counterpart to
   /// [wire]'s Firebase remote-tap handling, fed by
@@ -95,10 +141,14 @@ class NotificationDeepLink {
     if (parsed == null) return;
     switch (parsed['type']) {
       case 'feed':
-        await store.load();
-        final match =
-            findMessageForNotificationData(store.messages, {'pushed_at': parsed['identifier']});
-        if (match != null) openMessage(match);
+        // Spec 107, research R6: converged onto the SAME intent the remote path
+        // uses, rather than keeping a second mechanism for one behavior. This
+        // path was already correct — a local notification is only ever posted for
+        // a message the app has already stored, so its single read always
+        // succeeded — and it stays correct here, resolving immediately inside
+        // [recordTap]. Convergence means the next change to tap behavior is made
+        // once, not twice.
+        await recordTap(parsed['identifier']);
       case 'chat':
         final convoStore = conversationStore;
         if (convoStore == null) return;

--- a/mobile/netclaw-mobile/lib/ncfed/pending_open_intent.dart
+++ b/mobile/netclaw-mobile/lib/ncfed/pending_open_intent.dart
@@ -1,0 +1,114 @@
+import 'dart:async';
+
+import 'message_feed.dart';
+
+/// "The operator tapped a notification naming a message we may not have yet."
+///
+/// Why this exists (spec 107, research R1): the tap and the message's arrival
+/// are genuinely concurrent, so the old single read of the feed store at tap
+/// time could not win the race. Measured against a real Border — the channel
+/// authenticated at 16:49:12.513 and the replayed message landed at
+/// 16:49:15.514, a 3.0s gap set by the Border's own replay settle delay. Cold
+/// app launch from a notification tap completes well inside that window, so the
+/// single read was *guaranteed* to miss on a cold start, not merely likely to.
+///
+/// So the tap records an intent instead, and the intent resolves whenever the
+/// named message shows up — immediately if it is already stored. It is
+/// deliberately ignorant of *how* the message arrives: replay over the live
+/// channel and ingest from a push payload both just add to the feed, and both
+/// resolve this the same way.
+///
+/// In-memory only, by design (data-model.md): this describes a navigation
+/// intent within one app session, not durable state. Persisting it would let a
+/// stale intent hijack navigation on a later launch for a reason the operator
+/// no longer remembers.
+class PendingOpenIntent {
+  /// Well inside SC-007's 10s outer bound, with room for channel auth plus the
+  /// Border's replay settle plus retry margin on a slow network.
+  static const Duration defaultTimeout = Duration(seconds: 8);
+
+  final Duration timeout;
+
+  /// Fires at most once per recorded intent, and never on expiry (contract §1.6).
+  final void Function(EdgeMessage message) onOpen;
+
+  /// Optional. Lets the caller land the operator somewhere usable when the
+  /// named message never arrives (FR-003) rather than leaving them wherever the
+  /// app happened to open.
+  final void Function()? onExpire;
+
+  String? _identifier;
+  Timer? _timer;
+
+  PendingOpenIntent({
+    required this.onOpen,
+    this.onExpire,
+    this.timeout = defaultTimeout,
+  });
+
+  bool get isPending => _identifier != null;
+
+  /// The `pushed_at` the pending notification named, or null if nothing is
+  /// pending. Exposed for diagnostics and tests, not for callers to match on —
+  /// matching belongs in [tryResolve] so the fire-once guarantee stays here.
+  String? get identifier => _identifier;
+
+  /// Records a tap. A second record discards the first (contract §1.2), so the
+  /// operator lands on what they most recently tapped rather than the app
+  /// racing between two.
+  ///
+  /// Does not itself navigate (contract §1.1) — call [tryResolve] for that.
+  void record(String identifier) {
+    _timer?.cancel();
+    _identifier = identifier;
+    _timer = Timer(timeout, _expire);
+  }
+
+  /// Resolves against the messages currently in the feed. Returns true if the
+  /// named message was found and [onOpen] fired.
+  ///
+  /// Safe to call as often as you like — once resolved, the intent is cleared,
+  /// so [onOpen] cannot fire twice for one tap.
+  bool tryResolve(Iterable<EdgeMessage> messages) {
+    final wanted = _identifier;
+    if (wanted == null) return false;
+    for (final message in messages) {
+      if (messageIdentity(message.pushedAt) == identityOf(wanted)) {
+        _clearTimer();
+        _identifier = null;
+        onOpen(message);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /// Abandons any pending intent without firing either callback.
+  void cancel() {
+    _clearTimer();
+    _identifier = null;
+  }
+
+  void dispose() => cancel();
+
+  void _expire() {
+    if (_identifier == null) return;
+    _clearTimer();
+    _identifier = null;
+    onExpire?.call();
+  }
+
+  void _clearTimer() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  /// Parses a notification's `pushed_at` string to the same instant-based
+  /// identity [messageIdentity] produces, so a `Z`-suffixed timestamp and an
+  /// offset-suffixed one for the same moment still match. Returns null for
+  /// anything unparseable, which then matches nothing.
+  static int? identityOf(String pushedAt) {
+    final parsed = DateTime.tryParse(pushedAt);
+    return parsed == null ? null : messageIdentity(parsed);
+  }
+}

--- a/mobile/netclaw-mobile/lib/ncfed/push_message_ingest.dart
+++ b/mobile/netclaw-mobile/lib/ncfed/push_message_ingest.dart
@@ -1,0 +1,71 @@
+import 'message_feed.dart';
+
+/// What happened to one push payload.
+enum PushIngestOutcome {
+  /// New message, written to the feed.
+  stored,
+
+  /// Already had it. Expected, not an error (contract §2.4) — the live channel
+  /// and this path both carry the same message by design.
+  duplicate,
+
+  /// An approval request, handed to the approvals path. Never enters the feed.
+  approval,
+
+  /// Unusable payload. Deliberately terminal-but-harmless: spec 106 guarantees
+  /// the Border still replays the message over the live channel, so rejecting
+  /// costs latency, never the message.
+  rejected,
+}
+
+/// Records a message straight from its push payload, so it is readable without
+/// waiting for — or even having — a live connection to the Border (spec 107,
+/// User Story 2).
+///
+/// The sender already includes the full content as a push data payload beside
+/// the banner (`send_fcm`: a `notification` block plus
+/// `data: {k: str(v) for k, v in content.items()}`). Until spec 107 nothing on
+/// the device consumed it: the only writer to [MessageFeedStore] was the live
+/// channel handler, so a push while disconnected drew a banner and left the feed
+/// empty. That was the production report of 2026-08-13.
+///
+/// This path is an **acceleration**, not a guarantee (research R5). Background
+/// execution for a data-carrying push is at the operating system's discretion on
+/// both platforms; building as though it were guaranteed would reintroduce
+/// exactly the silent-loss class spec 106 removed. Spec 106's queue-and-replay
+/// remains the guarantee.
+///
+/// Deduplication is what makes this safe to add at all. Without it, every
+/// message recorded here would appear a second time when replay delivered it —
+/// see [MessageFeedStore.append], which is the single enforcement point.
+Future<PushIngestOutcome> ingestPushPayload(
+  Map<String, dynamic> data, {
+  required MessageFeedStore store,
+  void Function(Map<String, dynamic> params)? onApproval,
+  void Function(EdgeMessage message)? onMessage,
+}) async {
+  // Approvals are a live, time-sensitive list with no per-item history view, so
+  // they route to the approvals path and never to the feed (FR-009,
+  // contract §3.2) — the same discriminator the live channel handler uses.
+  if (data['content_type'] == 'approval') {
+    onApproval?.call(data);
+    return PushIngestOutcome.approval;
+  }
+
+  // Strict parse: a malformed payload must not corrupt the feed (FR-010), and a
+  // missing `pushed_at` must be rejected rather than defaulted — see
+  // EdgeMessage.tryFromWire for why defaulting would silently defeat dedup.
+  final message = EdgeMessage.tryFromWire(data);
+  if (message == null) return PushIngestOutcome.rejected;
+
+  try {
+    final stored = await store.append(message);
+    // Only announce a genuinely new message (contract §2.3).
+    if (stored) onMessage?.call(message);
+    return stored ? PushIngestOutcome.stored : PushIngestOutcome.duplicate;
+  } catch (_) {
+    // A write failure here is not worth crashing over, and must not leave the
+    // caller believing the message was recorded. Replay covers it.
+    return PushIngestOutcome.rejected;
+  }
+}

--- a/mobile/netclaw-mobile/test/message_feed_test.dart
+++ b/mobile/netclaw-mobile/test/message_feed_test.dart
@@ -149,6 +149,156 @@ void main() {
       expect(store.messages.single.acknowledged, isTrue);
     });
   });
+
+  group('deduplication by message identity (spec 107/US3, contract §2)', () {
+    Directory tmp() {
+      final d = Directory.systemTemp.createTempSync('ncfed_dedup_test_');
+      addTearDown(() => d.delete(recursive: true));
+      return d;
+    }
+
+    EdgeMessage msg(DateTime pushedAt, {String content = 'body', bool acked = false}) =>
+        EdgeMessage(
+          contentType: MessageContentType.text,
+          content: content,
+          designatedBy: 'agent',
+          pushedAt: pushedAt,
+          acknowledged: acked,
+        );
+
+    test('a duplicate pushed_at is declined (FR-004, FR-005)', () async {
+      final store = MessageFeedStore(tmp());
+      final at = DateTime.utc(2026, 8, 13, 16, 45, 34);
+
+      expect(await store.append(msg(at, content: 'first')), isTrue);
+      expect(await store.append(msg(at, content: 'second')), isFalse);
+
+      expect(store.messages, hasLength(1));
+      expect(store.messages.single.content, 'first',
+          reason: 'the stored message wins; a duplicate never overwrites');
+    });
+
+    test('two distinct messages both store, even one second apart', () async {
+      final store = MessageFeedStore(tmp());
+      expect(await store.append(msg(DateTime.utc(2026, 8, 13, 16, 45, 34))), isTrue);
+      expect(await store.append(msg(DateTime.utc(2026, 8, 13, 16, 45, 35))), isTrue);
+      expect(store.messages, hasLength(2));
+    });
+
+    test('read state survives re-delivery (FR-006, §2.2)', () async {
+      // A message the operator already read must not look unread again just
+      // because the Border replayed it.
+      final store = MessageFeedStore(tmp());
+      final at = DateTime.utc(2026, 8, 13, 16, 45, 34);
+      await store.append(msg(at));
+      await store.acknowledge(at);
+      expect(store.unreadCount, 0);
+
+      expect(await store.append(msg(at)), isFalse);
+
+      expect(store.unreadCount, 0, reason: 'a duplicate must not resurrect unread');
+      expect(store.messages.single.acknowledged, isTrue);
+    });
+
+    test('dedup survives a restart, matching on what is on disk', () async {
+      final dir = tmp();
+      final at = DateTime.utc(2026, 8, 13, 16, 45, 34);
+      await MessageFeedStore(dir).append(msg(at));
+
+      final reopened = MessageFeedStore(dir);
+      expect(await reopened.append(msg(at)), isFalse);
+      expect(reopened.messages, hasLength(1));
+    });
+
+    test('identity is instant-based, not DateTime-equality based', () async {
+      // Dart's DateTime.== also requires isUtc to agree, so the same moment
+      // expressed in local time would otherwise store a second copy.
+      final store = MessageFeedStore(tmp());
+      final utc = DateTime.utc(2026, 8, 13, 16, 45, 34);
+      expect(await store.append(msg(utc)), isTrue);
+      expect(await store.append(msg(utc.toLocal())), isFalse);
+      expect(store.messages, hasLength(1));
+    });
+
+    test('contains() reports what is stored', () async {
+      final store = MessageFeedStore(tmp());
+      final at = DateTime.utc(2026, 8, 13, 16, 45, 34);
+      await store.append(msg(at));
+      expect(store.contains(at), isTrue);
+      expect(store.contains(DateTime.utc(2026, 8, 13, 16, 45, 35)), isFalse);
+    });
+
+    test('a declined duplicate does not re-announce via wireMessageFeed (§2.3)', () async {
+      // Otherwise the double-entry bug becomes a double-badge bug.
+      final store = MessageFeedStore(tmp());
+      final client = _FakeEdgeMethodSource();
+      final announced = <EdgeMessage>[];
+      wireMessageFeed(client, store, onMessage: announced.add);
+      final handler = client.handlers['n2n/edge/message']!;
+
+      final params = {
+        'content_type': 'text',
+        'content': 'replayed body',
+        'designated_by': 'agent',
+        'pushed_at': '2026-08-13T16:45:34.000Z',
+      };
+      await handler(params);
+      await handler(params);
+
+      expect(store.messages, hasLength(1));
+      expect(announced, hasLength(1));
+    });
+  });
+
+  group('EdgeMessage.tryFromWire strictness (spec 107, contract §3.3)', () {
+    test('rejects a missing or unparseable pushed_at rather than defaulting', () {
+      expect(EdgeMessage.tryFromWire({'content_type': 'text', 'content': 'x'}), isNull);
+      expect(
+        EdgeMessage.tryFromWire(
+            {'content_type': 'text', 'content': 'x', 'pushed_at': 'nope'}),
+        isNull,
+      );
+    });
+
+    test('fromWire keeps its lenient fallback for the live channel', () {
+      // Unchanged on purpose (Principle XV): the authenticated live path always
+      // carries pushed_at, and tightening it here would be a behavior change to
+      // a path this feature is not fixing.
+      final lenient = EdgeMessage.fromWire({'content_type': 'text', 'content': 'x'});
+      expect(lenient.pushedAt, isNotNull);
+    });
+
+    test('accepts the fully stringified shape the sender emits', () {
+      final m = EdgeMessage.tryFromWire({
+        'content_type': 'text',
+        'content': 'hello',
+        'pushed_at': '2026-08-13T16:45:34.000Z',
+        'designated_by': 'agent',
+      });
+      expect(m, isNotNull);
+      expect(m!.content, 'hello');
+    });
+  });
+
+  test('wireMessageFeed is the ONLY n2n/edge/message registration site (§4)', () {
+    // EdgeClient.on() keeps only the LAST handler per method, so a second
+    // registration anywhere would silently displace this one and disable live
+    // delivery with no error — the highest-severity failure mode in spec 107,
+    // and the cheapest to guard. Structural, because the bug is the existence
+    // of a second call site, not the behavior of any one of them.
+    final libDir = Directory('lib');
+    final offenders = <String>[];
+    for (final entity in libDir.listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      final text = entity.readAsStringSync();
+      if (!text.contains("'n2n/edge/message'")) continue;
+      // The declaration inside wireMessageFeed is the one legitimate site.
+      if (entity.path.endsWith('message_feed.dart')) continue;
+      if (text.contains(".on('n2n/edge/message'")) offenders.add(entity.path);
+    }
+    expect(offenders, isEmpty,
+        reason: 'only wireMessageFeed may register n2n/edge/message; found: $offenders');
+  });
 }
 
 /// Minimal stand-in exposing just the `.on(method, handler)` surface

--- a/mobile/netclaw-mobile/test/notification_deep_link_test.dart
+++ b/mobile/netclaw-mobile/test/notification_deep_link_test.dart
@@ -148,4 +148,143 @@ void main() {
       await deepLink.handleLocalNotificationTap(null);
     });
   });
+
+  group('a tap whose message has not arrived yet (spec 107/US1)', () {
+    late Directory dir;
+    setUp(() async => dir = await Directory.systemTemp.createTemp('ncfed_intent_dl_test_'));
+    tearDown(() => dir.delete(recursive: true));
+
+    EdgeMessage msg(DateTime at) => EdgeMessage(
+          contentType: MessageContentType.text,
+          content: 'Replayed from the Border backlog.',
+          designatedBy: 'agent',
+          pushedAt: at,
+        );
+
+    test('resolves when the message arrives AFTER the tap (FR-002)', () async {
+      // THE production bug. Measured against a real Border: channel auth at
+      // 16:49:12.513, replay at 16:49:15.514. A cold app launch from a tap
+      // finishes well inside that 3s gap, so the old single read of the store at
+      // tap time could never match, and the tap opened nothing.
+      final feedStore = MessageFeedStore(dir);
+      final at = DateTime.utc(2026, 8, 13, 16, 45, 34);
+      EdgeMessage? opened;
+      final deepLink = NotificationDeepLink(
+        store: feedStore,
+        openMessage: (m) => opened = m,
+      );
+
+      await deepLink.recordTap(at.toIso8601String());
+      expect(opened, isNull, reason: 'nothing to open yet — but must keep waiting');
+      expect(deepLink.intent.isPending, isTrue);
+
+      // Replay lands seconds later.
+      await feedStore.append(msg(at));
+      deepLink.messageArrived();
+
+      expect(opened, isNotNull);
+      expect(opened!.pushedAt, at);
+      deepLink.dispose();
+    });
+
+    test('resolves immediately when already stored, with no wait (FR-001)', () async {
+      final feedStore = MessageFeedStore(dir);
+      final at = DateTime.utc(2026, 8, 13, 16, 45, 34);
+      await feedStore.append(msg(at));
+      EdgeMessage? opened;
+      final deepLink = NotificationDeepLink(
+        store: feedStore,
+        openMessage: (m) => opened = m,
+      );
+
+      await deepLink.recordTap(at.toIso8601String());
+
+      expect(opened, isNotNull);
+      expect(deepLink.intent.isPending, isFalse);
+      deepLink.dispose();
+    });
+
+    test('expires and reports it, rather than waiting forever (FR-003)', () async {
+      final feedStore = MessageFeedStore(dir);
+      EdgeMessage? opened;
+      var timedOut = false;
+      final deepLink = NotificationDeepLink(
+        store: feedStore,
+        openMessage: (m) => opened = m,
+        onOpenTimedOut: () => timedOut = true,
+        intentTimeout: const Duration(milliseconds: 30),
+      );
+
+      await deepLink.recordTap('2026-08-13T16:45:34.000Z');
+      await Future<void>.delayed(const Duration(milliseconds: 80));
+
+      expect(timedOut, isTrue);
+      expect(opened, isNull);
+      deepLink.dispose();
+    });
+
+    test('a message arriving with no tap opens nothing (FR-011)', () async {
+      final feedStore = MessageFeedStore(dir);
+      EdgeMessage? opened;
+      final deepLink = NotificationDeepLink(
+        store: feedStore,
+        openMessage: (m) => opened = m,
+      );
+
+      await feedStore.append(msg(DateTime.utc(2026, 8, 13, 16, 45, 34)));
+      deepLink.messageArrived();
+
+      expect(opened, isNull, reason: 'no tap means no forced navigation');
+      deepLink.dispose();
+    });
+
+    test('a tap naming nothing records nothing', () async {
+      final feedStore = MessageFeedStore(dir);
+      final deepLink = NotificationDeepLink(store: feedStore, openMessage: (_) {});
+      await deepLink.recordTap(null);
+      expect(deepLink.intent.isPending, isFalse);
+      await deepLink.recordTap('');
+      expect(deepLink.intent.isPending, isFalse);
+      deepLink.dispose();
+    });
+
+    test('the local-notification path converges on the same intent (§5.4)', () async {
+      // It was already correct, because a local notification is only posted for
+      // an already-stored message. Convergence must not regress that.
+      final feedStore = MessageFeedStore(dir);
+      final at = DateTime.utc(2026, 8, 13, 16, 45, 34);
+      await feedStore.append(msg(at));
+      EdgeMessage? opened;
+      final deepLink = NotificationDeepLink(
+        store: feedStore,
+        openMessage: (m) => opened = m,
+      );
+
+      await deepLink.handleLocalNotificationTap(
+          '{"type":"feed","identifier":"${at.toIso8601String()}"}');
+
+      expect(opened, isNotNull);
+      deepLink.dispose();
+    });
+
+    test('a local tap for a message not yet stored now also waits', () async {
+      // Strictly better than before: previously this silently did nothing.
+      final feedStore = MessageFeedStore(dir);
+      final at = DateTime.utc(2026, 8, 13, 16, 45, 34);
+      EdgeMessage? opened;
+      final deepLink = NotificationDeepLink(
+        store: feedStore,
+        openMessage: (m) => opened = m,
+      );
+
+      await deepLink.handleLocalNotificationTap(
+          '{"type":"feed","identifier":"${at.toIso8601String()}"}');
+      expect(opened, isNull);
+
+      await feedStore.append(msg(at));
+      deepLink.messageArrived();
+      expect(opened, isNotNull);
+      deepLink.dispose();
+    });
+  });
 }

--- a/mobile/netclaw-mobile/test/pending_open_intent_test.dart
+++ b/mobile/netclaw-mobile/test/pending_open_intent_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:netclaw_mobile/ncfed/message_feed.dart';
+import 'package:netclaw_mobile/ncfed/pending_open_intent.dart';
+
+/// Spec 107, contract §1. The intent exists because a notification tap and the
+/// tapped message's arrival are concurrent — see pending_open_intent.dart for the
+/// measured timings that make the old single-read approach always lose.
+
+EdgeMessage _msg(String iso, {String content = 'hello'}) => EdgeMessage(
+      contentType: MessageContentType.text,
+      content: content,
+      designatedBy: 'agent',
+      pushedAt: DateTime.parse(iso),
+    );
+
+void main() {
+  test('resolves immediately when the message is already present (§1.3)', () {
+    final opened = <EdgeMessage>[];
+    final intent = PendingOpenIntent(onOpen: opened.add);
+    final messages = [_msg('2026-08-13T16:45:34Z')];
+
+    intent.record('2026-08-13T16:45:34Z');
+    final resolved = intent.tryResolve(messages);
+
+    expect(resolved, isTrue);
+    expect(opened, hasLength(1));
+    expect(intent.isPending, isFalse);
+    intent.dispose();
+  });
+
+  test('resolves when the message arrives AFTER the tap (§1.4)', () {
+    // The actual production bug: the message lands ~3s after a cold-start tap.
+    final opened = <EdgeMessage>[];
+    final intent = PendingOpenIntent(onOpen: opened.add);
+    final messages = <EdgeMessage>[];
+
+    intent.record('2026-08-13T16:45:34Z');
+    expect(intent.tryResolve(messages), isFalse, reason: 'nothing to match yet');
+    expect(opened, isEmpty);
+    expect(intent.isPending, isTrue, reason: 'must keep waiting, not give up');
+
+    messages.add(_msg('2026-08-13T16:45:34Z'));
+    expect(intent.tryResolve(messages), isTrue);
+    expect(opened, hasLength(1));
+    intent.dispose();
+  });
+
+  test('a second record discards the first (§1.2)', () {
+    final opened = <EdgeMessage>[];
+    final intent = PendingOpenIntent(onOpen: opened.add);
+
+    intent.record('2026-08-13T16:45:34Z');
+    intent.record('2026-08-13T17:00:00Z');
+    expect(intent.identifier, '2026-08-13T17:00:00Z');
+
+    // The first-tapped message arriving must NOT open anything now.
+    expect(intent.tryResolve([_msg('2026-08-13T16:45:34Z')]), isFalse);
+    expect(opened, isEmpty);
+
+    expect(intent.tryResolve([_msg('2026-08-13T17:00:00Z')]), isTrue);
+    expect(opened, hasLength(1));
+    intent.dispose();
+  });
+
+  test('onOpen fires exactly once per tap (§1.6)', () {
+    final opened = <EdgeMessage>[];
+    final intent = PendingOpenIntent(onOpen: opened.add);
+    final messages = [_msg('2026-08-13T16:45:34Z')];
+
+    intent.record('2026-08-13T16:45:34Z');
+    intent.tryResolve(messages);
+    // Every later feed change re-offers the same list; must not re-open.
+    intent.tryResolve(messages);
+    intent.tryResolve(messages);
+
+    expect(opened, hasLength(1));
+    intent.dispose();
+  });
+
+  test('expires within the bound, and does NOT fire onOpen (§1.5, §1.6)', () async {
+    final opened = <EdgeMessage>[];
+    var expired = false;
+    final intent = PendingOpenIntent(
+      onOpen: opened.add,
+      onExpire: () => expired = true,
+      timeout: const Duration(milliseconds: 30),
+    );
+
+    intent.record('2026-08-13T16:45:34Z');
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+
+    expect(expired, isTrue, reason: 'FR-003: must stop waiting');
+    expect(opened, isEmpty, reason: 'expiry must never open a message');
+    expect(intent.isPending, isFalse);
+
+    // A message arriving after expiry must not retroactively navigate.
+    expect(intent.tryResolve([_msg('2026-08-13T16:45:34Z')]), isFalse);
+    expect(opened, isEmpty);
+    intent.dispose();
+  });
+
+  test('resolving cancels the expiry, so onExpire never fires after', () async {
+    final opened = <EdgeMessage>[];
+    var expired = false;
+    final intent = PendingOpenIntent(
+      onOpen: opened.add,
+      onExpire: () => expired = true,
+      timeout: const Duration(milliseconds: 30),
+    );
+
+    intent.record('2026-08-13T16:45:34Z');
+    intent.tryResolve([_msg('2026-08-13T16:45:34Z')]);
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+
+    expect(opened, hasLength(1));
+    expect(expired, isFalse, reason: 'a resolved intent must not also expire');
+    intent.dispose();
+  });
+
+  test('cancel abandons without firing either callback', () async {
+    final opened = <EdgeMessage>[];
+    var expired = false;
+    final intent = PendingOpenIntent(
+      onOpen: opened.add,
+      onExpire: () => expired = true,
+      timeout: const Duration(milliseconds: 30),
+    );
+
+    intent.record('2026-08-13T16:45:34Z');
+    intent.cancel();
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+
+    expect(opened, isEmpty);
+    expect(expired, isFalse);
+    expect(intent.isPending, isFalse);
+  });
+
+  test('nothing pending means tryResolve is a cheap no-op (FR-011)', () {
+    final opened = <EdgeMessage>[];
+    final intent = PendingOpenIntent(onOpen: opened.add);
+    expect(intent.tryResolve([_msg('2026-08-13T16:45:34Z')]), isFalse);
+    expect(opened, isEmpty);
+    intent.dispose();
+  });
+
+  test('matches the same instant across timezone spellings', () {
+    // The Border sends `Z`; a differently-formatted offset for the same moment
+    // must still match, or dedup and deep-linking would silently disagree.
+    final opened = <EdgeMessage>[];
+    final intent = PendingOpenIntent(onOpen: opened.add);
+
+    intent.record('2026-08-13T12:45:34-04:00'); // == 16:45:34Z
+    expect(intent.tryResolve([_msg('2026-08-13T16:45:34Z')]), isTrue);
+    expect(opened, hasLength(1));
+    intent.dispose();
+  });
+
+  test('an unparseable identifier matches nothing rather than throwing', () {
+    final opened = <EdgeMessage>[];
+    final intent = PendingOpenIntent(onOpen: opened.add);
+
+    intent.record('not-a-timestamp');
+    expect(intent.tryResolve([_msg('2026-08-13T16:45:34Z')]), isFalse);
+    expect(opened, isEmpty);
+    intent.dispose();
+  });
+}

--- a/mobile/netclaw-mobile/test/push_message_ingest_test.dart
+++ b/mobile/netclaw-mobile/test/push_message_ingest_test.dart
@@ -1,0 +1,169 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:netclaw_mobile/ncfed/message_feed.dart';
+import 'package:netclaw_mobile/ncfed/push_message_ingest.dart';
+
+/// Spec 107/US2, contract §3. Records a pushed message straight from its
+/// payload, so it is readable without a live channel.
+///
+/// Every value in these payloads is a String on purpose — the sender stringifies
+/// the whole content map (`{k: str(v) for k, v in content.items()}`), so a client
+/// that assumes types survived would fail in production and pass a naive test.
+
+Directory _tmp() => Directory.systemTemp.createTempSync('ncfed_ingest_test');
+
+/// Exactly the shape the sender emits: all values stringified.
+Map<String, dynamic> _payload({
+  String contentType = 'text',
+  String content = 'spec 107 wake-signal test',
+  String pushedAt = '2026-08-13T16:45:34.000Z',
+  String designatedBy = 'agent',
+}) =>
+    {
+      'content_type': contentType,
+      'content': content,
+      'pushed_at': pushedAt,
+      'designated_by': designatedBy,
+    };
+
+void main() {
+  test('a fully stringified payload reconstructs and stores (§3.1, FR-007)', () async {
+    final store = MessageFeedStore(_tmp());
+    final outcome = await ingestPushPayload(_payload(), store: store);
+
+    expect(outcome, PushIngestOutcome.stored);
+    expect(store.messages, hasLength(1));
+    expect(store.messages.single.content, 'spec 107 wake-signal test');
+    expect(store.messages.single.contentType, MessageContentType.text);
+    expect(store.messages.single.pushedAt.toUtc().toIso8601String(),
+        '2026-08-13T16:45:34.000Z');
+  });
+
+  test('survives a restart, so the message is readable with no connection (SC-004)', () async {
+    final dir = _tmp();
+    await ingestPushPayload(_payload(), store: MessageFeedStore(dir));
+
+    final reopened = MessageFeedStore(dir);
+    await reopened.load();
+    expect(reopened.messages, hasLength(1));
+  });
+
+  test('the same message from push then replay yields ONE entry (SC-005)', () async {
+    // The check that proves ingest and dedup work together. Without dedup this
+    // is where every pushed message would double.
+    final store = MessageFeedStore(_tmp());
+    final data = _payload();
+
+    expect(await ingestPushPayload(data, store: store), PushIngestOutcome.stored);
+    // Now the Border replays the identical message over the live channel.
+    final replayed = EdgeMessage.fromWire({...data, 'replayed': 'true'});
+    expect(await store.append(replayed), isFalse, reason: 'declined as duplicate');
+
+    expect(store.messages, hasLength(1));
+  });
+
+  test('a duplicate push reports duplicate and does not re-announce (§2.3)', () async {
+    final store = MessageFeedStore(_tmp());
+    final announced = <EdgeMessage>[];
+
+    await ingestPushPayload(_payload(), store: store, onMessage: announced.add);
+    final second =
+        await ingestPushPayload(_payload(), store: store, onMessage: announced.add);
+
+    expect(second, PushIngestOutcome.duplicate);
+    expect(store.messages, hasLength(1));
+    expect(announced, hasLength(1),
+        reason: 'a second badge/notification for a message already seen is the '
+            'same bug one layer up');
+  });
+
+  test("content_type 'approval' routes to approvals, never the feed (FR-009, §3.2)",
+      () async {
+    final store = MessageFeedStore(_tmp());
+    final approvals = <Map<String, dynamic>>[];
+    final feedAnnounced = <EdgeMessage>[];
+
+    final outcome = await ingestPushPayload(
+      _payload(contentType: 'approval'),
+      store: store,
+      onApproval: approvals.add,
+      onMessage: feedAnnounced.add,
+    );
+
+    expect(outcome, PushIngestOutcome.approval);
+    expect(approvals, hasLength(1));
+    expect(store.messages, isEmpty, reason: 'approvals must never enter the feed');
+    expect(feedAnnounced, isEmpty);
+  });
+
+  group('malformed payloads are rejected without corrupting the store (FR-010, §3.4)', () {
+    test('missing pushed_at', () async {
+      final store = MessageFeedStore(_tmp());
+      final data = _payload()..remove('pushed_at');
+      expect(await ingestPushPayload(data, store: store), PushIngestOutcome.rejected);
+      expect(store.messages, isEmpty);
+    });
+
+    test('unparseable pushed_at is rejected, NOT defaulted to now (§3.3)', () async {
+      // Defaulting would mint a fresh identity per delivery attempt and so
+      // silently defeat dedup — the one failure mode that reintroduces duplicates.
+      final store = MessageFeedStore(_tmp());
+      expect(
+        await ingestPushPayload(_payload(pushedAt: 'yesterday'), store: store),
+        PushIngestOutcome.rejected,
+      );
+      expect(store.messages, isEmpty);
+    });
+
+    test('unknown content_type', () async {
+      final store = MessageFeedStore(_tmp());
+      expect(
+        await ingestPushPayload(_payload(contentType: 'hologram'), store: store),
+        PushIngestOutcome.rejected,
+      );
+      expect(store.messages, isEmpty);
+    });
+
+    test('missing content', () async {
+      final store = MessageFeedStore(_tmp());
+      final data = _payload()..remove('content');
+      expect(await ingestPushPayload(data, store: store), PushIngestOutcome.rejected);
+      expect(store.messages, isEmpty);
+    });
+
+    test('an empty payload', () async {
+      final store = MessageFeedStore(_tmp());
+      expect(await ingestPushPayload({}, store: store), PushIngestOutcome.rejected);
+      expect(store.messages, isEmpty);
+    });
+
+    test('a rejection leaves already-stored messages intact', () async {
+      final store = MessageFeedStore(_tmp());
+      await ingestPushPayload(_payload(), store: store);
+      await ingestPushPayload(_payload(pushedAt: 'garbage'), store: store);
+
+      expect(store.messages, hasLength(1),
+          reason: 'a bad payload must not truncate or corrupt the feed');
+    });
+  });
+
+  test('missing designated_by falls back rather than rejecting', () async {
+    // Not identity-bearing, so absence is tolerable — unlike pushed_at.
+    final store = MessageFeedStore(_tmp());
+    final data = _payload()..remove('designated_by');
+    expect(await ingestPushPayload(data, store: store), PushIngestOutcome.stored);
+    expect(store.messages.single.designatedBy, 'agent');
+  });
+
+  test('voice and image content types both ingest', () async {
+    for (final type in ['voice', 'image']) {
+      final store = MessageFeedStore(_tmp());
+      final outcome = await ingestPushPayload(
+        _payload(contentType: type, content: 'YmFzZTY0'),
+        store: store,
+      );
+      expect(outcome, PushIngestOutcome.stored, reason: 'content_type $type');
+    }
+  });
+}

--- a/specs/107-push-render-deeplink/checklists/requirements.md
+++ b/specs/107-push-render-deeplink/checklists/requirements.md
@@ -1,0 +1,79 @@
+# Specification Quality Checklist: Notification tap opens the message it names
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+Validation ran over two iterations.
+
+**Iteration 1 — three failures, all "implementation details leaked":**
+
+1. The Context section and every functional requirement named specific
+   identifiers from the codebase (`NotificationDeepLink._handleRemote`,
+   `findMessageForNotificationData`, `MessageFeedStore.append`, `pushed_at`,
+   `FirebaseMessaging.onMessage`, `wireMessageFeed`, `N2N_EDGE_REPLAY_SETTLE_S`).
+   The originating bug report was written in those terms, which made it tempting
+   to carry them straight through. Rewritten in behavioral terms — "the message's
+   send time as recorded by the sender" rather than the field name, "a live
+   connection" rather than the transport. The precise call sites belong in
+   `plan.md`, not here.
+2. Success criteria cited implementation timings (the 3-second settle, the
+   measured millisecond timestamps). Restated from the operator's side: readable
+   within 2 seconds of the app becoming interactive; usable screen within 10
+   seconds when a message never arrives.
+3. Named platform services (FCM, APNs) in requirements. Replaced with "the
+   existing push transport", with the specific one pinned in Dependencies via
+   spec 103 instead.
+
+**Iteration 2 — one failure, "requirements are testable":**
+
+FR-008 originally read "deduplication should be done first", which states a work
+order rather than an observable property and cannot be tested. Reframed as a
+gating constraint on FR-007 and backed by User Story 3, which is independently
+testable. The ordering is now enforced by story priority (Story 3 is P1, Story 2
+is P2) rather than asserted in prose.
+
+**One assumption worth escalating at planning time**, recorded in Assumptions
+rather than raised as a clarification because a reasonable default exists: keying
+deduplication on send time makes two distinct messages sharing a whole-second
+timestamp collapse into one. Acceptable for operator-initiated traffic; a real
+risk if automated senders are added later. If planning finds that unacceptable,
+the sender would need to stamp a unique message id — which *would* make this a
+Border change and push it outside this spec's stated scope.
+
+**Not marked as clarifications** (informed defaults taken, per the workflow's
+3-marker limit and its guidance to prefer defaults):
+
+- Bounded wait for a named message: "bounded, then fall back to the feed" with a
+  10-second outer limit in SC-007. Exact value is a planning detail.
+- Read-state behavior on re-delivery: preserved (FR-006), the non-surprising
+  default.
+- Approval notifications: continue routing to approvals (FR-009), matching the
+  behavior spec 068/073 already established rather than inventing new handling.

--- a/specs/107-push-render-deeplink/contracts/notification-intent.md
+++ b/specs/107-push-render-deeplink/contracts/notification-intent.md
@@ -1,0 +1,100 @@
+# Contract: notification intent and push ingest
+
+**Feature**: 107-push-render-deeplink
+**Date**: 2026-08-13
+
+The app exposes no external API, so this is an **internal-collaboration
+contract** — the obligations each collaborator owes the others, which is the
+contract form appropriate to an application rather than a service. It exists so
+the two new modules and the two modified ones cannot drift apart, and so the
+tests in `tasks.md` have something to assert against.
+
+---
+
+## §1 Pending open intent
+
+### Obligations
+
+| # | Obligation |
+|---|---|
+| 1.1 | Recording an intent MUST NOT block, and MUST NOT itself trigger navigation. |
+| 1.2 | Recording a second intent MUST discard the first. Exactly one intent exists at any time. |
+| 1.3 | If the named message is already in the feed at record time, the intent MUST resolve without waiting. |
+| 1.4 | If the named message enters the feed later, the intent MUST resolve then. |
+| 1.5 | An intent MUST expire within a bounded interval, ≤10s (SC-007), and expiry MUST leave the operator on a usable screen. |
+| 1.6 | Resolution MUST fire the open callback exactly once. Expiry MUST NOT fire it at all. |
+| 1.7 | Intent state MUST NOT persist across app launches. |
+
+### Non-obligations
+
+- Does not guarantee the message ever arrives. That is spec 106's job.
+- Does not fetch, retry, or contact the Border. It only observes the local feed.
+
+---
+
+## §2 Feed append
+
+### Obligations
+
+| # | Obligation |
+|---|---|
+| 2.1 | Append MUST be the single enforcement point for message identity. Callers MUST NOT pre-check for duplicates. |
+| 2.2 | Appending a Message whose `pushedAt` matches a stored Message MUST leave the stored one byte-for-byte unchanged — including `read` state (FR-006). |
+| 2.3 | Append MUST report whether it stored or declined, so a caller can avoid firing an "arrived" side effect (badge, notification) for a message the operator already has. |
+| 2.4 | Declining MUST NOT be an error. It is the expected outcome whenever two delivery paths carry the same message. |
+
+### Rationale for 2.3
+
+Without a return signal, the ingest path would fire an unread badge for every
+replayed duplicate, so the fix for double *entries* would leave double
+*notifications* — a visibly identical bug one layer up.
+
+---
+
+## §3 Push payload ingest
+
+### Obligations
+
+| # | Obligation |
+|---|---|
+| 3.1 | MUST tolerate every value arriving as a string. The sender stringifies the whole content map (`data: {k: str(v) …}`), so no field may be assumed to have survived with its original type. |
+| 3.2 | MUST route `content_type: 'approval'` to the approvals path and MUST NOT write it to the feed (FR-009). |
+| 3.3 | MUST reject a payload with a missing or unparseable `pushed_at` rather than substituting a value (see data-model's validation rule — substituting would mint a fresh identity per attempt and defeat dedup). |
+| 3.4 | MUST NOT corrupt or truncate the stored feed on any malformed input (FR-010). Rejecting the payload is the correct outcome. |
+| 3.5 | MUST reconstruct through the same wire parser the live channel path uses. A second parser is forbidden — it would drift. |
+
+### Non-obligations
+
+- Not required to succeed. A rejected payload falls back to spec 106's replay,
+  which is the guarantee; this path is an acceleration of it (R5).
+
+---
+
+## §4 Handler registration
+
+### Obligations
+
+| # | Obligation |
+|---|---|
+| 4.1 | `wireMessageFeed` MUST remain the ONLY registration site for `n2n/edge/message`. |
+| 4.2 | The push ingest path MUST NOT register a channel handler. |
+
+### Why this is a contract clause and not a comment
+
+`EdgeClient.on()` keeps only the **last** handler registered per method. A second
+registration for `n2n/edge/message` would silently displace the first and disable
+live delivery entirely — with no error, and with the feature's own tests still
+passing if they exercised the new path. This is the highest-severity failure mode
+in the feature and the cheapest to guard: a structural test asserting a single
+registration site.
+
+---
+
+## §5 What this feature must not change
+
+| # | Obligation |
+|---|---|
+| 5.1 | No Border-side change. Spec 106 owns delivery. |
+| 5.2 | No new push transport. The existing one is used as-is (spec 103). |
+| 5.3 | No weakening of SC-006 — every message the Border delivers still reaches the feed, whether or not the push path accelerated it. |
+| 5.4 | Local-notification tap behavior (spec 073), which already deep-links correctly, MUST keep working; it converges on the shared intent rather than being replaced. |

--- a/specs/107-push-render-deeplink/data-model.md
+++ b/specs/107-push-render-deeplink/data-model.md
@@ -1,0 +1,124 @@
+# Phase 1 Data Model: Notification tap opens the message it names
+
+**Feature**: 107-push-render-deeplink
+**Date**: 2026-08-13
+
+Two of the three entities already exist; this feature gives one of them an
+explicit identity rule and the other an invariant it has been missing. Only
+`PendingOpenIntent` is new, and it is in-memory only.
+
+---
+
+## Message
+
+An existing entity (`EdgeMessage`). No new fields.
+
+| Field | Meaning | Notes |
+|---|---|---|
+| `pushedAt` | When the sender sent it | **Identity.** See the identity rule below. |
+| `content` | The message body | Arrives stringified over the push path (R4) |
+| `contentType` | `text` / `voice` / `image` / `approval` | `approval` never enters the Feed (FR-009) |
+| `replayed` | Whether it came from the Border's backlog | Renders as history rather than new |
+| `read` | Whether the operator has seen it | **Must survive re-delivery** (FR-006) |
+
+### Identity rule
+
+Two Messages are the same Message when their `pushedAt` values are equal.
+
+**This is a real constraint, not a formality.** The Border stamps `pushed_at` at
+whole-second granularity (`%Y-%m-%dT%H:%M:%SZ`), so two genuinely distinct
+messages sent inside the same second collapse into one feed entry. Accepted
+because this path carries operator- and agent-initiated pushes, not a high-rate
+stream. If that ever stops being true, the fix is a sender-assigned unique id —
+a Border change, therefore a different spec. Do not paper over it client-side by
+adding a second local identifier, which would break cross-path dedup (R2).
+
+### Validation
+
+- A Message with an unparseable `pushedAt` is **rejected, not defaulted**.
+  Defaulting to "now" would mint a new identity on every delivery attempt and
+  defeat dedup entirely — the one failure mode that would silently reintroduce
+  duplicates. Rejection is safe: spec 106 guarantees replay will deliver it again
+  over the live path.
+- Unknown `contentType` is ignored rather than stored, consistent with how the
+  live handler already treats it.
+
+---
+
+## Feed
+
+An existing entity (`MessageFeedStore`), gaining one invariant.
+
+### Invariant
+
+**At most one entry per distinct Message**, enforced inside the store's append
+path — not at its call sites (R3).
+
+This must hold across *every* writer. As of this feature there are two (the live
+channel handler and the push ingest path), and the enforcement point is
+deliberately the one place both must pass through, so a future third writer
+inherits it without knowing it exists.
+
+### Behavior on duplicate
+
+Declining the write is the whole behavior: the existing entry is left exactly as
+it is, including its `read` state (FR-006). Nothing is merged, updated, or
+re-ordered.
+
+> **Dedup is not an audit gap.** The Border records every delivery in its own
+> trail, including replays (`edge_push/queue_replay`). The device declining a
+> duplicate *local write* erases nothing and must not be "corrected" by
+> suppressing the Border-side record. Constitution Principle IV concerns the
+> audit trail, which lives on the Border and is untouched here.
+
+### Ordering
+
+Unchanged — by `pushedAt`. A duplicate cannot reorder the feed because it is
+never written.
+
+---
+
+## PendingOpenIntent
+
+**New**, and in-memory only.
+
+Represents "the operator tapped a notification naming a message we may not have
+yet."
+
+| Field | Meaning |
+|---|---|
+| `identifier` | The `pushedAt` of the message the notification named |
+| `createdAt` | When the tap happened, for expiry |
+
+### Lifecycle
+
+```
+                    ┌──────────────────────────────┐
+   notification     │                              │
+   tapped     ──────▶  pending(identifier)         │
+                    │                              │
+                    └──────┬──────────────┬────────┘
+                           │              │
+        message present    │              │  bounded wait elapses
+        or arrives         │              │
+                           ▼              ▼
+                      resolved       expired
+                   (open message)  (show feed)
+```
+
+- **At most one intent at a time.** A second tap replaces the first, so the
+  operator lands on what they most recently tapped rather than the app racing
+  between two (an Edge Case in the spec).
+- **Resolves immediately** when the named message is already stored — the common
+  case once Story 2 ships, and the reason the timeout path is rarely reached.
+- **Expires** after a bounded wait (10s outer bound, SC-007), then the app shows
+  the feed. Never a permanent loading state.
+- **Does not survive an app restart.** Deliberate: no persistence, per the open
+  item in R7. A tap whose app is killed before resolution loses only the
+  navigation, never the message — spec 106 still delivers it to the feed.
+
+### Why in-memory
+
+It describes a navigation intent within one app session, not durable state.
+Persisting it would mean a stale intent could hijack navigation on a later launch
+for a reason the operator no longer remembers.

--- a/specs/107-push-render-deeplink/plan.md
+++ b/specs/107-push-render-deeplink/plan.md
@@ -1,0 +1,144 @@
+# Implementation Plan: Notification tap opens the message it names
+
+**Branch**: `107-push-render-deeplink` | **Date**: 2026-08-13 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/107-push-render-deeplink/spec.md`
+
+## Summary
+
+Spec 106 made every pushed message survive to the device. This feature makes the
+device do the right thing with it: a notification tap opens the message it names
+(P1), the feed never shows a message twice (P1), and a pushed message renders
+without waiting for a live connection (P2).
+
+The approach is one shared *pending intent* for notification taps — record the
+tapped message's identifier, resolve it when that message is present or arrives,
+give up after a bounded wait — plus deduplication moved into the feed store's
+single append chokepoint so a second writer cannot double-record. The FCM data
+payload the Border already sends is then consumed through the existing wire
+parser, which is safe only *because* dedup landed first.
+
+No Border change. Entirely within `mobile/netclaw-mobile`.
+
+## Technical Context
+
+**Language/Version**: Dart 3.x / Flutter, SDK constraint `^3.12.2` (from `pubspec.yaml`)
+**Primary Dependencies**: No new packages. Reuses `firebase_messaging ^16.4.3`, `firebase_core ^4.12.1`, `flutter_local_notifications ^22.2.0`, all already present. Continues the 066–073 and 099 precedent of adding no dependency a story does not strictly require.
+**Storage**: Existing on-device stores, extended not replaced — `MessageFeedStore` (JSON-Lines) and, unchanged, `ConversationStore`. No migration of stored history.
+**Testing**: `flutter_test` (30 suites in `test/`, several direct analogues); `integration_test` for the device-only cases
+**Target Platform**: iOS 15+ and Android (min SDK 21), matching the existing build config
+**Project Type**: Mobile app (Flutter), single package
+**Performance Goals**: Pushed message readable within 2s of the app becoming interactive (SC-003); no added latency when the message is already stored
+**Constraints**: Must not weaken spec 106's guarantee that no delivered message is absent from the feed (SC-006); ships on the app's release cadence, not a server restart, because the iOS build is TestFlight-gated
+**Scale/Scope**: 3 user stories; ~4 existing files touched, 1 new; no new screens
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+| Principle | Applies | Assessment |
+|---|---|---|
+| **IV. Immutable Audit Trail** | Yes | No operation becomes silent. Delivery is already audited Border-side (`edge_push/queue_replay` recorded per replay, observed in production). This feature changes only device-side rendering of already-audited messages. **A deduplicated message must not suppress an audit record** — dedup is a display/storage concern on the device, and the Border's trail is untouched. |
+| **VIII. Verify After Every Change** | Yes | Every FR maps to a test in Phase 1's contract list; R7 partitions what the Dart suite can verify from what needs hardware, so verification is planned rather than assumed. |
+| **XI. Full-Stack Artifact Coherence** | Yes | Mobile-only feature: no MCP server, no skill, no catalog entry, no `config/openclaw.json` change. Doc surface is `mobile/netclaw-mobile/README.md` plus the known-rough-edges table in `TESTER-INSTRUCTIONS.md`, which currently lists "Tapping a notification doesn't deep-link" as a known issue — that row must be updated in the same PR. |
+| **XII. Documentation-as-Code** | Yes | See above; docs land in the same PR as the code. |
+| **XV. Backwards Compatibility** | Yes | Additive. Existing stored feeds remain readable; dedup only ever *declines* a write. No new dependency, so no version conflict surface. The one real hazard is displacing the single `n2n/edge/message` handler registration (R6) — guarded by a structural test. |
+| **XVI. Spec-Driven Development** | Yes | This plan completes specify → plan → task. `scripts/verify-spec-artifacts.py` is CI-enforced and requires `plan.md`, `research.md`, and tasks. |
+| I, II, III, V, VI, VII, IX, X, XIII, XIV, XVII | No | No device interaction, no config change, no MCP server or skill, no credentials, no external communication. Not a milestone warranting a blog post (a follow-on fix to 106). |
+
+**Gate result**: PASS, no violations. Complexity Tracking section omitted as
+unnecessary.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/107-push-render-deeplink/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── notification-intent.md
+├── checklists/
+│   └── requirements.md  # from /speckit.specify
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code
+
+```text
+mobile/netclaw-mobile/
+├── lib/ncfed/
+│   ├── message_feed.dart              # MODIFY — dedup in the append chokepoint (R3);
+│   │                                  #   wireMessageFeed stays the ONLY
+│   │                                  #   n2n/edge/message registration site (R6)
+│   ├── notification_deep_link.dart    # MODIFY — remote + local tap paths converge on
+│   │                                  #   the shared pending intent (R1, R6)
+│   ├── pending_open_intent.dart       # NEW — record/resolve/expire a tapped identifier
+│   └── push_message_ingest.dart       # NEW — reconstruct a message from the FCM data
+│                                      #   payload; approval routing preserved (R4)
+├── lib/main.dart                      # MODIFY — wire the foreground/background
+│                                      #   handlers and the intent into HomeShell
+└── test/
+    ├── message_feed_test.dart              # EXTEND — dedup, read-state preservation
+    ├── notification_deep_link_test.dart    # EXTEND — arrive-after-tap, timeout
+    ├── push_message_ingest_test.dart       # NEW — stringified + malformed payloads
+    └── pending_open_intent_test.dart       # NEW — resolution ordering, expiry
+```
+
+**Structure Decision**: Existing Flutter single-package layout, unchanged. New
+code goes in `lib/ncfed/` beside the modules it collaborates with, matching how
+066–073 organized every prior edge-node concern. Two new files rather than
+growing `notification_deep_link.dart`, because the intent mechanism is used by
+both tap paths and the ingest path is a separate concern with its own failure
+modes — Principle VII (single well-defined function per unit) argues for the
+split.
+
+## Phase 1 Design
+
+### Contract
+
+Interface contract for the intent mechanism and the ingest path is in
+[`contracts/notification-intent.md`](contracts/notification-intent.md). The app
+exposes no external API, so this is an internal-collaboration contract — the
+appropriate form for an application per the plan template's guidance.
+
+### Entities
+
+See [`data-model.md`](data-model.md). Three entities, all already existing in some
+form: **Message** (gains an explicit identity rule), **PendingOpenIntent** (new,
+in-memory), **Feed** (gains the at-most-once invariant).
+
+### Requirement → verification map
+
+| FR | Verified by | Where |
+|---|---|---|
+| FR-001, FR-002 | intent resolves when message arrives after tap | `notification_deep_link_test.dart` |
+| FR-003 | intent expires, feed shown | `pending_open_intent_test.dart` |
+| FR-004, FR-005 | append declines a duplicate `pushed_at` | `message_feed_test.dart` |
+| FR-006 | read state preserved on re-delivery | `message_feed_test.dart` |
+| FR-007 | message reconstructed from data payload | `push_message_ingest_test.dart` |
+| FR-008 | ordering enforced by task phasing, not asserted in code | `tasks.md` |
+| FR-009 | `content_type: 'approval'` routes to approvals | `push_message_ingest_test.dart` |
+| FR-010 | malformed payload rejected, store intact | `push_message_ingest_test.dart` |
+| FR-011 | no forced open without a tap | `notification_deep_link_test.dart` |
+| FR-012 | platform parity | device verification (R7) |
+| — | single `n2n/edge/message` registration site | structural test, `message_feed_test.dart` |
+
+### Post-design Constitution re-check
+
+**PASS.** The design adds no MCP server, skill, dependency, or credential
+surface. Two clarifications the design surfaced:
+
+1. **Dedup must not be mistaken for an audit gap** (Principle IV). The Border's
+   trail records every delivery including replays; the device declining a
+   duplicate *write* does not erase anything. Recorded in `data-model.md` so an
+   implementer does not "fix" it by suppressing the Border-side record.
+2. **`TESTER-INSTRUCTIONS.md` currently advertises this bug** as a known rough
+   edge. Principle XII requires that row change in the same PR, so it is a task,
+   not a follow-up.
+
+## Complexity Tracking
+
+Not applicable — Constitution Check passed with no violations.

--- a/specs/107-push-render-deeplink/quickstart.md
+++ b/specs/107-push-render-deeplink/quickstart.md
@@ -1,0 +1,141 @@
+# Quickstart: verifying spec 107
+
+**Feature**: 107-push-render-deeplink
+**Date**: 2026-08-13
+
+How to see the bug, and how to confirm each story fixed it. Written so a device
+session — which on iOS costs a TestFlight round trip — is spent only on what
+genuinely needs one.
+
+---
+
+## Reproduce the bug first (before any code changes)
+
+Requires a Border on spec 106 or later and an enrolled phone.
+
+```bash
+# 1. Confirm the phone is disconnected, so the push takes the wake-signal path.
+curl -s http://127.0.0.1:8179/n2n/health | python3 -c "
+import json,sys
+for e in json.load(sys.stdin).get('edge_nodes',[]):
+    print(e['member_id'], 'connected=', e['connected'], 'queued=', e['queued'])"
+
+# 2. With the app FULLY CLOSED, push a message.
+curl -s -H 'Content-Type: application/json' \
+  -d '{"member_id":"<member_id>","content_type":"text","content":"spec 107 repro"}' \
+  http://127.0.0.1:8179/n2n/edge/push
+#    Expect: "in_app_delivery": "pending_replay", "queued": true
+```
+
+3. **Tap the notification** on the phone.
+
+**Current (broken) behavior**: the app opens to whatever screen it was last on.
+The message appears in the Feed tab a few seconds later, but you were not taken
+to it. That gap is Story 1.
+
+Watch it from the Border side:
+
+```bash
+journalctl --user -u netclaw-mesh --since "2 min ago" | \
+  grep -E 'authenticated|Replaying'
+# Edge node … authenticated (source=…, 1 queued)
+# Replaying 1 queued message(s) …          ← ~3s after auth; the tap already lost
+```
+
+That ~3s gap between auth and replay is precisely why a single store read at tap
+time cannot succeed.
+
+---
+
+## Story 3 — no duplicates (P1, do this first)
+
+Fully verifiable in the Dart suite; no device needed.
+
+```bash
+cd mobile/netclaw-mobile
+flutter test test/message_feed_test.dart
+```
+
+Confirms: a second append with the same `pushed_at` is declined; the stored
+entry's `read` state is untouched; two distinct messages both store; and
+`wireMessageFeed` remains the only `n2n/edge/message` registration site.
+
+> Do this before Story 2. Story 2 adds a second writer, and without dedup every
+> message it persists will double when replay arrives.
+
+---
+
+## Story 1 — the tap opens the message (P1)
+
+Most of it is verifiable without a device:
+
+```bash
+flutter test test/notification_deep_link_test.dart test/pending_open_intent_test.dart
+```
+
+Confirms: an intent resolves when the message arrives *after* the tap (the actual
+bug); resolves immediately when already stored; expires within the bound and
+falls back to the feed; opening the app without a tap forces nothing open.
+
+**Then on a device** — this part cannot be faked:
+
+1. Close the app fully. Push a message (commands above).
+2. Tap the notification.
+3. **Expect**: the app opens *to that message*.
+4. Repeat with the app backgrounded rather than closed.
+
+---
+
+## Story 2 — renders without a live connection (P2)
+
+```bash
+flutter test test/push_message_ingest_test.dart
+```
+
+Confirms: a fully stringified payload reconstructs; a payload with a missing or
+unparseable `pushed_at` is rejected without corrupting the store;
+`content_type: 'approval'` routes to approvals and never the feed.
+
+**On a device**, the case worth the trip is *no connectivity*:
+
+1. Block the phone's route to the Border (airplane mode with wifi only, or a
+   firewall rule dropping `:8443` from that address).
+2. Push a message. The banner should still arrive — it comes via the push
+   service, not the Border channel.
+3. Open the app. **Expect**: the message is readable even though no live
+   connection can be established.
+4. Restore connectivity. **Expect**: exactly one copy of it, after replay
+   delivers the same message again. This is the check that proves dedup and
+   ingest work together, and it is the single most valuable device test in this
+   feature.
+
+---
+
+## Whole-feature regression
+
+```bash
+cd mobile/netclaw-mobile
+flutter test            # all suites
+flutter analyze
+```
+
+And on the Border, confirm nothing regressed in delivery:
+
+```bash
+cd /path/to/netclaw
+python3 -m pytest tests/n2n/ -q      # expect 445+ passed
+```
+
+That last one should be untouched — this feature makes no Border change. If it
+moves, something is out of scope.
+
+---
+
+## What "done" looks like
+
+| Story | Signal |
+|---|---|
+| 3 | 50 mixed-path messages → 50 feed entries, no duplicates (SC-005) |
+| 1 | Tap opens the named message ≥95% of attempts, zero manual navigation (SC-001, SC-002) |
+| 2 | Message readable with no Border connectivity at all (SC-004), within 2s of the app becoming interactive (SC-003) |
+| all | No message the Border delivered is missing from the feed (SC-006) |

--- a/specs/107-push-render-deeplink/research.md
+++ b/specs/107-push-render-deeplink/research.md
@@ -1,0 +1,223 @@
+# Phase 0 Research: Notification tap opens the message it names
+
+**Feature**: 107-push-render-deeplink
+**Date**: 2026-08-13
+
+Most of this feature's unknowns were resolved during the production investigation
+that produced spec 106 rather than by fresh research, so several decisions below
+cite direct observation of a running system. Where that is the case it is stated,
+because an observed fact and a design preference deserve different confidence.
+
+---
+
+## R1 — How should the tap handler wait for a message that has not arrived yet?
+
+**Decision**: Record the tapped identifier as a *pending intent*, then resolve it
+either immediately (message already stored) or when the store next gains a
+matching message, with a bounded timeout after which the intent is discarded and
+the feed shown.
+
+**Rationale**: The tap and the message's arrival are genuinely concurrent events
+with no guaranteed order, so any fix that only reads the store once will keep
+losing the race. Measured in production: channel auth completed at 16:49:12.513
+and the replayed message landed at 16:49:15.514 — a 3.0s gap, matching the
+Border's deliberate `N2N_EDGE_REPLAY_SETTLE_S`. App launch from a cold tap is
+well under that, so the current single read is *guaranteed* to miss on a
+cold-start tap, not merely likely to.
+
+An intent also composes with Story 2: once the FCM payload is persisted on
+receipt, the same intent resolves instantly from the store with no waiting, and
+the timeout path becomes dead code in the common case rather than needing
+separate handling.
+
+**Alternatives considered**:
+
+- *Poll the store on a timer* — simplest, but picks an arbitrary interval and
+  either wastes wakeups or adds latency. The store already has a change signal
+  (`wireMessageFeed`'s `onMessage` callback fires after every append), so polling
+  would ignore an existing mechanism.
+- *Delay the deep-link check by a fixed 3.5s* — couples the app to a Border-side
+  constant it cannot see, and breaks silently if that constant is retuned. Worse,
+  it adds 3.5s to the already-fast case where the message is present.
+- *Have the Border withhold the notification until after replay* — a Border
+  change, explicitly out of scope, and it would delay the banner (the thing that
+  works well today) to fix the tap.
+
+**Timeout value**: 10s outer bound, from SC-007. Long enough to cover auth plus
+the 3s settle plus retry margin on a slow network; short enough that a revoked
+device does not sit on a stalled screen.
+
+---
+
+## R2 — What identifies a message for deduplication?
+
+**Decision**: `pushed_at`, the sender's send timestamp.
+
+**Rationale**: It is already the de facto identifier throughout the app and
+requires no Border change. `EdgeMessage.fromWire` parses it; the local-notification
+tap path (`handleLocalNotificationTap`, spec 073) already matches on
+`{'pushed_at': identifier}`; and `findMessageForNotificationData` already searches
+by it. Adding a second identifier would mean two competing notions of message
+identity.
+
+**Known limitation, escalated from the spec's Assumptions**: the Border stamps
+`pushed_at` with whole-second granularity
+(`time.strftime("%Y-%m-%dT%H:%M:%SZ")`). Two genuinely distinct messages sent
+inside the same second would collapse into one feed entry. Judged acceptable
+because this route only carries operator- and agent-initiated pushes, not a
+high-rate stream — but it is a real correctness limit, not a theoretical one, and
+it is recorded in `data-model.md` as a constraint rather than buried here.
+
+**If that limitation ever becomes unacceptable**, the fix is a sender-assigned
+unique message id — which is a Border change and therefore a *different spec*.
+Deliberately not smuggled into this one.
+
+**Alternatives considered**:
+
+- *Content hash* — collapses two legitimately identical messages (e.g. the same
+  status pushed twice, deliberately). Wrong semantics.
+- *Client-assigned id on receipt* — cannot dedup across delivery paths, since each
+  path would mint its own id. Defeats the purpose.
+- *(pushed_at, content_type) composite* — marginal gain over `pushed_at` alone,
+  since a same-second collision with differing content types is vanishingly rare,
+  and it complicates every comparison site. Rejected as unearned complexity.
+
+---
+
+## R3 — Where does deduplication belong?
+
+**Decision**: Inside the feed store's append path, not at the call sites.
+
+**Rationale**: Story 2 adds a second writer. Dedup at the call sites would mean
+two implementations that must agree forever, which is precisely the drift pattern
+this repo has been bitten by before (the `member_liveness` inline-computation
+drift has its own regression test guarding it). One chokepoint in the store makes
+the invariant structural: it cannot be bypassed by a future third writer.
+
+`FR-006` (re-delivery must not reset read state) falls out naturally from a store
+that treats an existing `pushed_at` as "already have it, ignore".
+
+**Alternatives considered**:
+
+- *Dedup in `wireMessageFeed`'s handler* — leaves the FCM path to reimplement it.
+- *Dedup at render time* — hides duplicates rather than preventing them; the
+  stored file still grows with junk, and the badge/unread counts would still
+  double-count.
+
+---
+
+## R4 — How is the FCM data payload consumed, given every value arrives as a string?
+
+**Decision**: Reconstruct through the existing wire parser, tolerating stringified
+values, and route by `content_type` exactly as the live path does.
+
+**Rationale**: The Border already sends the full content as a data payload
+(`send_fcm`: a `notification` block for the banner plus
+`data: {k: str(v) for k, v in content.items()}`). Two consequences observed
+directly in that code:
+
+1. **Every value is stringified**, including any non-string field. The client must
+   not assume types survive the trip. This is the single most likely source of a
+   silent parse failure, and is why FR-010 (malformed payload must not corrupt the
+   feed) exists.
+2. **`content_type` is present in the data payload**, so approval routing (FR-009)
+   can be honored on this path with the same discriminator the live path uses —
+   `'approval'` goes to the approvals view, never the feed.
+
+Reusing the existing parser rather than writing a second one keeps a single
+definition of what a message is.
+
+**Alternatives considered**:
+
+- *A separate lightweight parser for FCM* — two parsers, guaranteed to drift.
+- *Ask the Border to send a JSON blob in one data key* — a Border change, out of
+  scope, and unnecessary since the current shape is already sufficient.
+
+---
+
+## R5 — Foreground, background, and terminated: which handlers are needed?
+
+**Decision**: Handle the foreground-message and background-message cases for
+persistence, and keep the existing tap entry points for navigation. Treat the
+terminated-app case as covered by the launch-time tap path plus replay, not by a
+background handler guarantee.
+
+**Rationale**: Background execution for a data-carrying push is subject to OS
+discretion on both platforms — it is not a delivery guarantee, and building the
+feature as though it were would reintroduce a silent-loss path of exactly the kind
+spec 106 just removed. Spec 106's queue-and-replay is the guarantee; this feature
+is an *acceleration* of it. That framing is what keeps SC-006 (no message
+absent from the feed) true even when the OS declines to run the handler.
+
+**Consequence for testing**: whether the OS actually runs a background handler for
+a given push is not determinable in the Dart test suite. Flagged in R7.
+
+**Alternatives considered**:
+
+- *Rely solely on a background handler* — would make correctness depend on OS
+  scheduling. Rejected on the same grounds spec 106 was written.
+- *Foreground-only persistence* — leaves the common case (app closed, tap the
+  banner) still waiting for replay, which is most of the value of Story 2.
+
+---
+
+## R6 — Must the remote and local notification tap paths converge?
+
+**Decision**: Yes — both resolve through one shared intent mechanism.
+
+**Rationale**: `handleLocalNotificationTap` (spec 073) already deep-links
+correctly, because a locally-posted notification is only ever posted for a message
+the app has *already* stored, so its single store read always succeeds. The remote
+path has the same job and a different outcome purely because of arrival timing.
+Two mechanisms for one behavior would mean the next change has to be made twice;
+the local path's existing correctness is a reason to converge on it, not to leave
+it alone.
+
+**Constraint to preserve**: `EdgeClient.on()` keeps only the **last** handler
+registered per method, so `wireMessageFeed` must remain the single registration
+site for `n2n/edge/message`. Any new store writer must not register a second
+handler for that method — it would silently displace the first. This is a real
+footgun already documented in that function's own comment.
+
+---
+
+## R7 — What can the existing Dart test suite verify, and what needs hardware?
+
+**Decision**: Cover identity/dedup, intent resolution ordering, payload parsing,
+and approval routing in the existing suite. Accept device verification only for
+OS-scheduling behavior.
+
+**Coverable in `test/`** (the suite already has close analogues —
+`message_feed_test.dart`, `notification_deep_link_test.dart`,
+`notification_response_routing_test.dart`, `feed_screen_highlight_test.dart`,
+`badge_lifecycle_test.dart`):
+
+- dedup by `pushed_at`, including the read-state-preservation case
+- intent resolves when the message arrives *after* the tap (the actual bug)
+- intent resolves immediately when the message is already stored
+- intent times out and falls back to the feed
+- stringified payload reconstructs correctly; malformed payload is rejected
+  without corrupting the store
+- `content_type: 'approval'` routes to approvals, not the feed
+- exactly one `n2n/edge/message` registration site remains
+
+**Requires real hardware, and cannot be faked**:
+
+- whether the OS runs the background handler for a given push
+- end-to-end tap→open from a genuinely terminated app
+- iOS specifically, since the build is TestFlight-gated
+
+**Rationale for calling this out prominently**: device verification on iOS costs a
+TestFlight round trip. Anything that *can* be pinned in the Dart suite should be,
+so a device session is spent only on what genuinely needs one. Spec 106's own
+lesson applies — its route tiering had no coverage at all, which is exactly why
+the bug shipped.
+
+---
+
+## Open items carried into planning
+
+| Item | Why not resolved here |
+|---|---|
+| Exact timeout constant (within the 10s bound of SC-007) | Implementation tuning; no user-visible difference across plausible values |
+| Whether the pending intent survives an app restart | Needs a product call — a tap whose app is killed before resolution is an edge case with no observed frequency data. Defaulting to "does not survive" (simpler, no persistence) unless planning finds otherwise |

--- a/specs/107-push-render-deeplink/spec.md
+++ b/specs/107-push-render-deeplink/spec.md
@@ -1,0 +1,224 @@
+# Feature Specification: Notification tap opens the message it names
+
+**Feature Branch**: `107-push-render-deeplink`
+**Created**: 2026-08-13
+**Status**: Draft
+**Input**: User description: "Notification tap opens the message it names, and a pushed message renders without waiting for replay"
+
+## Context
+
+Spec 106 (merged 2026-08-13) fixed the reported empty-feed bug: the Border now
+treats a platform push as a wake signal rather than a delivery, persisting every
+undelivered push and replaying it on the device's next connect. Verified
+end-to-end on real hardware — a message queued at 16:45:34 was replayed at
+16:49:15 and rendered in the app.
+
+That closed the data-loss half of the problem. Two **experience** gaps remain,
+both on the device, and neither loses data:
+
+1. **Tapping a notification does not open the message it names.** The tap
+   handler searches the local store the instant the app opens, but a replayed
+   message does not arrive until after channel authentication plus a deliberate
+   3-second settle delay (measured: auth 16:49:12.513, replay 16:49:15.514). The
+   search finds nothing, so no message opens — the operator lands on whatever
+   screen the app happened to be on and has to find the item themselves.
+
+2. **A pushed message is not visible until the device establishes a live
+   connection.** The push already carries the full message content, but the app
+   ignores it and waits for the message to arrive over the live channel instead.
+   On a device with a poor or blocked connection, the notification is all the
+   operator ever sees.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Tapping a notification opens that message (Priority: P1)
+
+An operator away from their desk gets a notification that their network agent has
+finished something. They tap it. The app opens directly to that message, already
+scrolled to it and marked read — not to the last screen they were on, and not to
+a feed where they have to hunt for what the banner just told them about.
+
+**Why this priority**: This is the entire point of a notification. It is also the
+gap the operator actually notices — spec 106 made the content arrive, so the
+remaining complaint is "I tapped it and it didn't take me there." Delivers value
+on its own with no other work in this spec.
+
+**Independent Test**: Send a message to a device with the app closed. Tap the
+notification. The message opens. Fully testable without touching how pushed
+content is stored.
+
+**Acceptance Scenarios**:
+
+1. **Given** the app is closed and a message has been pushed, **When** the
+   operator taps the notification, **Then** the app opens and displays that
+   specific message, even though the message arrives several seconds after the
+   app launches.
+2. **Given** the app is backgrounded and a message has been pushed, **When** the
+   operator taps the notification, **Then** the app foregrounds and displays that
+   specific message.
+3. **Given** the operator taps a notification for a message that is already in
+   the feed, **When** the app opens, **Then** it displays that message
+   immediately with no waiting.
+4. **Given** the operator taps a notification and the named message never
+   arrives, **When** a reasonable wait elapses, **Then** the app stops waiting
+   and shows the feed rather than a spinner that never resolves.
+5. **Given** the operator dismisses the notification without tapping and opens
+   the app normally, **When** the app loads, **Then** no message is force-opened
+   and the operator sees their normal starting screen.
+
+---
+
+### User Story 2 - A pushed message appears without a live connection (Priority: P2)
+
+An operator on a hotel network where the agent's port is blocked gets a
+notification. They open the app. The message is there and readable, even though
+the app cannot establish a live connection to the Border at all.
+
+**Why this priority**: Strictly an improvement on P1's outcome — it removes the
+several-second wait and the dependency on connectivity. Lower priority because
+spec 106 already guarantees the message is never lost; it will render whenever a
+connection is next established. This story is about immediacy and
+poor-connectivity resilience, not correctness.
+
+**Independent Test**: With the device unable to reach the Border, push a message
+and open the app. The message is visible.
+
+**Acceptance Scenarios**:
+
+1. **Given** the device cannot reach the Border, **When** a message is pushed and
+   the operator opens the app, **Then** the message is visible in the feed.
+2. **Given** a message was made visible from its notification, **When** the
+   device later establishes a live connection and the same message is replayed,
+   **Then** the operator sees exactly one copy of it.
+3. **Given** the app is in the foreground with a live connection, **When** a
+   message arrives, **Then** the operator sees exactly one copy of it.
+
+---
+
+### User Story 3 - No duplicates, ever (Priority: P1)
+
+The operator's feed shows each message exactly once, regardless of how many
+delivery paths carried it.
+
+**Why this priority**: P1 alongside Story 1, and a **hard prerequisite for
+Story 2** — Story 2 introduces a second way for a message to enter the feed, and
+without deduplication every message delivered that way would appear twice. A
+duplicated audit feed is worse than a delayed one: it makes the operator doubt
+whether the agent acted once or twice.
+
+**Independent Test**: Deliver the same message by two different paths and confirm
+one entry appears.
+
+**Acceptance Scenarios**:
+
+1. **Given** a message has already been recorded, **When** the identical message
+   is delivered again by any path, **Then** the feed still shows one entry.
+2. **Given** two genuinely different messages, **When** both are delivered,
+   **Then** the feed shows two entries, even if they arrive close together.
+3. **Given** a message already marked read, **When** the same message is
+   delivered again, **Then** it does not revert to unread.
+
+### Edge Cases
+
+- A notification is tapped for a message the operator's device is no longer
+  authorized to receive (the Border revoked it) — the app must not hang waiting
+  for a message that will never come.
+- Two notifications are tapped in quick succession — the app opens the most
+  recently tapped message rather than racing between them.
+- A message is delivered twice with identical content but genuinely distinct
+  send times — these are different messages and both must appear.
+- A malformed or truncated push payload — the app must not corrupt the feed or
+  crash; falling back to the live-connection path is acceptable.
+- An approval request delivered by notification — approvals are a live,
+  time-sensitive list with no per-item history view, so tapping one opens the
+  approvals view rather than a feed message.
+- The operator taps a notification while the app is already open and showing a
+  different message.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Tapping a notification MUST open the specific message that
+  notification names, whether the app was closed, backgrounded, or already open.
+- **FR-002**: The app MUST still open the named message when that message arrives
+  after the app has launched, rather than only when it is already stored.
+- **FR-003**: The app MUST stop waiting for a named message after a bounded
+  interval and fall back to showing the feed, so a message that never arrives
+  cannot leave the operator on a stalled screen.
+- **FR-004**: The feed MUST contain at most one entry per distinct message,
+  regardless of how many delivery paths carried it.
+- **FR-005**: Deduplication MUST key on the message's send time as recorded by
+  the sender, which is already the identifier notifications carry.
+- **FR-006**: Re-delivery of an already-recorded message MUST NOT alter its
+  existing read state.
+- **FR-007**: The app MUST record a message's content from its notification, so
+  the message is visible without a live connection to the Border.
+- **FR-008**: FR-007 MUST NOT be enabled before FR-004 is in place.
+- **FR-009**: A notification carrying an approval request MUST continue to route
+  to the approvals view, not the message feed.
+- **FR-010**: A malformed notification payload MUST NOT corrupt the stored feed
+  or crash the app.
+- **FR-011**: Opening the app without tapping a notification MUST NOT force any
+  message open.
+- **FR-012**: Behavior MUST be equivalent on both mobile platforms, allowing for
+  each platform's own notification permission and background-execution rules.
+
+### Key Entities
+
+- **Message**: A single Border-to-operator communication. Carries content, a
+  content type, the time the sender sent it, whether it was replayed from a
+  backlog, and whether the operator has read it. Its send time is what makes it
+  distinct from every other message.
+- **Notification**: The operating system's banner for a message. Names exactly
+  one message and carries enough of that message to record it.
+- **Feed**: The operator's ordered history of messages, held on the device and
+  surviving app restarts.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Tapping a notification opens the named message in at least 95% of
+  attempts, from a closed, backgrounded, or open app.
+- **SC-002**: The operator reaches the named message with zero manual navigation
+  steps after the tap — no scrolling or tab switching.
+- **SC-003**: A pushed message is readable within 2 seconds of the app becoming
+  interactive, down from the current several-second wait for a live connection.
+- **SC-004**: A pushed message is readable with no working connection to the
+  Border at all.
+- **SC-005**: Zero duplicate feed entries across 50 consecutive messages
+  delivered by mixed paths.
+- **SC-006**: No message delivered by the Border is absent from the feed — the
+  guarantee spec 106 established is preserved, not traded away.
+- **SC-007**: A notification whose message never arrives leaves the operator on a
+  usable screen within 10 seconds, never a permanent loading state.
+
+## Assumptions
+
+- The push payload already carries the full message content, so no change to what
+  the Border sends is required. Confirmed against the current sender.
+- The message's send time is unique per message at the granularity recorded.
+  Two distinct messages sharing an identical send time would be treated as one;
+  judged acceptable given the sender stamps whole seconds and the Border sends
+  operator-initiated messages, not high-rate streams. Worth revisiting if
+  automated senders are ever added.
+- Notification permission has already been granted. Re-prompting for it, and the
+  behavior when it is denied, are out of scope.
+- The existing on-device feed store is extended rather than replaced; no
+  migration of stored history is required.
+- Both stories ship on the app's own release cadence. The iOS build reaches
+  testers through TestFlight, so this cannot be delivered by a server restart the
+  way spec 106 was — it is gated on a build going out.
+- No change to the Border is in scope. Spec 106 owns delivery; this spec owns what
+  the device does with what it receives.
+- Adding a new push transport is out of scope. The existing one is used as-is.
+
+## Dependencies
+
+- **Spec 106** (merged): establishes that every undelivered push is persisted and
+  replayed. Story 1's waiting behavior assumes replay actually arrives.
+- **Spec 103** (merged): establishes the single push transport both platforms use.
+- **Spec 073** (merged): established locally-posted notifications and their own
+  tap routing, which already deep-links correctly. The remote-notification path
+  this spec fixes must end up consistent with it, not a second parallel mechanism.

--- a/specs/107-push-render-deeplink/tasks.md
+++ b/specs/107-push-render-deeplink/tasks.md
@@ -1,0 +1,200 @@
+---
+
+description: "Task list for 107-push-render-deeplink"
+---
+
+# Tasks: Notification tap opens the message it names
+
+**Input**: Design documents from `/specs/107-push-render-deeplink/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/notification-intent.md, quickstart.md
+
+**Tests**: Test tasks ARE included. The spec's own Success Criteria are behavioral
+and the plan carries an explicit requirement→verification map; spec 106 also
+demonstrated the cost of shipping this area untested — its route tiering had no
+coverage at all, which is exactly why the bug reached production.
+
+**Organization**: Grouped by user story. Note the one hard cross-story dependency
+below — it is the whole reason the phases are ordered this way.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1 / US2 / US3 from spec.md
+- **🔌 DEVICE**: requires real hardware; cannot be verified in the Dart suite
+- All paths are relative to repo root
+
+## Path Conventions
+
+Flutter single package at `mobile/netclaw-mobile/` — `lib/ncfed/` for edge-node
+modules, `test/` for the suite. Per plan.md's Structure Decision.
+
+---
+
+## ⚠️ The one ordering rule that matters
+
+**Phase 4 (US3, dedup) MUST fully complete before Phase 5 (US2, instant render).**
+
+US2 adds a second writer to the feed store. Without dedup in place, every message
+it persists will appear **twice** the moment the Border's replay delivers the same
+message — converting a fixed bug into a more visible one. This is FR-008, and it
+is enforced here by phase ordering rather than by a runtime assertion, so that it
+stays testable.
+
+US1 is independent of both and may run fully in parallel with US3.
+
+---
+
+## Phase 1: Setup
+
+No project initialization needed — this feature adds no dependency and no new
+package. Two orientation tasks only.
+
+- [ ] T001 Reproduce the bug on a device following `specs/107-push-render-deeplink/quickstart.md` §"Reproduce the bug first", and record the observed auth→replay gap from the Border journal 🔌 DEVICE
+- [ ] T002 [P] Confirm the baseline suite is green before any change: `cd mobile/netclaw-mobile && flutter test && flutter analyze`
+
+---
+
+## Phase 2: Foundational
+
+Blocking prerequisite for US1 and US2. The intent mechanism is shared by both tap
+paths, so it lands once, before either story consumes it.
+
+- [ ] T003 Create `PendingOpenIntent` in `mobile/netclaw-mobile/lib/ncfed/pending_open_intent.dart` — records one identifier with its creation time, exposes record / resolve-if-present / expire, holds at most one intent (a second record discards the first), and does not persist across launches. Implements contract §1.1–1.7 and data-model's PendingOpenIntent lifecycle
+- [ ] T004 [P] Create `test/pending_open_intent_test.dart` covering: resolves immediately when the message is already present (§1.3); resolves when it arrives later (§1.4); expires within the bound and does not fire the open callback (§1.5, §1.6); a second record discards the first (§1.2); open callback fires exactly once (§1.6)
+
+**Checkpoint**: intent mechanism exists and is unit-tested against the contract.
+
+---
+
+## Phase 3: User Story 1 — Tapping a notification opens that message (P1)
+
+**Goal**: The tap opens the named message whether the app was closed,
+backgrounded, or already open — including when the message arrives seconds after
+launch.
+
+**Independent test**: Push a message with the app closed, tap the notification,
+the message opens. Verifiable without US2 or US3.
+
+- [ ] T005 [US1] Rewrite `NotificationDeepLink._handleRemote` in `mobile/netclaw-mobile/lib/ncfed/notification_deep_link.dart` to record a `PendingOpenIntent` from the notification data instead of performing a single `store.load()` + `findMessageForNotificationData` read that cannot win the race (research R1)
+- [ ] T006 [US1] Converge `handleLocalNotificationTap` in `mobile/netclaw-mobile/lib/ncfed/notification_deep_link.dart` onto the shared intent, so the remote and local paths are one mechanism rather than two (research R6, contract §5.4). The local path's existing correct behavior must be preserved
+- [ ] T007 [US1] Wire intent resolution to the feed's existing change signal in `mobile/netclaw-mobile/lib/main.dart` — `wireMessageFeed`'s `onMessage` callback already fires after every append, so no polling is introduced (research R1)
+- [ ] T008 [P] [US1] Extend `test/notification_deep_link_test.dart`: message arrives AFTER the tap and the intent resolves (the actual production bug); message already stored resolves with no wait; intent expires and the feed is shown (FR-003); opening the app with no tap forces nothing open (FR-011)
+- [ ] T009 [P] [US1] Extend `test/notification_response_routing_test.dart` to confirm the local-notification tap path still deep-links after converging on the intent (regression guard for T006)
+- [ ] T010 [US1] Verify on hardware: app fully closed → push → tap → the named message opens; then repeat backgrounded (SC-001, SC-002) 🔌 DEVICE
+
+**Checkpoint**: US1 delivers standalone value. Shippable without US2 or US3.
+
+---
+
+## Phase 4: User Story 3 — No duplicates (P1) — **BLOCKS PHASE 5**
+
+**Goal**: The feed shows each message exactly once, regardless of delivery path.
+
+**Independent test**: Deliver the same message twice by different paths; one entry
+appears.
+
+- [ ] T011 [US3] Add identity-based dedup to the append path in `mobile/netclaw-mobile/lib/ncfed/message_feed.dart`, keyed on `pushedAt` (research R2, R3). Enforce inside the store, NOT at call sites, so a future writer inherits it
+- [ ] T012 [US3] Make append in `mobile/netclaw-mobile/lib/ncfed/message_feed.dart` report whether it stored or declined, per contract §2.3 — without this, a declined duplicate would still fire an unread badge and the double-entry bug becomes a double-notification bug one layer up
+- [ ] T013 [US3] In `mobile/netclaw-mobile/lib/ncfed/message_feed.dart`, ensure a declined duplicate leaves the stored entry byte-for-byte unchanged including `read` state (FR-006, contract §2.2)
+- [ ] T014 [US3] In `mobile/netclaw-mobile/lib/ncfed/message_feed.dart`, reject rather than default a Message whose `pushedAt` is missing or unparseable, per data-model's validation rule — defaulting to "now" would mint a fresh identity per attempt and silently defeat dedup entirely
+- [ ] T015 [P] [US3] Extend `test/message_feed_test.dart`: duplicate `pushedAt` declined (FR-004, FR-005); read state preserved on re-delivery (FR-006); two distinct messages both stored; unparseable `pushedAt` rejected without corrupting the store
+- [ ] T016 [P] [US3] Add a structural test to `test/message_feed_test.dart` asserting `wireMessageFeed` is the ONLY registration site for `n2n/edge/message` (contract §4). `EdgeClient.on()` keeps only the LAST handler per method, so a second registration would silently disable live delivery with no error — highest-severity failure mode in this feature, cheapest to guard
+
+**Checkpoint**: dedup enforced at the chokepoint. **Phase 5 is now unblocked.**
+
+---
+
+## Phase 5: User Story 2 — Renders without a live connection (P2)
+
+**⛔ Do not start until Phase 4 is complete.** See the ordering rule above.
+
+**Goal**: A pushed message is readable immediately, even with no connection to the
+Border at all.
+
+**Independent test**: With the device unable to reach the Border, push a message
+and open the app — the message is visible.
+
+- [ ] T017 [US2] Create `mobile/netclaw-mobile/lib/ncfed/push_message_ingest.dart` that reconstructs a Message from the push data payload through the SAME wire parser the live channel uses — a second parser is forbidden (contract §3.5)
+- [ ] T018 [US2] In `mobile/netclaw-mobile/lib/ncfed/push_message_ingest.dart`, tolerate fully stringified values (contract §3.1). The sender emits `data: {k: str(v) for k, v in content.items()}`, so no field survives with its original type — the most likely source of a silent parse failure
+- [ ] T019 [US2] In `mobile/netclaw-mobile/lib/ncfed/push_message_ingest.dart`, route `content_type: 'approval'` to the approvals path and never to the feed (FR-009, contract §3.2)
+- [ ] T020 [US2] In `mobile/netclaw-mobile/lib/ncfed/push_message_ingest.dart`, reject malformed payloads without corrupting or truncating the stored feed (FR-010, contract §3.4); falling back to spec 106's replay is the correct outcome
+- [ ] T021 [US2] Register the foreground and background push handlers in `mobile/netclaw-mobile/lib/main.dart`, routing through the ingest path. Must NOT register a channel handler (contract §4.2)
+- [ ] T022 [P] [US2] Create `test/push_message_ingest_test.dart`: fully stringified payload reconstructs; missing/unparseable `pushed_at` rejected; `approval` routes to approvals not the feed; malformed payload leaves the store intact
+- [ ] T023 [US2] Verify on hardware — the single most valuable device test in this feature: block the phone's route to the Border, push, open the app, confirm the message is readable (SC-004); then restore connectivity and confirm **exactly one** copy survives replay (proves dedup + ingest work together) 🔌 DEVICE
+
+**Checkpoint**: all three stories complete.
+
+---
+
+## Phase 6: Polish & Cross-Cutting
+
+- [ ] T024 Update the known-rough-edges table in `mobile/netclaw-mobile/TESTER-INSTRUCTIONS.md` — it currently advertises "Tapping a notification doesn't deep-link" as a known issue. Constitution XII requires this in the same PR, not as a follow-up
+- [ ] T025 [P] Update `mobile/netclaw-mobile/README.md` if it documents notification behavior
+- [ ] T026 [P] Confirm no Border regression: `python3 -m pytest tests/n2n/ -q` (expect 445+ passed, unchanged — this feature makes no Border change, so any movement means scope leaked)
+- [ ] T027 Full suite and analyzer: `cd mobile/netclaw-mobile && flutter test && flutter analyze`
+- [ ] T028 Run `python3 scripts/verify-spec-artifacts.py` and confirm exit 0 for this spec (CI-enforced, Principle XVI)
+- [ ] T029 Walk `specs/107-push-render-deeplink/quickstart.md` end to end and confirm every "What done looks like" row 🔌 DEVICE
+
+---
+
+## Dependencies
+
+```
+Phase 1 (Setup)
+      │
+      ▼
+Phase 2 (Foundational — PendingOpenIntent)
+      │
+      ├─────────────────────┬──────────────────────
+      ▼                     ▼
+Phase 3 (US1, P1)     Phase 4 (US3, P1)
+ tap opens message     dedup  ── BLOCKS ──┐
+      │                     │              │
+      │                     ▼              │
+      │              Phase 5 (US2, P2) ◀───┘
+      │               instant render
+      └─────────────────────┬──────────────
+                            ▼
+                    Phase 6 (Polish)
+```
+
+**Story completion order**: US1 and US3 in parallel → US2 → polish.
+
+**The only hard cross-story dependency**: US3 → US2 (FR-008). US1 depends on
+nothing but the foundational phase.
+
+## Parallel execution examples
+
+**After Phase 2, two developers:**
+
+- Developer A: Phase 3 (T005–T010, US1)
+- Developer B: Phase 4 (T011–T016, US3)
+
+They touch disjoint files — `notification_deep_link.dart` + `main.dart` wiring vs
+`message_feed.dart` — with the one exception that both eventually edit
+`main.dart` (T007 and T021). Sequence those two.
+
+**Within phases**, `[P]`-marked test tasks parallelize freely: T004, T008, T009,
+T015, T016, T022 all live in separate files.
+
+## Implementation strategy
+
+**MVP is US1 alone.** It is P1, independently shippable, and fixes the thing the
+operator actually notices — spec 106 already guarantees the message arrives, so
+the remaining complaint is "I tapped it and it didn't take me there." US1 makes
+the tap work while still relying on replay for the content.
+
+**Then US3.** Also P1, and it is pure invariant-strengthening with no
+user-visible change on its own — which makes it low-risk to land and a
+prerequisite worth having regardless of whether US2 ever ships.
+
+**US2 last**, and only after US3. It is the largest change, the only one that
+touches OS background execution, and the one whose benefit (seconds of latency,
+plus poor-connectivity resilience) is smallest relative to its risk. If schedule
+pressure appears, US2 is the story to defer — spec 106 means deferring it loses
+immediacy, never a message.
+
+**Device budget.** Four tasks are marked 🔌 DEVICE (T001, T010, T023, T029).
+iOS verification costs a TestFlight round trip, so batch them: reproduce once at
+the start (T001), then verify all stories in one session at the end (T010, T023,
+T029) rather than per-story.

--- a/specs/107-push-render-deeplink/tasks.md
+++ b/specs/107-push-render-deeplink/tasks.md
@@ -50,7 +50,7 @@ No project initialization needed — this feature adds no dependency and no new
 package. Two orientation tasks only.
 
 - [ ] T001 Reproduce the bug on a device following `specs/107-push-render-deeplink/quickstart.md` §"Reproduce the bug first", and record the observed auth→replay gap from the Border journal 🔌 DEVICE
-- [ ] T002 [P] Confirm the baseline suite is green before any change: `cd mobile/netclaw-mobile && flutter test && flutter analyze`
+- [x] T002 [P] Confirm the baseline suite is green before any change: `cd mobile/netclaw-mobile && flutter test && flutter analyze`
 
 ---
 
@@ -59,8 +59,8 @@ package. Two orientation tasks only.
 Blocking prerequisite for US1 and US2. The intent mechanism is shared by both tap
 paths, so it lands once, before either story consumes it.
 
-- [ ] T003 Create `PendingOpenIntent` in `mobile/netclaw-mobile/lib/ncfed/pending_open_intent.dart` — records one identifier with its creation time, exposes record / resolve-if-present / expire, holds at most one intent (a second record discards the first), and does not persist across launches. Implements contract §1.1–1.7 and data-model's PendingOpenIntent lifecycle
-- [ ] T004 [P] Create `test/pending_open_intent_test.dart` covering: resolves immediately when the message is already present (§1.3); resolves when it arrives later (§1.4); expires within the bound and does not fire the open callback (§1.5, §1.6); a second record discards the first (§1.2); open callback fires exactly once (§1.6)
+- [x] T003 Create `PendingOpenIntent` in `mobile/netclaw-mobile/lib/ncfed/pending_open_intent.dart` — records one identifier with its creation time, exposes record / resolve-if-present / expire, holds at most one intent (a second record discards the first), and does not persist across launches. Implements contract §1.1–1.7 and data-model's PendingOpenIntent lifecycle
+- [x] T004 [P] Create `test/pending_open_intent_test.dart` covering: resolves immediately when the message is already present (§1.3); resolves when it arrives later (§1.4); expires within the bound and does not fire the open callback (§1.5, §1.6); a second record discards the first (§1.2); open callback fires exactly once (§1.6)
 
 **Checkpoint**: intent mechanism exists and is unit-tested against the contract.
 
@@ -75,11 +75,11 @@ launch.
 **Independent test**: Push a message with the app closed, tap the notification,
 the message opens. Verifiable without US2 or US3.
 
-- [ ] T005 [US1] Rewrite `NotificationDeepLink._handleRemote` in `mobile/netclaw-mobile/lib/ncfed/notification_deep_link.dart` to record a `PendingOpenIntent` from the notification data instead of performing a single `store.load()` + `findMessageForNotificationData` read that cannot win the race (research R1)
-- [ ] T006 [US1] Converge `handleLocalNotificationTap` in `mobile/netclaw-mobile/lib/ncfed/notification_deep_link.dart` onto the shared intent, so the remote and local paths are one mechanism rather than two (research R6, contract §5.4). The local path's existing correct behavior must be preserved
-- [ ] T007 [US1] Wire intent resolution to the feed's existing change signal in `mobile/netclaw-mobile/lib/main.dart` — `wireMessageFeed`'s `onMessage` callback already fires after every append, so no polling is introduced (research R1)
-- [ ] T008 [P] [US1] Extend `test/notification_deep_link_test.dart`: message arrives AFTER the tap and the intent resolves (the actual production bug); message already stored resolves with no wait; intent expires and the feed is shown (FR-003); opening the app with no tap forces nothing open (FR-011)
-- [ ] T009 [P] [US1] Extend `test/notification_response_routing_test.dart` to confirm the local-notification tap path still deep-links after converging on the intent (regression guard for T006)
+- [x] T005 [US1] Rewrite `NotificationDeepLink._handleRemote` in `mobile/netclaw-mobile/lib/ncfed/notification_deep_link.dart` to record a `PendingOpenIntent` from the notification data instead of performing a single `store.load()` + `findMessageForNotificationData` read that cannot win the race (research R1)
+- [x] T006 [US1] Converge `handleLocalNotificationTap` in `mobile/netclaw-mobile/lib/ncfed/notification_deep_link.dart` onto the shared intent, so the remote and local paths are one mechanism rather than two (research R6, contract §5.4). The local path's existing correct behavior must be preserved
+- [x] T007 [US1] Wire intent resolution to the feed's existing change signal in `mobile/netclaw-mobile/lib/main.dart` — `wireMessageFeed`'s `onMessage` callback already fires after every append, so no polling is introduced (research R1)
+- [x] T008 [P] [US1] Extend `test/notification_deep_link_test.dart`: message arrives AFTER the tap and the intent resolves (the actual production bug); message already stored resolves with no wait; intent expires and the feed is shown (FR-003); opening the app with no tap forces nothing open (FR-011)
+- [x] T009 [P] [US1] Extend `test/notification_response_routing_test.dart` to confirm the local-notification tap path still deep-links after converging on the intent (regression guard for T006)
 - [ ] T010 [US1] Verify on hardware: app fully closed → push → tap → the named message opens; then repeat backgrounded (SC-001, SC-002) 🔌 DEVICE
 
 **Checkpoint**: US1 delivers standalone value. Shippable without US2 or US3.
@@ -93,12 +93,12 @@ the message opens. Verifiable without US2 or US3.
 **Independent test**: Deliver the same message twice by different paths; one entry
 appears.
 
-- [ ] T011 [US3] Add identity-based dedup to the append path in `mobile/netclaw-mobile/lib/ncfed/message_feed.dart`, keyed on `pushedAt` (research R2, R3). Enforce inside the store, NOT at call sites, so a future writer inherits it
-- [ ] T012 [US3] Make append in `mobile/netclaw-mobile/lib/ncfed/message_feed.dart` report whether it stored or declined, per contract §2.3 — without this, a declined duplicate would still fire an unread badge and the double-entry bug becomes a double-notification bug one layer up
-- [ ] T013 [US3] In `mobile/netclaw-mobile/lib/ncfed/message_feed.dart`, ensure a declined duplicate leaves the stored entry byte-for-byte unchanged including `read` state (FR-006, contract §2.2)
-- [ ] T014 [US3] In `mobile/netclaw-mobile/lib/ncfed/message_feed.dart`, reject rather than default a Message whose `pushedAt` is missing or unparseable, per data-model's validation rule — defaulting to "now" would mint a fresh identity per attempt and silently defeat dedup entirely
-- [ ] T015 [P] [US3] Extend `test/message_feed_test.dart`: duplicate `pushedAt` declined (FR-004, FR-005); read state preserved on re-delivery (FR-006); two distinct messages both stored; unparseable `pushedAt` rejected without corrupting the store
-- [ ] T016 [P] [US3] Add a structural test to `test/message_feed_test.dart` asserting `wireMessageFeed` is the ONLY registration site for `n2n/edge/message` (contract §4). `EdgeClient.on()` keeps only the LAST handler per method, so a second registration would silently disable live delivery with no error — highest-severity failure mode in this feature, cheapest to guard
+- [x] T011 [US3] Add identity-based dedup to the append path in `mobile/netclaw-mobile/lib/ncfed/message_feed.dart`, keyed on `pushedAt` (research R2, R3). Enforce inside the store, NOT at call sites, so a future writer inherits it
+- [x] T012 [US3] Make append in `mobile/netclaw-mobile/lib/ncfed/message_feed.dart` report whether it stored or declined, per contract §2.3 — without this, a declined duplicate would still fire an unread badge and the double-entry bug becomes a double-notification bug one layer up
+- [x] T013 [US3] In `mobile/netclaw-mobile/lib/ncfed/message_feed.dart`, ensure a declined duplicate leaves the stored entry byte-for-byte unchanged including `read` state (FR-006, contract §2.2)
+- [x] T014 [US3] In `mobile/netclaw-mobile/lib/ncfed/message_feed.dart`, reject rather than default a Message whose `pushedAt` is missing or unparseable, per data-model's validation rule — defaulting to "now" would mint a fresh identity per attempt and silently defeat dedup entirely
+- [x] T015 [P] [US3] Extend `test/message_feed_test.dart`: duplicate `pushedAt` declined (FR-004, FR-005); read state preserved on re-delivery (FR-006); two distinct messages both stored; unparseable `pushedAt` rejected without corrupting the store
+- [x] T016 [P] [US3] Add a structural test to `test/message_feed_test.dart` asserting `wireMessageFeed` is the ONLY registration site for `n2n/edge/message` (contract §4). `EdgeClient.on()` keeps only the LAST handler per method, so a second registration would silently disable live delivery with no error — highest-severity failure mode in this feature, cheapest to guard
 
 **Checkpoint**: dedup enforced at the chokepoint. **Phase 5 is now unblocked.**
 
@@ -114,12 +114,12 @@ Border at all.
 **Independent test**: With the device unable to reach the Border, push a message
 and open the app — the message is visible.
 
-- [ ] T017 [US2] Create `mobile/netclaw-mobile/lib/ncfed/push_message_ingest.dart` that reconstructs a Message from the push data payload through the SAME wire parser the live channel uses — a second parser is forbidden (contract §3.5)
-- [ ] T018 [US2] In `mobile/netclaw-mobile/lib/ncfed/push_message_ingest.dart`, tolerate fully stringified values (contract §3.1). The sender emits `data: {k: str(v) for k, v in content.items()}`, so no field survives with its original type — the most likely source of a silent parse failure
-- [ ] T019 [US2] In `mobile/netclaw-mobile/lib/ncfed/push_message_ingest.dart`, route `content_type: 'approval'` to the approvals path and never to the feed (FR-009, contract §3.2)
-- [ ] T020 [US2] In `mobile/netclaw-mobile/lib/ncfed/push_message_ingest.dart`, reject malformed payloads without corrupting or truncating the stored feed (FR-010, contract §3.4); falling back to spec 106's replay is the correct outcome
-- [ ] T021 [US2] Register the foreground and background push handlers in `mobile/netclaw-mobile/lib/main.dart`, routing through the ingest path. Must NOT register a channel handler (contract §4.2)
-- [ ] T022 [P] [US2] Create `test/push_message_ingest_test.dart`: fully stringified payload reconstructs; missing/unparseable `pushed_at` rejected; `approval` routes to approvals not the feed; malformed payload leaves the store intact
+- [x] T017 [US2] Create `mobile/netclaw-mobile/lib/ncfed/push_message_ingest.dart` that reconstructs a Message from the push data payload through the SAME wire parser the live channel uses — a second parser is forbidden (contract §3.5)
+- [x] T018 [US2] In `mobile/netclaw-mobile/lib/ncfed/push_message_ingest.dart`, tolerate fully stringified values (contract §3.1). The sender emits `data: {k: str(v) for k, v in content.items()}`, so no field survives with its original type — the most likely source of a silent parse failure
+- [x] T019 [US2] In `mobile/netclaw-mobile/lib/ncfed/push_message_ingest.dart`, route `content_type: 'approval'` to the approvals path and never to the feed (FR-009, contract §3.2)
+- [x] T020 [US2] In `mobile/netclaw-mobile/lib/ncfed/push_message_ingest.dart`, reject malformed payloads without corrupting or truncating the stored feed (FR-010, contract §3.4); falling back to spec 106's replay is the correct outcome
+- [x] T021 [US2] Register the **foreground** push handler in `mobile/netclaw-mobile/lib/main.dart`, routing through the ingest path. Must NOT register a channel handler (contract §4.2). **Background handler deliberately NOT implemented** — research R5 establishes that background execution for a data-carrying push is at the OS's discretion, so treating it as a delivery path would reintroduce the silent-loss class spec 106 removed. A push arriving while backgrounded still reaches the feed via replay, and US1 makes its tap open the message. Revisit only with real-device evidence that the OS runs the handler reliably
+- [x] T022 [P] [US2] Create `test/push_message_ingest_test.dart`: fully stringified payload reconstructs; missing/unparseable `pushed_at` rejected; `approval` routes to approvals not the feed; malformed payload leaves the store intact
 - [ ] T023 [US2] Verify on hardware — the single most valuable device test in this feature: block the phone's route to the Border, push, open the app, confirm the message is readable (SC-004); then restore connectivity and confirm **exactly one** copy survives replay (proves dedup + ingest work together) 🔌 DEVICE
 
 **Checkpoint**: all three stories complete.
@@ -128,11 +128,11 @@ and open the app — the message is visible.
 
 ## Phase 6: Polish & Cross-Cutting
 
-- [ ] T024 Update the known-rough-edges table in `mobile/netclaw-mobile/TESTER-INSTRUCTIONS.md` — it currently advertises "Tapping a notification doesn't deep-link" as a known issue. Constitution XII requires this in the same PR, not as a follow-up
-- [ ] T025 [P] Update `mobile/netclaw-mobile/README.md` if it documents notification behavior
-- [ ] T026 [P] Confirm no Border regression: `python3 -m pytest tests/n2n/ -q` (expect 445+ passed, unchanged — this feature makes no Border change, so any movement means scope leaked)
-- [ ] T027 Full suite and analyzer: `cd mobile/netclaw-mobile && flutter test && flutter analyze`
-- [ ] T028 Run `python3 scripts/verify-spec-artifacts.py` and confirm exit 0 for this spec (CI-enforced, Principle XVI)
+- [x] T024 Update the known-rough-edges table in `mobile/netclaw-mobile/TESTER-INSTRUCTIONS.md` — it currently advertises "Tapping a notification doesn't deep-link" as a known issue. Constitution XII requires this in the same PR, not as a follow-up
+- [x] T025 [P] Update `mobile/netclaw-mobile/README.md` if it documents notification behavior
+- [x] T026 [P] Confirm no Border regression: `python3 -m pytest tests/n2n/ -q` (expect 445+ passed, unchanged — this feature makes no Border change, so any movement means scope leaked)
+- [x] T027 Full suite and analyzer: `cd mobile/netclaw-mobile && flutter test && flutter analyze`
+- [x] T028 Run `python3 scripts/verify-spec-artifacts.py` and confirm exit 0 for this spec (CI-enforced, Principle XVI)
 - [ ] T029 Walk `specs/107-push-render-deeplink/quickstart.md` end to end and confirm every "What done looks like" row 🔌 DEVICE
 
 ---
@@ -198,3 +198,33 @@ immediacy, never a message.
 iOS verification costs a TestFlight round trip, so batch them: reproduce once at
 the start (T001), then verify all stories in one session at the end (T010, T023,
 T029) rather than per-story.
+
+
+---
+
+## Status — 2026-08-13
+
+**Implemented and verified in CI: 25 of 29 tasks.** All four outstanding tasks
+are the 🔌 DEVICE ones (T001, T010, T023, T029); everything verifiable without
+hardware is done and green.
+
+| Gate | Result |
+|---|---|
+| `flutter test` | **280 passed** (was 234; +46 for this feature) |
+| `flutter analyze` | No issues found |
+| `pytest tests/n2n/` | **445 passed**, unchanged — confirms no Border-side scope leak |
+| `verify-spec-artifacts.py` | exit 0 |
+| `reconcile-mcp.py` | exit 0 |
+
+**One deliberate scope reduction**, recorded in T021: the background push handler
+was not implemented. Foreground ingest ships; background delivery is OS-discretionary
+(research R5), so building on it would reintroduce silent loss. Nothing is lost —
+a backgrounded push still reaches the feed via the Border's replay, and US1 makes
+its tap open the message on arrival.
+
+**Remaining device verification**, best done in one TestFlight session:
+
+- T010 — app closed → push → tap → the named message opens; repeat backgrounded
+- T023 — with the phone unable to reach the Border, push, open, message readable;
+  then restore connectivity and confirm exactly one copy survives replay
+- T029 — walk `quickstart.md`'s "What done looks like" table


### PR DESCRIPTION
Follow-on to #239 (spec 106). That fixed the **data-loss** half of the production
empty-feed report by making the Border treat a platform push as a wake signal.
This fixes the two **experience** gaps left on the device.

App-side only. `pytest tests/n2n/` is unchanged at 445 passed, which is the check
that confirms no Border-side scope leak.

## US1 — the tap deep-links (P1)

`NotificationDeepLink` read the feed store **once**, the instant the app opened,
and gave up if the message was not there. It never could be. Measured against a
real Border:

```
16:49:12.513  Edge node … authenticated (source=…, 1 queued)
16:49:15.514  Replaying 1 queued message(s) …
```

A cold launch from a notification tap finishes well inside that 3.0s
replay-settle gap, so the read was **guaranteed** to miss — not merely likely to.
The tap opened nothing and the operator had to go find the message once it
appeared seconds later.

Now the tap records a `PendingOpenIntent` that resolves when the named message
arrives, wired to `wireMessageFeed`'s existing `onMessage` signal so no polling is
introduced. Expires after 8s (inside SC-007's 10s bound) and lands the operator on
the Feed rather than wherever the app happened to open.

The local-notification tap path **converged onto the same intent** rather than
remaining a second mechanism for one behavior. It was already correct — a local
notification is only posted for an already-stored message — and now it also waits
for a message it does not yet have.

## US3 — no duplicates (P1, prerequisite for US2)

Dedup at the **single append chokepoint**, keyed on `pushed_at`. Deliberately not
at the call sites: US2 adds a second writer, and two implementations that must
agree forever is the drift pattern this repo already guards against elsewhere.

Identity is instant-based (`toUtc().microsecondsSinceEpoch`) rather than
`DateTime.==`, which also requires both operands to agree on `isUtc` — the same
moment expressed in local time would otherwise have stored a second copy.

`append()` now reports stored-vs-declined, and `wireMessageFeed` only announces a
genuinely new message. Without that, fixing double *entries* would have left
double *badges and notifications* — a visibly identical bug one layer up.

## US2 — renders without a live connection (P2)

Foreground pushes are recorded straight from their data payload, which the sender
has always included beside the banner and which nothing on the device read.

Strict parse via a new `EdgeMessage.tryFromWire`: a missing or unparseable
`pushed_at` is **rejected, never defaulted**. `fromWire`'s `now()` fallback would
mint a fresh identity on every delivery attempt and so silently defeat dedup —
the one failure mode that reintroduces duplicates. `fromWire` itself is unchanged
(Principle XV): the authenticated live path always carries the field, and
tightening it would be a behavior change to a path this feature is not fixing.

## Deliberate scope reduction

**No background push handler**, recorded in T021. Background execution for a
data-carrying push is at the OS's discretion on both platforms, so building on it
would reintroduce exactly the silent-loss class spec 106 removed (research R5).
Nothing is lost: a backgrounded push still reaches the feed via the Border's
replay, and US1 makes its tap open the message on arrival.

## Verification

| Gate | Result |
|---|---|
| `flutter test` | **280 passed** (+46) |
| `flutter analyze` | No issues found |
| `pytest tests/n2n/` | 445 passed, unchanged |
| `verify-spec-artifacts.py` | exit 0 |
| `reconcile-mcp.py` | exit 0 |

Includes a structural guard that `wireMessageFeed` remains the **only**
`n2n/edge/message` registration site — `EdgeClient.on()` keeps just the last
handler per method, so a second one would silently disable live delivery with no
error. Highest-severity failure mode in this feature, cheapest to guard.

## Outstanding

25 of 29 tasks. The 4 remaining are all 🔌 DEVICE verification (T001, T010, T023,
T029) and need a TestFlight round trip. The one most worth the trip is T023:
block the phone's route to the Border, push, confirm the message is readable, then
restore connectivity and confirm exactly **one** copy survives replay — that is
what proves ingest and dedup work together.

## Docs

Per Principle XII, in this PR rather than as follow-ups. `TESTER-INSTRUCTIONS.md`
advertised both of these as known rough edges; those rows now describe the fix.
`README.md`'s push section updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)