### PR TITLE
fix(docs): guard README inventory and MCP config claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -2360,7 +2360,7 @@ netclaw/
 ├── MISSION01.md                          # Completed — core pyATS + 11 skills
 ├── MISSION02.md                          # Completed — full platform, 78 skills, 32 MCP
 ├── workspace/
-│   └── skills/                           # 82 skill definitions (source of truth)
+│   └── skills/                           # 223 skill definitions (source of truth)
 │       ├── pyats-network/                # Core device automation (8 MCP tools)
 │       ├── pyats-health-check/           # Health + NetBox cross-ref + pCall
 │       ├── pyats-routing/                # OSPF, BGP, EIGRP, IS-IS analysis
@@ -2515,7 +2515,7 @@ netclaw/
 | `HEARTBEAT.md` | Periodic checks. Device reachability, OSPF/BGP state, CPU/memory, syslog. |
 | `workspace/skills/` | Skill source files. `install.sh` copies these to `~/.openclaw/workspace/skills/` |
 | `testbed/testbed.yaml` | pyATS device inventory. Referenced by `PYATS_TESTBED_PATH` env var |
-| `config/openclaw.json` | Model config template. Sets primary/fallback model only — no MCP config |
+| `config/openclaw.json` | Model config template. Contains primary/fallback model settings and pre-registered MCP server definitions |
 | `mcp-servers/` | Tool backends cloned by `install.sh`. Gitignored — rebuilt on install |
 | `scripts/mcp-call.py` | Handles MCP JSON-RPC protocol: initialize, notify, tool call, terminate |
 | `scripts/gait-stdio.py` | Wraps GAIT MCP server for stdio mode (default is SSE) |

--- a/scripts/verify-inventory-counts.py
+++ b/scripts/verify-inventory-counts.py
@@ -152,7 +152,7 @@ def count_mcp_integrations():
 
 
 def check_doc_claims(skill_count, mcp_count):
-    """Best-effort scan of README.md/SOUL.md for numeric skill/MCP claims.
+    """Check selected README.md/SOUL.md inventory claims.
 
     Deliberately scoped to the specific "headline" claim locations spec 047
     identified (top prose, HUD prose, section headings, SOUL.md identity
@@ -168,8 +168,10 @@ def check_doc_claims(skill_count, mcp_count):
     unlocatable = []
     notes = []
 
+    # Numeric claims provide capture groups to compare. Qualitative claims use
+    # the same fail-closed location check with an empty capture list.
     # (file, description, compiled pattern, [(kind, capture group index), ...])
-    headline_patterns = [
+    claim_patterns = [
         (README, "top prose (skills + MCP)",
          re.compile(r"Claude,\s*(\d+)\s*skills,\s*and\s*(\d+)\s*MCP integrations"),
          [("skill", 1), ("MCP", 2)]),
@@ -195,6 +197,22 @@ def check_doc_claims(skill_count, mcp_count):
         (README, "Skills section heading",
          re.compile(r"^## Skills \((\d+)\)", re.MULTILINE),
          [("skill", 1)]),
+        (README, "project tree (skills)",
+         re.compile(
+             r"^│\s+└── skills/\s+#\s+(\d+)\s+skill definitions \(source of truth\)$",
+             re.MULTILINE,
+         ),
+         [("skill", 1)]),
+        (README, "config/openclaw.json role (models + MCP registration)",
+         re.compile(
+             r"^\| `config/openclaw\.json` \| "
+             r"(?=[^|\n]*\bmodels?\b)"
+             r"(?=[^|\n]*\bMCP\b)"
+             r"(?![^|\n]*\bno\s+MCP\b)"
+             r"[^|\n]+ \|$",
+             re.IGNORECASE | re.MULTILINE,
+         ),
+         []),
         (SOUL, "identity line (skills + MCP)",
          re.compile(r"\*\*(\d+) skills\*\* backed by (\d+) MCP servers"),
          [("skill", 1), ("MCP", 2)]),
@@ -204,7 +222,7 @@ def check_doc_claims(skill_count, mcp_count):
     ]
 
     doc_cache = {}
-    for doc_path, description, pattern, kinds in headline_patterns:
+    for doc_path, description, pattern, kinds in claim_patterns:
         doc_name = os.path.basename(doc_path)
         if doc_path not in doc_cache:
             if not os.path.isfile(doc_path):


### PR DESCRIPTION
## Summary

- Correct the README project-tree Skill count from 82 to 223.
- Correct the documented role of `config/openclaw.json`, which contains both model settings and pre-registered MCP server definitions.
- Register both claims with the existing inventory verifier so future drift fails the docs reconciliation check.

## Context

While reviewing the README project structure, I noticed that it still reported 82 Skill definitions even though the repository contains 223 and the existing verifier reports that count correctly. The configuration table also described `config/openclaw.json` as having no MCP configuration, while the file now contains `mcpServers`.

Both descriptions were originally accurate but became stale as the project evolved. The existing verifier still passed because neither the project-tree count nor the qualitative config description was included in its registered claim locations.

This change extends the existing fail-closed claim table rather than adding a separate checker or changing runtime behavior.

## Testing

- `python3 scripts/verify-inventory-counts.py`
- `python3 scripts/reconcile-mcp.py --surface docs`