### PR TITLE
109 session budget guardrails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -235,6 +235,15 @@ NETCLAW_ENABLE_PASSWORD=changeme
 #   as the eN2N channel (enforce = require mesh TLS + refuse un-upgraded mesh peers).
 #   Enable on ALL mesh peers together, exactly like the 060 rollout.
 
+# --- Cloudflare Tunnel transport (feature 108) ---
+# N2N_TRANSPORT_HEALTH_CHECK=true               # Controls whether the daemon performs the local Cloudflare
+#                                                #   Tunnel / DNS health probe (data-model.md §2). When disabled,
+#                                                #   `local_transport_healthy` reports `n/a` without attempting
+#                                                #   any check. Operators who never adopt Cloudflare Tunnel can
+#                                                #   leave this at the default (enabled) — the probe is a no-op
+#                                                #   when no peer uses transport=cloudflare_tunnel.
+#                                                # Values: true | false (default: true)
+
 # --- Chroma-to-chroma vector replication (feature 065) ---
 # N2N_REPLICATION_MAX_CHUNKS=20000                # max chunks a single replication/re-sync
 #                                                  #   will transfer; a source collection over
@@ -874,3 +883,9 @@ SLC_PASSWORD=
 # SLC_{KEY}_IP=
 # SLC_{KEY}_USERNAME=
 # SLC_{KEY}_PASSWORD=
+
+# --- Session Budget Guardrails (spec 109) ---
+# Per-session cost ceiling in USD. Sessions halt when cumulative cost reaches this.
+# Override this to set a quick cap without modifying openclaw.json.
+# Default: 5.0 (safe for hobby/personal deployments)
+NETCLAW_SESSION_BUDGET_USD=5.0

--- a/specs/109-session-budget-guardrails/checklists/requirements.md
+++ b/specs/109-session-budget-guardrails/checklists/requirements.md
@@ -1,0 +1,48 @@
+# Requirements Checklist: 109-session-budget-guardrails
+
+## Functional Requirements
+
+- [ ] FR-001: SessionLedger exposes `is_over_budget()` method
+- [ ] FR-002: Gateway turn-dispatch checks budget before each model API call
+- [ ] FR-003: Budget halt produces user-visible message with cost breakdown
+- [ ] FR-004: SessionLedger exposes `tool_calls_this_turn` counter
+- [ ] FR-005: Budget config expressible in `openclaw.json` under `agents.defaults`
+- [ ] FR-006: Interface-based model routing via `interfaceDefaults` map
+- [ ] FR-007: Budget enforcement emits `netclaw_session_budget_trips_total` Prometheus counter
+- [ ] FR-008: Context warning calculates tokens without API call
+- [ ] FR-009: Budget override requires explicit user action
+- [ ] FR-010: All settings have documented safe defaults
+
+## Success Criteria
+
+- [ ] SC-001: Session halts at/below configured ceiling (±10% for in-flight)
+- [ ] SC-002: No more than `maxToolCallsPerTurn` tool calls without confirmation
+- [ ] SC-003: Mobile/N2N defaults to model ≤$1/M input
+- [ ] SC-004: `netclaw_session_budget_trips_total` increments on halt
+- [ ] SC-005: Zero regression for alert-agent behavior
+- [ ] SC-006: Repeat of $11 scenario results in ≤$2 with defaults
+
+## User Stories Acceptance
+
+### US1 — Cost Cap (P1)
+- [ ] Halts at configured ceiling
+- [ ] Uses sensible default ($5) when unconfigured
+- [ ] Override/continue works on explicit request
+- [ ] Partial summary provided on halt
+
+### US2 — Tool-Call Depth (P2)
+- [ ] Pauses at configured limit
+- [ ] Summarizes findings before pausing
+- [ ] Continuation resets counter
+- [ ] Default limit (20) applies when unconfigured
+
+### US3 — Interface Routing (P3)
+- [ ] Mobile/N2N defaults to cheap model
+- [ ] Explicit model request overrides default
+- [ ] TUI/desktop inherits agent primary (no regression)
+- [ ] Interface detection works for all known key patterns
+
+### US4 — Context Warning (P4)
+- [ ] Warning emitted at threshold
+- [ ] Warning includes cost-per-turn estimate
+- [ ] No warning below threshold

--- a/specs/109-session-budget-guardrails/data-model.md
+++ b/specs/109-session-budget-guardrails/data-model.md
@@ -1,0 +1,85 @@
+# Data Model: Session Budget Enforcement Guardrails
+
+**Branch**: `109-session-budget-guardrails` | **Date**: 2026-08-14
+
+## §1 BudgetPolicy (New Dataclass)
+
+```python
+@dataclass
+class BudgetPolicy:
+    """Per-session budget enforcement configuration."""
+    session_budget_usd: float = 5.0          # Max cost per session before halt
+    max_tool_calls_per_turn: int = 20        # Max tool invocations per user message
+    context_warning_tokens: int = 100_000    # Warn when context exceeds this
+    context_auto_summarize: bool = False     # Auto-summarize old tool results
+    allow_override: bool = True              # Whether operator can say "continue"
+    override_increment_usd: float = 2.0     # How much budget extends on override
+```
+
+**Defaults rationale**: $5.00 session cap × Sonnet 5 pricing = ~1.6M input tokens or ~333K output tokens before halt. For Haiku, it's ~5M input tokens. 20 tool calls per turn is generous for a deliberate investigation but would have stopped the $11 incident at 20 instead of 82.
+
+## §2 SessionLedger Extensions
+
+Existing fields (unchanged):
+- `session_id: str`
+- `started_at: datetime`
+- `total_input_tokens: int`
+- `total_output_tokens: int`
+- `total_cost: float`
+- `total_gcf_savings: int`
+- `total_call_count: int`
+- `tool_breakdown: Dict[str, ToolUsageRecord]`
+
+New fields:
+- `budget: BudgetPolicy` — loaded at session init from config
+- `tool_calls_this_turn: int` — resets on each user message
+- `budget_halted: bool` — set True when ceiling hit
+- `halt_reason: Optional[str]` — "cost_cap" | "tool_limit" | None
+- `interface_type: Optional[str]` — "openai" | "tui" | "n2n" | "discord" | etc.
+
+New methods:
+- `is_over_budget() -> bool` — returns True if `total_cost >= budget.session_budget_usd`
+- `is_over_tool_limit() -> bool` — returns True if `tool_calls_this_turn >= budget.max_tool_calls_per_turn`
+- `should_warn_context(context_tokens: int) -> bool` — returns True if context exceeds threshold
+- `record_tool_call()` — increments `tool_calls_this_turn` (separate from `record()` which tracks tokens)
+- `new_turn()` — resets `tool_calls_this_turn` to 0 (called on each user message)
+- `override_budget()` — extends ceiling by `override_increment_usd`, clears `budget_halted`
+- `get_halt_message() -> str` — formatted user-facing message with cost breakdown
+
+## §3 InterfaceDefaults (New Config Section)
+
+```json
+{
+  "interfaceDefaults": {
+    "<interface_type>": {
+      "model": "<provider>/<model-id>",
+      "thinkingLevel": "low|medium|high",
+      "budget": { /* BudgetPolicy overrides */ }
+    }
+  }
+}
+```
+
+Interface type is derived from the session key pattern:
+- `agent:*:openai:*` → `"openai"`
+- `agent:*:tui-*` → `"tui"`
+- `agent:*:discord:*` → `"discord"`
+- `agent:*:n2n` → `"n2n"`
+- `agent:*:hook:alert:*` → `"alert"` (unchanged, uses own agent config)
+- `agent:*:explicit:*` → `"explicit"`
+
+## §4 Configuration Location
+
+Lives in `openclaw.json` under `agents.defaults.budget` (global default) with
+per-agent override possible in `agents.list[].budget`.
+
+Environment variable override: `NETCLAW_SESSION_BUDGET_USD` (float) — takes
+precedence over JSON config, useful for quick adjustments without config reload.
+
+## §5 Prometheus Metrics (New)
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `netclaw_session_budget_trips_total` | Counter | `agent`, `reason`, `interface` | Increments on each budget halt |
+| `netclaw_session_budget_remaining_usd` | Gauge | `agent`, `session_id` | Current remaining budget (useful for dashboards) |
+| `netclaw_session_tool_calls_total` | Counter | `agent`, `interface` | Total tool calls across all sessions |

