### PR TITLE
spec: Cloudflare Tunnel as a hardened eN2N transport (108)

### DIFF
--- a/specs/108-cloudflare-tunnel-transport/checklists/requirements.md
+++ b/specs/108-cloudflare-tunnel-transport/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Cloudflare Tunnel as a Hardened eN2N Transport
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-14
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain (resolved in Clarifications session 2026-08-14: additional-option transport, default-off per-peer Access, TCP/private-network tunnel mode)
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Grounded in a live incident (2026-08-14): two eN2N mesh peers (`as65001-4.4.4.4`, `as65007-7.7.7.7`) found stuck 21–23 days on stale ngrok addresses via `n2n_health`/`n2n_chat` diagnosis, requiring manual `n2n_forget_endpoint` intervention. Root cause traced against spec 063's actual endpoint-persistence code: it only helps a channel that is *still alive* to announce a new address, which structurally cannot help a channel that's already dead with a rotated ngrok address.
+- Explicitly scoped as **complementary to, not overlapping with**, specs 059/060/063 — transport substitution + optional edge hardening, zero wire-format or peer-identity-model changes.
+- Three genuine operator decisions were deferred to a Clarifications session rather than guessed: (1) additive vs. exclusive transport adoption, (2) Access edge-gate default-on vs. default-off, (3) tunnel mode (HTTP-terminating-at-edge vs. TCP/private-network opaque-relay). All three resolved 2026-08-14, all three consistent with the "additive, never forces peer/operator migration" philosophy already established by 060's own patched/unpatched-peer rollout model.
+- The operator's "not sure I would say opt-in but what would that change?" question on (2) was answered inline in the spec's Clarifications section with the concrete consequence (default-on would force uncoordinated re-credentialing of every existing peer simultaneously) rather than just recording the resolved value — this is the kind of reasoning worth keeping visible for a future re-read of this spec.

