### PR TITLE
fix(zoom-rtms): add upper bound to the websockets pin

### DIFF
--- a/mcp-servers/zoom-rtms-mcp/requirements.txt
+++ b/mcp-servers/zoom-rtms-mcp/requirements.txt
@@ -1,7 +1,7 @@
 # Upper bound is LOAD-BEARING, same reason as every other NetClaw FastMCP
 # server (spec 077): mcp 2.0.0 removed mcp.server.fastmcp. Do not remove.
 mcp>=1.0.0,<2
-websockets>=12.0
+websockets>=12.0,<16
 python-dotenv>=1.0.0
 # Zoom's official RTMS Python SDK (research.md R4, spec 118). Confirmed
 # installable from PyPI (verified 2026-08-17) as package "rtms" — ships only


### PR DESCRIPTION
## What

`mcp-servers/zoom-rtms-mcp/requirements.txt` pins `websockets>=12.0` with no
upper bound. The server code imports a **submodule** of `websockets`, and a new
major release can remove or relocate that submodule — the same failure mode
spec 077 documents for every NetClaw FastMCP server (mcp 2.0.0 removed
`mcp.server.fastmcp`). The file's own top comment already says the upper bound
is load-bearing.

```diff
-websockets>=12.0
+websockets>=12.0,<16
```

## Why now

`scripts/reconcile-mcp.py --surface dependencies` currently fails on `main`
because of this one pin:

```
pins: zoom-rtms-mcp: 'websockets' is pinned '>=12.0' with no upper bound, but
the code imports a SUBMODULE of it — a new major can remove that submodule
```

`dependencies` is a hard gate in `.github/workflows/mcp-reconciliation.yml`
(no `--warn-only`), so this blocks unrelated PRs that touch any reconciled path.

## Verification

- `python3 scripts/reconcile-mcp.py --surface dependencies` — **PASS** after the change (FAIL before).