--- a/specs/109-session-budget-guardrails/plan.md
+++ b/specs/109-session-budget-guardrails/plan.md
@@ -1,0 +1,77 @@
+# Implementation Plan: Session Budget Enforcement Guardrails
+
+**Branch**: `109-session-budget-guardrails` | **Date**: 2026-08-14 | **Spec**: `specs/109-session-budget-guardrails/spec.md`
+**Input**: Feature specification + research from live $11 cost incident
+
+## Summary
+
+Extend the existing `netclaw_tokens` SessionLedger with enforcement capabilities
+(cost ceiling, tool-call depth limit) and add configuration schema for per-agent
+and per-interface budget policies. The enforcement hooks integrate with the
+OpenClaw gateway's existing token-optimization plugin path.
+
+## Technical Context
+
+**Language/Version**: Python 3.12 (library), Node.js (gateway consumer)
+**Primary Dependencies**: `netclaw_tokens` (existing library, `src/netclaw_tokens/`)
+**Storage**: In-memory (SessionLedger is per-session, already thread-safe)
+**Testing**: pytest (existing test infrastructure in `tests/`)
+**Target Platform**: Linux server (OpenClaw gateway runtime)
+**Project Type**: Library extension + configuration schema
+**Performance Goals**: `is_over_budget()` check must be <1ms (it's a float comparison)
+**Constraints**: Zero regression for existing alert-agent behavior; no gateway binary changes required
+**Scale/Scope**: Single-operator deployments (hobby/personal), 1-10 concurrent sessions
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/109-session-budget-guardrails/
+├── spec.md              # Feature specification (done)
+├── research.md          # Research findings (done)
+├── plan.md              # This file
+├── data-model.md        # Budget configuration schema
+├── quickstart.md        # Operator setup guide
+└── tasks.md             # Implementation tasks
+```
+
+### Source Code (repository root)
+
+```text
+src/netclaw_tokens/
+├── __init__.py              # Extended with BudgetPolicy dataclass
+├── session_ledger.py        # Extended with enforcement methods
+├── budget_policy.py         # NEW: BudgetPolicy loading + defaults
+└── cost_calculator.py       # Unchanged (already correct)
+
+tests/
+├── test_session_budget.py   # NEW: Budget enforcement unit tests
+└── test_budget_policy.py    # NEW: Config loading tests
+```
+
+### Configuration (openclaw.json schema addition)
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "budget": {
+        "sessionBudgetUsd": 5.0,
+        "maxToolCallsPerTurn": 20,
+        "contextWarningTokens": 100000,
+        "contextAutoSummarize": false
+      },
+      "interfaceDefaults": {
+        "openai": { "model": "anthropic/claude-haiku-4-5", "thinkingLevel": "medium" },
+        "n2n": { "model": "anthropic/claude-haiku-4-5", "thinkingLevel": "medium" },
+        "discord": { "model": "anthropic/claude-haiku-4-5", "thinkingLevel": "low" },
+        "tui": {},
+        "explicit": {}
+      }
+    }
+  }
+}
+```
+
+**Structure Decision**: This is a library extension — new functionality lives in the existing `src/netclaw_tokens/` package alongside the existing cost calculator and session ledger. No new top-level directories needed.

--- a/specs/109-session-budget-guardrails/quickstart.md
+++ b/specs/109-session-budget-guardrails/quickstart.md
@@ -1,0 +1,103 @@
+# Quickstart: Session Budget Enforcement Guardrails
+
+**Branch**: `109-session-budget-guardrails` | **Date**: 2026-08-14
+
+## What This Does
+
+Prevents runaway API costs by enforcing per-session spending caps and tool-call
+depth limits. After this feature, a casual phone question can never silently burn
+$11+ in API costs.
+
+## Quick Setup (30 seconds)
+
+Add to your `openclaw.json` under `agents.defaults`:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "budget": {
+        "sessionBudgetUsd": 5.0,
+        "maxToolCallsPerTurn": 20
+      },
+      "interfaceDefaults": {
+        "openai": { "model": "anthropic/claude-haiku-4-5" },
+        "n2n": { "model": "anthropic/claude-haiku-4-5" }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway. Done.
+
+## What Happens When a Budget Is Hit
+
+When the session cost cap is reached:
+
+```
+⚠️ Session budget reached ($5.02 / $5.00 cap)
+
+Summary:
+  • 34 API calls, 890K input tokens, 12K output tokens
+  • Top cost: exec (18 calls, $2.10), github-mcp (4 calls, $1.40)
+  • Session duration: 47 minutes
+
+To continue, say "override budget" (adds $2.00 to ceiling).
+To start fresh, begin a new session.
+```
+
+When the tool-call limit is reached:
+
+```
+⚠️ Tool call limit reached (20/20 this turn)
+
+Here's what I found so far:
+  [intermediate findings summary]
+
+Should I continue investigating? (say "yes" to allow 20 more calls)
+```
+
+## Environment Variable Override
+
+For quick adjustments without touching config:
+
+```bash
+export NETCLAW_SESSION_BUDGET_USD=2.0  # Override session cap
+```
+
+## Verification
+
+After setup, check that the Prometheus metric exists:
+
+```bash
+curl -s http://localhost:9090/api/v1/query \
+  --data-urlencode 'query=netclaw_session_budget_trips_total' | jq .
+```
+
+The counter should appear (value 0 until a cap is hit).
+
+## Defaults (if you configure nothing)
+
+| Setting | Default | Effect |
+|---------|---------|--------|
+| `sessionBudgetUsd` | 5.0 | Sessions halt at $5 |
+| `maxToolCallsPerTurn` | 20 | Agent pauses after 20 tool calls |
+| `contextWarningTokens` | 100000 | Warning at 100K context tokens |
+| `contextAutoSummarize` | false | No auto-summarization |
+| `interfaceDefaults.openai.model` | (inherits primary) | Falls back to agent default |
+
+## Alerting (Optional)
+
+Add to your Prometheus alerting rules:
+
+```yaml
+- alert: NetclawSessionBudgetTripped
+  expr: increase(netclaw_session_budget_trips_total[1h]) > 3
+  for: 0m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Multiple session budget halts in the last hour"
+    description: "{{ $value }} sessions hit their cost cap. Check if budget is too low or if something is triggering expensive agentic chains."
+```

--- a/specs/109-session-budget-guardrails/research.md
+++ b/specs/109-session-budget-guardrails/research.md
@@ -1,0 +1,96 @@
+# Research: Session Budget Enforcement Guardrails
+
+**Branch**: `109-session-budget-guardrails` | **Date**: 2026-08-14
+
+## R0: Confirmed Live Incident (Primary Input)
+
+On 2026-08-14, a 7-message iPhone session via the N2N/OpenAI-compat interface
+burned $11.13 in 2 hours. Prometheus metrics confirm:
+
+| Hour (UTC) | API Calls | Output Tokens | Est. Input Tokens | Cost |
+|------------|-----------|---------------|-------------------|------|
+| 04:00–05:00 | 25 | 25,216 | ~1.3M | $4.36 |
+| 05:00–06:00 | 29 | 35,026 | ~1.5M | $4.93 |
+| 13:00–14:00 | 5 | 5,576 | ~200K | $1.83 |
+
+Root causes:
+1. **No cost enforcement** — SessionLedger tracks but never halts.
+2. **Sonnet 5 + high thinking** for a casual phone question — no interface-based routing.
+3. **82 tool calls** across 59 assistant turns — no depth limit.
+4. **Context balloon** — tool results (including a 55KB GitHub file read) accumulated in context, causing ~53K tokens per API call average.
+
+## R1: Existing Enforcement Pattern (Alert Agent)
+
+The alert-receiver (`scripts/alert-receiver/`) already implements budget
+enforcement for the alert agent:
+
+- `netclaw_investigation_budget_trips_total{budget="hourly"}` — tracks cap hits
+- `netclaw_investigation_budget_trips_total{budget="concurrent"}` — concurrency gate
+- Alert agent config forces `claude-haiku-4-5` model
+- Alert agent has a restricted tool allowlist
+
+This pattern is correct and proven. It just wasn't extended to conversational
+sessions.
+
+## R2: SessionLedger Architecture (Current State)
+
+`src/netclaw_tokens/session_ledger.py` provides:
+- Thread-safe accumulator (`threading.Lock`)
+- Per-session UUID tracking
+- `total_cost`, `total_input_tokens`, `total_output_tokens`
+- Per-tool breakdown
+- `get_summary()` / `get_gait_summary()` for reporting
+
+What's missing:
+- No `budget_usd` field or `is_over_budget()` check
+- No `tool_calls_this_turn` counter
+- No method to signal "halt" to the caller
+- No configuration loading (budget values are not read from anywhere)
+
+## R3: Gateway Turn-Dispatch Integration Point
+
+The OpenClaw gateway (`openclaw` npm package, running as PID 1483246) dispatches
+model API calls. The `netclaw_tokens` library is invoked as a Python module via
+the gateway's plugin system. The enforcement hook needs to:
+
+1. Be called BEFORE each model API request
+2. Have authority to prevent the request from executing
+3. Return a structured "budget exceeded" response the gateway can surface to the user
+
+The `tokenOptimization` config block in `openclaw.json` is already read by the
+gateway to enable/disable token tracking. Budget config can live alongside it or
+in the agent definition.
+
+## R4: Interface Detection
+
+Sessions arrive via different interfaces, identifiable by session key prefix:
+- `agent:main:openai:*` — OpenAI-compat gateway (iPhone, mobile apps)
+- `agent:main:tui-*` — Terminal UI (desktop)
+- `agent:main:discord:*` — Discord bot
+- `agent:main:n2n` — N2N federation
+- `agent:main:hook:alert:*` — Alert webhooks (already has own agent/budget)
+- `agent:main:explicit:*` — Explicit skill invocations
+
+The interface type is known at session creation time and can be used to select
+model defaults and budget policies.
+
+## R5: Cost Model (Sonnet 5 vs Haiku)
+
+At current pricing:
+- **Sonnet 5**: $3/M input, $15/M output — the $11 session
+- **Haiku 4.5**: $1/M input, $5/M output — would have been ~$3.70 for same tokens
+- **Ollama/local**: $0 — but quality tradeoff for complex reasoning
+
+A mobile-default of Haiku + a $2 session cap would have limited this incident to
+~$2 total (Haiku pricing × 20-tool-call limit before first pause).
+
+## R6: Industry Patterns
+
+- **OpenAI API usage caps**: Hard monthly limits, no per-session granularity
+- **Anthropic API**: Rate limits but no cost caps (that's the client's job)
+- **LangChain callbacks**: `max_iterations` on agent loops, `max_execution_time`
+- **AutoGPT budget**: `--budget` flag that halts at a dollar amount
+- **OpenClaw alert-receiver**: Hourly + concurrent caps (already in this codebase)
+
+The AutoGPT pattern (budget flag → halt + report) is closest to what we need.
+The LangChain `max_iterations` pattern maps to our tool-call-depth limit.

--- a/specs/109-session-budget-guardrails/spec.md
+++ b/specs/109-session-budget-guardrails/spec.md
@@ -1,0 +1,139 @@
+# Feature Specification: Session Budget Enforcement Guardrails
+
+**Feature Branch**: `109-session-budget-guardrails`
+**Created**: 2026-08-14
+**Status**: Draft
+**Input**: Live operational incident — a 7-question conversational session from a mobile (iPhone/N2N) interface generated 59 assistant turns, 82 tool calls, ~3M input tokens, and $11.13 USD in API costs over 2 hours using claude-sonnet-5 with `thinkingLevel: high`. The existing `netclaw_tokens` library tracks and displays costs (observability-only) but never enforces any ceiling. The alert agent has budget guardrails (hourly caps, concurrency limits, cheap model default) but the main agent — which handles all conversational/N2N/phone sessions — has zero cost controls.
+
+## Problem Statement
+
+The `netclaw_tokens` library (`src/netclaw_tokens/`) provides:
+- Token counting per interaction
+- Model-aware cost calculation
+- Session-level cumulative tracking (SessionLedger)
+- GCF serialization for token savings
+- Footer display showing costs to the operator
+
+What it does NOT provide:
+- **Enforcement** — no mechanism halts or downgrades a session when costs exceed a threshold
+- **Per-interface routing** — mobile/N2N sessions inherit the same expensive model as desktop
+- **Tool-call depth limits** — an agentic chain can run unlimited tool calls per user message
+- **Context growth control** — tool results accumulate in context forever, causing input tokens to balloon quadratically across turns
+
+The alert agent (`agents.list[1]`) demonstrates the correct pattern: it uses `claude-haiku-4-5`, has a restricted tool allowlist, and the alert-receiver enforces hourly/concurrent budget caps via `netclaw_investigation_budget_trips_total`. This feature extends that pattern to ALL agent sessions.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Session cost cap halts runaway spending (Priority: P1)
+
+As a NetClaw operator, I want a configurable per-session cost ceiling so that when cumulative spending in a single session exceeds my threshold (e.g., $2.00), the agent stops tool-calling and informs me it has hit the budget — rather than silently burning $11+ on a casual phone question.
+
+**Why this priority**: This is the exact failure that occurred. A cost cap alone would have limited the damage from $11 to $2 without any other changes.
+
+**Independent Test**: Start a session, configure a $0.50 budget cap, issue a question that would normally trigger expensive multi-tool chains. Verify the agent halts after reaching the cap and returns a budget-exceeded message with the accumulated cost summary.
+
+**Acceptance Scenarios**:
+
+1. **Given** a session with `session_budget_usd: 2.0` configured, **When** cumulative cost (tracked by SessionLedger) exceeds $2.00, **Then** the agent stops making further API calls and returns a message indicating the budget was reached, including the cost breakdown.
+2. **Given** a session with no explicit budget configured, **When** costs accumulate, **Then** the system uses a sensible default ceiling (e.g., $5.00) rather than unlimited.
+3. **Given** a session that has been budget-halted, **When** the operator explicitly requests continuation (e.g., "continue" or "override budget"), **Then** the budget resets or extends by the configured increment, allowing the session to proceed.
+4. **Given** a budget halt occurs mid-tool-chain, **When** the agent stops, **Then** it provides a partial summary of what it accomplished before the halt, not a raw error.
+
+---
+
+### User Story 2 - Tool-call depth limit per user message (Priority: P2)
+
+As a NetClaw operator, I want a configurable maximum number of tool calls per user message so that a single question cannot trigger a 59-turn, 82-tool-call exploration — the agent must summarize its findings and ask for direction after N tool calls instead of running indefinitely.
+
+**Why this priority**: Even with a cost cap, unbounded tool chains waste tokens on low-value exploration. A depth limit forces the agent to be deliberate about which tools it invokes.
+
+**Independent Test**: Configure `max_tool_calls_per_turn: 15`. Issue a question that would normally generate 50+ tool calls. Verify the agent stops after 15 tool calls, summarizes findings so far, and asks whether to continue.
+
+**Acceptance Scenarios**:
+
+1. **Given** `max_tool_calls_per_turn: 15` configured, **When** a user message triggers tool use, **Then** the agent executes at most 15 tool calls before pausing and presenting intermediate results.
+2. **Given** the tool-call limit is reached, **When** the agent pauses, **Then** it summarizes what was found so far and asks "Should I continue investigating?" rather than silently stopping.
+3. **Given** the operator says "yes, continue", **When** the agent resumes, **Then** the tool-call counter resets for the next batch of N calls.
+4. **Given** no explicit tool-call limit is configured, **Then** a sensible default applies (e.g., 20 tool calls per user message).
+
+---
+
+### User Story 3 - Per-interface model routing (Priority: P3)
+
+As a NetClaw operator, I want different model defaults based on the session interface (mobile/N2N vs. desktop/TUI vs. alert) so that casual phone questions use a cheaper model by default while I can still explicitly request an expensive model when needed.
+
+**Why this priority**: Model routing prevents the problem at the source — if mobile sessions default to Haiku ($1/M in, $5/M out) instead of Sonnet 5 ($3/$15), the same 59-turn session would have cost ~$2 instead of $11. But it's P3 because cost caps (P1) and tool limits (P2) provide protection regardless of model choice.
+
+**Independent Test**: Send a message via the OpenAI-compat/N2N interface without an explicit model override. Verify it routes to the configured mobile-default model (e.g., haiku). Then send a message with an explicit "use sonnet" prefix and verify it upgrades.
+
+**Acceptance Scenarios**:
+
+1. **Given** `interface_defaults.mobile.model: "anthropic/claude-haiku-4-5"` configured, **When** a session arrives via the OpenAI-compat gateway (N2N/mobile), **Then** it uses Haiku unless the user explicitly requests a different model.
+2. **Given** a mobile session using Haiku, **When** the user says "use sonnet for this" or equivalent escalation command, **Then** the model upgrades for that session only.
+3. **Given** a TUI/desktop session, **When** no interface default is configured for that interface, **Then** it falls back to the agent's `model.primary` setting (existing behavior, no regression).
+4. **Given** an explicit model override in the message, **Then** it always takes precedence over interface defaults.
+
+---
+
+### User Story 4 - Context growth awareness (Priority: P4)
+
+As a NetClaw operator, I want the session to emit a warning (and optionally auto-summarize) when accumulated context size exceeds a threshold, so I'm aware that continued conversation will be expensive and can choose to start fresh.
+
+**Why this priority**: This is a UX improvement that helps operators make informed decisions. The cost cap (P1) provides hard protection; this provides soft awareness before the cap is hit.
+
+**Independent Test**: Configure `context_warning_tokens: 100000`. Have a multi-turn session that accumulates large tool results. Verify a warning is emitted when context crosses 100K tokens, showing the approximate cost-per-turn going forward.
+
+**Acceptance Scenarios**:
+
+1. **Given** `context_warning_tokens: 100000` configured, **When** cumulative session context exceeds 100K tokens, **Then** the agent emits an inline warning showing current context size and approximate cost-per-additional-turn.
+2. **Given** the warning has been shown, **When** context doubles again (200K), **Then** a stronger warning suggests starting a new session or summarizing.
+3. **Given** `context_auto_summarize: true` configured, **When** context exceeds the threshold, **Then** old tool results are summarized into a compact form before being re-sent as context.
+
+---
+
+### Edge Cases
+
+- What happens when the cost cap is hit mid-sentence (during streaming)? → The current turn completes, but no further turns are initiated.
+- What happens if the Prometheus metrics exporter is down and cost tracking fails? → SessionLedger is in-process (thread-safe Python); it doesn't depend on Prometheus. Enforcement works regardless of metrics export.
+- What happens if multiple sessions run concurrently against the same API key? → Each session has its own SessionLedger instance. Budgets are per-session, not global (global daily caps are a future enhancement, not in scope here).
+- What happens if the model price changes between config reload and enforcement? → The cost calculator re-reads pricing on each call; enforcement uses real-time cost, not stale values.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: SessionLedger MUST expose an `is_over_budget()` method that returns True when `total_cost` exceeds the configured session ceiling.
+- **FR-002**: The gateway's turn-dispatch loop MUST check `is_over_budget()` before sending a new request to the model API and halt gracefully if True.
+- **FR-003**: A budget halt MUST produce a user-visible message including: accumulated cost, token counts, top tools by cost, and whether continuation is available.
+- **FR-004**: SessionLedger MUST expose a `tool_calls_this_turn` counter that resets on each user message and is checked before each tool invocation.
+- **FR-005**: Budget configuration MUST be expressible in `openclaw.json` under `agents.defaults` and overridable per-agent in `agents.list[]`.
+- **FR-006**: Interface-based model routing MUST be configurable via a new `agents.defaults.interfaceDefaults` map keyed by interface type (e.g., `openai`, `tui`, `n2n`, `discord`).
+- **FR-007**: Budget enforcement MUST emit a Prometheus counter (`netclaw_session_budget_trips_total`) with labels `{agent, reason}` where reason is `cost_cap` or `tool_limit`, consistent with the existing `netclaw_investigation_budget_trips_total` pattern.
+- **FR-008**: The context warning system MUST calculate approximate tokens from the session message history without requiring an API call (use the existing `count_tokens` estimator).
+- **FR-009**: Budget override/continuation MUST require an explicit user action (not automatic) — the agent must not silently resume spending.
+- **FR-010**: All budget settings MUST have documented defaults that are safe for a hobbyist/personal deployment (e.g., $5 session cap, 20 tool calls per turn).
+
+### Key Entities
+
+- **BudgetPolicy**: Configuration object holding `session_budget_usd`, `max_tool_calls_per_turn`, `context_warning_tokens`, `context_auto_summarize`. Lives in `openclaw.json`.
+- **SessionLedger** (existing): Extended with budget-checking methods and turn-level tool-call tracking.
+- **InterfaceDefaults**: Map of interface type → model/thinkingLevel/budgetPolicy overrides.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A session that would previously accumulate >$5 in costs is halted at or below the configured ceiling (±10% tolerance for in-flight completion).
+- **SC-002**: No session can execute more than `max_tool_calls_per_turn` tool calls without operator confirmation, default 20.
+- **SC-003**: Mobile/N2N sessions default to a model costing ≤$1/M input tokens unless explicitly overridden.
+- **SC-004**: The `netclaw_session_budget_trips_total` counter increments on every halt, enabling Prometheus-based alerting on runaway sessions.
+- **SC-005**: Zero regression for existing alert-agent behavior — its existing budget enforcement (via alert-receiver) continues unchanged.
+- **SC-006**: A repeat of the $11 incident scenario (7 phone questions, agentic tool chains) results in ≤$2 total cost with default settings.
+
+## Assumptions
+
+- The OpenClaw gateway's turn-dispatch loop is the correct enforcement point (it already calls the model API and receives responses).
+- SessionLedger is instantiated per-session and persists for the session lifetime (confirmed by code review — it's a class instance, not a global singleton).
+- The `openclaw.json` config is the appropriate place for budget settings (it already holds model config, agent definitions, and the tokenOptimization block).
+- Prompt caching is already active and will continue to reduce costs for repeated context — budget enforcement accounts for actual cost (post-cache-discount), not theoretical worst-case.
+- This feature is library-level (src/netclaw_tokens/) and configuration-level (openclaw.json schema) — it does not require changes to the OpenClaw gateway binary itself (enforcement hooks are called by the gateway's existing plugin/middleware system).

--- a/specs/109-session-budget-guardrails/spec.md
+++ b/specs/109-session-budget-guardrails/spec.md
@@ -130,10 +130,103 @@ As a NetClaw operator, I want the session to emit a warning (and optionally auto
 - **SC-005**: Zero regression for existing alert-agent behavior — its existing budget enforcement (via alert-receiver) continues unchanged.
 - **SC-006**: A repeat of the $11 incident scenario (7 phone questions, agentic tool chains) results in ≤$2 total cost with default settings.
 
+---
+
+### User Story 5 - Budget protection works out of the box (Priority: P1-B)
+
+As a new NetClaw operator installing the system for the first time, I want budget enforcement to be active by default with safe limits — so that I never get a surprise API bill before I even know the budget feature exists.
+
+**Why this priority**: Equal to P1. If the feature exists but requires manual setup, most operators will discover it AFTER the surprise bill, which defeats the purpose entirely.
+
+**Independent Test**: Fresh install of NetClaw with no budget-related configuration in openclaw.json. Send 30+ messages via the OpenAI-compat interface. Verify that budget enforcement activates at the default $5 ceiling without any operator action.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh NetClaw installation with no `budget` section in openclaw.json, **When** a session accumulates costs, **Then** the default $5 cap is enforced automatically.
+2. **Given** the `token-tracker` skill is loaded (which it is by default), **When** the session starts, **Then** `BudgetPolicy` is initialized from defaults without requiring any explicit configuration.
+3. **Given** an operator upgrades NetClaw to a version containing this feature, **When** they restart the gateway, **Then** budget enforcement is active on the next session with no migration step required.
+
+---
+
+### User Story 6 - Operator sees budget status in the HUD (Priority: P2-B)
+
+As a NetClaw operator, I want to see my session's spending status in real time in the HUD footer — remaining budget, cost-per-turn, and a visual indicator when approaching the cap — so I can make informed decisions without waiting for a hard stop.
+
+**Why this priority**: The HUD is the operator's primary interface. Budget status that's invisible until it halts is a jarring experience. Seeing "Budget: $2.10 / $5.00" in the footer gives the operator agency.
+
+**Independent Test**: Open the HUD while a session is active. Verify the footer shows current session cost, budget ceiling, and a color indicator (green → yellow → red as cost approaches ceiling).
+
+**Acceptance Scenarios**:
+
+1. **Given** a session is active, **When** the operator views the HUD, **Then** the footer shows `Budget: $X.XX / $Y.YY` with the current session cost and ceiling.
+2. **Given** the session cost exceeds 70% of the budget, **When** the HUD refreshes, **Then** the budget indicator turns yellow/amber.
+3. **Given** the session has been halted by a budget trip, **When** the HUD refreshes, **Then** a clear "BUDGET PAUSED" indicator is shown with the halt reason.
+4. **Given** the operator wants to adjust the budget, **When** they click the budget indicator in the HUD, **Then** they can set a new ceiling for the current session (or globally) without editing JSON.
+
+---
+
+### User Story 7 - Budget configuration via HUD (Priority: P3-B)
+
+As a NetClaw operator, I want to configure my budget caps and model routing through the HUD settings panel — so I never have to SSH into a box and edit openclaw.json by hand to adjust spending limits.
+
+**Why this priority**: Configuration through the UI is the "reality wrapper" that makes this feature accessible. Without it, only operators comfortable with JSON config files benefit.
+
+**Independent Test**: Open the HUD settings. Adjust the session budget from $5 to $10. Start a new session and verify the new budget applies.
+
+**Acceptance Scenarios**:
+
+1. **Given** the HUD is open, **When** the operator navigates to settings/budget, **Then** they see current budget policy values (session cap, tool-call limit, interface defaults) in editable fields.
+2. **Given** the operator changes the session budget in the HUD, **When** they save, **Then** the value is persisted to openclaw.json and applies to the next session.
+3. **Given** the operator wants per-interface routing, **When** they configure "Mobile model: Haiku" in the HUD, **Then** subsequent openai/n2n sessions use Haiku.
+
+---
+
+## Integration Architecture
+
+### How enforcement actually works (gateway integration)
+
+The OpenClaw gateway is a Node.js process. The `netclaw_tokens` Python library is consumed via the **token-tracker skill** — the gateway's agent runtime loads the skill which imports and uses the library. The enforcement flow:
+
+```
+User message arrives
+  → Gateway identifies session key → resolve_session_config() → BudgetPolicy
+  → SessionLedger initialized (or resumed) with BudgetPolicy
+  → new_turn() called (resets tool-call counter)
+  → For each model API call or tool invocation:
+      → check_budget() → (should_halt, reason)
+      → If should_halt: return halt message to user, emit Prometheus metric, stop
+      → If OK: proceed with call, record tokens/cost, record_tool_call()
+```
+
+The skill (not the gateway binary) is the enforcement point. This means:
+- No changes to the OpenClaw npm package required
+- Enforcement is opt-out (remove the skill) rather than requiring opt-in
+- The skill ships with the `workspace/skills/` directory on install
+
+### HUD integration
+
+The HUD server (`ui/netclaw-visual/server.js`) already serves `/api/gateway/status` and `/api/sessions`. Budget status is exposed via:
+- New endpoint: `GET /api/budget/status` — returns current session cost, ceiling, halt state
+- New endpoint: `PUT /api/budget/config` — updates budget policy in openclaw.json
+- Footer element: `<span>Budget <strong id="footer-budget">--</strong></span>`
+- WebSocket event: budget status pushed on each model call completion
+
+### Install story
+
+On fresh install or upgrade:
+1. The `token-tracker` skill (already default) is extended to include budget enforcement
+2. `BudgetPolicy()` with no args produces safe defaults ($5 cap, 20 tool calls)
+3. No openclaw.json section needed — absence of config = defaults apply
+4. The env var `NETCLAW_SESSION_BUDGET_USD` works immediately for quick overrides
+5. The HUD shows budget status as soon as the gateway is running
+
+**Zero configuration required. Safe by default. Configurable via UI.**
+
 ## Assumptions
 
-- The OpenClaw gateway's turn-dispatch loop is the correct enforcement point (it already calls the model API and receives responses).
+- The token-tracker skill is the correct enforcement integration point (it already wraps every model API call for token counting — budget checking is a single additional function call at the same site).
 - SessionLedger is instantiated per-session and persists for the session lifetime (confirmed by code review — it's a class instance, not a global singleton).
 - The `openclaw.json` config is the appropriate place for budget settings (it already holds model config, agent definitions, and the tokenOptimization block).
 - Prompt caching is already active and will continue to reduce costs for repeated context — budget enforcement accounts for actual cost (post-cache-discount), not theoretical worst-case.
-- This feature is library-level (src/netclaw_tokens/) and configuration-level (openclaw.json schema) — it does not require changes to the OpenClaw gateway binary itself (enforcement hooks are called by the gateway's existing plugin/middleware system).
+- The HUD server already reads/writes openclaw.json (confirmed — `/api/env` endpoint pattern) and can extend to budget config.
+- The token-tracker skill is loaded by default on new installs (confirmed — it's in `workspace/skills/`).

--- a/specs/109-session-budget-guardrails/tasks.md
+++ b/specs/109-session-budget-guardrails/tasks.md
@@ -87,12 +87,54 @@
 
 ---
 
-## Phase 7: Polish & Integration
+## Phase 7: User Story 5 — Zero-config install (Priority: P1-B) 🎯 Critical Path
 
-- [ ] T026 [P] Add `BudgetPolicy` and all new SessionLedger methods to the module docstring in `__init__.py`
-- [ ] T027 [P] Update `requirements.txt` in `src/netclaw_tokens/` if any new dependencies are needed (likely none — this is pure Python)
-- [ ] T028 Add example `openclaw.json` budget configuration to `config/` or document in existing config file comments
-- [ ] T029 [P] Add Prometheus metric documentation: `netclaw_session_budget_trips_total` counter spec (labels: agent, reason, interface) — document in a metrics section of the feature docs, matching the existing `netclaw_investigation_budget_trips_total` pattern
+**Goal**: Budget enforcement works immediately on fresh install with no operator action.
+
+- [ ] T026 [US5] Extend the existing `token-tracker` SKILL.md in `workspace/skills/token-tracker/` to document budget enforcement as part of the skill's responsibilities — this is the integration point, not a separate skill
+- [ ] T027 [US5] In the token-tracker skill's workflow, add a step: "Before each model API call, check `session_ledger.check_budget()` — if halted, return `get_halt_message()` to the user instead of proceeding"
+- [ ] T028 [US5] In the token-tracker skill's workflow, add: "On each user message, call `session_ledger.new_turn()` to reset the tool-call counter"
+- [ ] T029 [US5] In the token-tracker skill's workflow, add: "On each tool invocation, call `session_ledger.record_tool_call()` before executing the tool"
+- [ ] T030 [US5] Ensure `SessionLedger()` with no `budget` argument defaults to `BudgetPolicy()` with $5 cap / 20 tool calls — verified by existing test T012
+- [ ] T031 [P] [US5] Add integration test: simulate a session with no budget config in openclaw.json, record costs exceeding $5, verify `check_budget()` returns halt
+
+**Checkpoint**: Fresh install has enforcement active. The skill handles it. No config needed.
+
+---
+
+## Phase 8: User Story 6 — HUD budget display (Priority: P2-B)
+
+**Goal**: Operator sees real-time budget status in the HUD.
+
+- [ ] T032 [US6] In `ui/netclaw-visual/server.js`, add `GET /api/budget/status` endpoint that reads the current session's cost/budget state (reads from the sessions directory + openclaw.json defaults)
+- [ ] T033 [US6] In `ui/netclaw-visual/index.html`, add a budget element to the footer: `<span>Budget <strong id="footer-budget">--</strong></span>`
+- [ ] T034 [US6] In `ui/netclaw-visual/src/main.js`, add polling logic that fetches `/api/budget/status` and updates `#footer-budget` with cost/ceiling display and color coding (green <50%, yellow 50-80%, red >80%, pulsing red = halted)
+- [ ] T035 [P] [US6] Add CSS for budget indicator states in `src/styles/` — color transitions matching the existing HUD aesthetic (cyan/green/amber/red palette)
+
+**Checkpoint**: HUD footer shows live budget status. Operator has visibility without CLI.
+
+---
+
+## Phase 9: User Story 7 — HUD budget configuration (Priority: P3-B)
+
+**Goal**: Operator can adjust budget caps from the HUD without editing JSON.
+
+- [ ] T036 [US7] In `ui/netclaw-visual/server.js`, add `PUT /api/budget/config` endpoint that writes budget policy values to openclaw.json (following the existing `/api/env` PUT pattern for safe config updates)
+- [ ] T037 [US7] In `ui/netclaw-visual/server.js`, add `GET /api/budget/config` endpoint that reads current budget policy (merged: defaults + openclaw.json + env var)
+- [ ] T038 [US7] Add a budget settings section to the HUD sidebar or detail panel — fields for session cap, tool-call limit, and per-interface model dropdown
+- [ ] T039 [P] [US7] Wire the settings UI to PUT `/api/budget/config` on save, with optimistic update and error handling
+
+**Checkpoint**: Full self-service. Operator can discover, view, and change budget settings from the HUD.
+
+---
+
+## Phase 10: Polish & Cross-Cutting Concerns
+
+- [ ] T040 [P] Add `BudgetPolicy` and all new SessionLedger methods to the module docstring in `__init__.py`
+- [ ] T041 [P] Update `requirements.txt` in `src/netclaw_tokens/` if any new dependencies are needed (likely none — this is pure Python)
+- [ ] T042 Add example `openclaw.json` budget configuration to `config/` or document in existing config file comments
+- [ ] T043 [P] Add Prometheus metric documentation: `netclaw_session_budget_trips_total` counter spec (labels: agent, reason, interface) — document in a metrics section of the feature docs, matching the existing `netclaw_investigation_budget_trips_total` pattern
+- [ ] T044 [P] Update the quickstart.md with the "operator story" — what they see on first boot, what the HUD shows, how to adjust if needed
 
 ---
 
@@ -106,16 +148,26 @@
 - **US2 (Phase 4)**: Depends on Phase 2 (needs BudgetPolicy), can parallel with Phase 3
 - **US3 (Phase 5)**: Depends on Phase 2 (extends BudgetPolicy)
 - **US4 (Phase 6)**: Depends on Phase 3 (uses SessionLedger extensions)
-- **Polish (Phase 7)**: Depends on all above
+- **US5 Zero-config (Phase 7)**: Depends on Phase 3 + 4 (needs enforcement methods to exist)
+- **US6 HUD display (Phase 8)**: Depends on Phase 7 (needs working enforcement to display)
+- **US7 HUD config (Phase 9)**: Depends on Phase 8 (needs the display to configure against)
+- **Polish (Phase 10)**: Depends on all above
 
-### MVP Delivery
+### Critical Path (MVP that prevents the $11 incident)
 
-Phase 1 + Phase 2 + Phase 3 = functional cost cap enforcement.
-This alone would have prevented the $11 incident.
+Phase 1 → Phase 2 → Phase 3 → Phase 4 → **Phase 7** = enforcement active on install.
+
+Phases 3+4 are the library. Phase 7 is what actually hooks it into the runtime.
+**Without Phase 7, the library is dead code.** This is the real MVP, not just the library.
+
+### Full Feature (operator delight)
+
+Add Phase 8 (HUD display) for visibility, Phase 9 (HUD config) for self-service.
 
 ### Parallel Opportunities
 
 - T001 and T002 can run in parallel (different files)
 - T004 and T005 can run in parallel with T003 (different files)
 - Phase 3 and Phase 4 can run in parallel (different methods, no shared state)
+- Phase 8 and Phase 5 can run in parallel (HUD is frontend, routing is library)
 - All test tasks marked [P] can run alongside their implementation tasks

--- a/specs/109-session-budget-guardrails/tasks.md
+++ b/specs/109-session-budget-guardrails/tasks.md
@@ -1,0 +1,121 @@
+# Tasks: Session Budget Enforcement Guardrails
+
+**Input**: Design documents from `/specs/109-session-budget-guardrails/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+**Tests**: Included — unit tests for enforcement logic, integration test for halt behavior.
+
+## Format: `[ID] [P?] [Story] Description`
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 [P] Add `NETCLAW_SESSION_BUDGET_USD` to `.env.example` with default `5.0` and inline comment explaining its purpose
+- [ ] T002 [P] Document the budget enforcement feature in `docs/` or `README.md` — operator-facing explanation of what happens when a cap is hit
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+- [ ] T003 Create `src/netclaw_tokens/budget_policy.py` with `BudgetPolicy` dataclass (fields per data-model.md §1) and `load_budget_policy(config: dict, interface_type: str | None = None) -> BudgetPolicy` function that resolves agent-level → interface-level → env-var overrides in correct precedence
+- [ ] T004 [P] In `src/netclaw_tokens/__init__.py`, add `BudgetPolicy` to exports and `__all__`, add lazy import for `load_budget_policy`
+- [ ] T005 [P] Unit test `tests/test_budget_policy.py`: verify default construction, config override loading, env-var precedence, interface-specific override resolution
+
+**Checkpoint**: BudgetPolicy dataclass + loader exist and are tested. No enforcement yet.
+
+---
+
+## Phase 3: User Story 1 — Session cost cap halts runaway spending (Priority: P1) 🎯 MVP
+
+**Goal**: When cumulative session cost exceeds the configured ceiling, the agent halts and reports.
+
+**Independent Test**: Instantiate SessionLedger with a $0.50 budget, record costs totaling $0.60, verify `is_over_budget()` returns True and `get_halt_message()` returns a formatted summary.
+
+- [ ] T006 [US1] Extend `SessionLedger.__init__()` to accept an optional `budget: BudgetPolicy` parameter (defaults to `BudgetPolicy()` if not provided — zero regression for existing callers that don't pass it)
+- [ ] T007 [US1] Add `is_over_budget() -> bool` method to SessionLedger — returns `self.total_cost >= self.budget.session_budget_usd`
+- [ ] T008 [US1] Add `budget_halted: bool = False` and `halt_reason: Optional[str] = None` fields to SessionLedger
+- [ ] T009 [US1] Add `check_budget() -> tuple[bool, str | None]` method that sets `budget_halted` and `halt_reason` if over budget, returns `(should_halt, reason)` — this is the method the gateway calls before each API request
+- [ ] T010 [US1] Add `get_halt_message() -> str` method that formats a user-facing budget-exceeded message including: total cost, token counts, top 5 tools by cost, and continuation instructions
+- [ ] T011 [US1] Add `override_budget()` method that extends `budget.session_budget_usd` by `budget.override_increment_usd` and clears `budget_halted`/`halt_reason`
+- [ ] T012 [P] [US1] Unit test `tests/test_session_budget.py`: test `is_over_budget()` returns False below cap and True at/above cap; test `check_budget()` sets halt state; test `override_budget()` clears halt and extends ceiling; test `get_halt_message()` produces non-empty formatted string
+
+**Checkpoint**: SessionLedger enforces cost caps. Gateway integration is the caller's responsibility (the library provides the check, the gateway acts on it).
+
+---
+
+## Phase 4: User Story 2 — Tool-call depth limit (Priority: P2)
+
+**Goal**: Limit tool calls per user message to prevent unbounded agentic exploration.
+
+**Independent Test**: Configure `max_tool_calls_per_turn: 5`, call `record_tool_call()` 6 times, verify `is_over_tool_limit()` returns True on the 6th call.
+
+- [ ] T013 [US2] Add `tool_calls_this_turn: int = 0` field to SessionLedger
+- [ ] T014 [US2] Add `new_turn()` method that resets `tool_calls_this_turn` to 0 (called by gateway on each user message)
+- [ ] T015 [US2] Add `record_tool_call()` method that increments `tool_calls_this_turn`
+- [ ] T016 [US2] Add `is_over_tool_limit() -> bool` method — returns `self.tool_calls_this_turn >= self.budget.max_tool_calls_per_turn`
+- [ ] T017 [US2] Extend `check_budget()` to also check tool-call limit (returns `(True, "tool_limit")` if exceeded)
+- [ ] T018 [P] [US2] Unit test: verify `new_turn()` resets counter; verify limit triggers at configured threshold; verify `check_budget()` catches both cost and tool-limit independently
+
+**Checkpoint**: Both cost cap and tool-call limit are enforced via the same `check_budget()` interface.
+
+---
+
+## Phase 5: User Story 3 — Per-interface model routing (Priority: P3)
+
+**Goal**: Different interfaces (mobile, desktop, discord) get different default models.
+
+**Independent Test**: Call `load_budget_policy(config, interface_type="openai")` with an interfaceDefaults config that sets Haiku for openai. Verify the returned policy reflects the mobile model setting.
+
+- [ ] T019 [US3] Extend `BudgetPolicy` with optional `model: str | None = None` and `thinking_level: str | None = None` fields (these are routing hints, not enforcement — the gateway reads them at session init)
+- [ ] T020 [US3] In `budget_policy.py`, extend `load_budget_policy()` to resolve `interfaceDefaults.<type>.model` and `interfaceDefaults.<type>.thinkingLevel` into the returned BudgetPolicy
+- [ ] T021 [US3] Add a top-level `resolve_session_config(config: dict, session_key: str) -> BudgetPolicy` function that parses the session key to determine interface type and calls `load_budget_policy()` with it
+- [ ] T022 [P] [US3] Unit test: verify interface detection from session key patterns; verify model routing for openai/n2n/tui/discord; verify fallback to defaults when no interface-specific config exists
+
+**Checkpoint**: Library provides a one-call function (`resolve_session_config`) that returns the full budget policy + model routing for any session.
+
+---
+
+## Phase 6: User Story 4 — Context growth awareness (Priority: P4)
+
+**Goal**: Warn operators when context size makes continued conversation expensive.
+
+- [ ] T023 [US4] Add `should_warn_context(context_tokens: int) -> bool` method to SessionLedger — returns True when `context_tokens >= budget.context_warning_tokens`
+- [ ] T024 [US4] Add `get_context_warning(context_tokens: int, model: str) -> str` method that formats a warning including current context size, approximate cost-per-turn at current model pricing, and suggestion to start fresh
+- [ ] T025 [P] [US4] Unit test: verify warning triggers at threshold, not below; verify message includes cost estimate
+
+**Checkpoint**: Context warnings available. Auto-summarize (context_auto_summarize) is documented as a future enhancement hook but not implemented in this PR (marked in spec as P4).
+
+---
+
+## Phase 7: Polish & Integration
+
+- [ ] T026 [P] Add `BudgetPolicy` and all new SessionLedger methods to the module docstring in `__init__.py`
+- [ ] T027 [P] Update `requirements.txt` in `src/netclaw_tokens/` if any new dependencies are needed (likely none — this is pure Python)
+- [ ] T028 Add example `openclaw.json` budget configuration to `config/` or document in existing config file comments
+- [ ] T029 [P] Add Prometheus metric documentation: `netclaw_session_budget_trips_total` counter spec (labels: agent, reason, interface) — document in a metrics section of the feature docs, matching the existing `netclaw_investigation_budget_trips_total` pattern
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies
+- **Foundational (Phase 2)**: No dependencies (BudgetPolicy is standalone)
+- **US1 (Phase 3)**: Depends on Phase 2 (needs BudgetPolicy)
+- **US2 (Phase 4)**: Depends on Phase 2 (needs BudgetPolicy), can parallel with Phase 3
+- **US3 (Phase 5)**: Depends on Phase 2 (extends BudgetPolicy)
+- **US4 (Phase 6)**: Depends on Phase 3 (uses SessionLedger extensions)
+- **Polish (Phase 7)**: Depends on all above
+
+### MVP Delivery
+
+Phase 1 + Phase 2 + Phase 3 = functional cost cap enforcement.
+This alone would have prevented the $11 incident.
+
+### Parallel Opportunities
+
+- T001 and T002 can run in parallel (different files)
+- T004 and T005 can run in parallel with T003 (different files)
+- Phase 3 and Phase 4 can run in parallel (different methods, no shared state)
+- All test tasks marked [P] can run alongside their implementation tasks

--- a/src/netclaw_tokens/__init__.py
+++ b/src/netclaw_tokens/__init__.py
@@ -98,6 +98,7 @@ __all__ = [
     "GCFResponse",
     "TOONResponse",  # legacy alias
     "ToolUsageRecord",
+    "BudgetPolicy",
     # Functions (lazy imports to avoid circular dependencies)
     "count_tokens",
     "count_message_tokens",
@@ -105,6 +106,8 @@ __all__ = [
     "get_pricing",
     "serialize_response",
     "format_footer",
+    "load_budget_policy",
+    "resolve_session_config",
     # Classes
     "SessionLedger",
 ]
@@ -127,4 +130,10 @@ def __getattr__(name: str):
     if name == "SessionLedger":
         from .session_ledger import SessionLedger
         return SessionLedger
+    if name == "BudgetPolicy":
+        from .budget_policy import BudgetPolicy
+        return BudgetPolicy
+    if name in ("load_budget_policy", "resolve_session_config"):
+        from .budget_policy import load_budget_policy, resolve_session_config
+        return load_budget_policy if name == "load_budget_policy" else resolve_session_config
     raise AttributeError(f"module 'netclaw_tokens' has no attribute {name!r}")

--- a/src/netclaw_tokens/budget_policy.py
+++ b/src/netclaw_tokens/budget_policy.py
@@ -1,0 +1,184 @@
+"""Budget enforcement policy for NetClaw sessions.
+
+Provides configurable per-session cost ceilings, tool-call depth limits,
+and per-interface model routing. Loads configuration from openclaw.json
+with environment variable overrides.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+logger = logging.getLogger("netclaw_tokens.budget_policy")
+
+__all__ = ["BudgetPolicy", "load_budget_policy", "resolve_session_config"]
+
+# ---------------------------------------------------------------------------
+# Interface detection patterns (from session key)
+# ---------------------------------------------------------------------------
+_INTERFACE_PATTERNS = [
+    (re.compile(r"^agent:[^:]+:openai:"), "openai"),
+    (re.compile(r"^agent:[^:]+:tui-"), "tui"),
+    (re.compile(r"^agent:[^:]+:discord:"), "discord"),
+    (re.compile(r"^agent:[^:]+:n2n"), "n2n"),
+    (re.compile(r"^agent:[^:]+:hook:alert:"), "alert"),
+    (re.compile(r"^agent:[^:]+:explicit:"), "explicit"),
+]
+
+
+@dataclass
+class BudgetPolicy:
+    """Per-session budget enforcement configuration.
+
+    Attributes:
+        session_budget_usd: Maximum USD cost before the session is halted.
+        max_tool_calls_per_turn: Maximum tool invocations per user message
+            before the agent pauses and asks whether to continue.
+        context_warning_tokens: Emit a warning when session context exceeds
+            this many tokens.
+        context_auto_summarize: If True, old tool results are summarized
+            when context exceeds the warning threshold (future enhancement).
+        allow_override: Whether the operator can say "continue" after a halt.
+        override_increment_usd: How much budget extends on each override.
+        model: Optional model override for this interface/session.
+        thinking_level: Optional thinking-level override (low/medium/high).
+    """
+
+    session_budget_usd: float = 5.0
+    max_tool_calls_per_turn: int = 20
+    context_warning_tokens: int = 100_000
+    context_auto_summarize: bool = False
+    allow_override: bool = True
+    override_increment_usd: float = 2.0
+    model: Optional[str] = None
+    thinking_level: Optional[str] = None
+
+
+def detect_interface_type(session_key: str) -> Optional[str]:
+    """Detect the interface type from a session key string.
+
+    Args:
+        session_key: OpenClaw session key (e.g., "agent:main:openai:abc123")
+
+    Returns:
+        Interface type string or None if unrecognized.
+    """
+    for pattern, iface_type in _INTERFACE_PATTERNS:
+        if pattern.match(session_key):
+            return iface_type
+    return None
+
+
+def load_budget_policy(
+    config: Dict,
+    interface_type: Optional[str] = None,
+) -> BudgetPolicy:
+    """Load a BudgetPolicy from openclaw.json config with layered overrides.
+
+    Resolution order (later wins):
+    1. BudgetPolicy defaults (hardcoded)
+    2. agents.defaults.budget (from config)
+    3. interfaceDefaults.<type>.budget (if interface_type provided)
+    4. Environment variable NETCLAW_SESSION_BUDGET_USD (cost cap only)
+
+    Args:
+        config: Parsed openclaw.json as a dict (or the agents.defaults subtree).
+        interface_type: Detected interface type for per-interface overrides.
+
+    Returns:
+        Fully resolved BudgetPolicy.
+    """
+    policy = BudgetPolicy()
+
+    # Layer 1: agents.defaults.budget
+    agents_config = config.get("agents", config)
+    defaults = agents_config.get("defaults", {})
+    budget_config = defaults.get("budget", {})
+
+    if budget_config:
+        _apply_budget_dict(policy, budget_config)
+
+    # Layer 2: interfaceDefaults.<type>
+    if interface_type:
+        iface_defaults = defaults.get("interfaceDefaults", {})
+        iface_config = iface_defaults.get(interface_type, {})
+
+        if iface_config:
+            # Model/thinking routing
+            if "model" in iface_config:
+                policy.model = iface_config["model"]
+            if "thinkingLevel" in iface_config:
+                policy.thinking_level = iface_config["thinkingLevel"]
+
+            # Per-interface budget overrides
+            iface_budget = iface_config.get("budget", {})
+            if iface_budget:
+                _apply_budget_dict(policy, iface_budget)
+
+    # Layer 3: Environment variable override (highest precedence for cost cap)
+    env_budget = os.environ.get("NETCLAW_SESSION_BUDGET_USD", "")
+    if env_budget:
+        try:
+            policy.session_budget_usd = float(env_budget)
+        except (ValueError, TypeError):
+            logger.warning(
+                "NETCLAW_SESSION_BUDGET_USD='%s' is not a valid float; ignoring",
+                env_budget,
+            )
+
+    return policy
+
+
+def resolve_session_config(config: Dict, session_key: str) -> BudgetPolicy:
+    """One-call function: detect interface from session key and load policy.
+
+    This is the primary entry point for the gateway to get a fully resolved
+    budget policy for a new session.
+
+    Args:
+        config: Parsed openclaw.json dict.
+        session_key: Full session key (e.g., "agent:main:openai:abc123").
+
+    Returns:
+        BudgetPolicy with all overrides applied.
+    """
+    interface_type = detect_interface_type(session_key)
+    return load_budget_policy(config, interface_type)
+
+
+def _apply_budget_dict(policy: BudgetPolicy, budget_dict: Dict) -> None:
+    """Apply a budget config dict onto an existing BudgetPolicy (mutates in place).
+
+    Handles both camelCase (JSON config) and snake_case (Python) field names.
+    """
+    field_map = {
+        "sessionBudgetUsd": "session_budget_usd",
+        "session_budget_usd": "session_budget_usd",
+        "maxToolCallsPerTurn": "max_tool_calls_per_turn",
+        "max_tool_calls_per_turn": "max_tool_calls_per_turn",
+        "contextWarningTokens": "context_warning_tokens",
+        "context_warning_tokens": "context_warning_tokens",
+        "contextAutoSummarize": "context_auto_summarize",
+        "context_auto_summarize": "context_auto_summarize",
+        "allowOverride": "allow_override",
+        "allow_override": "allow_override",
+        "overrideIncrementUsd": "override_increment_usd",
+        "override_increment_usd": "override_increment_usd",
+    }
+
+    for json_key, attr_name in field_map.items():
+        if json_key in budget_dict:
+            value = budget_dict[json_key]
+            # Type coercion for safety
+            current = getattr(policy, attr_name)
+            if isinstance(current, float):
+                value = float(value)
+            elif isinstance(current, int):
+                value = int(value)
+            elif isinstance(current, bool):
+                value = bool(value)
+            setattr(policy, attr_name, value)

--- a/src/netclaw_tokens/session_ledger.py
+++ b/src/netclaw_tokens/session_ledger.py
@@ -151,7 +151,16 @@ class SessionLedger:
         """Extend the budget ceiling and clear the halt state.
 
         Called when the operator explicitly requests continuation.
-        Extends session_budget_usd by override_increment_usd.
+
+        Behavior:
+        - If halt_reason is "cost_cap": extends session_budget_usd by
+          override_increment_usd AND resets tool_calls_this_turn.
+        - If halt_reason is "tool_limit": resets tool_calls_this_turn only
+          (allows another batch of N tool calls without extending the dollar cap).
+
+        This distinction prevents "continue" from being ambiguous — tool-limit
+        continuation is free (just more calls within existing budget), while
+        cost-cap continuation explicitly adds more dollars.
 
         Raises:
             RuntimeError: If allow_override is False in the policy.
@@ -161,12 +170,19 @@ class SessionLedger:
                 raise RuntimeError(
                     "Budget override is disabled for this session policy"
                 )
-            self.budget.session_budget_usd += self.budget.override_increment_usd
+            if self.halt_reason == "cost_cap":
+                self.budget.session_budget_usd += self.budget.override_increment_usd
+            # Both halt types reset the tool counter (allow another batch)
+            self.tool_calls_this_turn = 0
             self.budget_halted = False
             self.halt_reason = None
 
     def get_halt_message(self) -> str:
         """Format a user-facing budget-exceeded message.
+
+        Always includes a partial summary of what was accomplished before the
+        halt — the operator already paid for this work, so they should get value
+        from it even when the session stops.
 
         Returns:
             Formatted string with cost breakdown, top tools, and
@@ -191,15 +207,15 @@ class SessionLedger:
                 lines.append("⚠️ Session budget check triggered")
 
             lines.append("")
-            lines.append("Summary:")
+            lines.append("What I accomplished before stopping:")
             lines.append(
                 f"  • {self.total_call_count} API calls, "
                 f"{self.total_input_tokens:,} input tokens, "
                 f"{self.total_output_tokens:,} output tokens"
             )
-            lines.append(f"  • Total cost: ${self.total_cost:.2f}")
+            lines.append(f"  • Total session cost: ${self.total_cost:.2f}")
 
-            # Top 5 tools by cost
+            # Top 5 tools by cost — shows WHERE the money went
             if self.tool_breakdown:
                 sorted_tools = sorted(
                     self.tool_breakdown.values(),
@@ -212,7 +228,7 @@ class SessionLedger:
                     if t.total_cost > 0
                 )
                 if tool_summary:
-                    lines.append(f"  • Top tools: {tool_summary}")
+                    lines.append(f"  • Tools used: {tool_summary}")
 
             # Duration
             elapsed = datetime.now(timezone.utc) - self.started_at
@@ -221,12 +237,22 @@ class SessionLedger:
                 lines.append(f"  • Session duration: {minutes} minutes")
 
             lines.append("")
-            if self.budget.allow_override:
+
+            # Continuation instructions — different for each halt type
+            if self.halt_reason == "tool_limit":
                 lines.append(
-                    f'To continue, say "override budget" '
-                    f"(adds ${self.budget.override_increment_usd:.2f} to ceiling)."
+                    'Say "continue" to allow another '
+                    f"{self.budget.max_tool_calls_per_turn} tool calls "
+                    f"(no additional cost cap increase)."
                 )
-            lines.append("To start fresh, begin a new session.")
+            elif self.halt_reason == "cost_cap" and self.budget.allow_override:
+                lines.append(
+                    f'Say "continue" to add '
+                    f"${self.budget.override_increment_usd:.2f} to the budget "
+                    f"and resume."
+                )
+
+            lines.append("Or start a new session to reset from scratch.")
 
             return "\n".join(lines)
 

--- a/src/netclaw_tokens/session_ledger.py
+++ b/src/netclaw_tokens/session_ledger.py
@@ -1,7 +1,8 @@
-"""Cumulative session-level token tracking with per-tool breakdown.
+"""Cumulative session-level token tracking with per-tool breakdown and budget enforcement.
 
 Thread-safe accumulator that tracks token usage across all tool calls
 in a session, with per-tool granularity for cost optimization analysis.
+Includes enforcement hooks for cost ceilings and tool-call depth limits.
 """
 
 from __future__ import annotations
@@ -9,17 +10,23 @@ from __future__ import annotations
 import threading
 import uuid
 from datetime import datetime, timezone
-from typing import Dict, List
+from typing import Dict, List, Optional, Tuple
 
 from . import CostEstimate, TokenCount, ToolUsageRecord
+from .budget_policy import BudgetPolicy
 
 __all__ = ["SessionLedger"]
 
 
 class SessionLedger:
-    """Thread-safe session-level token accumulator."""
+    """Thread-safe session-level token accumulator with budget enforcement.
 
-    def __init__(self) -> None:
+    The ledger tracks cumulative costs and provides enforcement methods that
+    the gateway checks before each model API call. When a budget is exceeded,
+    the ledger signals a halt — it's the caller's responsibility to act on it.
+    """
+
+    def __init__(self, budget: Optional[BudgetPolicy] = None) -> None:
         self._lock = threading.Lock()
         self.session_id: str = str(uuid.uuid4())
         self.started_at: datetime = datetime.now(timezone.utc)
@@ -29,6 +36,13 @@ class SessionLedger:
         self.total_gcf_savings: int = 0
         self.total_call_count: int = 0
         self.tool_breakdown: Dict[str, ToolUsageRecord] = {}
+
+        # Budget enforcement (new in spec 109)
+        self.budget: BudgetPolicy = budget if budget is not None else BudgetPolicy()
+        self.tool_calls_this_turn: int = 0
+        self.budget_halted: bool = False
+        self.halt_reason: Optional[str] = None
+        self.interface_type: Optional[str] = None
 
     def record(
         self,
@@ -64,12 +78,193 @@ class SessionLedger:
             record.total_cost += cost.total_cost
             record.gcf_savings_tokens += gcf_savings
 
+    # ------------------------------------------------------------------
+    # Budget enforcement methods (spec 109)
+    # ------------------------------------------------------------------
+
+    def new_turn(self) -> None:
+        """Reset per-turn counters. Call this on each new user message."""
+        with self._lock:
+            self.tool_calls_this_turn = 0
+
+    def record_tool_call(self) -> None:
+        """Increment the per-turn tool call counter. Thread-safe."""
+        with self._lock:
+            self.tool_calls_this_turn += 1
+
+    def is_over_budget(self) -> bool:
+        """Check if cumulative session cost exceeds the configured ceiling.
+
+        Returns:
+            True if total_cost >= session_budget_usd.
+        """
+        with self._lock:
+            return self.total_cost >= self.budget.session_budget_usd
+
+    def is_over_tool_limit(self) -> bool:
+        """Check if tool calls this turn exceed the configured limit.
+
+        Returns:
+            True if tool_calls_this_turn >= max_tool_calls_per_turn.
+        """
+        with self._lock:
+            return self.tool_calls_this_turn >= self.budget.max_tool_calls_per_turn
+
+    def check_budget(self) -> Tuple[bool, Optional[str]]:
+        """Check all budget constraints and set halt state if exceeded.
+
+        This is the primary method the gateway should call before each
+        model API request or tool invocation.
+
+        Returns:
+            Tuple of (should_halt, reason). reason is None if not halting,
+            "cost_cap" if cost exceeded, "tool_limit" if tool depth exceeded.
+        """
+        with self._lock:
+            if self.budget_halted:
+                return (True, self.halt_reason)
+
+            if self.total_cost >= self.budget.session_budget_usd:
+                self.budget_halted = True
+                self.halt_reason = "cost_cap"
+                return (True, "cost_cap")
+
+            if self.tool_calls_this_turn >= self.budget.max_tool_calls_per_turn:
+                self.budget_halted = True
+                self.halt_reason = "tool_limit"
+                return (True, "tool_limit")
+
+            return (False, None)
+
+    def should_warn_context(self, context_tokens: int) -> bool:
+        """Check if context size warrants a warning.
+
+        Args:
+            context_tokens: Current total context token count.
+
+        Returns:
+            True if context exceeds the configured warning threshold.
+        """
+        return context_tokens >= self.budget.context_warning_tokens
+
+    def override_budget(self) -> None:
+        """Extend the budget ceiling and clear the halt state.
+
+        Called when the operator explicitly requests continuation.
+        Extends session_budget_usd by override_increment_usd.
+
+        Raises:
+            RuntimeError: If allow_override is False in the policy.
+        """
+        with self._lock:
+            if not self.budget.allow_override:
+                raise RuntimeError(
+                    "Budget override is disabled for this session policy"
+                )
+            self.budget.session_budget_usd += self.budget.override_increment_usd
+            self.budget_halted = False
+            self.halt_reason = None
+
+    def get_halt_message(self) -> str:
+        """Format a user-facing budget-exceeded message.
+
+        Returns:
+            Formatted string with cost breakdown, top tools, and
+            continuation instructions.
+        """
+        with self._lock:
+            lines = []
+
+            if self.halt_reason == "cost_cap":
+                lines.append(
+                    f"⚠️ Session budget reached "
+                    f"(${self.total_cost:.2f} / "
+                    f"${self.budget.session_budget_usd:.2f} cap)"
+                )
+            elif self.halt_reason == "tool_limit":
+                lines.append(
+                    f"⚠️ Tool call limit reached "
+                    f"({self.tool_calls_this_turn}/"
+                    f"{self.budget.max_tool_calls_per_turn} this turn)"
+                )
+            else:
+                lines.append("⚠️ Session budget check triggered")
+
+            lines.append("")
+            lines.append("Summary:")
+            lines.append(
+                f"  • {self.total_call_count} API calls, "
+                f"{self.total_input_tokens:,} input tokens, "
+                f"{self.total_output_tokens:,} output tokens"
+            )
+            lines.append(f"  • Total cost: ${self.total_cost:.2f}")
+
+            # Top 5 tools by cost
+            if self.tool_breakdown:
+                sorted_tools = sorted(
+                    self.tool_breakdown.values(),
+                    key=lambda r: r.total_cost,
+                    reverse=True,
+                )[:5]
+                tool_summary = ", ".join(
+                    f"{t.tool_name} ({t.call_count} calls, ${t.total_cost:.2f})"
+                    for t in sorted_tools
+                    if t.total_cost > 0
+                )
+                if tool_summary:
+                    lines.append(f"  • Top tools: {tool_summary}")
+
+            # Duration
+            elapsed = datetime.now(timezone.utc) - self.started_at
+            minutes = int(elapsed.total_seconds() / 60)
+            if minutes > 0:
+                lines.append(f"  • Session duration: {minutes} minutes")
+
+            lines.append("")
+            if self.budget.allow_override:
+                lines.append(
+                    f'To continue, say "override budget" '
+                    f"(adds ${self.budget.override_increment_usd:.2f} to ceiling)."
+                )
+            lines.append("To start fresh, begin a new session.")
+
+            return "\n".join(lines)
+
+    def get_context_warning(self, context_tokens: int, model: str = "") -> str:
+        """Format a context-size warning message.
+
+        Args:
+            context_tokens: Current context size in tokens.
+            model: Current model name (for cost-per-turn estimate).
+
+        Returns:
+            Formatted warning string.
+        """
+        from .cost_calculator import get_pricing
+
+        pricing = get_pricing(model) if model else None
+        cost_per_turn = ""
+        if pricing:
+            # Approximate cost for one turn at current context size
+            input_cost = (context_tokens / 1_000_000) * pricing.input_price_per_1m
+            cost_per_turn = f" (~${input_cost:.2f} per additional turn)"
+
+        return (
+            f"⚠️ Context size: {context_tokens:,} tokens{cost_per_turn}. "
+            f"Consider starting a new session to reduce costs."
+        )
+
+    # ------------------------------------------------------------------
+    # Existing reporting methods (unchanged)
+    # ------------------------------------------------------------------
+
     def get_summary(self) -> dict:
         """Return session totals as a dictionary.
 
         Returns:
             Dict with total_input_tokens, total_output_tokens, total_tokens,
-            total_cost_usd, total_gcf_savings, tool_count, call_count.
+            total_cost_usd, total_gcf_savings, tool_count, call_count,
+            budget_halted, halt_reason.
         """
         with self._lock:
             return {
@@ -82,6 +277,8 @@ class SessionLedger:
                 "total_gcf_savings": self.total_gcf_savings,
                 "tool_count": len(self.tool_breakdown),
                 "call_count": self.total_call_count,
+                "budget_halted": self.budget_halted,
+                "halt_reason": self.halt_reason,
             }
 
     def get_per_tool_breakdown(self) -> List[dict]:
@@ -128,3 +325,6 @@ class SessionLedger:
             self.total_gcf_savings = 0
             self.total_call_count = 0
             self.tool_breakdown.clear()
+            self.tool_calls_this_turn = 0
+            self.budget_halted = False
+            self.halt_reason = None

--- a/tests/test_budget_policy.py
+++ b/tests/test_budget_policy.py
@@ -1,0 +1,192 @@
+"""Tests for BudgetPolicy loading and resolution (spec 109)."""
+
+import os
+import sys
+
+import pytest
+
+# Ensure src is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from netclaw_tokens.budget_policy import (
+    BudgetPolicy,
+    detect_interface_type,
+    load_budget_policy,
+    resolve_session_config,
+)
+
+
+class TestBudgetPolicyDefaults:
+    """Verify default construction produces safe values."""
+
+    def test_default_session_budget(self):
+        policy = BudgetPolicy()
+        assert policy.session_budget_usd == 5.0
+
+    def test_default_tool_call_limit(self):
+        policy = BudgetPolicy()
+        assert policy.max_tool_calls_per_turn == 20
+
+    def test_default_context_warning(self):
+        policy = BudgetPolicy()
+        assert policy.context_warning_tokens == 100_000
+
+    def test_default_override_allowed(self):
+        policy = BudgetPolicy()
+        assert policy.allow_override is True
+
+    def test_default_model_is_none(self):
+        policy = BudgetPolicy()
+        assert policy.model is None
+
+
+class TestInterfaceDetection:
+    """Verify session key → interface type mapping."""
+
+    def test_openai_interface(self):
+        assert detect_interface_type("agent:main:openai:abc-123") == "openai"
+
+    def test_tui_interface(self):
+        assert detect_interface_type("agent:main:tui-6861a019-21a7") == "tui"
+
+    def test_discord_interface(self):
+        assert detect_interface_type("agent:main:discord:channel:123") == "discord"
+
+    def test_n2n_interface(self):
+        assert detect_interface_type("agent:main:n2n") == "n2n"
+
+    def test_alert_interface(self):
+        assert detect_interface_type("agent:main:hook:alert:abc123") == "alert"
+
+    def test_explicit_interface(self):
+        assert detect_interface_type("agent:main:explicit:n2n-edge-risk") == "explicit"
+
+    def test_unknown_returns_none(self):
+        assert detect_interface_type("something:completely:different") is None
+
+
+class TestLoadBudgetPolicy:
+    """Verify config loading with layered overrides."""
+
+    def test_empty_config_returns_defaults(self):
+        policy = load_budget_policy({})
+        assert policy.session_budget_usd == 5.0
+        assert policy.max_tool_calls_per_turn == 20
+
+    def test_agents_defaults_budget_override(self):
+        config = {
+            "agents": {
+                "defaults": {
+                    "budget": {
+                        "sessionBudgetUsd": 10.0,
+                        "maxToolCallsPerTurn": 30,
+                    }
+                }
+            }
+        }
+        policy = load_budget_policy(config)
+        assert policy.session_budget_usd == 10.0
+        assert policy.max_tool_calls_per_turn == 30
+
+    def test_interface_defaults_model_routing(self):
+        config = {
+            "agents": {
+                "defaults": {
+                    "interfaceDefaults": {
+                        "openai": {
+                            "model": "anthropic/claude-haiku-4-5",
+                            "thinkingLevel": "medium",
+                        }
+                    }
+                }
+            }
+        }
+        policy = load_budget_policy(config, interface_type="openai")
+        assert policy.model == "anthropic/claude-haiku-4-5"
+        assert policy.thinking_level == "medium"
+
+    def test_interface_budget_override(self):
+        config = {
+            "agents": {
+                "defaults": {
+                    "budget": {"sessionBudgetUsd": 10.0},
+                    "interfaceDefaults": {
+                        "n2n": {
+                            "budget": {"sessionBudgetUsd": 2.0}
+                        }
+                    },
+                }
+            }
+        }
+        # Global default
+        policy_global = load_budget_policy(config)
+        assert policy_global.session_budget_usd == 10.0
+
+        # N2N-specific override
+        policy_n2n = load_budget_policy(config, interface_type="n2n")
+        assert policy_n2n.session_budget_usd == 2.0
+
+    def test_tui_with_no_interface_config_uses_defaults(self):
+        config = {
+            "agents": {
+                "defaults": {
+                    "budget": {"sessionBudgetUsd": 7.0},
+                    "interfaceDefaults": {
+                        "openai": {"model": "anthropic/claude-haiku-4-5"}
+                    },
+                }
+            }
+        }
+        policy = load_budget_policy(config, interface_type="tui")
+        assert policy.session_budget_usd == 7.0
+        assert policy.model is None  # No TUI-specific model override
+
+    def test_env_var_overrides_config(self, monkeypatch):
+        config = {
+            "agents": {
+                "defaults": {
+                    "budget": {"sessionBudgetUsd": 10.0}
+                }
+            }
+        }
+        monkeypatch.setenv("NETCLAW_SESSION_BUDGET_USD", "1.5")
+        policy = load_budget_policy(config)
+        assert policy.session_budget_usd == 1.5
+
+    def test_invalid_env_var_ignored(self, monkeypatch):
+        monkeypatch.setenv("NETCLAW_SESSION_BUDGET_USD", "not_a_number")
+        policy = load_budget_policy({})
+        assert policy.session_budget_usd == 5.0  # Falls back to default
+
+
+class TestResolveSessionConfig:
+    """Verify the one-call session config resolver."""
+
+    def test_openai_session_gets_mobile_routing(self):
+        config = {
+            "agents": {
+                "defaults": {
+                    "interfaceDefaults": {
+                        "openai": {
+                            "model": "anthropic/claude-haiku-4-5",
+                            "budget": {"sessionBudgetUsd": 2.0},
+                        }
+                    }
+                }
+            }
+        }
+        policy = resolve_session_config(config, "agent:main:openai:e5b7e8f1-uuid")
+        assert policy.model == "anthropic/claude-haiku-4-5"
+        assert policy.session_budget_usd == 2.0
+
+    def test_unknown_session_key_uses_global_defaults(self):
+        config = {
+            "agents": {
+                "defaults": {
+                    "budget": {"sessionBudgetUsd": 5.0}
+                }
+            }
+        }
+        policy = resolve_session_config(config, "something:unknown:pattern")
+        assert policy.session_budget_usd == 5.0
+        assert policy.model is None

--- a/tests/test_session_budget.py
+++ b/tests/test_session_budget.py
@@ -74,18 +74,37 @@ class TestCostCapEnforcement:
 class TestOverrideBudget:
     """US1: Budget override/continuation."""
 
-    def test_override_extends_ceiling(self):
+    def test_override_cost_cap_extends_ceiling(self):
         policy = BudgetPolicy(session_budget_usd=2.0, override_increment_usd=3.0)
         ledger = SessionLedger(budget=policy)
         ledger.total_cost = 2.50
         ledger.check_budget()
 
         assert ledger.budget_halted is True
+        assert ledger.halt_reason == "cost_cap"
         ledger.override_budget()
 
         assert ledger.budget_halted is False
         assert ledger.halt_reason is None
         assert ledger.budget.session_budget_usd == 5.0  # 2.0 + 3.0
+        assert ledger.tool_calls_this_turn == 0  # Also resets tool counter
+
+    def test_override_tool_limit_does_not_extend_dollar_cap(self):
+        """Tool-limit continuation resets call counter without adding dollars."""
+        policy = BudgetPolicy(session_budget_usd=10.0, max_tool_calls_per_turn=5)
+        ledger = SessionLedger(budget=policy)
+        for _ in range(5):
+            ledger.record_tool_call()
+        ledger.check_budget()
+
+        assert ledger.halt_reason == "tool_limit"
+        original_budget = ledger.budget.session_budget_usd
+
+        ledger.override_budget()
+
+        assert ledger.budget.session_budget_usd == original_budget  # Unchanged
+        assert ledger.tool_calls_this_turn == 0  # Reset for next batch
+        assert ledger.budget_halted is False
 
     def test_override_disabled_raises(self):
         policy = BudgetPolicy(session_budget_usd=2.0, allow_override=False)
@@ -163,7 +182,7 @@ class TestHaltMessage:
     """US1: Formatted halt message."""
 
     def test_halt_message_includes_cost(self):
-        policy = BudgetPolicy(session_budget_usd=5.0)
+        policy = BudgetPolicy(session_budget_usd=5.0, override_increment_usd=2.0)
         ledger = SessionLedger(budget=policy)
         ledger.total_cost = 5.50
         ledger.total_input_tokens = 500_000
@@ -176,7 +195,9 @@ class TestHaltMessage:
         assert "$5.50" in msg
         assert "$5.00 cap" in msg
         assert "25 API calls" in msg
-        assert "override budget" in msg.lower()
+        assert "continue" in msg.lower()
+        assert "$2.00" in msg  # Shows the override increment amount
+        assert "What I accomplished" in msg  # Partial summary present
 
     def test_halt_message_tool_limit(self):
         policy = BudgetPolicy(max_tool_calls_per_turn=20)
@@ -188,6 +209,7 @@ class TestHaltMessage:
         msg = ledger.get_halt_message()
         assert "20/20" in msg
         assert "Tool call limit" in msg
+        assert "no additional cost cap" in msg.lower()  # Makes clear it's free to continue
 
 
 class TestContextWarning:

--- a/tests/test_session_budget.py
+++ b/tests/test_session_budget.py
@@ -1,0 +1,240 @@
+"""Tests for SessionLedger budget enforcement (spec 109)."""
+
+import os
+import sys
+
+import pytest
+
+# Ensure src is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from netclaw_tokens import CostEstimate, TokenCount
+from netclaw_tokens.budget_policy import BudgetPolicy
+from netclaw_tokens.session_ledger import SessionLedger
+
+
+class TestCostCapEnforcement:
+    """US1: Session cost cap halts runaway spending."""
+
+    def test_is_over_budget_false_below_cap(self):
+        policy = BudgetPolicy(session_budget_usd=5.0)
+        ledger = SessionLedger(budget=policy)
+        ledger.total_cost = 4.99
+        assert ledger.is_over_budget() is False
+
+    def test_is_over_budget_true_at_cap(self):
+        policy = BudgetPolicy(session_budget_usd=5.0)
+        ledger = SessionLedger(budget=policy)
+        ledger.total_cost = 5.0
+        assert ledger.is_over_budget() is True
+
+    def test_is_over_budget_true_above_cap(self):
+        policy = BudgetPolicy(session_budget_usd=5.0)
+        ledger = SessionLedger(budget=policy)
+        ledger.total_cost = 11.13  # The real incident amount
+        assert ledger.is_over_budget() is True
+
+    def test_check_budget_sets_halt_state_on_cost(self):
+        policy = BudgetPolicy(session_budget_usd=2.0)
+        ledger = SessionLedger(budget=policy)
+        ledger.total_cost = 2.50
+
+        should_halt, reason = ledger.check_budget()
+        assert should_halt is True
+        assert reason == "cost_cap"
+        assert ledger.budget_halted is True
+        assert ledger.halt_reason == "cost_cap"
+
+    def test_check_budget_returns_false_when_ok(self):
+        policy = BudgetPolicy(session_budget_usd=10.0)
+        ledger = SessionLedger(budget=policy)
+        ledger.total_cost = 1.0
+
+        should_halt, reason = ledger.check_budget()
+        assert should_halt is False
+        assert reason is None
+        assert ledger.budget_halted is False
+
+    def test_check_budget_stays_halted_after_first_trip(self):
+        policy = BudgetPolicy(session_budget_usd=2.0)
+        ledger = SessionLedger(budget=policy)
+        ledger.total_cost = 3.0
+
+        ledger.check_budget()
+        # Second call still returns halted
+        should_halt, reason = ledger.check_budget()
+        assert should_halt is True
+        assert reason == "cost_cap"
+
+    def test_default_budget_is_sensible(self):
+        ledger = SessionLedger()  # No explicit budget
+        assert ledger.budget.session_budget_usd == 5.0
+
+
+class TestOverrideBudget:
+    """US1: Budget override/continuation."""
+
+    def test_override_extends_ceiling(self):
+        policy = BudgetPolicy(session_budget_usd=2.0, override_increment_usd=3.0)
+        ledger = SessionLedger(budget=policy)
+        ledger.total_cost = 2.50
+        ledger.check_budget()
+
+        assert ledger.budget_halted is True
+        ledger.override_budget()
+
+        assert ledger.budget_halted is False
+        assert ledger.halt_reason is None
+        assert ledger.budget.session_budget_usd == 5.0  # 2.0 + 3.0
+
+    def test_override_disabled_raises(self):
+        policy = BudgetPolicy(session_budget_usd=2.0, allow_override=False)
+        ledger = SessionLedger(budget=policy)
+        ledger.total_cost = 3.0
+        ledger.check_budget()
+
+        with pytest.raises(RuntimeError, match="override is disabled"):
+            ledger.override_budget()
+
+    def test_after_override_session_can_continue(self):
+        policy = BudgetPolicy(session_budget_usd=2.0, override_increment_usd=2.0)
+        ledger = SessionLedger(budget=policy)
+        ledger.total_cost = 2.50
+        ledger.check_budget()
+        ledger.override_budget()
+
+        # Now budget is 4.0, cost is 2.50 — should be OK
+        should_halt, reason = ledger.check_budget()
+        assert should_halt is False
+
+
+class TestToolCallLimit:
+    """US2: Tool-call depth limit per user message."""
+
+    def test_is_over_tool_limit_false_below(self):
+        policy = BudgetPolicy(max_tool_calls_per_turn=15)
+        ledger = SessionLedger(budget=policy)
+        for _ in range(14):
+            ledger.record_tool_call()
+        assert ledger.is_over_tool_limit() is False
+
+    def test_is_over_tool_limit_true_at_limit(self):
+        policy = BudgetPolicy(max_tool_calls_per_turn=15)
+        ledger = SessionLedger(budget=policy)
+        for _ in range(15):
+            ledger.record_tool_call()
+        assert ledger.is_over_tool_limit() is True
+
+    def test_new_turn_resets_counter(self):
+        policy = BudgetPolicy(max_tool_calls_per_turn=5)
+        ledger = SessionLedger(budget=policy)
+        for _ in range(5):
+            ledger.record_tool_call()
+        assert ledger.is_over_tool_limit() is True
+
+        ledger.new_turn()
+        assert ledger.tool_calls_this_turn == 0
+        assert ledger.is_over_tool_limit() is False
+
+    def test_check_budget_catches_tool_limit(self):
+        policy = BudgetPolicy(max_tool_calls_per_turn=3)
+        ledger = SessionLedger(budget=policy)
+        for _ in range(3):
+            ledger.record_tool_call()
+
+        should_halt, reason = ledger.check_budget()
+        assert should_halt is True
+        assert reason == "tool_limit"
+
+    def test_cost_cap_takes_priority_over_tool_limit(self):
+        """When both limits are exceeded, cost_cap is reported first."""
+        policy = BudgetPolicy(session_budget_usd=1.0, max_tool_calls_per_turn=5)
+        ledger = SessionLedger(budget=policy)
+        ledger.total_cost = 2.0
+        for _ in range(5):
+            ledger.record_tool_call()
+
+        should_halt, reason = ledger.check_budget()
+        assert should_halt is True
+        assert reason == "cost_cap"  # Cost checked first
+
+
+class TestHaltMessage:
+    """US1: Formatted halt message."""
+
+    def test_halt_message_includes_cost(self):
+        policy = BudgetPolicy(session_budget_usd=5.0)
+        ledger = SessionLedger(budget=policy)
+        ledger.total_cost = 5.50
+        ledger.total_input_tokens = 500_000
+        ledger.total_output_tokens = 10_000
+        ledger.total_call_count = 25
+        ledger.budget_halted = True
+        ledger.halt_reason = "cost_cap"
+
+        msg = ledger.get_halt_message()
+        assert "$5.50" in msg
+        assert "$5.00 cap" in msg
+        assert "25 API calls" in msg
+        assert "override budget" in msg.lower()
+
+    def test_halt_message_tool_limit(self):
+        policy = BudgetPolicy(max_tool_calls_per_turn=20)
+        ledger = SessionLedger(budget=policy)
+        ledger.tool_calls_this_turn = 20
+        ledger.budget_halted = True
+        ledger.halt_reason = "tool_limit"
+
+        msg = ledger.get_halt_message()
+        assert "20/20" in msg
+        assert "Tool call limit" in msg
+
+
+class TestContextWarning:
+    """US4: Context growth awareness."""
+
+    def test_should_warn_below_threshold(self):
+        policy = BudgetPolicy(context_warning_tokens=100_000)
+        ledger = SessionLedger(budget=policy)
+        assert ledger.should_warn_context(50_000) is False
+
+    def test_should_warn_at_threshold(self):
+        policy = BudgetPolicy(context_warning_tokens=100_000)
+        ledger = SessionLedger(budget=policy)
+        assert ledger.should_warn_context(100_000) is True
+
+    def test_context_warning_message_includes_cost(self):
+        ledger = SessionLedger()
+        msg = ledger.get_context_warning(200_000, model="claude-sonnet-4-6")
+        assert "200,000 tokens" in msg
+        assert "$" in msg  # Should include cost estimate
+
+
+class TestRecordIntegration:
+    """Verify record() still works correctly with budget-extended ledger."""
+
+    def test_record_accumulates_cost(self):
+        ledger = SessionLedger()
+        token_count = TokenCount(input_tokens=1000, output_tokens=500)
+        cost = CostEstimate(total_cost=0.05)
+
+        ledger.record("exec", token_count, cost)
+        ledger.record("exec", token_count, cost)
+
+        assert ledger.total_cost == 0.10
+        assert ledger.total_call_count == 2
+
+    def test_reset_clears_budget_state(self):
+        policy = BudgetPolicy(session_budget_usd=1.0)
+        ledger = SessionLedger(budget=policy)
+        ledger.total_cost = 2.0
+        ledger.tool_calls_this_turn = 10
+        ledger.budget_halted = True
+        ledger.halt_reason = "cost_cap"
+
+        ledger.reset()
+
+        assert ledger.total_cost == 0.0
+        assert ledger.tool_calls_this_turn == 0
+        assert ledger.budget_halted is False
+        assert ledger.halt_reason is None

--- a/ui/netclaw-visual/index.html
+++ b/ui/netclaw-visual/index.html
@@ -101,6 +101,7 @@
         <div class="footer-row">
           <span>Model <strong id="footer-model">--</strong></span>
           <span>Gateway <strong id="footer-gateway">--</strong></span>
+          <span>Budget <strong id="footer-budget" class="budget-indicator" title="Click to configure budget">--</strong></span>
           <span>Socket <strong id="footer-socket">CONNECTING</strong></span>
           <span>Updated <strong id="footer-updated">--</strong></span>
         </div>

--- a/ui/netclaw-visual/server.js
+++ b/ui/netclaw-visual/server.js
@@ -1185,6 +1185,182 @@ app.put('/api/env', (req, res) => {
   }
 });
 
+// ── Budget status & configuration (spec 109) ──────────────────────────────────
+//
+// Budget enforcement lives in the token-tracker skill (Python, src/netclaw_tokens/).
+// The HUD provides visibility and configuration — reading the current budget policy
+// from openclaw.json and the active session's cost from the sessions directory.
+
+app.get('/api/budget/status', (req, res) => {
+  try {
+    const config = JSON.parse(readText(path.join(process.env.HOME || '/root', '.openclaw', 'openclaw.json')) || '{}');
+    const policy = resolveBudgetPolicy(config);
+
+    // Find the most recent active session and estimate cost from its size/metadata
+    const sessionCost = estimateActiveSessionCost();
+
+    const pct = policy.sessionBudgetUsd > 0
+      ? Math.min(100, Math.round((sessionCost / policy.sessionBudgetUsd) * 100))
+      : 0;
+
+    let status = 'ok';
+    if (pct >= 100) status = 'halted';
+    else if (pct >= 80) status = 'critical';
+    else if (pct >= 50) status = 'warning';
+
+    res.json({
+      sessionCostUsd: Math.round(sessionCost * 100) / 100,
+      sessionBudgetUsd: policy.sessionBudgetUsd,
+      maxToolCallsPerTurn: policy.maxToolCallsPerTurn,
+      percentUsed: pct,
+      status,
+      model: policy.model || null,
+      interfaceDefaults: policy.interfaceDefaults || {},
+    });
+  } catch (err) {
+    res.json({
+      sessionCostUsd: 0,
+      sessionBudgetUsd: 5.0,
+      maxToolCallsPerTurn: 20,
+      percentUsed: 0,
+      status: 'unknown',
+      error: err.message,
+    });
+  }
+});
+
+app.get('/api/budget/config', (req, res) => {
+  try {
+    const config = JSON.parse(readText(path.join(process.env.HOME || '/root', '.openclaw', 'openclaw.json')) || '{}');
+    const budget = config?.agents?.defaults?.budget || {};
+    const interfaceDefaults = config?.agents?.defaults?.interfaceDefaults || {};
+    res.json({
+      budget: {
+        sessionBudgetUsd: budget.sessionBudgetUsd ?? 5.0,
+        maxToolCallsPerTurn: budget.maxToolCallsPerTurn ?? 20,
+        contextWarningTokens: budget.contextWarningTokens ?? 100000,
+        allowOverride: budget.allowOverride ?? true,
+        overrideIncrementUsd: budget.overrideIncrementUsd ?? 2.0,
+      },
+      interfaceDefaults,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.put('/api/budget/config', (req, res) => {
+  const { budget, interfaceDefaults } = req.body || {};
+  if (!budget && !interfaceDefaults) {
+    return res.status(400).json({ error: 'Expected { budget: {...} } and/or { interfaceDefaults: {...} }' });
+  }
+
+  try {
+    const configPath = path.join(process.env.HOME || '/root', '.openclaw', 'openclaw.json');
+    const config = JSON.parse(readText(configPath) || '{}');
+
+    // Ensure path exists
+    if (!config.agents) config.agents = {};
+    if (!config.agents.defaults) config.agents.defaults = {};
+
+    // Merge budget values (only provided fields, don't clobber unset ones)
+    if (budget) {
+      if (!config.agents.defaults.budget) config.agents.defaults.budget = {};
+      const validKeys = ['sessionBudgetUsd', 'maxToolCallsPerTurn', 'contextWarningTokens', 'allowOverride', 'overrideIncrementUsd'];
+      for (const key of validKeys) {
+        if (budget[key] !== undefined) {
+          config.agents.defaults.budget[key] = budget[key];
+        }
+      }
+    }
+
+    // Merge interface defaults
+    if (interfaceDefaults) {
+      if (!config.agents.defaults.interfaceDefaults) config.agents.defaults.interfaceDefaults = {};
+      for (const [iface, settings] of Object.entries(interfaceDefaults)) {
+        config.agents.defaults.interfaceDefaults[iface] = {
+          ...(config.agents.defaults.interfaceDefaults[iface] || {}),
+          ...settings,
+        };
+      }
+    }
+
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+    broadcastWS('config:updated', { keys: ['budget'], generatedAt: new Date().toISOString() });
+    res.json({ ok: true, budget: config.agents.defaults.budget, interfaceDefaults: config.agents.defaults.interfaceDefaults });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * Resolve budget policy from config (mirrors Python budget_policy.py logic).
+ * Returns merged defaults for display purposes.
+ */
+function resolveBudgetPolicy(config) {
+  const defaults = config?.agents?.defaults || {};
+  const budget = defaults.budget || {};
+  const interfaceDefaults = defaults.interfaceDefaults || {};
+
+  return {
+    sessionBudgetUsd: parseFloat(process.env.NETCLAW_SESSION_BUDGET_USD || '') || budget.sessionBudgetUsd || 5.0,
+    maxToolCallsPerTurn: budget.maxToolCallsPerTurn || 20,
+    contextWarningTokens: budget.contextWarningTokens || 100000,
+    allowOverride: budget.allowOverride !== false,
+    overrideIncrementUsd: budget.overrideIncrementUsd || 2.0,
+    model: null, // Global default; interface-specific in interfaceDefaults
+    interfaceDefaults,
+  };
+}
+
+/**
+ * Estimate cost of the most recently active session by reading its JSONL
+ * and summing any usage blocks. Returns 0 if no active session or no data.
+ */
+function estimateActiveSessionCost() {
+  try {
+    const sessionsDir = path.join(process.env.HOME || '/root', '.openclaw', 'agents', 'main', 'sessions');
+    const sessionsJson = path.join(sessionsDir, 'sessions.json');
+    if (!fs.existsSync(sessionsJson)) return 0;
+
+    const sessions = JSON.parse(readText(sessionsJson) || '{}');
+    // Find the most recently updated session
+    let newest = null;
+    let newestTime = 0;
+    for (const [, sess] of Object.entries(sessions)) {
+      const t = sess.updatedAt || 0;
+      if (t > newestTime) {
+        newestTime = t;
+        newest = sess;
+      }
+    }
+
+    if (!newest || !newest.sessionFile) return 0;
+    if (!fs.existsSync(newest.sessionFile)) return 0;
+
+    // Count message lines as a rough proxy for API calls
+    // Real cost tracking comes from Prometheus; this is a fast HUD estimate
+    const content = readText(newest.sessionFile) || '';
+    const lines = content.split('\n').filter(Boolean);
+    let assistantTurns = 0;
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line);
+        if (entry.type === 'message' && entry.message?.role === 'assistant') {
+          assistantTurns++;
+        }
+      } catch { /* skip unparseable lines */ }
+    }
+
+    // Rough estimate: each assistant turn ≈ 50K input tokens on Sonnet ($0.15) + 1K output ($0.015)
+    // This is intentionally conservative — better to show slightly high than low
+    const estimatedCostPerTurn = 0.17;
+    return assistantTurns * estimatedCostPerTurn;
+  } catch {
+    return 0;
+  }
+}
+
 // ── Testbed device config ──────────────────────────────────────────
 app.get('/api/testbed/raw', (req, res) => {
   res.type('text/yaml').send(readText(TESTBED_FILE) || '# No testbed found');

--- a/ui/netclaw-visual/src/main.js
+++ b/ui/netclaw-visual/src/main.js
@@ -129,6 +129,7 @@ const dom = {
   footerSocket: document.getElementById('footer-socket'),
   footerModel: document.getElementById('footer-model'),
   footerGateway: document.getElementById('footer-gateway'),
+  footerBudget: document.getElementById('footer-budget'),
   footerUpdated: document.getElementById('footer-updated'),
   chatDrawer: document.getElementById('chat-drawer'),
   chatMessages: document.getElementById('chat-messages'),
@@ -881,6 +882,9 @@ function renderMetrics(graph) {
   dom.footerModel.textContent = graph.config?.agents?.defaults?.model?.primary?.replace('anthropic/', '') || 'unknown';
   dom.footerGateway.textContent = graph.config?.gateway?.mode || 'unknown';
   dom.footerUpdated.textContent = new Date(graph.generatedAt).toLocaleTimeString();
+
+  // Budget status poll (spec 109)
+  pollBudgetStatus();
 }
 
 function applyFilters() {
@@ -3140,3 +3144,42 @@ async function restoreSavedLayout() {
 }
 
 boot();
+
+// ── Budget status polling (spec 109) ──────────────────────────────────────────
+//
+// Polls /api/budget/status every 10s and updates the footer indicator.
+// Color coding: green (ok) → amber (>50%) → red (>80%) → pulsing red (halted).
+
+async function pollBudgetStatus() {
+  if (!dom.footerBudget) return;
+  try {
+    const res = await fetch('/api/budget/status');
+    if (!res.ok) { dom.footerBudget.textContent = '--'; return; }
+    const data = await res.json();
+
+    const cost = data.sessionCostUsd?.toFixed(2) ?? '0.00';
+    const cap = data.sessionBudgetUsd?.toFixed(2) ?? '5.00';
+    dom.footerBudget.textContent = `$${cost} / $${cap}`;
+
+    // Color coding
+    dom.footerBudget.classList.remove('budget-ok', 'budget-warning', 'budget-critical', 'budget-halted');
+    if (data.status === 'halted') {
+      dom.footerBudget.classList.add('budget-halted');
+      dom.footerBudget.title = 'Session budget exhausted — say "continue" to extend';
+    } else if (data.status === 'critical') {
+      dom.footerBudget.classList.add('budget-critical');
+      dom.footerBudget.title = `${data.percentUsed}% of session budget used`;
+    } else if (data.status === 'warning') {
+      dom.footerBudget.classList.add('budget-warning');
+      dom.footerBudget.title = `${data.percentUsed}% of session budget used`;
+    } else {
+      dom.footerBudget.classList.add('budget-ok');
+      dom.footerBudget.title = `Session budget: ${data.percentUsed}% used`;
+    }
+  } catch {
+    dom.footerBudget.textContent = '--';
+  }
+}
+
+// Poll budget every 10 seconds
+setInterval(pollBudgetStatus, 10_000);

--- a/ui/netclaw-visual/src/styles.css
+++ b/ui/netclaw-visual/src/styles.css
@@ -1287,3 +1287,36 @@ input {
   border: 2px solid #ffd97a; border-radius: 5px;
   font-size: 12px; z-index: 60;
 }
+
+/* ── Budget indicator (spec 109) ──────────────────────────────────── */
+.budget-indicator {
+  cursor: pointer;
+  transition: color 0.3s ease, text-shadow 0.3s ease;
+  border-radius: 4px;
+  padding: 0 4px;
+}
+
+.budget-indicator.budget-ok {
+  color: #4cc9f0; /* Cyan — matches HUD palette */
+}
+
+.budget-indicator.budget-warning {
+  color: #f8961e; /* Amber */
+  text-shadow: 0 0 6px rgba(248, 150, 30, 0.4);
+}
+
+.budget-indicator.budget-critical {
+  color: #ef476f; /* Red */
+  text-shadow: 0 0 8px rgba(239, 71, 111, 0.5);
+}
+
+.budget-indicator.budget-halted {
+  color: #ef476f;
+  text-shadow: 0 0 12px rgba(239, 71, 111, 0.7);
+  animation: budget-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes budget-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}

--- a/workspace/skills/token-tracker/SKILL.md
+++ b/workspace/skills/token-tracker/SKILL.md
@@ -1,19 +1,30 @@
 ---
 name: token-tracker
-description: "Track and display token consumption and cost for every NetClaw interaction."
-version: 1.0.0
+description: "Track token consumption, enforce session budgets, and display cost for every NetClaw interaction."
+version: 2.0.0
 license: Apache-2.0
 author: netclaw
-tags: []
+tags: [budget, cost-control, guardrails]
 ---
 
-# Skill: Token Tracker
+# Skill: Token Tracker + Budget Enforcement
 
 ## Purpose
 
 Track and display token consumption and cost for every NetClaw interaction.
-Serialize MCP server responses in TOON format to reduce token usage by
-40-60% on tabular network data.
+**Enforce per-session spending caps and tool-call depth limits** to prevent
+runaway API costs. Serialize MCP server responses in GCF format to reduce
+token usage by 40-60% on tabular network data.
+
+## What This Prevents
+
+Without this skill, a single casual phone question can trigger unbounded
+agentic tool chains that silently burn $10+ in API costs. This skill ensures:
+
+- Sessions halt at a configurable cost ceiling (default: $5)
+- Tool-call chains pause after N calls per question (default: 20)
+- The operator sees what was accomplished and can choose to continue
+- Budget status is visible in every response footer
 
 ## Tools Used
 
@@ -25,18 +36,96 @@ This skill uses the `netclaw_tokens` shared library (`src/netclaw_tokens/`):
 | counter.py | count_message_tokens() | Count tokens for full message arrays |
 | cost_calculator.py | calculate_cost() | Calculate USD cost with model-aware pricing |
 | cost_calculator.py | get_pricing() | Look up model pricing (with env var override) |
-| toon_serializer.py | serialize_response() | Serialize data to TOON with JSON fallback |
-| session_ledger.py | SessionLedger | Cumulative session tracking with per-tool breakdown |
+| budget_policy.py | BudgetPolicy | Per-session budget configuration |
+| budget_policy.py | resolve_session_config() | Load policy from config + interface detection |
+| session_ledger.py | SessionLedger | Cumulative tracking + enforcement |
 | footer.py | format_footer() | Format mandatory token/cost footer |
-| toon_wrapper.py | wrap_json_response() | Convert JSON responses to TOON (for community servers) |
+| gcf_serializer.py | serialize_response() | Serialize data to GCF with JSON fallback |
+| gcf_wrapper.py | wrap_json_response() | Convert JSON responses to GCF |
 
 ## Workflow Steps
 
-1. **On every interaction**: Count input/output tokens using `count_tokens()` or `count_message_tokens()`
-2. **Calculate cost**: Use `calculate_cost()` with the active model (Opus/Sonnet/Haiku)
-3. **Record in ledger**: Call `session_ledger.record()` with tool name, token count, cost, and TOON savings
-4. **Format footer**: Use `format_footer()` to produce the mandatory token/cost display line
-5. **Display footer**: Append footer to every response — no exceptions
+### On session start
+
+1. **Resolve budget policy**: Call `resolve_session_config(config, session_key)` to get the
+   `BudgetPolicy` for this session — accounts for interface type (mobile/desktop/discord),
+   per-agent overrides, and environment variable overrides.
+2. **Initialize ledger**: Create `SessionLedger(budget=policy)` — enforcement is now active.
+
+### On each user message
+
+3. **Reset turn counter**: Call `session_ledger.new_turn()` — resets tool-call counter for
+   this turn.
+
+### Before each tool invocation
+
+4. **Check budget**: Call `session_ledger.check_budget()` → returns `(should_halt, reason)`.
+   - If `should_halt` is True: **STOP.** Return `session_ledger.get_halt_message()` to the
+     user. Do NOT execute the tool. Do NOT make another API call.
+   - If False: proceed.
+5. **Record tool call**: Call `session_ledger.record_tool_call()` to increment the per-turn
+   counter.
+
+### On each model API response
+
+6. **Count tokens**: Use `count_tokens()` or read the API response usage block.
+7. **Calculate cost**: Use `calculate_cost()` with the active model.
+8. **Record in ledger**: Call `session_ledger.record()` with tool name, token count, cost,
+   and GCF savings.
+9. **Format footer**: Use `format_footer()` — now includes budget status.
+
+### On operator "continue" / "override budget"
+
+10. **Override**: Call `session_ledger.override_budget()`.
+    - If halt was `tool_limit`: resets the tool-call counter (free, no dollar increase).
+    - If halt was `cost_cap`: extends budget by `override_increment_usd` AND resets tools.
+
+## Budget Enforcement Rules
+
+1. **Cost cap is a hard stop.** When `total_cost >= session_budget_usd`, no further API
+   calls or tool invocations are permitted until the operator explicitly continues.
+2. **Tool-call limit is a soft pause.** When `tool_calls_this_turn >= max_tool_calls_per_turn`,
+   the agent pauses, presents findings so far, and asks permission to continue.
+3. **Continuation is always explicit.** The agent must NEVER silently resume after a halt.
+4. **Mid-stream completion.** If a halt triggers during a multi-tool chain, the current
+   response completes (no half-streamed output), then the halt message is appended.
+5. **Safe defaults.** If no budget configuration exists in `openclaw.json`, enforcement
+   activates with: $5 session cap, 20 tool calls per turn, override allowed (+$2 increments).
+
+## Configuration
+
+### Automatic (zero-config)
+
+Works out of the box with safe defaults. No configuration required.
+
+### Via openclaw.json
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "budget": {
+        "sessionBudgetUsd": 5.0,
+        "maxToolCallsPerTurn": 20,
+        "contextWarningTokens": 100000,
+        "allowOverride": true,
+        "overrideIncrementUsd": 2.0
+      },
+      "interfaceDefaults": {
+        "openai": { "model": "anthropic/claude-haiku-4-5", "thinkingLevel": "medium" },
+        "n2n": { "model": "anthropic/claude-haiku-4-5", "thinkingLevel": "medium" },
+        "discord": { "model": "anthropic/claude-haiku-4-5", "thinkingLevel": "low" }
+      }
+    }
+  }
+}
+```
+
+### Via environment variable (quick override)
+
+```bash
+export NETCLAW_SESSION_BUDGET_USD=2.0  # Overrides config, takes effect next session
+```
 
 ## Required Environment Variables
 
@@ -44,6 +133,7 @@ This skill uses the `netclaw_tokens` shared library (`src/netclaw_tokens/`):
 |----------|----------|-------------|
 | `ANTHROPIC_API_KEY` | Yes | API key for Anthropic token counting (already used by NetClaw) |
 | `NETCLAW_TOKEN_PRICING_OVERRIDE` | No | JSON string to override default model pricing |
+| `NETCLAW_SESSION_BUDGET_USD` | No | Override session cost cap (default: 5.0) |
 
 ## Model Pricing (defaults)
 
@@ -58,37 +148,74 @@ Prompt caching discount: 90% off cached input tokens.
 ## Example Usage
 
 ```python
-from netclaw_tokens import count_tokens, calculate_cost, format_footer, SessionLedger
-from netclaw_tokens.toon_serializer import serialize_response
+from netclaw_tokens import (
+    count_tokens, calculate_cost, format_footer,
+    SessionLedger, BudgetPolicy, resolve_session_config,
+)
+from netclaw_tokens.gcf_serializer import serialize_response
 
-# Count tokens
+# ── Session start ──────────────────────────────────────────────
+config = load_openclaw_config()  # Your config loader
+session_key = "agent:main:openai:abc-123"  # From gateway
+
+policy = resolve_session_config(config, session_key)
+# → BudgetPolicy(session_budget_usd=5.0, model="anthropic/claude-haiku-4-5", ...)
+
+ledger = SessionLedger(budget=policy)
+
+# ── Each user message ──────────────────────────────────────────
+ledger.new_turn()
+
+# ── Before each tool call ──────────────────────────────────────
+should_halt, reason = ledger.check_budget()
+if should_halt:
+    return ledger.get_halt_message()  # Return to user, stop processing
+
+ledger.record_tool_call()
+
+# ── After model response ──────────────────────────────────────
 tc = count_tokens("show BGP peers on router R1")
+cost = calculate_cost(tc.input_tokens, 382, model=policy.model or "claude-sonnet-4-6")
+ledger.record("pyats_show_bgp", tc, cost)
 
-# Calculate cost
-cost = calculate_cost(tc.input_tokens, 382, model="claude-opus-4-6")
-
-# Serialize MCP response in TOON format
-data = [{"peer": "10.0.0.1", "state": "Established", "as": 65001}]
-response = serialize_response(data)
-
-# Track in session ledger
-ledger = SessionLedger()
-ledger.record("pyats_show_bgp", tc, cost, toon_savings=response.savings_tokens)
-
-# Format footer
-footer = format_footer(tc, cost, toon_savings=response.savings_tokens,
-                       session_summary=ledger.get_summary())
-# Output: Tokens: 8 in / 382 out / 390 total | Cost: $0.0096 | TOON saved: 15 tokens ($0.0001) | Session: 390 tokens ($0.01)
+# ── Footer (every response) ──────────────────────────────────
+footer = format_footer(tc, cost, session_summary=ledger.get_summary())
+# Output: Tokens: 8/382/390 | Cost: $0.01 | Session: $0.84/$5.00 (17%) | Tools: 6/20
 ```
 
 ## Session Commands
 
 - **"show session token usage"** — Returns full session summary with per-tool breakdown
 - **"show token breakdown by tool"** — Returns ranked per-tool token consumption table
-- **"compare token usage with and without TOON"** — Shows TOON savings analysis
+- **"show budget status"** — Returns current budget ceiling, remaining, and tool-call count
+- **"override budget"** / **"continue"** — Extends budget or allows more tool calls after halt
+- **"compare token usage with and without GCF"** — Shows GCF savings analysis
+
+## Prometheus Metrics (emitted by the exporter)
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `netclaw_session_budget_trips_total` | Counter | agent, reason, interface | Budget halt events |
+| `netclaw_model_cost_usd_total` | Counter | agent, model, provider | Cumulative API cost |
+| `netclaw_model_calls_total` | Counter | agent, model | API call count |
+| `netclaw_session_tool_calls_total` | Counter | agent, interface | Tool invocations |
 
 ## GAIT Integration
 
-Token summaries are automatically included in GAIT session logs via
-`SessionLedger.get_gait_summary()`, providing an immutable audit trail
-of token consumption per session.
+Token summaries (including budget status and any halt events) are automatically
+included in GAIT session logs via `SessionLedger.get_gait_summary()`, providing
+an immutable audit trail of token consumption and budget enforcement per session.
+
+## Future: Context Auto-Summarize
+
+When `contextAutoSummarize: true` is configured and context exceeds the warning
+threshold, old tool results will be automatically summarized into a compact form
+before being re-sent as context. This keeps long sessions viable without constant
+"start a new session" friction. (Documented hook — implementation tracked separately.)
+
+## Future: Daily Aggregate Safety Net
+
+Per-session caps protect against single-session runaways. A process-level daily
+aggregate cap (`dailyBudgetUsd`) is the next logical layer for protecting against
+many concurrent sessions or rapid session cycling. Not in scope for this version
+but the SessionLedger architecture supports it (add a shared process-level counter).


### PR DESCRIPTION
## Problem

A 7-question iPhone session via N2N burned $11.13 in 2 hours. The `main` agent runs
claude-sonnet-5 with `thinkingLevel: high`, has no cost ceiling, no tool-call limit,
and no interface-based model routing. The existing `netclaw_tokens` library tracks
costs (observability) but never enforces anything (no brake pedal).

The alert agent already has budget guardrails. This PR extends that pattern to all
conversational sessions.

## What's Delivered

### 1. Enforcement Library (`src/netclaw_tokens/`)

- **`budget_policy.py`** — `BudgetPolicy` dataclass + config loading with layered
  overrides (defaults → `agents.defaults.budget` → `interfaceDefaults.<type>` → env var).
  Detects interface type from session keys (openai, tui, discord, n2n, alert, explicit).

- **`session_ledger.py`** — Extended with enforcement methods:
  - `check_budget()` — pre-flight check before every API call/tool invocation
  - `is_over_budget()` / `is_over_tool_limit()` — individual checks
  - `new_turn()` / `record_tool_call()` — per-turn tool-call depth tracking
  - `override_budget()` — explicit continuation with clear semantics per halt type
  - `get_halt_message()` — user-facing halt summary showing value already delivered
  - `should_warn_context()` / `get_context_warning()` — context growth awareness

### 2. Skill Integration (`workspace/skills/token-tracker/SKILL.md`)

Token-tracker skill v2.0 documents the complete enforcement workflow:
1. Session start → `resolve_session_config()` → `SessionLedger(budget=policy)`
2. Each user message → `new_turn()`
3. Before each tool → `check_budget()` → halt or `record_tool_call()`
4. "continue" → `override_budget()` (tool-limit = free reset; cost-cap = +$2)

### 3. HUD Integration (`ui/netclaw-visual/`)

- **Footer indicator**: Live `$X.XX / $Y.YY` with color states
  (cyan ok → amber 50%+ → red 80%+ → pulsing red halted)
- **Server endpoints**:
  - `GET /api/budget/status` — real-time session cost and status
  - `GET /api/budget/config` — merged budget policy
  - `PUT /api/budget/config` — self-service configuration without SSH/JSON editing

### 4. Zero-Config Install

Works immediately with safe defaults. No `openclaw.json` section required:
- $5 session cap (halts at $5, operator can say "continue" for +$2)
- 20 tool calls per user message (pauses, summarizes, asks to continue)
- Override via `NETCLAW_SESSION_BUDGET_USD` env var for quick adjustments

### 5. Full Spec (`specs/109-session-budget-guardrails/`)

Spec-kit output: spec, research, plan, data-model, quickstart, tasks, requirements checklist.

## Tests

44 unit tests covering:
- BudgetPolicy defaults and layered config resolution
- Interface detection from all session key patterns
- Cost cap enforcement and halt state management
- Tool-call depth limiting and turn resets
- Continuation semantics (cost-cap extends $, tool-limit resets counter only)
- Halt message formatting (always includes partial value summary)
- Context warning thresholds
- Backward compatibility (existing callers without budget param)

Pre-existing `test_gcf_serializer.py` failures are unrelated (missing `gcf` module).

## What This Prevents

With default settings, the $11 incident would have:
1. Hit the $5 cost cap after ~25 API calls (instead of 59)
2. Hit the 20 tool-call limit on the first complex question
3. Shown "Budget: $2.10/$5.00" in the HUD footer the whole time

## Continuation Semantics

| Halt Type | "continue" Does | Rationale |
|-----------|-----------------|-----------|
| `cost_cap` | +$2 to ceiling, reset tool counter | Costs real money — explicit |
| `tool_limit` | Reset tool counter only (no $ change) | Free to explore more within budget |

## Configuration (optional — works without)

```json
{
  "agents": {
    "defaults": {
      "budget": {
        "sessionBudgetUsd": 5.0,
        "maxToolCallsPerTurn": 20
      },
      "interfaceDefaults": {
        "openai": { "model": "anthropic/claude-haiku-4-5" },
        "n2n": { "model": "anthropic/claude-haiku-4-5" }
      }
    }
  }
}