--- a/specs/108-cloudflare-tunnel-transport/contracts/interfaces.md
+++ b/specs/108-cloudflare-tunnel-transport/contracts/interfaces.md
@@ -1,0 +1,47 @@
+# Contract: Operator & Wire Interface Deltas (108)
+
+Deltas only — everything else is unchanged from 057/060/063.
+
+## Daemon HTTP (localhost:8179)
+
+| Route | Change |
+|---|---|
+| `POST /n2n/connect` | Gains an optional `transport` field (`ngrok`\|`cloudflare_tunnel`\|`other`, default `ngrok` when omitted — existing callers/scripts unaffected). On a **successful, authenticated** channel (same precondition 063 already established for endpoint persistence), persist `transport` to the peer record alongside the existing `endpoint_host`/`endpoint_port` write. No new field is required to specify Access — that's edge-side config, not a per-connect argument. |
+| `POST /n2n/peer/edge_gate` (new, small) | Operator-facing toggle: `{"peer": "as65007-7.7.7.7", "edge_gate": "cloudflare_access"\|"none"}`. Sets `federation_peer.edge_gate` directly (US2) — independent of, and does not require, changing `transport`. Defaults every peer to `none`; this route is the only way to change it (never implied by adopting `cloudflare_tunnel` transport — Clarifications). |
+| `GET /n2n/health` (existing `n2n_health` backing route) | Each peer entry gains `transport` and `edge_gate` (US3). The overall response gains `local_transport_healthy` (`true`\|`false`\|`"n/a"`) describing *this claw's own* advertised endpoint, not any specific peer (data-model.md §2). |
+| `GET /n2n/faults` (existing `n2n_faults` backing route) | `fault_class` gains a new distinguishable value/cause: when a peer channel is down **and** `local_transport_healthy=false`, the fault is attributed to this claw's own transport layer, named explicitly (e.g. `fault_class: "transport"`, distinct from `daemon`/`member`/`backend`/`none`) — never folded into a generic member-down report, matching spec 057's stated fault-isolation principle. When `local_transport_healthy` is `true` or `n/a`, classification is byte-for-byte unchanged from today. |
+| `GET /n2n/posture` | Per-peer entries in the existing trust-model/credential view gain `transport` and `edge_gate` (US3, same fields as `/n2n/health`, same source row — one write, two read surfaces, consistent with how 060/063 already expose the same underlying facts from both `/n2n/certs`-style and `/n2n/posture`-style endpoints). |
+
+## MCP tool surface (`n2n-mcp`)
+
+No new tool names required for US1 or US3 — `n2n_health`, `n2n_status`, `n2n_faults` response shapes simply carry the new fields above, since they proxy the daemon HTTP routes directly (per the `n2n-federation` skill's existing tool-to-route mapping).
+
+US2 gains one new tool, mirroring the existing small-surface pattern (`n2n_forget_endpoint` from spec 100 is the closest precedent — a single-purpose, explicitly-named operator action):
+
+| Tool | Signature | Behavior |
+|---|---|---|
+| `n2n_set_edge_gate` | `(peer: str, edge_gate: "cloudflare_access"\|"none")` | Proxies `POST /n2n/peer/edge_gate`. Explicitly per-peer, explicitly opt-in each way — no bulk/"enable for all peers" variant, so an operator must deliberately choose each peer, matching the Clarifications resolution that default-on-for-all-peers would force uncoordinated re-credentialing. |
+
+## Ops layer (not wire, not MCP) — `cloudflared` deployment
+
+Not a code contract, but a repeatable deployment contract analogous to spec 057's `in2n-services.py generate`/`enable`/`status` pattern:
+
+```
+cloudflared tunnel create <claw-name>              # one-time: creates tunnel + credentials file
+cloudflared tunnel route dns <claw-name> <hostname> # binds the stable DNS hostname
+# config.yml: ingress rule maps the hostname to the LOCAL eN2N listener port,
+#   in TCP/private-network mode (R1) — never http/https ingress type.
+systemctl --user enable --now cloudflared-<claw-name>.service   # durable, mirrors netclaw-mesh.service
+```
+
+The federation daemon's `asyncio.start_server`/`asyncio.open_connection` calls (`bgp-daemon-v2.py`, `bgp/federation/service.py`) are **unchanged** — `cloudflared` makes the configured `host:port` resolve and route correctly from the outside; the Python code has no awareness of which transport delivered a given TCP connection, exactly as it has no awareness today of whether ngrok or a direct route delivered it.
+
+## Wire — NCFED channel
+
+**Unchanged.** No discrimination-preamble, handshake, or TLS-upgrade wire-format change (FR-008). This is the entire point of choosing TCP/private-network tunnel mode (R1) — `cloudflared` relays opaque bytes; the NCFED protocol running inside is byte-for-byte identical to a direct or ngrok-carried connection.
+
+## Degradation contract (honesty, mirrors 063's own degradation contract)
+
+- An operator who never configures `cloudflared` sees `transport: "ngrok"` (or whatever they already had) on every peer, `local_transport_healthy: "n/a"`, and zero behavior change — this feature must never make a claw that hasn't adopted it behave differently.
+- An operator who adopts `cloudflare_tunnel` transport but never enables Access sees `edge_gate: "none"` on every peer and functions exactly as if they were still on ngrok, just with a stable address — Access is never silently implied.
+- A local tunnel/DNS health-probe failure MUST be visible (`local_transport_healthy: false`) and MUST drive `fault_class` toward the new transport-specific value rather than silently degrading to a misleading `member`/`backend` classification.

--- a/specs/108-cloudflare-tunnel-transport/data-model.md
+++ b/specs/108-cloudflare-tunnel-transport/data-model.md
@@ -1,0 +1,51 @@
+# Phase 1 Data Model: Cloudflare Tunnel Transport (108)
+
+All state reuses existing stores (mirrors 063's own rule) — no new tables, no new databases. SQLite `~/.openclaw/n2n/federation.db`, same `FederationManager`-owned schema 060/063 already extended.
+
+## 1. `federation_peer` (existing) — transport display fields (US1/US3)
+
+Two new columns, additive only, default values preserve current behavior for every existing row (no backfill required beyond the default):
+
+| Column | Type | Default | Role in 108 |
+|---|---|---|---|
+| `transport` | text | `'ngrok'` | Which carrier currently reaches this peer: `ngrok` \| `cloudflare_tunnel` \| `other`. Set by the operator at connect/config time (mirrors how `endpoint_host`/`endpoint_port` are already operator/peer-supplied); not auto-detected from the address string, since a Cloudflare Tunnel hostname is just a DNS name indistinguishable from any other by pattern-matching alone. |
+| `edge_gate` | text | `'none'` | Whether an edge-level access-control gate sits in front of this peer's channel from *this claw's* side: `none` \| `cloudflare_access`. Defaults to `none` per FR-005 (opt-in, not auto-enabled by adopting `cloudflare_tunnel` transport). |
+
+Write rules:
+- Set alongside `endpoint_host`/`endpoint_port` when an operator configures a peer's transport via `/n2n/connect` (extended, see contracts/interfaces.md) — an explicit `transport` argument, defaulting to `ngrok` when omitted so existing callers/scripts are unaffected (FR-008, SC-005).
+- `edge_gate` is set independently (US2 is a separate opt-in decision from US1's transport choice, per Clarifications) — never implied by `transport=cloudflare_tunnel` alone.
+- Neither field affects `_recompute_state`/`PeerState` (FEDERATED/etc.) — they are descriptive/display only, consistent with `display_name` and other non-trust-bearing peer attributes already in the row.
+
+## 2. Local tunnel/DNS health probe (new, but no new store — computed on read)
+
+Not persisted; computed live when `n2n_health`/`n2n_faults`-equivalent status is requested, mirroring how 063's `kex_group`/`pq` fields are live negotiation facts rather than stored rows (data-model.md #2 in 063).
+
+| Field | Source | Meaning |
+|---|---|---|
+| `local_transport_healthy` | Local check: does the configured Cloudflare Tunnel hostname resolve and is the local `cloudflared` service active (systemd unit state, per spec 057's durable-service pattern)? | `true`/`false`/`n/a` (n/a when this claw is not using `cloudflare_tunnel` transport at all). Independent of any specific peer — this is about *this claw's own* advertised endpoint's reachability, not a peer's. |
+| `fault_class` (extends existing 057 enum) | Derived | Existing values `daemon`\|`member`\|`backend`\|`none` from spec 057 gain a new distinguishable cause: a peer channel down **while** `local_transport_healthy=false` is attributable to *this claw's own transport*, not the peer — reported as a transport-layer fault, never folded into a generic "member down." A peer channel down while `local_transport_healthy=true` (or `n/a`) is classified exactly as today (peer/member-down), unaffected by this feature. |
+
+## 3. Posture surface (existing 060/063 view) — transport/edge-gate visibility (US3)
+
+Extends the per-peer posture record 060 already populates (trust model, fingerprint, issuer, expiry) and 063 already extended (kex_group, pq), following the same "extend, don't parallel" pattern both those specs established:
+
+| Field | Source | Notes |
+|---|---|---|
+| `transport` | `federation_peer.transport` (§1) | Displayed alongside existing trust-model/credential facts for the same peer row. |
+| `edge_gate` | `federation_peer.edge_gate` (§1) | Same placement. |
+| `local_transport_healthy` | §2 (live) | Shown once, for this claw's own row/summary — not per-peer, since it describes this claw's own advertised endpoint, not each peer's. |
+
+## 4. Config surface additions (ops-level, not `.env.example` — `cloudflared` is external)
+
+Unlike 063's `N2N_PQ_MODE` (an in-process Python env var), the Cloudflare Tunnel itself is configured via `cloudflared`'s own config file (`config.yml` / tunnel credentials JSON) and a systemd unit generated the same way spec 057's `in2n-services.py` generates the mesh daemon unit. The federation daemon's own env surface gains only:
+
+| Variable | Meaning |
+|---|---|
+| `N2N_TRANSPORT_HEALTH_CHECK` (optional, default enabled) | Whether the daemon performs the local tunnel/DNS health probe (§2) at all — allows disabling the check entirely for operators who never adopt Cloudflare Tunnel, so `local_transport_healthy` simply reports `n/a` without attempting any check. |
+
+No env var is needed to "turn on" `cloudflare_tunnel` as a transport option for a given peer — that's the per-peer `transport` field (§1), set via the connect call, not a global mode switch (consistent with FR-001: additive, per-peer, never a global replacement of ngrok).
+
+## 5. Documentation artifacts (not data)
+
+- **Transport-mode statement**: TCP/private-network mode only, never HTTP(S) ingress, with the confidentiality rationale (R1) — a fixed statement in quickstart.md/README, analogous to 063's "mesh trust-boundary statement."
+- **Access opt-in rollout note**: default-off, per-peer, and what changes if an operator enables it for one peer vs. globally (the Clarifications answer) — recorded so a future operator revisiting this doesn't have to re-derive the reasoning.

--- a/specs/108-cloudflare-tunnel-transport/plan.md
+++ b/specs/108-cloudflare-tunnel-transport/plan.md
@@ -1,0 +1,102 @@
+# Implementation Plan: Cloudflare Tunnel as a Hardened eN2N Transport
+
+**Branch**: `108-cloudflare-tunnel-transport` | **Date**: 2026-08-14 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/108-cloudflare-tunnel-transport/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Add Cloudflare Tunnel as an **additional, operator-opt-in** eN2N transport alongside the existing raw-TCP/ngrok path, run in **TCP/private-network (opaque-relay) mode** so it requires zero NCFED wire-format changes. This directly closes the confirmed live gap between spec 063's endpoint-persistence fix (which only helps a channel that is *still alive* to receive an announced address) and reality (a channel dead long enough has no live session left to announce over, and a rotating ngrok address can't be guessed back) — by removing the underlying cause: a Cloudflare-Tunnel-bound hostname doesn't change on restart, so there is nothing to re-announce. Layered on top, an optional (default-off, per-peer opt-in) Cloudflare Access policy rejects unauthenticated connection attempts at Cloudflare's edge, strictly before any bytes reach the claw's `asyncio.start_server` listener or spec 060's TLS/peer-identity negotiation — a defense-in-depth addition, not a replacement for 060's identity checks. Transport type and edge-gate status are surfaced in the existing 060/063 posture view (no new UI surface), and a local tunnel/DNS health probe extends spec 057's fault-class model so a transport-layer outage is never misattributed as "peer down."
+
+## Technical Context
+
+**Language/Version**: Python 3.14 (matches the reference host per spec 063 R0-addendum; `asyncio`-based daemon)
+**Primary Dependencies**: Existing `bgp/federation/{service,channel,tls,manager}.py` (unchanged); external `cloudflared` binary/service (ops-level, not a Python dependency) for the tunnel; Cloudflare Access (edge-hosted policy engine, no local library) for the optional US2 gate
+**Storage**: Existing SQLite-backed `federation_peer` table (via `FederationManager`) — extended with two new display columns (`transport`, `edge_gate`), no new store
+**Testing**: Existing repo test pattern (pytest under `tests/n2n/`), consistent with 052/053/056/057's test layout
+**Target Platform**: Linux server (systemd-managed durable services, per spec 057's `in2n-services.py` pattern) — this claw's reference host (`as65099-10.255.255.1`, domain `byrnbaker.me`, Cloudflare-managed DNS)
+**Project Type**: Single project (existing `mcp-servers/protocol-mcp` daemon + `n2n-mcp` tool surface) — no new project/service boundary
+**Performance Goals**: N/A — this is a transport/ops substitution; no new hot path in the federation code (`open_channel`/`asyncio.start_server` are unchanged; `cloudflared` sits underneath at the OS/network layer exactly where ngrok does today)
+**Constraints**: Zero NCFED wire-format changes (FR-008); zero forced peer migration (FR-001, FR-008); TCP/private-network mode only, never HTTP(S) ingress (FR-009); Access default-off (FR-005)
+**Scale/Scope**: Two known live peers to validate against once they independently adopt this (John/as65001, Nick/as65007) plus this claw's own advertised endpoint; scope is this claw's transport configuration and the small posture/fault-reporting extensions, not a peer-side mandate
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Reviewed against `.specify/memory/constitution.md` and the precedent set by specs 057/060/063 (the most directly analogous prior features — all touch the same federation trust/transport surface):
+
+- **No wire-protocol change**: PASS. FR-008 explicitly forbids it; R1's TCP/private-network mode decision is chosen specifically to keep this true. Consistent with 063's own constraint (FR-013: "MUST NOT weaken... existing... guarantees").
+- **No parallel state/surfaces**: PASS. R4 extends the existing 060/063 posture record and R3 extends the existing 057 `n2n_faults` model rather than introducing new stores or views — matches the explicit cross-cutting requirement both 060 (FR cross-cutting) and 063 (FR-014) impose on themselves.
+- **Additive, non-breaking to existing peers**: PASS. FR-001/FR-008/SC-005 require zero regression for peers who stay on ngrok or any other transport; mirrors 060's own patched-vs-unpatched-peer philosophy (peers upgrade independently).
+- **Honest posture, never a false claim**: PASS by design — FR-004 makes Access's non-interference with 060's identity checks true *by construction* (R2: Access sits strictly earlier in the connection lifecycle, invisible to the federation code), not by an enforcement flag that could be wrong. This follows spec 057's "never claim a control is active when it isn't" principle.
+- **Immutable audit trail (GAIT) for security-relevant events**: applicable if/when Access enable/disable or tunnel-transport-adopted events are treated as security-relevant per spec 057 US4's GAIT event list — flagged in Complexity Tracking below as a scope question for `/speckit.tasks`, not a blocker to planning.
+
+No violations requiring justification at this stage. Re-check after Phase 1 (data-model/contracts) below.
+
+**Post-Phase-1 re-check**: The two new peer-record display fields (`transport`, `edge_gate` — see data-model.md) and the local tunnel-health probe (no new store, computed on read) do not introduce any new trust boundary, wire format, or bypass of existing 060 TLS/identity checks. Constitution Check remains PASS.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/108-cloudflare-tunnel-transport/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md         # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+mcp-servers/protocol-mcp/
+├── bgp/
+│   └── federation/
+│       ├── manager.py        # FederationManager — extend upsert_peer/get_peer/list_peers
+│       │                     #   with transport/edge_gate display fields (US3)
+│       ├── posture.py        # Existing 060 posture surface — add transport/edge_gate
+│       │                     #   fields to the per-peer posture record (US3, R4)
+│       ├── service.py        # UNCHANGED — open_channel/on_conn already work against
+│       │                     #   whatever host:port resolves; cloudflared is transparent
+│       ├── channel.py        # UNCHANGED — no wire-format touch (FR-008)
+│       └── tls.py            # UNCHANGED — 060's TLS layer is untouched (FR-004, R2)
+├── bgp-daemon-v2.py           # Add a local tunnel/DNS health probe surfaced via the
+│                               #   existing /n2n/faults-equivalent status endpoint (US2/US3, R3)
+└── (ops, not Python) cloudflared systemd unit + config — new durable service,
+    generated the same way spec 057's in2n-services.py generates the mesh
+    daemon/member units (US1)
+
+n2n-mcp/                       # MCP tool surface — n2n_health/n2n_faults/n2n_status
+                                #   response shapes gain transport/edge_gate fields;
+                                #   no new tool names required for US1/US3.
+                                #   US2 (Access) is pure Cloudflare-side + cloudflared
+                                #   config — no new MCP tool is required to "enable" it
+                                #   from this claw's side (operator-managed at the
+                                #   Cloudflare dashboard/API), but n2n_health SHOULD
+                                #   reflect its configured state if detectable.
+
+tests/n2n/
+├── test_endpoint_stability.py     # NEW — US1: simulate cloudflared/host restart,
+│                                   #   assert stored endpoint host:port unchanged
+├── test_transport_posture.py      # NEW — US3: assert transport/edge_gate fields
+│                                   #   appear in posture output for mixed-transport peers
+└── test_fault_classification.py   # NEW — US2/US3 support: assert local tunnel-health
+                                    #   failure is classified distinctly from peer-down
+```
+
+**Structure Decision**: Single project, extending the existing `mcp-servers/protocol-mcp` federation daemon in place — the same structure specs 057/060/063 already used for this exact subsystem. No new service boundary or repository is introduced; `cloudflared` is an external, ops-managed process (a durable systemd service, mirroring spec 057's pattern for the mesh daemon itself), not a new in-repo component.
+
+## Complexity Tracking
+
+> Fill ONLY if Constitution Check has violations that must be justified
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| *(none — no gate violations)* | — | — |
+
+**Open scope question for `/speckit.tasks`** (not a constitution violation, but flagged for task-breakdown time): should enabling/disabling the Cloudflare Access edge-gate for a peer be logged to the GAIT immutable trail per spec 057 US4's existing event list (delegation, enrollment, member removal, quarantine)? It is a security-posture-relevant change to a peer's channel, which suggests yes, but it is not explicitly named in 057's list and this spec does not mandate it (FR-005/FR-006 only require it be *visible* in posture, not that its toggle be GAIT-audited). Recommend deciding this explicitly in `/speckit.tasks` rather than defaulting silently either way.

--- a/specs/108-cloudflare-tunnel-transport/quickstart.md
+++ b/specs/108-cloudflare-tunnel-transport/quickstart.md
@@ -1,0 +1,97 @@
+# Quickstart: Verify Cloudflare Tunnel Transport (108)
+
+Reference deployment: this claw is `as65099-10.255.255.1`, domain `byrnbaker.me` (Cloudflare-managed DNS), the same host referenced throughout specs 057/060/063. Peers `as65001-4.4.4.4` (John) and `as65007-7.7.7.7` (Nick) are the two live peers whose ngrok-address rot motivated this feature — full end-to-end validation against them requires *they* also adopt Cloudflare Tunnel (this feature never requires that; see Assumptions in spec.md), but US1's core claim (this claw's own endpoint survives restarts) is fully verifiable unilaterally.
+
+## US1 — Endpoint never goes stale (the confirmed bug this feature fixes)
+
+```bash
+# 1. One-time: create the tunnel and bind a stable hostname (ops layer, see contracts/interfaces.md)
+cloudflared tunnel create netclaw-byrnbaker
+cloudflared tunnel route dns netclaw-byrnbaker netclaw-en2n.byrnbaker.me
+# config.yml ingress: TCP/private-network mode targeting the local eN2N listener port — NOT http/https ingress.
+
+# 2. Install as a durable service (mirrors spec 057's mesh-daemon pattern)
+systemctl --user enable --now cloudflared-netclaw-byrnbaker.service
+
+# 3. Tell the daemon this is now the advertised transport for outbound dials
+curl -s -X POST http://127.0.0.1:8179/n2n/connect -H 'Content-Type: application/json' \
+  -d '{"peer":"as65007-7.7.7.7","host":"netclaw-en2n.byrnbaker.me","port":<TUNNEL_PORT>,"transport":"cloudflare_tunnel"}'
+
+# 4. Confirm it persisted, including the new transport field:
+python3 - <<'PY'
+import sqlite3; c=sqlite3.connect("/home/USER/.openclaw/n2n/federation.db")
+print(c.execute("SELECT endpoint_host,endpoint_port,transport,endpoint_updated_at FROM federation_peer WHERE peer_as=65007").fetchone())
+PY
+
+# 5. Restart BOTH the tunnel and the mesh daemon, do NOT re-dial or reconfigure anything:
+systemctl --user restart cloudflared-netclaw-byrnbaker.service
+systemctl --user restart netclaw-mesh.service
+
+# 6. PASS: the hostname is unchanged (it's a fixed DNS name, not a rotated ngrok URL) —
+#    the reconnect supervisor targets the SAME netclaw-en2n.byrnbaker.me:<TUNNEL_PORT>
+#    with zero manual action, zero n2n_forget_endpoint call needed.
+#    Contrast with the pre-108 failure: an ngrok restart would have produced a NEW
+#    host:port with no live channel left to announce it (research.md R0).
+
+# 7. Also restart the whole host — PASS: hostname survives (it's DNS, not process state).
+```
+
+## US2 — Unauthenticated probes never reach the NCFED listener (Access edge-gate, opt-in)
+
+```bash
+# 1. In the Cloudflare dashboard (or API), attach an Access policy requiring
+#    mTLS client cert (or a service token) to the tunnel's hostname.
+
+# 2. Enable it for ONE peer only (per-peer opt-in, default off — Clarifications):
+curl -s -X POST http://127.0.0.1:8179/n2n/peer/edge_gate -H 'Content-Type: application/json' \
+  -d '{"peer":"as65007-7.7.7.7","edge_gate":"cloudflare_access"}'
+
+# 3. Attempt a connection with NO client credential (simulating a random prober):
+#    PASS: connection refused at Cloudflare's edge. Confirm zero NCFED bytes reached
+#    the listener — no discrimination-preamble log line, no audit row, nothing:
+journalctl --user -u netclaw-mesh.service --since "1 min ago" | grep -i "netclaw-en2n" || echo "PASS: no listener-side trace of the rejected attempt"
+
+# 4. Attempt a connection WITH the correct client credential:
+#    PASS: reaches the listener, proceeds to normal spec-060 TLS + peer-identity
+#    negotiation exactly as an Access-free connection would (FR-004 — Access never
+#    replaces or weakens 060's identity check, by construction, not by extra code).
+
+# 5. Confirm a SECOND peer with edge_gate still "none" is completely unaffected:
+curl -s http://127.0.0.1:8179/n2n/health | python3 -m json.tool | grep -A3 '"as65001-4.4.4.4"'
+# PASS: edge_gate: "none", behaves exactly as before this feature — Access is never
+# silently implied by adopting cloudflare_tunnel transport alone.
+```
+
+## US3 — Transport and edge-gate status are visible in existing posture view
+
+```bash
+curl -s http://127.0.0.1:8179/n2n/posture | python3 -m json.tool | grep -E 'transport|edge_gate|local_transport_healthy'
+# PASS: every peer row shows transport (ngrok|cloudflare_tunnel|other) and edge_gate
+# (none|cloudflare_access) alongside the existing 060 trust-model/credential fields —
+# no second tool, no second view.
+
+curl -s http://127.0.0.1:8179/n2n/health | python3 -m json.tool | grep local_transport_healthy
+# PASS: reflects this claw's OWN tunnel health, independent of any specific peer.
+```
+
+## Fault classification — transport outage vs. peer-down (extends spec 057)
+
+```bash
+# Simulate a local tunnel outage (stop cloudflared without touching any peer):
+systemctl --user stop cloudflared-netclaw-byrnbaker.service
+
+curl -s http://127.0.0.1:8179/n2n/faults | python3 -m json.tool
+# PASS: fault_class names the transport-layer condition explicitly (e.g. "transport"),
+# distinct from "member" — the operator is told "your own tunnel is down," not
+# "peer X is flapping." Restart the service and confirm fault_class returns to "none"
+# once the tunnel and any dependent channels recover:
+systemctl --user start cloudflared-netclaw-byrnbaker.service
+```
+
+## Degradation check — an operator who never adopts this feature sees zero change
+
+```bash
+# On a peer still configured with transport unset/default:
+curl -s http://127.0.0.1:8179/n2n/health | python3 -m json.tool | grep -B2 -A2 '"transport": "ngrok"'
+# PASS: identical behavior to pre-108 — this field simply documents what was already true.
+```

--- a/specs/108-cloudflare-tunnel-transport/research.md
+++ b/specs/108-cloudflare-tunnel-transport/research.md
@@ -1,0 +1,73 @@
+# Phase 0 Research: Cloudflare Tunnel as a Hardened eN2N Transport (108)
+
+Ground truth: read the running code (`bgp-daemon-v2.py`, `bgp/federation/{service,tls,manager,channel}.py`) on the reference host (`as65099-10.255.255.1`, domain `byrnbaker.me`, Cloudflare-managed) and confirmed live symptoms via `n2n_health`/`n2n_status`/`n2n_chat` against the two dead peers (`as65001-4.4.4.4` "John", `as65007-7.7.7.7` "Nick") that motivated this feature.
+
+## R0 — Confirming the failure mode against the actual code (gates US1)
+
+The eN2N listener is a plain `asyncio.start_server(on_conn, "0.0.0.0", port)` in `bgp-daemon-v2.py`. Outbound dials go through `service.py`'s `open_channel(peer_as, router_id, host, port)`, which does `asyncio.open_connection(host, port)` against whatever `host:port` is stored on the peer row.
+
+**Confirmed via code read**: endpoint persistence (spec 063 FR-001/FR-002, already shipped) writes `manager.upsert_peer(peer_as, router_id, endpoint_host=host, endpoint_port=port)` in exactly two places:
+1. `open_channel()`, only after a dial **succeeds and authenticates** (comment in code: "so the reconnect supervisor re-dials this current address instead of a stale one").
+2. `_on_endpoint_update()`, when a **live, authenticated channel** delivers an `n2n/endpoint_update` notification from the peer.
+
+**This confirms the exact gap this feature exists to close**: both write paths require an already-working channel (either a dial that just succeeded, or a live session to carry an announcement). Neither path helps when the channel has been dead long enough that no dial has succeeded *and* no live session exists to announce a new address — which is precisely the state `n2n_health` showed for both John and Nick (`channel_state: reconnecting`, `endpoint_updated_at` 21–23 days stale). The reconnect supervisor (referenced in `open_channel`'s docstring context, driven by `_health_for(ident)`) keeps re-dialing the *stored* stale address forever (dampened per spec 100, but never corrected) because there is no mechanism to learn a new address without a live channel.
+
+**Decision**: This is not a bug to fix in the persistence logic (063 already did that correctly for the case it covers) — it is a structural limitation of any transport whose address changes on every process restart. The fix is to remove the precondition (an address that doesn't change doesn't need to be re-learned), which is exactly what a Cloudflare Tunnel bound to a fixed hostname provides. `open_channel(peer_as, router_id, host="tunnel.example.com", port=<fixed>)` never needs a fresh `host` value across restarts, so the "no live channel to announce over" failure mode structurally cannot occur for a Cloudflare-Tunnel-hosted claw's *own* advertised address (a peer's transport choice is independent — see Assumptions in spec.md).
+
+**Alternatives considered**:
+- *Reserved/paid ngrok static address*: solves US1's address-stability problem alone, at a recurring cost, but provides none of US2's edge-gate capability and doesn't change the "openly reachable socket" property (a reserved ngrok TCP endpoint is still just as reachable as a free one, just at a fixed address — arguably *worse* for scanning since it never rotates away from anyone who's found it). Rejected as the sole fix per spec.md Assumptions (kept as a peer-side option outside this feature's scope, since peers choose their own transport independently).
+- *Fix the reconnect supervisor to brute-force rediscovery somehow*: no mechanism exists or is proposed anywhere in the codebase for a dead peer to be rediscovered without an out-of-band signal; rejected as unbuildable without the peer proactively re-announcing, which requires exactly the live channel that's missing.
+
+## R1 — Cloudflare Tunnel mode: TCP/private-network vs HTTP(S)
+
+`cloudflared` supports exposing an arbitrary TCP port via **TCP tunnel mode** (`cloudflared access tcp` / `cloudflared tunnel --url tcp://...` depending on client-side tooling) as opposed to **HTTP(S) ingress mode**, which terminates TLS at Cloudflare's edge and proxies HTTP(S) semantics.
+
+The eN2N listener speaks a custom framed protocol (`NCFED_MAGIC` handshake bytes, then either cleartext or — post spec-060 — TLS-upgraded JSON-RPC 2.0 frames per `channel.py`). This is **not HTTP**. Terminating "TLS" at Cloudflare's edge in HTTP(S) mode would require the connection to look like HTTP to Cloudflare, which the NCFED wire protocol does not; forcing it through HTTP ingress would require wrapping the whole protocol (e.g. inside WebSocket), which is a wire-format change out of scope for a transport-substitution feature.
+
+**Decision (confirmed by operator, Clarifications session)**: use `cloudflared`'s **private-network / raw TCP tunnel mode**, which relays opaque bytes end-to-end with no protocol awareness at Cloudflare's edge. This is the *only* mode compatible with the existing NCFED discrimination preamble and 060's TLS-upgrade-in-place design without any wire change, and it satisfies the confidentiality goal (Cloudflare's infrastructure never observes decrypted NCFED payload — consistent with spec 063 R2's "encrypt in-protocol, don't rely on an incidental transport" stance for the mesh layer, applied here to the transport choice itself rather than a protocol change).
+
+**Rationale**: zero NCFED protocol changes required (FR-008); the existing `asyncio.start_server`/`asyncio.open_connection` pair on both ends is unaffected — `cloudflared` simply becomes the thing that makes the listening/dialing addresses resolve, transparently to the Python code, exactly as ngrok does today. This is a deployment/ops change, not a code change to `service.py`/`channel.py`/`tls.py`.
+
+**Alternatives considered**: HTTP(S) ingress with a WebSocket wrapper — rejected (wire-format change, violates FR-008; also reintroduces the exact plaintext-at-edge regression the operator explicitly rejected in Clarifications).
+
+## R2 — Where Cloudflare Access fits relative to the existing 060 TLS layer
+
+Spec 060 established that eN2N channels negotiate TLS (or refuse, per production posture) at the application layer, inside the TCP stream, using `bgp/federation/tls.py` (`server_context`/`client_context`, `upgrade_to_tls`). This happens **after** the raw TCP connection is already established — i.e., after `asyncio.start_server`'s `on_conn` callback fires, or after `asyncio.open_connection` returns.
+
+Cloudflare Access, when placed in front of a private-network tunnel, operates as an **edge-level gate on the tunnel connection itself** — a client must authenticate to Cloudflare's edge (mTLS client cert or service token) before Cloudflare will even open the far side of the tunnel to the origin (the claw's listener). This happens **before** any bytes reach `asyncio.start_server`'s `on_conn` — i.e., strictly earlier than even the NCFED discrimination-magic read, let alone 060's TLS upgrade.
+
+**Decision**: these are two independent, stackable gates at different layers:
+1. Cloudflare Access (edge, pre-listener, optional per FR-005) — rejects unauthorized *connections* before the claw's process sees any bytes.
+2. NCFED/060 TLS + peer-identity verification (application, post-connection, already mandatory in production posture) — authenticates *who* is on an already-accepted connection.
+
+**Rationale**: this composition requires zero changes to `channel.py`/`tls.py`/`service.py` — Access operates entirely at the Cloudflare edge and the tunnel client, invisible to the Python federation code, which continues to see exactly the same `asyncio.start_server` callback and TLS upgrade flow it does today. This is why FR-004 ("Access MUST NOT replace or weaken 060's peer-identity TLS") is true by construction rather than requiring enforcement code — there is no code path by which enabling Access could bypass the existing TLS negotiation, since Access sits strictly earlier in the connection lifecycle and the federation code is unaware it exists.
+
+**Alternatives considered**: implementing Access-awareness inside the Python federation code (e.g., reading a Cloudflare-injected header/claim) — rejected as unnecessary complexity; the edge-gate/app-auth separation is cleaner and requires no code changes, matching this feature's "transport + ops hardening only" scope (FR-008).
+
+## R3 — Fault classification for tunnel/edge failures (extends spec 057's fault-class model)
+
+Spec 057 (`n2n_faults`) already distinguishes `daemon` (mesh daemon down) / `member` (a specific member unreachable) / `backend` (member up, its device/API unreachable) / `none`. This feature's FR-007 requires a tunnel/edge-layer failure (Cloudflare outage, DNS failure, `cloudflared` process down) to be distinguishable from a peer-process-down condition.
+
+**Observation from the live incident**: `n2n_health`'s existing per-peer fields (`channel_state: reconnecting`, `endpoint`, `endpoint_updated_at`, `attempts`) already carry enough raw signal to distinguish "my own tunnel is down" (a *local* `cloudflared`/DNS health check, independent of any peer) from "the peer's process is gone" (repeated dial failures against a peer's endpoint that is otherwise DNS-resolvable and TCP-connectable up to the point cloudflared or the origin refuses). The distinction is really: is the *unreachability signal local to my own egress/tunnel* (I can't get out, or my own inbound tunnel is down — checkable independently of any specific peer) vs. *remote* (I can reach the transport fine, but nothing answers NCFED on the other end)?
+
+**Decision**: extend `n2n_faults`' existing per-peer/per-member fault classification with a new checkable signal (a local tunnel/DNS health probe, independent of peer state) that can be consulted *before* attributing a dead channel to "peer down." This reuses the existing fault-class enum's pattern (name a specific, checkable cause) rather than inventing a new ambiguous top-level state. Concretely, this composes as: if the local tunnel health probe fails, report a transport-layer fault for *this claw's own* advertised endpoint (distinct from any peer's fault); if the local tunnel is healthy but a specific peer's channel is still down, classification proceeds exactly as today (peer/member-down, unaffected by this feature).
+
+**Rationale**: mirrors 057's stated principle exactly ("Always report the specific cause, never a generic 'something's down'") and reuses the existing `n2n_faults`/`n2n_health` surface (FR-006, avoiding a parallel surface) rather than introducing new tooling.
+
+**Alternatives considered**: a generic "transport degraded" catch-all — rejected, repeats the exact misdiagnosis pattern 057 was built to fix (a poll bug reported as a member flap).
+
+## R4 — Posture/HUD surface extension point
+
+Spec 060 already extended the operator posture/HUD surface with trust-model, credential fingerprint, issuer, and expiry per peer. FR-006 requires this feature's transport type and edge-gate status to appear in that same surface.
+
+**Decision**: extend the existing per-peer posture record (the same one 060 populates) with two additional display fields — `transport` (`ngrok` | `cloudflare_tunnel` | `other`) and `edge_gate` (`none` | `cloudflare_access`) — rather than building a second view. This is directly analogous to how 063 added `negotiated_kex_group`/`pq_indicator` to the same existing surface (063 R4/FR-014) instead of a parallel one.
+
+**Rationale**: consistent with the repo's established pattern (both 060 and 063 explicitly avoid parallel surfaces); operators already look in one place for channel trust facts.
+
+**Alternatives considered**: a separate "transport health" panel — rejected, violates FR-006 and the established cross-cutting pattern from both prior specs.
+
+## R5 — Cross-cutting
+
+**Decision**: No new Python packages in the federation code itself — `cloudflared` is an external ops-level binary/service (like ngrok is today), configured and run as a durable service per spec 057's pattern (`scripts/in2n-services.py`-style systemd unit), not a library dependency of `bgp/federation/*`. The federation code's only awareness of the transport is the `host:port` (or Cloudflare-tunnel-resolved equivalent) it already dials/listens on today — this feature changes *what infrastructure makes that address stable and gated*, not the Python connection logic itself. New state is limited to: (a) the per-peer `transport`/`edge_gate` display fields (R4), reusing the existing peer/posture record; (b) the local tunnel health probe (R3), a new lightweight check, not a new store.
+
+**Sequencing**: US1 (stable endpoint via `cloudflared`, ops-only, zero code changes to `service.py`/`channel.py`) ships first and is fully independent — it is pure infrastructure substitution and can be validated against the two currently-dead peers (John, Nick) once *they* also adopt it, or unilaterally by confirming this claw's own endpoint survives `cloudflared`/host restarts. US3 (posture display) is a small, low-risk addition to the existing 060/063 surface and can follow immediately. US2 (Access edge-gate) is operator-config + a local health/status read of Access policy state — no core federation code changes — and can ship independently and later, consistent with its default-off, opt-in-per-peer resolution.

--- a/specs/108-cloudflare-tunnel-transport/spec.md
+++ b/specs/108-cloudflare-tunnel-transport/spec.md
@@ -1,0 +1,125 @@
+# Feature Specification: Cloudflare Tunnel as a Hardened eN2N Transport
+
+**Feature Branch**: `108-cloudflare-tunnel-transport`
+**Created**: 2026-08-14
+**Status**: Clarified — ready for planning
+**Input**: Live operational finding, 2026-08-14 — while investigating why two eN2N mesh peers (`as65001-4.4.4.4` "John", `as65007-7.7.7.7` "Nick") had been unreachable for 3+ weeks, the root cause traced to free ngrok TCP tunnels: every process restart on either side issues a brand-new random `host:port`, and once a channel has been dead long enough there is no live session left to receive an announced-address update (spec 063 FR-002/FR-003), so the stale address persists indefinitely and requires manual operator intervention (`n2n_forget_endpoint` + out-of-band re-dial) to recover. Separately, a raw ngrok TCP tunnel is an openly reachable public socket gated only by URL obscurity, not by any access-control layer in front of the NCFED listener itself.
+
+## Problem Statement
+
+eN2N federation today reaches peers over ngrok TCP tunnels. Two independent, compounding weaknesses were observed live rather than hypothesized:
+
+1. **Endpoint churn breaks the self-heal loop.** ngrok free-tier tunnels are ephemeral — a new `host:port` is assigned on every restart of the tunneling process. Spec 063's endpoint-persistence fix (FR-001–FR-004) correctly updates the stored address whenever a *live, authenticated* channel exists to carry the announcement — but that mechanism has no way to help a channel that is already dead. If a peer's process cycles while the channel is down (the common case for two consumer/lab operators whose machines aren't always on), the next reconnect attempt dials a `host:port` that no longer exists, and there is no live channel left to receive a fresh one. The result is exactly what was observed: two peers stuck at 23- and 21-day-old dead addresses, silently retried forever (or, post spec-100, dampened and summarized forever) with no path back to `federated` short of an operator noticing, confirming out-of-band, and manually re-dialing.
+2. **The transport has no access-control layer of its own.** A raw ngrok TCP tunnel is a real, publicly reachable socket. Reachability is gated only by knowing (or guessing/portscanning for) the current `host:port` — the NCFED discrimination preamble and, once negotiated, TLS (spec 060) authenticate *who* is on the wire, but nothing today decides *whether an unauthenticated connection attempt is even allowed to reach the listener* before that negotiation begins.
+
+Both weaknesses share a root cause: the transport (ngrok) was chosen for zero-config convenience, not for address stability or perimeter control. Cloudflare Tunnel (`cloudflared`) is a drop-in replacement that is outbound-only from both ends (no listening port exposed to the internet on either side, unlike ngrok's forwarded TCP port) and can be bound to a durable, operator-owned DNS name instead of a randomly assigned one. Layering Cloudflare Access in front of the tunnel additionally allows gating connections with mutual TLS/service-token verification *before* they ever reach the NCFED listener — a defense-in-depth control that is independent of, and additional to, the peer-identity certificate work in spec 060.
+
+This feature is a **transport substitution and perimeter-hardening** change. It does not alter NCFED wire format, peer identity semantics, or the certificate/trust model in spec 060 — it changes what carries the bytes and adds an optional gate in front of them.
+
+## Relationship to Existing Specs
+
+- **Spec 060 (Claw Certification)** establishes *who* is on a channel (domain-verified or pinned TLS identity) once a connection is negotiated. This feature is transport-layer and complementary: it does not replace certificate-based peer authentication, and a Cloudflare-tunneled channel still requires 060-style identity verification once the tunnel delivers bytes to the NCFED listener.
+- **Spec 063 (Wire Hardening)** fixed endpoint persistence *for channels that are still alive to announce a new address*. This feature removes the underlying reason that mechanism can't help: an address that doesn't change on restart doesn't need announcing. The two are complementary, not overlapping — 063's fix still matters for peers who remain on ngrok or any other rotating-address transport.
+- **Spec 059 (NCFED Internet-Draft)** documents the protocol as transport-agnostic (cleartext-over-ngrok today, TLS-over-tunnel per 060). This feature is consistent with that framing: Cloudflare Tunnel is one more transport option, not a protocol change.
+
+## Clarifications
+
+### Session 2026-08-14
+
+- Q: Should Cloudflare Tunnel become the *only* supported eN2N transport, or an additional option alongside ngrok? → **A: Additional option.** Cloudflare Tunnel ships as one more supported transport alongside the existing raw-TCP/ngrok path; a peer without a Cloudflare account/domain is unaffected and continues to federate over ngrok or any other transport with zero forced migration. Per-peer, the two ends of a channel may each independently choose their own transport (FR-001 is a MUST-support, not a MUST-replace).
+- Q: Does Cloudflare Access sit in front of every eN2N connection, or is it operator-optional per peer? → **A: Operator-optional, default off.** Enabling Access is a deliberate opt-in per claw. **What changes if it were default-on instead:** every peer — including ones who haven't provisioned an Access client cert/service token — would be locked out at the edge the moment Cloudflare Tunnel is adopted, turning a transport-stability upgrade into a forced, coordinated re-credentialing of every existing federation relationship simultaneously (no partial rollout, no per-peer pacing). Default-off means adopting the tunnel for address stability (US1) and adopting the edge access-control gate (US2) are two separate operator decisions on two separate timelines — an operator can fix the ngrok-churn problem today and layer on Access later, peer by peer, once each peer has a credential ready. This mirrors 060's own rollout philosophy (peers upgrade independently; unpatched peers are refused only for the *specific* thing they haven't adopted, not federation as a whole).
+- Q: When Cloudflare Tunnel mode is used, should the tunnel run in HTTP(S) mode (Cloudflare edge terminates TLS) or private-network/TCP mode (edge only relays opaque bytes, NCFED's own TLS from spec 060 is the only thing that can read the payload)? → **A: TCP/private-network mode**, confirmed. Cloudflare's edge relays opaque bytes only; NCFED's own TLS (spec 060) remains the sole layer that can decrypt payload, consistent with spec 063's "encrypt in-protocol, don't rely on an incidental transport" position. HTTP(S) mode is explicitly out of scope for this feature (would regress confidentiality by exposing plaintext NCFED traffic to Cloudflare's edge).
+- Q: Does adopting this feature retroactively invalidate any pinned peer identity or consent record? → No — this is transport substitution only; peer identity, consent, grants, and audit history are keyed to `as<ASN>-<router-id>` (per 060's existing decision) and are untouched by a change of carrier.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A peer's address never goes stale (Priority: P1)
+
+As a claw operator federating with peers over the public internet, I want my claw's eN2N endpoint bound to a durable DNS name I control, so that restarting my tunnel process (or my whole host) never changes the address my peers need to reach me at — eliminating the class of failure where a peer's stored endpoint silently rots and requires manual `n2n_forget_endpoint` + re-dial to recover.
+
+**Why this priority**: This is the confirmed, currently-recurring failure this feature exists to fix. It's a pure reliability win independent of the security posture changes in User Story 2.
+
+**Independent Test**: Configure a claw's eN2N listener behind a Cloudflare Tunnel bound to a fixed hostname. Restart the tunnel process (and separately, the whole host) repeatedly over an extended period. Confirm a federated peer's stored endpoint for this claw never needs manual correction and every reconnect succeeds against the same hostname.
+
+**Acceptance Scenarios**:
+
+1. **Given** a claw whose eN2N listener is exposed via a Cloudflare Tunnel bound to a fixed hostname, **When** the `cloudflared` process restarts, **Then** the claw's public address is unchanged and federated peers' next reconnect attempt succeeds with no address update needed.
+2. **Given** the same setup, **When** the underlying host reboots, **Then** the hostname remains valid and reachable once the tunnel service comes back up (durable service, consistent with spec 057's durable-runtime pattern).
+3. **Given** a peer still on a rotating-address transport (e.g. ngrok), **When** federating with a Cloudflare-Tunnel-hosted claw, **Then** federation is unaffected — this feature changes only the advertising side's stability, not the peer's own transport choice.
+4. **Given** an operator migrating an existing federated peer relationship from ngrok to Cloudflare Tunnel, **When** the migration completes, **Then** existing consent, grants, and audit history for that peer identity are preserved unchanged (identity is `as<ASN>-<router-id>`, not the transport address).
+
+---
+
+### User Story 2 - Unauthenticated probes never reach the NCFED listener (Priority: P2)
+
+As a claw operator, I want an access-control gate (mutual TLS client certificates or a Cloudflare Access service token) in front of my Cloudflare Tunnel, so that a connection attempt from anyone other than an already-provisioned peer is rejected at Cloudflare's edge — before it ever reaches my NCFED listener or consumes local resources — rather than relying solely on the difficulty of guessing a tunnel URL.
+
+**Why this priority**: This is defense-in-depth on top of 060's peer-identity TLS, not a replacement for it. It's P2 because User Story 1 (stability) is the confirmed, currently-broken behavior; this is a hardening addition on a transport that, absent this feature, doesn't exist yet.
+
+**Independent Test**: Stand up a Cloudflare Access policy requiring mTLS client-cert or service-token auth in front of a claw's tunnel. Attempt a connection presenting no credential, and one presenting the wrong credential; confirm both are rejected at the edge with no bytes reaching the NCFED listener. Attempt a connection with the correct credential and confirm it reaches the listener and proceeds to normal 060 peer-identity negotiation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Cloudflare Access policy configured in front of the tunnel, **When** a connection presents no client credential, **Then** it is refused at the edge and no NCFED traffic (not even the discrimination preamble) reaches the listener.
+2. **Given** the same policy, **When** an authorized peer's client presents the correct credential, **Then** the connection passes the edge gate and proceeds to normal spec-060 identity negotiation unaffected.
+3. **Given** an operator who has not configured Access (feature used for transport stability only), **When** a connection arrives via the tunnel, **Then** behavior is identical to today (no forced Access requirement) — this control is additive and operator-opt-in, never silently mandatory.
+4. **Given** a peer's Access credential expires or is revoked, **When** they next attempt to connect, **Then** they are refused at the edge with a reason the operator can see, distinct from a 060 identity-verification failure (different layer, different failure mode — must not be conflated in logs/posture).
+
+---
+
+### User Story 3 - Transport choice and posture are operator-visible (Priority: P3)
+
+As a claw operator, I want to see, per peer, which transport carries the channel (ngrok, Cloudflare Tunnel, or other) and whether an Access-style edge gate is active, alongside the existing 060 trust-model/credential facts, so I can assess my federation's exposure at a glance rather than having to remember which peers I migrated.
+
+**Why this priority**: Pure visibility; depends on User Stories 1–2 existing to have something to display.
+
+**Independent Test**: Federate with a mix of ngrok-transported and Cloudflare-Tunnel-transported peers, one with Access enabled and one without. Confirm the operator posture/HUD view (same surface 060 already extended) shows transport type and edge-gate status per peer without requiring a second tool or view.
+
+**Acceptance Scenarios**:
+
+1. **Given** a mix of peer transports, **When** the operator views posture, **Then** each peer's transport type and edge-gate status (if any) is visible alongside its existing trust-model/credential facts.
+2. **Given** a peer migrates from ngrok to Cloudflare Tunnel, **When** the operator next views posture, **Then** the displayed transport updates to reflect the change with no manual record edit.
+
+---
+
+### Edge Cases
+
+- **Operator has a Cloudflare account but no owned domain suitable for a stable tunnel hostname**: must degrade cleanly to today's ngrok behavior; this feature is additive, not a hard requirement to federate at all.
+- **Cloudflare Tunnel or Cloudflare's edge has an outage**: the claw's public address (the DNS name) doesn't change, but reachability drops — this must be distinguishable in health/fault reporting (spec 057's `n2n_faults` fault-class model) from a peer being genuinely down, since the two look different (one is "my hostname resolves but times out," the other is "peer's process is gone").
+- **Access policy misconfigured to block legitimate peers**: must be detectable and correctable by the operator without needing to fall back to disabling Access entirely (i.e., policy edits, not an all-or-nothing kill switch, should be the recovery path) — though `n2n_kill`/removing the tunnel remain available as an escape hatch.
+- **A peer that has not adopted Cloudflare Tunnel at all**: must continue to federate exactly as today (this feature never requires both sides to adopt it simultaneously — the two endpoints of a channel can use different transports independently).
+- **HTTP-mode vs TCP/private-network tunnel mode chosen incorrectly**: if HTTP mode is used, Cloudflare's edge terminates TLS and can observe plaintext NCFED traffic in transit — this must be flagged as a documented posture trade-off, not a silent security regression relative to 063's "protocol encrypts itself" stance.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The claw's eN2N listener MUST support being exposed via a Cloudflare Tunnel bound to an operator-supplied, stable DNS hostname, as an **additional** transport option alongside the existing raw-TCP/ngrok path (resolved: added option, not a replacement — see Clarifications). Adopting it for one claw MUST NOT require any peer to adopt it.
+- **FR-002**: When a claw's advertised endpoint is a Cloudflare Tunnel hostname, that hostname MUST remain valid and correctly routable across restarts of the `cloudflared` process and of the host, requiring no operator action and no peer-side endpoint update (consistent with, and reducing reliance on, spec 063's endpoint-persistence mechanism).
+- **FR-003**: The claw MUST support an optional Cloudflare Access policy (mutual TLS client certificate or service token) in front of the tunnel. When enabled, an unauthorized connection attempt MUST be rejected at the edge before any NCFED bytes (including the discrimination preamble) reach the claw's listener.
+- **FR-004**: Enabling the Access edge gate MUST NOT replace or weaken spec 060's peer-identity TLS negotiation — an Access-authorized connection still MUST complete normal peer-identity verification once it reaches the listener. The two layers are independent and both apply when both are configured.
+- **FR-005**: The Access edge gate MUST be operator-opt-in per claw (and effectively per peer, since Access policies gate the tunnel a specific peer connects through), **defaulting to off** (resolved — see Clarifications), so adopting Cloudflare Tunnel for stability alone (US1) does not force an unplanned, all-or-nothing access-control migration of every existing federation relationship (US2). An operator MAY enable Access per peer once that peer has provisioned a credential, without affecting peers who haven't.
+- **FR-006**: The claw's operator posture/HUD surface (the same one spec 060 extended with trust-model/credential facts) MUST show, per peer channel, which transport is in use and whether an Access-style edge gate is active. [Depends on: existing 060 posture surface being the extension point, not a new one — consistent with 063's cross-cutting requirement to avoid parallel surfaces.]
+- **FR-007**: A tunnel/edge-layer reachability failure (e.g., Cloudflare outage, DNS failure, tunnel process down) MUST be distinguishable in fault/health reporting from a peer-process-down condition, extending the existing daemon/member/backend fault-class model (spec 057) rather than introducing an ambiguous new "unreachable" catch-all.
+- **FR-008**: This feature MUST NOT change NCFED wire format, peer-identity semantics, consent records, or any 060/063 mechanism — it is additive at the transport layer only. Existing peers on ngrok or any other transport MUST continue to federate unaffected.
+- **FR-009**: The tunnel MUST run in **TCP/private-network (opaque-relay) mode** (resolved — see Clarifications), never HTTP(S)/TLS-terminating-at-edge mode, so Cloudflare's edge never sees decrypted NCFED payload. This is not operator-configurable to HTTP mode for eN2N traffic — the confidentiality regression it would introduce is not an acceptable trade-off this feature offers.
+
+### Key Entities
+
+- **Peer channel transport (new attribute on existing peer/channel record)**: which carrier (ngrok, Cloudflare Tunnel, other) currently carries a given peer's channel; extends the existing peer record (per 063's pattern of extending, not replacing, existing durable records).
+- **Edge access-gate status (new attribute)**: whether an Access-style pre-listener gate is configured and active for a given claw/peer channel, surfaced alongside existing 060 trust-model/credential facts.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: Zero manual `n2n_forget_endpoint` + re-dial interventions are needed for a Cloudflare-Tunnel-hosted claw's address across repeated `cloudflared` restarts and host reboots, measured over an extended observation period equivalent to the ngrok failure window that motivated this feature (weeks, not hours).
+- **SC-002**: With an Access edge gate enabled, 100% of connection attempts lacking a valid credential are rejected before any NCFED discrimination-preamble byte reaches the listener (verifiable by absence of any listener-side log/audit entry for the rejected attempt).
+- **SC-003**: An operator can determine, for any peer channel, its transport type and edge-gate status within one existing view, with no separate tool required.
+- **SC-004**: A tunnel/edge outage and a peer-process-down condition produce distinguishable fault classifications in `n2n_faults`/health output, with zero misattribution in testing (mirroring spec 057 US6's existing fault-isolation bar).
+- **SC-005**: Zero regressions: peers who remain on ngrok or any other existing transport continue to federate exactly as before this feature ships.
+
+## Assumptions
+
+- The reference operator (this claw, `as65099-10.255.255.1`, domain `byrnbaker.me`) already owns a Cloudflare-managed domain suitable for a stable tunnel hostname, consistent with how spec 060's reference deployment already assumes DNS-provider access for domain-verified certificates.
+- This feature composes with, and should ideally ship after or alongside, spec 060 (peer identity/TLS) — a Cloudflare Tunnel without 060's identity layer still leaves the *content* of the channel exactly as trustworthy as it is today (string-asserted identity); the transport hardening and the identity hardening are separate, complementary axes.
+- Cloudflare Tunnel is assumed available at no cost sufficient for this use case (as ngrok's free tier is today); paid-tier features (e.g. reserved ngrok addresses) are an alternative mitigation for User Story 1 alone but do not provide User Story 2's edge-gate capability, so are treated as out of scope for this spec.
+- Peers are independent operators (John/as65001, Nick/as65007, etc.) who must separately choose to adopt this on their own claws — this spec covers what the local claw supports and advertises, not a way to force a peer's transport choice.

--- a/specs/108-cloudflare-tunnel-transport/tasks.md
+++ b/specs/108-cloudflare-tunnel-transport/tasks.md
@@ -1,0 +1,144 @@
+# Tasks: Cloudflare Tunnel as a Hardened eN2N Transport
+
+**Input**: Design documents from `/specs/108-cloudflare-tunnel-transport/`
+**Prerequisites**: plan.md, spec.md (clarified 2026-08-14, 4 Qs), research.md (R0 confirmed live gap + R1–R5), data-model.md, contracts/interfaces.md, quickstart.md
+
+**Tests**: Included — spec defines an Independent Test per story + measurable SCs; mirrors 063's own testing bar (integration reuses the existing `tests/n2n/` loopback pattern).
+
+**Phase order = implementation order** (not strictly spec priority order): US1 (P1, pure ops + small persistence-field addition, zero risk to existing peers) first, then US3 (P3, posture display — small, depends only on US1's new field existing) next since it's low-risk and immediately useful once US1 lands, then **US2 (P2) last** because it's the one story with an external dependency (Cloudflare Access configuration) and a security-relevant default (off) that deserves to be validated against a real US1 deployment first, not built in parallel with it.
+
+## Format: `[ID] [P?] [Story] Description`
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 [P] Add `N2N_TRANSPORT_HEALTH_CHECK` (bool, default enabled) to `.env.example`, documented per data-model.md §4 — controls whether the local tunnel/DNS health probe runs at all (allows a full no-op for operators who never touch this feature)
+- [ ] T002 [P] Document the TCP/private-network-mode-only decision (never HTTP(S) ingress) in `mcp-servers/protocol-mcp/README.md` or equivalent ops doc, with the confidentiality rationale from research.md R1 — this is a fixed decision, not operator-configurable, and needs to be findable before anyone stands up a `cloudflared` config
+
+---
+
+## Phase 2: Foundational (blocking prerequisites)
+
+- [ ] T003 In `mcp-servers/protocol-mcp/bgp/federation/manager.py`, add `transport` (text, default `'ngrok'`) and `edge_gate` (text, default `'none'`) columns to the `federation_peer` schema (migration-safe: `ALTER TABLE ... ADD COLUMN ... DEFAULT ...`, matching how 063 relied on already-existing columns — here the columns are new but the pattern of additive, defaulted columns is identical) (data-model.md §1)
+- [ ] T004 [P] In `mcp-servers/protocol-mcp/bgp/federation/manager.py`, extend `upsert_peer()` to accept optional `transport` and `edge_gate` kwargs, writing them only when explicitly supplied (never overwritten to a default on an unrelated call, mirroring how `endpoint_host`/`endpoint_port` are only touched when supplied) (FR-001, FR-005)
+- [ ] T005 [P] In `mcp-servers/protocol-mcp/bgp/federation/manager.py`, extend `get_peer()`/`list_peers()` to include `transport` and `edge_gate` in returned peer dicts (needed by every downstream US)
+- [ ] T006 Unit test in `tests/n2n/test_transport_field_108.py`: `upsert_peer` with no `transport`/`edge_gate` args leaves existing values unchanged; a peer inserted with no explicit values defaults to `('ngrok', 'none')`; explicit values round-trip through `get_peer`/`list_peers` (SC-005 — zero regression for existing rows)
+
+**Checkpoint**: schema + manager primitives ready; no external behavior has changed yet (all new fields default to today's implicit reality).
+
+---
+
+## Phase 3: User Story 1 — Endpoint never goes stale (P1) 🎯 MVP
+
+**Goal**: A claw's advertised eN2N endpoint survives `cloudflared`/host restarts with zero manual `n2n_forget_endpoint` + re-dial cycles, closing the confirmed live gap between spec 063's endpoint-persistence fix and reality (research.md R0).
+
+**Independent Test**: bind a Cloudflare Tunnel to a fixed hostname; restart `cloudflared` and the host repeatedly over an extended period; confirm a federated peer's stored endpoint for this claw never needs manual correction and every reconnect succeeds against the same hostname (spec.md US1 Independent Test, SC-001).
+
+- [ ] T007 [US1] In `mcp-servers/protocol-mcp/bgp-daemon-v2.py` `/n2n/connect` handler, accept an optional `transport` field (`ngrok`\|`cloudflare_tunnel`\|`other`, default `ngrok` when omitted — existing callers/scripts unaffected) and pass it through to `open_channel`/`upsert_peer` (contracts/interfaces.md, FR-001, FR-008)
+- [ ] T008 [US1] In `mcp-servers/protocol-mcp/bgp/federation/service.py` `open_channel`, extend the existing "successful, authenticated channel" persistence call (the same call site 063/T004 added) to also pass through `transport` when supplied, using T004's extended `upsert_peer` signature — no change to the success/failure-path logic itself, only the additional field (FR-001, reuses 063's precondition exactly)
+- [ ] T009 [P] [US1] Author the ops-layer deployment doc/script mirroring spec 057's `in2n-services.py` pattern: `scripts/cloudflared-transport.sh` (or extend `in2n-services.py`) to generate a durable systemd unit for `cloudflared tunnel run <name>`, so a Cloudflare Tunnel is provisioned repeatably rather than hand-run (spec.md US1 durability requirement, FR-002, mirrors 057 US5's "not hand-authored" bar)
+- [ ] T010 [US1] Confirm (read + smoke-test, no code change expected) that the reconnect supervisor in `service.py` — already reading `endpoint_host`/`endpoint_port` from the peer row per 063 — requires no change to correctly re-dial a Cloudflare-Tunnel-hosted `host:port`, since from the daemon's perspective it is just another stable address (FR-002; if a change IS needed, it indicates a hidden ngrok-specific assumption and must be fixed here)
+- [ ] T011 [P] [US1] Integration test in `tests/n2n/test_endpoint_stability_108.py`: configure a peer with `transport=cloudflare_tunnel` and a fixed host:port; simulate a "restart" (fresh `FederationManager` instance over the same DB, per 063's own test pattern in `test_endpoint_persistence_063.py`); assert the stored `endpoint_host`/`endpoint_port`/`transport` are unchanged and the supervisor's next-dial target is identical to before the simulated restart (SC-001)
+- [ ] T012 [P] [US1] Regression test in `tests/n2n/test_endpoint_stability_108.py`: a peer with `transport` unset/`ngrok` behaves byte-for-byte as it did before this feature (no field, no behavior change) — explicit SC-005 guard
+
+**Checkpoint**: US1 independently shippable — a Cloudflare-Tunnel-configured peer's address is durable across restarts, verified by test; zero change for peers who haven't adopted it.
+
+---
+
+## Phase 4: User Story 3 — Transport and edge-gate status are operator-visible (P3)
+
+**Goal**: An operator can see, per peer, which transport carries the channel and whether an edge gate is active, in the existing 060/063 posture surface — no second tool or view.
+
+**Independent Test**: federate with a mix of ngrok- and Cloudflare-Tunnel-transported peers, one with Access enabled and one without; confirm the posture/HUD view shows transport type and edge-gate status per peer without a second tool (spec.md US3 Independent Test).
+
+- [ ] T013 [US3] In `mcp-servers/protocol-mcp/bgp/federation/posture.py`, extend the existing per-peer posture record (already carrying trust model/fingerprint/expiry per 060, kex_group/pq per 063) with `transport` and `edge_gate`, sourced from `manager.get_peer()`/`list_peers()` (T005) (data-model.md §3, FR-006)
+- [ ] T014 [P] [US3] In `mcp-servers/protocol-mcp/bgp-daemon-v2.py`, extend the `/n2n/health` route's per-peer entries with `transport`/`edge_gate` (mirrors `/n2n/posture`'s addition — one write via T005, two read surfaces, matching the existing 060/063 dual-exposure pattern) (contracts/interfaces.md)
+- [ ] T015 [US3] Add the local tunnel/DNS health probe (data-model.md §2): a small function in `bgp-daemon-v2.py` (or a new tiny helper module alongside `service.py`) that, when `N2N_TRANSPORT_HEALTH_CHECK` is enabled and at least one peer/self-record uses `transport=cloudflare_tunnel`, checks DNS resolution of the configured hostname and the local `cloudflared` systemd unit's active state; returns `true`/`false`/`"n/a"` — surfaced as `local_transport_healthy` on `/n2n/health` (FR-007)
+- [ ] T016 [US3] In the `n2n-mcp` server (wherever `n2n_health`/`n2n_status` map to the daemon HTTP routes), confirm the new fields pass through unmodified to the MCP tool response shape — likely no code change needed if the mapping is a direct passthrough, but verify and add a test if any field allowlist/schema needs updating
+- [ ] T017 [P] [US3] Test in `tests/n2n/test_transport_posture_108.py`: posture/health output for a peer with `transport=cloudflare_tunnel, edge_gate=cloudflare_access` shows both fields distinctly from a peer with `transport=ngrok, edge_gate=none`; `local_transport_healthy` reflects a forced-down local check (mock/stub the systemd-unit-state read) as `false`, and `"n/a"` when no peer uses `cloudflare_tunnel` at all
+
+**Checkpoint**: US1 + US3 both independently functional — transport reality is durable (US1) and visible (US3) with no separate tooling required.
+
+---
+
+## Phase 5: User Story 2 — Unauthenticated probes never reach the NCFED listener (P2, opt-in, default off)
+
+**Goal**: An optional, per-peer, default-off Cloudflare Access gate rejects unauthenticated connections at Cloudflare's edge, before any bytes reach the NCFED listener — additive to, never a replacement for, spec 060's peer-identity TLS.
+
+**Independent Test**: with an Access policy configured in front of a claw's tunnel, confirm a credential-less or wrong-credential connection is rejected at the edge with zero NCFED traffic reaching the listener; confirm a correctly-credentialed connection proceeds to normal spec-060 negotiation unaffected (spec.md US2 Independent Test).
+
+**Note on scope**: Cloudflare Access itself is configured entirely on the Cloudflare side (dashboard/API) — this phase's tasks are the local-side plumbing (the toggle, the visibility, the verification that nothing in the federation code path needs to change), not an implementation of Access itself.
+
+- [ ] T018 [US2] In `mcp-servers/protocol-mcp/bgp-daemon-v2.py`, add `POST /n2n/peer/edge_gate` accepting `{"peer": "<identity>", "edge_gate": "cloudflare_access"|"none"}`, validating the peer exists, and calling `manager.upsert_peer(..., edge_gate=...)` (T004) — this is the ONLY way `edge_gate` changes from its `none` default; never implied by setting `transport=cloudflare_tunnel` (contracts/interfaces.md, FR-005, Clarifications default-off resolution)
+- [ ] T019 [P] [US2] Add `n2n_set_edge_gate(peer, edge_gate)` to the `n2n-mcp` server, proxying T018's route, following the existing small-single-purpose-tool pattern (`n2n_forget_endpoint` from spec 100 is the closest precedent) — deliberately no bulk/"all peers" variant (contracts/interfaces.md)
+- [ ] T020 [US2] Verify (read + targeted test, expect no code change) that nothing in `bgp/federation/channel.py`/`tls.py`/`service.py`'s connection-acceptance or TLS-upgrade path is aware of or gated by Access — per research.md R2, this must be true by construction (Access operates strictly before `asyncio.start_server`'s `on_conn` fires), so this task is a verification, not an implementation, of FR-004
+- [ ] T021 [P] [US2] Integration test in `tests/n2n/test_edge_gate_108.py`: setting `edge_gate=cloudflare_access` for peer A and leaving peer B at `none` does not change either peer's `PeerState`/consent/trust-model computation — confirms FR-004/FR-005's "additive only, never bypasses or replaces 060" claim at the code level (the live Cloudflare-side Access enforcement itself is validated via quickstart.md's manual procedure, not unit-testable without a real Cloudflare account)
+- [ ] T022 [US2] Add the GAIT-audit scope decision from plan.md's Complexity Tracking open question: record `edge_gate` toggles (via T018) to the GAIT immutable trail if the operator decides they are security-relevant per spec 057 US4's event model — **decision required before this task can be marked done**; if the operator declines, close this task as "decided: not GAIT-audited, posture-visible only" rather than leaving it silently unaddressed
+
+**Checkpoint**: All three user stories independently functional. US1 fixes the confirmed live bug; US3 makes the new reality visible; US2 adds an optional, clearly-scoped, non-default hardening layer on top, none of which touches or weakens 060's existing identity guarantees.
+
+---
+
+## Phase 6: Polish & Cross-Cutting
+
+- [ ] T023 [P] Extend `n2n-federation` skill (`~/.openclaw/workspace/skills/n2n-federation/SKILL.md`) with a short section documenting `transport`/`edge_gate` fields and when to reach for `n2n_set_edge_gate`, mirroring how the skill already documents `n2n_forget_endpoint` (spec 100) — keeps the skill in sync with the new tool surface
+- [ ] T024 Run `quickstart.md` end-to-end against this claw's own reference deployment (`as65099-10.255.255.1`, `byrnbaker.me`) for US1 and US3 unilaterally (US2 additionally requires a Cloudflare Access policy to be configured, which is an operator action outside the codebase)
+- [ ] T025 [P] Full `tests/n2n/` suite green, confirming zero regression to existing 052/053/056/057/060/063/100 test coverage (SC-005 — the cross-feature regression bar every prior spec in this lineage has held itself to)
+- [ ] T026 Update `.env.example` and any deployment README with the final `N2N_TRANSPORT_HEALTH_CHECK` default and the TCP/private-network-mode-only note (T001/T002 follow-through once implementation confirms no surprises)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately.
+- **Foundational (Phase 2)**: Depends on Setup. BLOCKS all three user stories (every story reads/writes the `transport`/`edge_gate` fields Phase 2 introduces).
+- **User Story 1 (Phase 3)**: Depends on Foundational only. No dependency on US2/US3.
+- **User Story 3 (Phase 4)**: Depends on Foundational (needs `transport`/`edge_gate` to exist) and benefits from US1 having landed (something real to display), but is not code-blocked by US1 — could technically run in parallel if staffed, since it only reads the fields US1 also reads/writes.
+- **User Story 2 (Phase 5)**: Depends on Foundational only, code-wise. Sequenced last per plan.md's stated rationale (validate against a real US1 deployment first; it's the one story with an external Cloudflare-side dependency and a security-relevant default).
+- **Polish (Phase 6)**: Depends on all three user stories being complete (or explicitly deferred, mirroring how 063 deferred its own US2 with a documented status note).
+
+### Within Each User Story
+
+- Schema/manager changes (Phase 2) before any route/tool changes.
+- Route changes before MCP tool passthrough verification.
+- Implementation before its integration test (tests may be written first per the repo's stated pattern of "write to fail first," but are listed after implementation tasks here for readability, consistent with 063's own tasks.md ordering).
+
+### Parallel Opportunities
+
+- T001/T002 (Setup) in parallel.
+- T004/T005 (Foundational, different methods on the same file but non-overlapping) in parallel.
+- T009/T011/T012 (US1 ops-doc + tests) in parallel with each other once T007/T008 land.
+- T014/T017 (US3) in parallel once T013 lands.
+- T019/T021 (US2) in parallel once T018 lands.
+- US1 and US3 could be staffed in parallel by different people once Foundational completes, since US3 only reads what US1 writes and doesn't block on US1's ops-deployment task (T009).
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 (Setup) + Phase 2 (Foundational).
+2. Complete Phase 3 (US1) — this alone closes the confirmed live bug (stale ngrok endpoints for John/Nick-style peers) for any peer that adopts Cloudflare Tunnel, with zero visibility polish and zero Access hardening yet.
+3. **STOP and VALIDATE** via quickstart.md's US1 section against this claw's own reference deployment.
+4. Ship/demo if ready — US1 alone is a complete, independently valuable increment (mirrors how 063 shipped US1 alone and explicitly deferred its own US2).
+
+### Incremental Delivery
+
+1. Setup + Foundational → foundation ready, zero externally visible change.
+2. US1 → the address-rot bug is fixed for adopters → validate → ship (MVP).
+3. US3 → the fix (and any ngrok peers still in the mix) become visible in the existing posture view → validate → ship.
+4. US2 → optional edge hardening becomes available, off by default → validate against a real Cloudflare Access policy → ship.
+5. Polish → skill docs, full regression pass, config docs finalized.
+
+---
+
+## Notes
+
+- [P] tasks = different files or non-overlapping methods, no dependencies.
+- [Story] label maps each task to spec.md's US1/US2/US3 for traceability, matching 063's tasks.md convention exactly.
+- No task in this file requires changing NCFED wire format, `channel.py`, or `tls.py`'s core negotiation logic — verified explicitly by T020, consistent with FR-004/FR-008.
+- T022 is deliberately left as an explicit decision point rather than a default, per plan.md's Complexity Tracking note — do not silently skip it.


### PR DESCRIPTION
Root-caused the live outage where two eN2N mesh peers (as65001, as65007) sat stuck 21-23 days on stale ngrok addresses: spec 063's endpoint persistence only re-announces over a LIVE channel, which structurally cannot help a channel that's already dead with a rotated ngrok URL.

Proposes Cloudflare Tunnel (TCP/private-network mode) as an additional, opt-in eN2N transport bound to a stable DNS hostname, plus an optional default-off, per-peer Cloudflare Access edge gate -- additive to, never a replacement for, spec 060's peer-identity TLS.

Full spec-kit pipeline: spec (clarified), plan, research (grounded in reading bgp/federation/{service,tls,manager}.py), data-model, contracts, quickstart, tasks. No wire-format or peer-identity changes; zero forced migration for peers who stay on ngrok.